### PR TITLE
check: mechanize the Engine/Content Boundary Rule (name-in-engine gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ cd fireemblem8u
 - Engine code (`engine/`, `fireemblem8u/src/`) must be campaign-agnostic
 - Campaign data (`campaigns/rime-of-the-frostmaiden/`) is injected at build time by `tools/build_campaign.py`
 - If you're about to hardcode "braulo" or "ch03" in a `.c` file — stop. It belongs in YAML.
-- Code review rule: any C change that references a character by name, a chapter number, or a plot event is rejected
+- Enforced: `check.py check_engine_campaign_agnostic` (CI + pre-commit) scans the hand-written engine sources (`engine/**`, `tools/inject/engine_hooks.py`, `decomp.py`) for any campaign character id and rejects it. (Chapter-number / plot-event references stay a review-judgment call.)
 
 ## Coordination: feature-flow (one feature, one branch, one PR)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -234,7 +234,9 @@ and got welded onto the same `inst/<track>` worktree, forcing work to partition 
   replacing the pre-commit glob block.
 - **Engine/content stays a HARD invariant.** The Engine/Content Boundary Rule (no character/chapter/plot
   in `.c`/`.s`) + the 5 engine hooks in `tools/inject/` (`check_engine_guards_present`) are genuine
-  decision-hiding and remain gates. *Follow-up:* mechanize the name-in-C check (today a review rule).
+  decision-hiding and remain gates. The character-name half is now mechanized
+  (`check_engine_campaign_agnostic` scans the hand-written engine sources for any campaign id);
+  chapter-number / plot-event references stay a review-judgment call.
 - **`check_lane_ownership` is demoted to an advisory** desk-span note (no longer a block). The glob map it
   carries is the seed of the **desk map**: each desk = a responsibility + its phone (interface) + its
   cabinet (private files), the design vocabulary enforced at review.

--- a/tools/check.py
+++ b/tools/check.py
@@ -187,6 +187,59 @@ def check_engine_guards_present(fail):
                         '(see docs/decisions.md)' % (fn, fn, mechanic))
 
 
+# ── Engine campaign-agnosticism (the Engine/Content Boundary Rule, mechanized) ─────
+# Hand-written engine code must never name a campaign character: build_campaign INJECTS
+# names into the fireemblem8u working tree at build time, so the committed engine sources
+# stay reusable for any campaign ("braulo" belongs in YAML, not a .c). This was a
+# code-review rule (CLAUDE.md Engine/Content Boundary Rule); now a gate. Scope = what WE
+# author -- engine/** + the engine-hook injectors; the fireemblem8u submodule is vanilla +
+# build-injected and never committed by us, so it's deliberately excluded. Decision:
+# docs/decisions.md -> Coordination model (mechanize the name-in-C check).
+ENGINE_SOURCE_GLOBS = ('engine/**/*.c', 'engine/**/*.h', 'engine/**/*.s',
+                       'tools/inject/engine_hooks.py', 'tools/inject/decomp.py')
+
+
+def _campaign_character_ids():
+    """Lowercased character ids from every pcs/npcs YAML -- the campaign-specific tokens
+    engine code must not hardcode. Read off the `id:` line so the lightweight checks job
+    needs no YAML load."""
+    ids = set()
+    for sub in ('pcs', 'npcs'):
+        for f in glob.glob(os.path.join(REPO, 'campaigns/**', sub, '*.yaml'), recursive=True):
+            m = re.search(r'(?m)^id:\s*([A-Za-z0-9_-]+)', open(f, encoding='utf-8').read())
+            if m:
+                ids.add(m.group(1).lower())
+    return ids
+
+
+def _engine_name_hits(ids, text):
+    """(token, lineno) for each campaign character id named in `text`. Word-boundaried and
+    case-insensitive, so 'brie' never matches 'brief' but 'BRAULO' in a comment is caught.
+    Pure (no I/O) so it's unit-tested directly."""
+    if not ids:
+        return []
+    pat = re.compile(r'\b(' + '|'.join(re.escape(i) for i in sorted(ids)) + r')\b', re.I)
+    hits = []
+    for n, line in enumerate(text.splitlines(), 1):
+        m = pat.search(line)
+        if m:
+            hits.append((m.group(1).lower(), n))
+    return hits
+
+
+def check_engine_campaign_agnostic(fail):
+    ids = _campaign_character_ids()
+    if not ids:
+        return
+    for g in ENGINE_SOURCE_GLOBS:
+        for path in glob.glob(os.path.join(REPO, g), recursive=True):
+            rel = os.path.relpath(path, REPO)
+            for tok, n in _engine_name_hits(ids, open(path, encoding='utf-8').read()):
+                fail.append('engine: %s:%d names campaign character %r -- engine code must be '
+                            'campaign-agnostic; inject it from YAML (CLAUDE.md Engine/Content '
+                            'Boundary Rule)' % (rel, n, tok))
+
+
 # ── Save-layout stability (so testers can carry their .sav across builds) ──────────
 # A battery .sav is accepted on a new build iff its validity magics + checksum still
 # match (bmsave-lib.c:125-128, ReadSaveBlockInfo). Those magics are constant, so a
@@ -361,6 +414,7 @@ def main():
     for check in (check_python_compiles, check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
+                  check_engine_campaign_agnostic,
                   check_save_layout_stable, check_lane_ownership):
         check(fail)
     if fail:

--- a/tools/inject/engine_hooks.py
+++ b/tools/inject/engine_hooks.py
@@ -178,7 +178,7 @@ def _inject_lord_select_engine():
          member on the Eirika slot inherits free convoy access.
       6. gForceDeploymentList (data_event_trigger.c): cleared. Vanilla's static
          by-slot force-deploy table would force-field cast riding those slots
-         (e.g. CHARACTER_EIRIKA/COMMON = Braulo, every chapter) on top of hook 2's
+         (e.g. whoever rides CHARACTER_EIRIKA in COMMON mode, every chapter) on top of hook 2's
          chosen lead. Hook 2 is now the ONLY force-deploy.
     """
     # 1 + 2: eventinfo.c -- GetPid above the force-deploy lookup, hook inside it.
@@ -313,7 +313,7 @@ def _inject_lord_select_engine():
 
     # 5: bmmenu.c -- convoy/supply gate. SupplyUsability hardcodes the route lord
     #    (Eirika/Ephraim) as the unit that can open the supply anywhere; a cast member
-    #    riding that slot (Braulo on CHARACTER_EIRIKA) inherits free convoy access.
+    #    riding that slot (e.g. CHARACTER_EIRIKA) inherits free convoy access.
     #    Route it through the chosen lead instead (mirrors the Seize gate).
     with open(BMMENU_C, encoding='utf-8') as f:
         text = f.read()
@@ -347,7 +347,7 @@ def _inject_lord_select_engine():
 
     # 6: data_event_trigger.c -- the vanilla static force-deploy table. It hard-fields
     #    Eirika/Ephraim (and later-route units) BY SLOT; our cast ride those slots, so
-    #    e.g. CHARACTER_EIRIKA in COMMON mode force-fields Braulo every chapter, on top
+    #    e.g. CHARACTER_EIRIKA in COMMON mode force-fields whoever rides it every chapter, on top
     #    of the player's chosen lead. Clear it: the ONLY forced unit is the chosen lead
     #    (the IsCharacterForceDeployed_ hook, #2 above). Any future per-chapter forced
     #    unit is added our way, not via this vanilla table.

--- a/tools/test_check_engine_agnostic.py
+++ b/tools/test_check_engine_agnostic.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Tests for the mechanized Engine/Content Boundary Rule in tools/check.py.
+
+Pins the pure name-scan: hand-written engine code must not hardcode a campaign character
+id ("braulo" belongs in YAML, not a .c). Run: python3 tools/test_check_engine_agnostic.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check
+
+
+class EngineNameHits(unittest.TestCase):
+    IDS = {'braulo', 'prof-rbg', 'brie', 'marty'}
+
+    def test_bare_name_is_caught(self):
+        self.assertEqual(check._engine_name_hits(self.IDS, 'if (pid == braulo) {'),
+                         [('braulo', 1)])
+
+    def test_caught_in_a_comment_case_insensitively(self):
+        self.assertEqual(check._engine_name_hits(self.IDS, '/* MARTY rides the lord slot */'),
+                         [('marty', 1)])
+
+    def test_hyphenated_id_is_caught(self):
+        self.assertEqual(check._engine_name_hits(self.IDS, '    /* prof-rbg hook */'),
+                         [('prof-rbg', 1)])
+
+    def test_substring_is_not_a_false_positive(self):
+        # 'brie' must not fire on 'brief'; word boundaries protect common-word ids.
+        self.assertEqual(check._engine_name_hits(self.IDS, 'int brief_count = 0;'), [])
+
+    def test_clean_engine_text_passes(self):
+        self.assertEqual(
+            check._engine_name_hits(self.IDS, 'StartFace(0, GetUnitPortraitId(gActiveUnit));'),
+            [])
+
+    def test_reports_the_line_number(self):
+        text = 'line one\nline two\n    if (pid == sclorbo) act();'
+        self.assertEqual(check._engine_name_hits({'sclorbo'}, text), [('sclorbo', 3)])
+
+    def test_empty_id_set_is_a_noop(self):
+        self.assertEqual(check._engine_name_hits(set(), 'braulo everywhere'), [])
+
+
+class CampaignIds(unittest.TestCase):
+    def test_real_roster_loads_from_yaml(self):
+        ids = check._campaign_character_ids()
+        # The real campaign should yield its leads (sanity that the YAML scan works).
+        self.assertIn('braulo', ids)
+        self.assertIn('prof-rbg', ids)
+
+    def test_the_live_tree_is_already_agnostic(self):
+        # The committed engine sources must be clean right now -- the guard ships green.
+        fail = []
+        check.check_engine_campaign_agnostic(fail)
+        self.assertEqual(fail, [], 'engine sources name a campaign character:\n' + '\n'.join(fail))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Mechanizes the **Engine/Content Boundary Rule** ("no campaign character in engine code") — it was code-review-only; now it's a CI + pre-commit **gate**.

`check_engine_campaign_agnostic` reads the campaign character ids off the `pcs/npcs` YAML `id:` lines and scans the **hand-written** engine sources (`engine/**`, `tools/inject/engine_hooks.py`, `decomp.py`) for any of them. `fireemblem8u` is vanilla + build-injected and never committed, so it's deliberately out of scope — this guards what *we* author.

Matching is **word-boundaried + case-insensitive**: `brie` never trips on `brief` or `basil` on `basilisk`, but a `Braulo` in a comment is caught. The scan core (`_engine_name_hits`) is pure and **TDD'd** (`test_check_engine_agnostic.py`, 9 asserts incl. a "the live tree is already clean" assert).

## It caught real hits

Running it immediately flagged **3** references: `engine_hooks.py` named "Braulo" in *explanatory comments* (e.g. `CHARACTER_EIRIKA = Braulo`). The hook **code** was already agnostic — but a reusable engine module shouldn't name our campaign character even in prose (the FE slot `CHARACTER_EIRIKA` is vanilla vocabulary and stays). Rewrote those 3 comments to generic phrasing (`whoever rides CHARACTER_EIRIKA`); the only change to `engine_hooks.py` is comments.

## Scope note

The **character-name** half is now mechanical. **Chapter-number / plot-event** references stay a review-judgment call (too ambiguous to grep without false positives). Docs updated (`CLAUDE.md` Boundary Rule + the Coordination-model follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
