### PR TITLE
playtest(#65): localize the boot decision + unblock recordrbgtest end-to-end

### DIFF
--- a/HANDOFF-pipeline.md
+++ b/HANDOFF-pipeline.md
@@ -8,30 +8,27 @@ the lane guard is `check.py check_lane_ownership`). Seam enforcement (#55) + par
 pipeline-lane-specific gotchas.** Don't touch `HANDOFF-content.md`.
 
 ## Now (2026-06-24) — #65 capture tooling landed + the rbg capture made honest/robust; parity gate enforcing (#48 b); #63 M1 landed (M2 next)
-- **#65 capture tooling LANDED + the deferred `captureAttack` fix LANDED (2026-06-24).** Added `recordrbg`
+- **#65 capture tooling LANDED + `recordrbgtest` fully unblocked end-to-end (2026-06-24).** Added `recordrbg`
   (loads an `rbgch01` checkpoint instead of replaying the prologue → ~12s), `make_gif.py --mp4`
   (local-only; **GIF stays the GitHub-review format** — a committed `.mp4` is a binary download, not
-  inline), and `recordrbgtest` (capture on a `make TESTCH=1` ROM that boots straight into the Ch1
-  sandbox). **The capture is now honest + robust:** `captureAttack` (1) **settles the action menu
-  (`wait(20)`) before the first A** — `positionRbgForShot`'s `moveUnit` returns the instant
-  `menuOpen()` flips true, while the slide-in is still eating input, so without the settle only 2 of
-  the 3 menu confirms land and the unit stalls parked on target-selection (the reported symptom); and
-  (2) **RETURNS whether combat actually started** (US_UNSELECTABLE), and `recordrbg`/`recordrbgtest`
-  now **FAIL** when it didn't, instead of returning PASS unconditionally (the old misleading green).
-  Verified end-to-end on **`recordrbg`** (fresh checkpoint, normal build): real Soldier-vs-RBG battle
-  anim captured (122 frames, 70 distinct sizes — not a frozen menu), loop broke at US_UNSELECTABLE,
-  honest PASS; `lua` playtest tests + `check.py` clean. **`recordrbgtest`'s sandbox end-to-end is NOT
-  pipeline-verifiable** — its `make TESTCH=1` build is content-lane and **unwired on this branch**
-  (`inject_test_chapter` exists but `main()` never calls it; a pipeline-side reconstruction deploys RBG
-  as vanilla `CLASS_ARCHER 0x19`, not the `0x6C` clone, and fails before the menu). So the settle is
-  the best-supported mitigation but is only proven on `recordrbg`; if it's insufficient on the real
-  sandbox, `recordrbgtest` now goes **truthfully RED** rather than false-green. **Content follow-up:**
-  wire `make TESTCH=1` (skip `inject_prologue`'s boot-cut — `inject_test_chapter` does its own; they
-  double-cut otherwise) so `recordrbgtest` can be verified faithfully. **Checkpoint reuse caveat
+  inline), and `recordrbgtest` (`make TESTCH=1` ROM boots straight into the Ch1 sandbox, RBG the `0x6C`
+  archer-clone pre-deployed). **Three real root causes fixed** (the "needs a settle" hypothesis was
+  wrong — the menu was always responsive): (1) the **boot-cut decision is localized** to one
+  `_configure_boot()` owner in `build_campaign.py`, called once from `main()` — `inject_prologue` /
+  `inject_test_chapter` no longer each cut the intro + redirect New Game (the duplication that
+  double-cut/crashed; content had already made them XOR, this removes the duplication itself);
+  (2) **`clearbot.pickTarget` gained `min_range`** — RBG fires a BOW (2-range only), so `positionRbgForShot`
+  must not park it adjacent (range 1) where there's NO Attack command and `captureAttack`'s presses
+  wander the Item menu; (3) **`captureAttack`'s target confirm is feedback-driven** — with several foes in
+  bow range the BKSEL cursor can start off a target, so it presses A and cycles targets (RIGHT) until a
+  battle actually animates (`gProc_ekrBattle`), then stops (pressing during the anim would skip it). It
+  also **RETURNS whether combat started** (US_UNSELECTABLE); `recordrbg`/`recordrbgtest` **FAIL** if it
+  didn't (no more unconditional PASS). **Verified end-to-end on BOTH**: `recordrbgtest` captures a real
+  Soldier-vs-RBG bow anim on the sandbox (162 frames, 97 distinct sizes, honest PASS); `recordrbg`
+  unregressed (cached checkpoint, PASS); `lua` tests + `make` green. **Checkpoint reuse caveat
   unchanged:** DON'T reuse an `rbgch01` checkpoint across an injection/build change (ROM layout shifts
   corrupt the save-state → capture shows the map/menu, never the battle; safe only across pure
-  graphics-byte swaps). The `TESTCH=1` build + the anim/platform "how" live in **content**
-  (`build_campaign` docstrings); this is just the capture scenario.
+  graphics-byte swaps).
 - **#48 (b) parity gate is now ENFORCING, per-chapter & opt-in — LANDED & verified** (decisions.md §The parity
   curve is surfaced in CI…). CI flipped `make difficulty` → **`make difficulty-gate`**. A chapter is gated only
   once content marks it balance-final with **`balance_locked: true`** in its chapter YAML; `curve_gate_failures`

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -249,6 +249,19 @@ file seam — **stand**: worktrees are now ephemeral-per-feature, and the file s
 feature-flow keeps.
 _Decided: 2026-06-24 (Nicolas — chose feature-flow + PRs; codified from the "not my job" design review)_
 
+**Boot decision localized; bows need a min-range in playtest targeting (the first feature-flow feature).**
+The boot cut + New-Game redirect were decided in BOTH `inject_prologue` and `inject_test_chapter` (the
+duplication the Coordination ADR cites). Localized to one `_configure_boot(target, montage)` owner called
+once from `build_campaign.main()`; the two target injectors no longer re-decide it. This — plus two
+playtest fixes — unblocks `recordrbgtest` (capture RBG's bow anim on the `make TESTCH=1` sandbox)
+end-to-end: (a) `clearbot.pickTarget` takes a **`min_range`** so a 2-range-only bow isn't parked
+adjacent (range 1), where there is no Attack command; (b) `captureAttack`'s target confirm is
+**feedback-driven** (press A, cycle targets, until `gProc_ekrBattle` animates) because with several foes
+in range the BKSEL select cursor can start off a target. Verified end-to-end on the sandbox AND on
+`recordrbg` (no regression). The "menu just opened, settle before the first A" hypothesis was wrong — the
+menu was responsive throughout; positioning + multi-target confirm were the real causes.
+_Decided: 2026-06-24_
+
 ---
 
 ## Combat System

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -1244,6 +1244,17 @@ def _redirect_new_game(chapter_index):
         f.write(bmio)
 
 
+def _configure_boot(new_game_target, montage=False):
+    """Single owner of the boot decision. inject_prologue and inject_test_chapter each used
+    to cut the intro + redirect New Game themselves -- the SAME decision scattered across two
+    desks, which double-cut and crashed if both ran. Localized here: cut the attract / intro /
+    world-map sequences, then point New Game at `new_game_target` (the host chapter slot the
+    prologue OR the Ch1 sandbox loads through -- both PROLOGUE_HOST_INDEX). Call ONCE from
+    main(), after whichever target injector ran."""
+    _cut_boot_intro(montage=montage)
+    _redirect_new_game(new_game_target)
+
+
 def inject_opening_montage(campaign, verbose=True):
     """#43 lore crawl: re-render vanilla's seven opening-monologue slides from the
     campaign's locked card text and retime the display LUT to our word counts.
@@ -1575,12 +1586,9 @@ def inject_test_chapter(campaign, verbose=True):
     with open(CH1_EVENTSCRIPT_H, 'w', encoding='utf-8') as f:
         f.write(script)
 
-    # Dev loop: cut every pre-map sequence so a fresh boot lands on the title and New
-    # Game drops straight onto the map, then redirect the prologue slot -> Ch1 so the
-    # New Game target is this sandbox chapter.
-    _cut_boot_intro()
-    _redirect_new_game(TEST_CHAPTER_INDEX)
-
+    # The boot cut + New-Game redirect (so a fresh boot lands on the title and New Game drops
+    # straight onto this sandbox chapter) are the single owner _configure_boot()'s job, called
+    # once from main() -- not re-decided here.
     if verbose:
         for unit_id, slot, class_enum, _ in units:
             print('  %-10s -> Ch1 ally (%s as %s)'
@@ -3155,13 +3163,11 @@ def inject_prologue(campaign, verbose=True, montage=False):
     with open(BATTLEQUOTES_C, 'w', encoding='utf-8') as f:
         f.write(bq)
 
-    # 6. Boot flow: cut the attract/intro/world-map sequences, and redirect New Game from
-    #    the prologue slot (0) to the host chapter (1) at StartBattleMap -- so the game
-    #    loads our prologue through the normal-chapter path, dodging the prologue slot's
-    #    special-cased HUD/terrain handling that garbled the screen. MONTAGE=1 keeps the
-    #    intro monologue and re-renders its slides as our lore crawl (#43).
-    _cut_boot_intro(montage=montage)
-    _redirect_new_game(PROLOGUE_HOST_INDEX)
+    # 6. Opening montage (#43): when MONTAGE=1, re-render the intro-monologue slides as our
+    #    lore crawl + the world-map tour. The boot cut + New-Game redirect themselves (so the
+    #    prologue loads through host chapter slot 1, dodging the prologue slot's special-cased
+    #    HUD/terrain handling) are the single owner _configure_boot()'s job, called once from
+    #    main() -- MONTAGE=1 there keeps the intro monologue for these slides to replace.
     if montage:
         print('opening montage (#43):')
         inject_opening_montage(campaign, verbose=verbose)
@@ -4637,9 +4643,11 @@ def main():
         if args.test_chapter:
             print('TEST CHAPTER (playtest: New Game -> Ch1 sandbox, cast deployed):')
             inject_test_chapter(args.campaign)   # slot 1 sandbox, in place of the prologue
+            _configure_boot(TEST_CHAPTER_INDEX)  # sandbox never montages
         else:
             print('prologue (New Game target):')
             inject_prologue(args.campaign, montage=args.montage)
+            _configure_boot(PROLOGUE_HOST_INDEX, montage=args.montage)
         print('death quotes (#6):')
         inject_pc_death_quotes(args.campaign)
     print('done. Run `make` to compile the ROM.')

--- a/tools/playtest/clearbot.lua
+++ b/tools/playtest/clearbot.lua
@@ -9,10 +9,13 @@
 -- pickTarget(reachable, enemies, prefs) -> { target = <enemy>, tile = {x,y} } | nil
 --   reachable: list of {x,y} tiles the unit can move to this turn (its own tile included)
 --   enemies:   list of {x,y,hp,is_boss}
---   prefs.range: weapon reach in tiles (1 = melee adjacency; 2 = e.g. a hand axe)
+--   prefs.range:     weapon MAX reach in tiles (1 = melee adjacency; 2 = e.g. a hand axe)
+--   prefs.min_range: weapon MIN reach (default 1); 2 for a bow, which CANNOT hit an adjacent
+--                    foe -- striking from range 1 leaves no Attack command, so the strike
+--                    tile must sit at min_range..range, not 1..range.
 --   Returns the best attackable enemy + the reachable tile to strike from, or nil if no
---   enemy sits within `range` of any reachable tile. Preference: the boss first, then the
---   lowest-HP enemy (likeliest kill).
+--   enemy sits within [min_range, range] of any reachable tile. Preference: the boss first,
+--   then the lowest-HP enemy (likeliest kill).
 
 local M = {}
 
@@ -20,11 +23,12 @@ local function manhattan(ax, ay, bx, by)
     return math.abs(ax - bx) + math.abs(ay - by)
 end
 
--- A reachable tile from which `e` is within `range` (and not the enemy's own tile), or nil.
-local function attackTileFor(reachable, e, range)
+-- A reachable tile from which `e` is within [minRange, range] (so a bow, minRange 2, won't
+-- pick an adjacent tile it can't fire from), or nil.
+local function attackTileFor(reachable, e, range, minRange)
     for _, t in ipairs(reachable) do
         local d = manhattan(t.x, t.y, e.x, e.y)
-        if d >= 1 and d <= range then return t end
+        if d >= minRange and d <= range then return t end
     end
     return nil
 end
@@ -37,9 +41,10 @@ end
 
 function M.pickTarget(reachable, enemies, prefs)
     local range = (prefs and prefs.range) or 1
+    local minRange = (prefs and prefs.min_range) or 1
     local best, bestTile
     for _, e in ipairs(enemies) do
-        local tile = attackTileFor(reachable, e, range)
+        local tile = attackTileFor(reachable, e, range, minRange)
         if tile and (not best or preferred(e, best)) then
             best, bestTile = e, tile
         end

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -45,6 +45,9 @@ WANTED = [
                                 # quote box is on screen NOW -> hold + screenshot it.
     'ProcScr_StdEventEngine',   # proc script: the standard (map) event engine. A live
                                 # instance == a map cutscene/talk event is running.
+    'gProc_ekrBattle',          # proc script: the on-map battle (EKR) animation engine
+                                # (src/banim-ekrbattle.c). A live instance == a combat is
+                                # actually animating -> used to confirm an attack committed.
 ]
 
 

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -2164,16 +2164,23 @@ end
 -- frames across the battle anim. RETURNS whether combat actually started -- the caller
 -- MUST check it; a stall on the menu is a FAIL, not a silent PASS (#65).
 local function captureAttack(actorAddr, tag) -- like chooseAttack but shoot frames through the anim
-    -- The action menu can have JUST opened: positionRbgForShot's moveUnit returns the
-    -- instant menuOpen() flips true, while the slide-in is still animating and eating
-    -- input. Settle before the first A or that press is dropped, only 2 of the 3 confirms
-    -- land, and we stall parked on target-selection (the recordrbgtest symptom). recordrbg
-    -- dodged this only via its pre-settled checkpoint + wait(60); make captureAttack itself
-    -- robust so any caller (live or checkpoint) is safe.
-    wait(20)
+    -- The action menu is open with Attack available (the caller positions the unit so its
+    -- weapon can reach a foe -- a bow parked at range 1 has NO Attack command; the returned
+    -- verdict catches a miss). Attack -> weapon select -> target select. In target select the
+    -- BKSEL cursor (separate from the map cursor) can start OFF a target when several foes are
+    -- in range, so a single blind A may not commit -- press A to confirm and, if no battle
+    -- starts, cycle to the next target (RIGHT) and retry. Stop the instant a battle animates
+    -- (gProc_ekrBattle): pressing A during the anim would skip it.
+    local function combatLive() return procActive(SYM.gProc_ekrBattle)
+        or (ru32(actorAddr + 0x0C) & 0x2) ~= 0 end
     press(K.A); wait(20)  -- Attack -> weapon select
     press(K.A); wait(20)  -- weapon  -> target select
-    press(K.A)            -- target  -> combat
+    for _ = 1, 8 do
+        if combatLive() then break end
+        press(K.A); wait(14)          -- confirm the highlighted target
+        if combatLive() then break end
+        press(K.RIGHT); wait(8)       -- A didn't commit -> cycle to the next in-range target
+    end
     local done = false
     for f = 1, 500 do
         if (ru32(actorAddr + 0x0C) & 0x2) ~= 0 then done = true; break end -- US_UNSELECTABLE = combat done
@@ -2232,7 +2239,9 @@ local function positionRbgForShot()
         local reach = selectAndReach(rbg, 24, 15)
         press(K.B); wait(10)  -- deselect; re-select to act
         if reach then
-            local pick = CLEARBOT.pickTarget(reach, liveEnemies(), { range = 2 })
+            -- RBG fires a BOW: min_range 2, so we don't park adjacent (range 1) where the
+            -- bow has no Attack command and captureAttack would wander the Item menu (#65).
+            local pick = CLEARBOT.pickTarget(reach, liveEnemies(), { range = 2, min_range = 2 })
             if pick then
                 if moveUnit(rbg.x, rbg.y, pick.tile.x, pick.tile.y) then
                     return true  -- on the firing tile, action menu open

--- a/tools/playtest/test_clearbot.lua
+++ b/tools/playtest/test_clearbot.lua
@@ -68,6 +68,20 @@ do
     check(pick ~= nil, true, "range 2 reaches distance 2")
 end
 
+-- A BOW (min_range 2): an ADJACENT enemy is NOT attackable -- striking from range 1 leaves
+-- no Attack command, so pickTarget must skip the adjacent tile (#65 recordrbgtest bug).
+do
+    local adjacent = tiles({ 4, 5 })  -- distance 1 from the foe at (4,6)
+    local enemies = { { x = 4, y = 6, hp = 20, is_boss = false } }
+    check(C.pickTarget(adjacent, enemies, { range = 2, min_range = 2 }), nil,
+          "bow (min_range 2) won't pick an adjacent tile it can't fire from")
+    -- but a true range-2 tile IS picked, and an adjacent one is left out of a mixed reach.
+    local mixed = tiles({ 4, 5 }, { 4, 4 })  -- (4,5)=dist 1, (4,4)=dist 2
+    local pick = C.pickTarget(mixed, enemies, { range = 2, min_range = 2 })
+    check(pick ~= nil and pick.tile.x == 4 and pick.tile.y == 4, true,
+          "bow strikes from the range-2 tile (4,4), not the adjacent (4,5)")
+end
+
 if fails > 0 then
     print(string.format("\n%d/%d FAILED", fails, tests)); os.exit(1)
 else


### PR DESCRIPTION
## What

Localizes the **boot decision** (the Cockburn "scattered decision" the feature-flow ADR cites) and **unblocks `recordrbgtest` end-to-end** — capturing RBG's custom bow battle-anim on the `make TESTCH=1` sandbox, which has been deferred/un-verifiable.

The "needs a settle before the first A" hypothesis from the handoff was **wrong** — instrumentation (menu def + `gActiveUnit` + cursor + `gProc_ekrBattle`) showed the menu was responsive throughout. Three real root causes:

1. **Boot decision localized.** `inject_prologue` *and* `inject_test_chapter` each cut the intro + redirected New Game — the *same decision in two desks* (double-cut crash when both ran). Extracted to one `_configure_boot(target, montage)` owner called once from `main()`; the target injectors no longer re-decide it.
2. **`clearbot.pickTarget` gained `min_range`.** RBG fires a **bow** (2-range only), so `positionRbgForShot` must not park it adjacent (range 1) — there the action menu has **no Attack command** (`count=2` = `[Item, Wait]`) and the presses wandered the Item menu. TDD'd.
3. **`captureAttack` target-confirm is feedback-driven.** With several foes in bow range, the BKSEL select cursor can start off a target, so one blind A doesn't commit — press A and cycle targets (`RIGHT`) until a battle animates (`gProc_ekrBattle`), then stop (pressing during the anim would skip it). It also **returns whether combat started**; the scenarios FAIL if it didn't.

## Verified

- **`recordrbgtest`**: real Soldier-vs-RBG bow anim on the sandbox — **162 frames, 97 distinct sizes, honest PASS** (`US_UNSELECTABLE` set = real combat).
- **`recordrbg`**: unregressed (cached checkpoint, PASS).
- `lua` playtest tests + `make` green; `check.py` clean.

Closes the deferred #65 `recordrbgtest` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
