### PR TITLE
governance: feature-flow over fixed lanes ("not my job" design review)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,28 +72,45 @@ cd fireemblem8u
 - If you're about to hardcode "braulo" or "ch03" in a `.c` file — stop. It belongs in YAML.
 - Code review rule: any C change that references a character by name, a chapter number, or a plot event is rejected
 
-## Tracks & the engine/content seam
+## Coordination: feature-flow (one feature, one branch, one PR)
 
-Work splits into a **content** track (`campaigns/**`, `tools/build_campaign.py` + art tools) and a
-**pipeline** track (`tools/difficulty.py`, `fe_combat.py`, `check.py`, `playtest/**`, `build.sh`, CI).
-Shared by both: `tools/inject/**`, `docs/**`, `HANDOFF*`, `CLAUDE.md`, `Makefile`. Rationale +
-enforcement: `docs/decisions.md` → Seam enforcement (#55).
+Work is organized by **feature**, not by fixed lanes (rationale: `docs/decisions.md` → Coordination
+model). A task = a GitHub issue → a short-lived `feat/<n>-slug` branch off `main` → an **ephemeral
+worktree** for build isolation (`git worktree add ../ms-<slug> -b feat/<n>-slug origin/main`; drop it
+when merged) → a **PR** → CI + `/code-review` → squash-merge to `main` → delete the branch + worktree.
+Concurrency = as many worktrees as you have features in flight (two ROM builds in one tree corrupt each
+other, so each concurrent agent gets its own worktree — that's the *only* thing isolation is for).
 
-**Working a track means working in that track's worktree** — always, even solo. When asked to
-"work the content track" / "work the pipeline track", switch into that track's worktree first
-(`../ms-content` on `inst/content`, `../ms-pipeline` on `inst/pipeline`); they're already bootstrapped,
-and `tools/worktree-setup.sh ../ms-<track>` re-creates one if missing. **Don't do track work on `main`.**
+A feature **may span** what used to be the "content" and "pipeline" lanes — that's the point: capturing
+a unit's battle anim is one feature (the `record*` scenario **and** the sandbox build it fires on).
+Ownership lives on the **PR + issue**, decided at review, not on a file glob.
 
-**This handoff/checklist routes by where you are** (run `git rev-parse --abbrev-ref HEAD`):
-- On **`main`** (the primary `manchego-stars` checkout) → the integration/solo tree, for cross-track
-  merges and ad-hoc one-offs only. Read `HANDOFF.md`. **No lane is enforced here.**
-- On **`inst/content`** / **`inst/pipeline`** (a worktree, opened as its own VS Code folder) → you ARE
-  that track. Read `HANDOFF-content.md` / `HANDOFF-pipeline.md` and stay in your lane:
-  `check.py check_lane_ownership` (pre-commit + CI) blocks editing the *other* lane's files
-  (`--no-verify` overrides). Worktree isolation is also what lets two instances run **at once** (two
-  builds in one tree would corrupt each other); each instance gets its own worktree = its own VS Code window.
+**Two boundaries, two strengths** — don't conflate them:
+- **Engine/content invariant (HARD gate):** the Engine/Content Boundary Rule above + the 5 engine hooks
+  in `tools/inject/` (guarded by `check.py check_engine_guards_present`). A `.c`/`.s` change that names a
+  character, chapter, or plot event is **rejected**. Real decision-hiding; it stays a gate.
+- **Desk ownership (REVIEWED, not blocked):** which desk owns a responsibility is a review judgment.
+  `check.py check_lane_ownership` is now an **advisory** that flags a cross-desk change so the PR names
+  the contract.
 
 Never commit the `fireemblem8u` submodule pointer.
+
+## Design placement test ("not my job" / "no need to know")
+
+Deciding *where a line of code goes* (Cockburn, *Simplifying Software Design*, 2026): treat each module
+as a clerk with a **filing cabinet** (its private state) and a **phone** (its interface), then —
+- **"Not my job"** — push each line downhill to the desk that owns it. A handler that only forwards
+  ("call the Buy process") should be *one line*. A desk doing work it doesn't own → move the work.
+- **"No need to know"** — a desk must not reach into another's cabinet (private state) or depend on its
+  internals. Talk over the phone (interface) only.
+- **Futures, not "simplicity"** — judge a boundary by *which future changes it makes cheap*. Localize
+  decisions likely to change (Parnas); gather what changes for the same reason, separate what changes for
+  different reasons. Don't refactor for futures you can't name (the 109 KB `harness.lua` stays whole —
+  its only likely change is "add a scenario," which is cheap).
+
+**Code-review rule:** a change where one desk reaches into another's cabinet — or that scatters one
+decision across desks (e.g. the boot-cut duplicated in `inject_prologue` + `inject_test_chapter`) — is
+rejected; localize the decision first.
 
 ## Working Conventions (Definition of Done)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -209,46 +209,45 @@ per hook, that it is *defined* in `engine_hooks.py` AND *called* (`engine_hooks.
 byte-identical ROM (md5 unchanged) plus `lordfloor`/`ch01win` playtests. Work tracker #50.
 _Decided: 2026-06-19_
 
-**Seam enforcement: a lane-ownership guard, because the seam was honor-system and got crossed.**
-The first parallel run had violations — the pipeline instance edited `build_campaign.py` (content-owned)
-because nothing *stopped* it (and because no worktree isolation was actually engaged: both sessions ran in
-the primary checkout on `main`). Documentation + the file seam weren't enough; ownership is now **enforced**.
-`tools/check.py` carries the ownership map (single source, also summarized in `CLAUDE.md` §Tracks:
-pipeline = `difficulty.py`/`fe_combat.py`/`check.py`/`playtest/**`/`build.sh`/`worktree-setup.sh`/`hooks/**`/
-`.github/workflows/**`; content = `campaigns/**`/`build_campaign.py`/`portrait_tool.py`/`map_sprite_tool.py`/
-`ref_to_bust.py`; everything else incl. `tools/inject/**` + docs = shared) and `check_lane_ownership()`, run
-by the pre-commit hook + CI. The lane is read from the `inst/<track>` **branch name** (inherently
-per-worktree; `.git/config` is shared), `manchego.lane` config as fallback. **Enforcement is scoped to lane
-worktrees**: on `inst/<track>` a staged file owned by the *other* lane is blocked (`--no-verify` overrides;
-CI enforces on `inst/*` PRs via `GITHUB_HEAD_REF`/`BASE_REF`). The **primary checkout (`main`) is
-unrestricted** — it's the integration/solo tree where one person does one thing at a time, so there's no seam
-to cross; blocking it would only tax normal single-window work. The seam can only be *violated* when two
-instances run concurrently, and concurrency already **requires** a worktree per instance (two builds in one
-tree corrupt each other) — so enforcing exactly where worktrees exist covers the real risk. Shared cross-lane
-constants (e.g. the weapon↔ITEM map) live in `tools/inject/decomp.py`, not either side's file. Issue #55.
-_Decided: 2026-06-19_
+**Coordination model: feature-flow over fixed lanes.** We first split work into two fixed lanes
+(content = `campaigns/**` + `build_campaign.py` + art tools; pipeline = `difficulty.py`/`fe_combat.py`/
+`check.py`/`playtest/**`/`build.sh`/CI) and **enforced** them with a file-glob ownership guard
+(`check.py check_lane_ownership`, keyed off the `inst/<track>` branch; #55) because the seam was
+honor-system and got crossed. The guard worked, but the lanes were the wrong *shape*: real features
+routinely **span** the glob seam — the per-chapter parity gate (gate + `balance_locked`), adding a weapon
+(combat-model map + `WEAPON_ITEM_ENUM`), lord-select UX (bounced engine→content over *file paths*), and
+capturing a unit's battle anim (the `record*` scenario **and** the sandbox build it fires on). A fixed
+partition doesn't *prevent* collisions on a spanning feature; it **saws the feature in half** so neither
+lane can finish-and-verify it. We already patched around it once (the 2026-06-22 "content `record*` are
+content spot-checks" carve-out — queued, never landed) and hit the same wall again with `recordrbgtest`
+(capture = pipeline scenario, sandbox = content build → un-verifiable from either lane).
 
-**Seam refinement: content-feature `record*` playtest scenarios are content spot-checks, not pipeline infra.**
-The playtest *harness/framework* (`harness.lua`, clearbot, liveness, the verification scenarios) stays
-pipeline-owned. But a `record*` scenario that captures a **content** feature for review (e.g. `recordlord`
-for the #46 lord-select cards) is a content spot-check — the `dialogue-pass` workflow itself mandates
-`run.sh record` + `make_gif.py` to show Nicolas cutscene/card renders — so the content lane must be able to
-author it without a worktree hop. *Running* any scenario was always in-lane; only *editing* `tools/playtest/**`
-was blocked. **Mechanism (queued, pipeline-owned edit): carve content review scenarios into a content-owned
-file** the harness includes (e.g. `tools/playtest/content_scenarios.lua` added to `CONTENT_EXCLUSIVE_FILES`,
-or a `record*`-name carve-out in `_file_lane`), so the lane guard lets content own its capture scenarios while
-the framework stays pipeline. Until that lands, a content `record*` addition commits with `--no-verify`.
-_Decided: 2026-06-22 (Nicolas — "B for sure"; mechanism queued for a pipeline-lane instance)_
+The root error was **conflating build-isolation with ownership**. Isolation (two ROM builds corrupt one
+tree) is physical and is solved by *a* worktree — any worktree. Ownership (who may change what) is logical
+and got welded onto the same `inst/<track>` worktree, forcing work to partition by file type. Unwelded:
 
-**Track work always happens in that track's worktree — even solo.** "Work the content track" / "work the
-pipeline track" means: switch into `../ms-content` (`inst/content`) or `../ms-pipeline` (`inst/pipeline`)
-*first*, then work. `main` is reserved for cross-track integration and ad-hoc one-offs. This is broader than
-the build-isolation rationale above (which only *requires* a worktree when two instances run concurrently):
-making the worktree the unconditional home for track work removes the "is anyone else running?" judgment call,
-keeps every track commit on its `inst/<track>` branch where the lane guard applies, and means a fresh instance
-told to "work the content track" lands in the right tree by default instead of editing `main`. The worktrees
-are persistent (already bootstrapped); `tools/worktree-setup.sh` only re-creates a missing one.
-_Decided: 2026-06-19 (Nicolas)_
+- **Feature-flow.** A task = issue → short-lived `feat/<n>-slug` branch off `main` → an **ephemeral**
+  worktree (isolation only) → a **PR** → CI + `/code-review` → squash-merge → drop the branch + worktree.
+  Concurrency = N feature worktrees, not two fixed slots. A PR may span the old seam; that is the point.
+- **The "not my job" propagation test runs at PR review** — push the change through the desks and watch
+  the reactions (my job / I can help / no impact / no need to know). Review is where ownership is decided,
+  replacing the pre-commit glob block.
+- **Engine/content stays a HARD invariant.** The Engine/Content Boundary Rule (no character/chapter/plot
+  in `.c`/`.s`) + the 5 engine hooks in `tools/inject/` (`check_engine_guards_present`) are genuine
+  decision-hiding and remain gates. *Follow-up:* mechanize the name-in-C check (today a review rule).
+- **`check_lane_ownership` is demoted to an advisory** desk-span note (no longer a block). The glob map it
+  carries is the seed of the **desk map**: each desk = a responsibility + its phone (interface) + its
+  cabinet (private files), the design vocabulary enforced at review.
+- **Design placement** follows the three reflexes (`CLAUDE.md` → Design placement test): *not my job*
+  (push each line to its owner), *no need to know* (no desk reaches into another's cabinet), *futures*
+  (judge boundaries by the changes they make cheap; localize decisions likely to change — but don't split
+  what has no expensive future, e.g. `harness.lua`).
+
+Supersedes the fixed-lane ADRs (Seam enforcement #55; the 2026-06-22 `record*` refinement; "track work
+always in that track's worktree"). The two ADRs above — worktree isolation and the 5-hook engine/content
+file seam — **stand**: worktrees are now ephemeral-per-feature, and the file seam is the hard invariant
+feature-flow keeps.
+_Decided: 2026-06-24 (Nicolas — chose feature-flow + PRs; codified from the "not my job" design review)_
 
 ---
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -343,14 +343,17 @@ def _changed_files():
 
 
 def check_lane_ownership(fail):
-    """Block a commit that crosses the engine/content seam (#55) when you're in a lane worktree
-    (branch inst/<track>). The primary checkout is unrestricted integration. `git commit
-    --no-verify` overrides for a deliberate exception."""
-    lane = _current_lane()
-    for path, owner in _lane_violations(lane, _changed_files()):
-        fail.append('lane: %s is %s-owned, but this worktree is the %s lane -- coordinate via '
-                    'an issue instead of crossing the seam (--no-verify to override)'
-                    % (path, owner, lane))
+    """ADVISORY since 2026-06-24 (feature-flow, decisions.md -> Coordination model): NOT a gate.
+    Fixed lanes were retired because features routinely span the engine/content seam (e.g. an
+    anim capture = its record* scenario + the sandbox build it fires on), and a hard glob block
+    sawed such a feature in half. So this no longer fails -- it just surfaces, on a legacy
+    `inst/<track>` branch, that a change touches the other desk's historical files, so the PR
+    review names the cross-desk contract. The HARD invariant is now check_engine_guards_present
+    (the 5 engine hooks); desk ownership is reviewed at the PR. The glob map (above) is the seed
+    of the desk map. Dormant on `feat/*` branches (no lane), which is the steady state."""
+    for path, owner in _lane_violations(_current_lane(), _changed_files()):
+        print('  note: %s is historically %s-side -- if this PR spans desks, name the contract in review'
+              % (path, owner))
 
 
 def main():


### PR DESCRIPTION
## What & why

Codifies the coordination model from the **"not my job" / "no need to know"** design review (Cockburn, *Simplifying Software Design* 2026; Parnas decision-localization). This PR is itself the first feature-flow change — authored on `feat/feature-flow-governance` off `main`, delivered as a PR.

**The diagnosis:** the fixed `content`/`pipeline` lanes conflated **build-isolation** (physical — two ROM builds corrupt one tree) with **ownership** (logical — who may change what). Both got welded onto the `inst/<track>` worktree, forcing work to partition by *file type*. But real features routinely **span** the seam (per-chapter parity gate, adding a weapon, lord-select UX, anim capture), so a fixed glob partition doesn't prevent collisions — it **saws the feature in half**. Proven again today: `recordrbgtest` (capture scenario = pipeline, sandbox build = content) is **un-verifiable from either lane**, and we'd already queued a never-landed carve-out for the same problem (`recordlord`, 2026-06-22).

## Changes

- **`docs/decisions.md`** — consolidate the three fixed-lane ADRs (seam enforcement #55, `record*` refinement, worktree-home) into one **"Coordination model: feature-flow over fixed lanes."** Worktree-isolation + the 5-hook engine/content file-seam ADRs **stand**.
- **`CLAUDE.md`** — replace §Tracks with **feature-flow** (issue → `feat/` branch → ephemeral worktree → PR → CI + `/code-review` → squash-merge), and add the **Design placement test** (the three reflexes + a code-review rule).
- **`tools/check.py`** — **demote** `check_lane_ownership` from a hard pre-commit block to an **advisory** desk-span note. The **engine/content invariant stays HARD** (`check_engine_guards_present`). The glob map becomes the **desk-map** seed.

## Boundaries kept vs re-drawn
- **HARD (kept):** engine/content invariant — no character/chapter/plot in `.c`/`.s`; the 5 engine hooks in `tools/inject/`. Genuine decision-hiding.
- **REVIEWED (re-drawn):** desk ownership — now a PR-review judgment, not a glob block.

## Follow-ups (separate features)
1. **Localize the boot-cut decision** (`_cut_boot_intro` duplicated in `inject_prologue` + `inject_test_chapter`) → one `boot_config` owner; this unblocks `recordrbgtest` end-to-end.
2. **Mechanize the name-in-C check** (today a manual review rule).
3. Reconcile the 31-ahead / 6-behind `inst/*` divergence into `main`, then retire the `inst/*` branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
