### PR TITLE
playtest(#65): generalize anim capture to the whole cast (recordanim)

### DIFF
--- a/HANDOFF-pipeline.md
+++ b/HANDOFF-pipeline.md
@@ -29,6 +29,19 @@ pipeline-lane-specific gotchas.** Don't touch `HANDOFF-content.md`.
   unchanged:** DON'T reuse an `rbgch01` checkpoint across an injection/build change (ROM layout shifts
   corrupt the save-state → capture shows the map/menu, never the battle; safe only across pure
   graphics-byte swaps).
+- **#65 capture GENERALIZED to the whole cast — `recordanim PT_CHAR=<id>` (2026-06-24).** The capture is
+  no longer RBG-specific: one scenario captures ANY deployed cast member's battle anim on the `make
+  TESTCH=1` sandbox (which already stages the whole cast). `positionRbgForShot` → generic
+  `positionForShot(pid)` that **reads the unit's actual weapon reach from `gItemData`** (encodedRange
+  min<<4|max; ItemData stride 0x24) — so a bow parks at range 2, a melee weapon at range 1, no
+  per-character range table. A **staff user (sclorbo) is auto-detected** (no `IA_WEAPON`) and FAILs
+  cleanly ("no attack weapon → no combat anim"). The capture verdict is now **`sawCombat`** (the
+  `gProc_ekrBattle` proc actually ran), robust to the attacker dying in the counter or killing + a
+  level-up that outlasts the budget (plain `US_UNSELECTABLE` missed those). The only hand-data is a
+  `name→pid` `CAST` table mirroring `build_campaign` PORTRAIT_MAP. `PT_CHAR` rides through `run.sh` like
+  `PT_SEED`; `recordrbgtest` stays as the RBG back-compat alias. **Verified on the sandbox:** `prof-rbg`
+  (bow 2-2) PASS, `braulo` (axe 1-1, levels up) PASS, `sclorbo` (staff) clean FAIL; `recordrbg`
+  (checkpoint, real campaign) unregressed; `lua` tests + `make` green.
 - **#48 (b) parity gate is now ENFORCING, per-chapter & opt-in — LANDED & verified** (decisions.md §The parity
   curve is surfaced in CI…). CI flipped `make difficulty` → **`make difficulty-gate`**. A chapter is gated only
   once content marks it balance-final with **`balance_locked: true`** in its chapter YAML; `curve_gate_failures`

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -19,6 +19,9 @@ WANTED = [
     'gBmSt',                    # live map cursor (include/types.h)
     'gUnitArrayBlue',           # player units (include/bmunit.h)
     'gUnitArrayRed',            # enemy units
+    'gItemData',                # struct ItemData[] (include/bmitem.h): per-item attributes
+                                # (IA_WEAPON/IA_STAFF @ +0x08) + encodedRange (min<<4|max @ +0x19).
+                                # Lets the harness read a unit's weapon reach generically.
     'sProcArray',               # proc pool: 64 x 0x6C (src/proc.c)
     'gBmMapMovement',           # u8** move-cost map, valid while a unit is selected
                                 # (include/bmmap.h; < 120 = reachable)

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -2181,16 +2181,49 @@ local function captureAttack(actorAddr, tag) -- like chooseAttack but shoot fram
         if combatLive() then break end
         press(K.RIGHT); wait(8)       -- A didn't commit -> cycle to the next in-range target
     end
-    local done = false
-    for f = 1, 500 do
-        if (ru32(actorAddr + 0x0C) & 0x2) ~= 0 then done = true; break end -- US_UNSELECTABLE = combat done
+    -- Shoot through the anim. Success = the battle proc (gProc_ekrBattle) actually ran, i.e. a
+    -- battle ANIMATED and we captured it -- robust whether the attacker survives, dies in the
+    -- counter, or kills + triggers a level-up that outlasts the budget (US_UNSELECTABLE alone
+    -- misses those). A stall on the menu never starts the proc, so sawCombat stays false -> FAIL.
+    -- Stop early once combat finishes (or the actor is greyed) so we don't shoot dead frames.
+    local sawCombat = false
+    for f = 1, 600 do
+        local inCombat = procActive(SYM.gProc_ekrBattle)
+        if inCombat then sawCombat = true
+        elseif sawCombat then break end                        -- combat played and finished
+        if (ru32(actorAddr + 0x0C) & 0x2) ~= 0 then break end  -- actor acted (survived)
         if f % 3 == 0 then shot(tag) end
         yield()
     end
     wait(30)
-    return done
+    return sawCombat
 end
 local RBG_PID = 0x05           -- CHARACTER_MOULDER (RBG's slot), lord-select menu index 4
+
+-- The deployable custom-art cast: friendly id -> the vanilla character slot it rides
+-- (CHARACTER_* pid), mirroring build_campaign's PORTRAIT_MAP. The `make TESTCH=1` sandbox
+-- deploys all of these, so `recordanim` (PT_CHAR=<id>) can capture ANY of them. Per-unit
+-- weapon reach + "is this a non-attacker" are READ from the game (below), not hard-coded.
+local CAST = {
+    braulo = 0x01, marty = 0x02, meesmickle = 0x03, wolfram = 0x04,
+    ['prof-rbg'] = 0x05, rootis = 0x06, sclorbo = 0x07, pinky = 0x08,
+    rbg = 0x05,  -- alias for prof-rbg (the #65 first mover)
+}
+
+-- A unit's attack reach from its equipped (items[0]) weapon, via gItemData (include/bmitem.h:
+-- attributes +0x08, encodedRange +0x19 = min<<4 | max; ItemData stride 0x24). Returns
+-- (minRange, maxRange) for a real weapon, or nil for a staff / non-attacker (no IA_WEAPON) --
+-- which is how a healer is detected (no combat anim to capture).
+local ITEMDATA_STRIDE = 0x24
+local function unitAttackRange(u)
+    local item = ru16(u.addr + 0x1E) & 0xFF       -- items[0] item id (low byte; high byte = uses)
+    if item == 0 then return nil end
+    local data = SYM.gItemData + item * ITEMDATA_STRIDE
+    if (ru32(data + 0x08) & 0x1) == 0 then return nil end   -- IA_WEAPON unset -> staff/non-weapon
+    local er = ru8(data + 0x19)
+    return (er >> 4), (er & 0xF)
+end
+
 -- Shared lead-up for the RBG demo: win the prologue, lord-select RBG into ch01,
 -- stop on ch01 turn-1 player phase with RBG deployed. Returns (rbg unit) or (false, err).
 -- Built ONCE at 240fps into the "rbgch01" checkpoint (ckpt_rbgch01); recordrbg LOADS it
@@ -2227,28 +2260,29 @@ local function reachRbgCh01()
     return rbg
 end
 
--- Drive RBG (already deployed in ch01) within bow range of an enemy and leave him
--- ON the firing tile with his action menu open. Marches over turns until something
--- is in 2-range. Returns true (ready to attack) or false. The slow part of the demo,
--- so the checkpoint is saved right AFTER this -- recordrbg then just fires (#65).
-local function positionRbgForShot()
+-- Drive the deployed unit `pid` within its weapon's reach of an enemy and leave it ON the
+-- firing tile with its action menu open. Reads the unit's ACTUAL reach each phase
+-- (unitAttackRange), so a bow won't park adjacent (range 1, no Attack) and a melee weapon
+-- won't park at range 2 -- one function for every cast member. Returns true (ready) or false.
+-- The slow part of the checkpoint demo, so the state is saved right AFTER this (#65).
+local function positionForShot(pid)
     for phase = 1, 6 do
-        local rbg = blue(RBG_PID)
-        if isDead(rbg) then return false end
+        local u = blue(pid)
+        if isDead(u) then return false end
+        local mn, mx = unitAttackRange(u)
+        if not mn then return false end   -- staff/non-attacker: nothing to position for
         pokeAnimsOn()
-        local reach = selectAndReach(rbg, 24, 15)
+        local reach = selectAndReach(u, 24, 15)
         press(K.B); wait(10)  -- deselect; re-select to act
         if reach then
-            -- RBG fires a BOW: min_range 2, so we don't park adjacent (range 1) where the
-            -- bow has no Attack command and captureAttack would wander the Item menu (#65).
-            local pick = CLEARBOT.pickTarget(reach, liveEnemies(), { range = 2, min_range = 2 })
+            local pick = CLEARBOT.pickTarget(reach, liveEnemies(), { range = mx, min_range = mn })
             if pick then
-                if moveUnit(rbg.x, rbg.y, pick.tile.x, pick.tile.y) then
+                if moveUnit(u.x, u.y, pick.tile.x, pick.tile.y) then
                     return true  -- on the firing tile, action menu open
                 end
             else
                 local es = liveEnemies()
-                if #es > 0 then marchToward(rbg, es[1].x, es[1].y, 24, 15); chooseWait() end
+                if #es > 0 then marchToward(u, es[1].x, es[1].y, 24, 15); chooseWait() end
             end
         end
         endTurn()
@@ -2260,7 +2294,7 @@ end
 scenarios.ckpt_rbgch01 = function()
     local rbg, err = reachRbgCh01()
     if not rbg then shot("ckpt-rbgch01-fail"); return result("FAIL", err) end
-    if not positionRbgForShot() then shot("ckpt-rbgch01-noshot")
+    if not positionForShot(RBG_PID) then shot("ckpt-rbgch01-noshot")
         return result("FAIL", "RBG never got into firing position in 6 phases") end
     saveState("rbgch01")
     result("PASS", "rbgch01 checkpoint saved (RBG on firing tile, action menu open)")
@@ -2284,24 +2318,46 @@ scenarios.recordrbg = function()
     return result("PASS", string.format("RBG bow shot captured (class 0x%X)", cls))
 end
 
--- RECORDRBGTEST (#65): capture RBG firing on a `make TESTCH=1` playtest ROM. New Game boots
--- straight into the Ch1 sandbox with RBG pre-deployed + foes loaded, so there's NO prologue
--- grind, lord-select, or save-state -- boot -> position -> fire (~30s). Build with TESTCH=1
--- first; on a normal ROM RBG isn't deployed and this FAILs with a clear message.
+-- Capture one cast member's battle anim on the TESTCH sandbox: find its deployed unit, read
+-- its weapon reach, drive it to fire, and shoot frames tagged with its id (so make_gif picks
+-- them up per character). The verdict is honest -- combat must actually start.
+local function captureCharAnim(name)
+    local pid = CAST[name]
+    if not pid then
+        return result("FAIL", "unknown cast id '" .. tostring(name) .. "' -- set PT_CHAR to one of: "
+            .. "braulo marty meesmickle wolfram prof-rbg rootis sclorbo pinky") end
+    wait(60); pokeAnimsOn()
+    local u = blue(pid)
+    if not u then return result("FAIL", name .. " not deployed -- build the ROM with `make TESTCH=1`") end
+    local cls = ru8(ru32(u.addr + 0x04) + 0x04)
+    local mn, mx = unitAttackRange(u)
+    if not mn then
+        return result("FAIL", string.format(
+            "%s has no attack weapon (staff/healer, class 0x%X) -- no combat anim to capture", name, cls)) end
+    log(string.format("%s at (%d,%d) class=0x%X weapon-range %d-%d", name, u.x, u.y, cls, mn, mx))
+    if not positionForShot(pid) then shot(name .. "-noshot")
+        return result("FAIL", name .. " never reached firing position") end
+    shot(name .. "-deploy")
+    local fired = captureAttack(u.addr, name); shot(name .. "-after")
+    if not fired then
+        return result("FAIL", "captureAttack never reached combat for " .. name) end
+    return result("PASS", string.format("%s anim captured (class 0x%X)", name, cls))
+end
+
+-- RECORDANIM (#65): capture any custom-art cast member firing on a `make TESTCH=1` ROM (New
+-- Game boots straight into the Ch1 sandbox with the whole cast + foes deployed). Pick the unit
+-- with PT_CHAR=<id> (default prof-rbg); no prologue grind / lord-select / save-state. On a
+-- normal ROM the unit isn't deployed and this FAILs with a clear message.
+scenarios.recordanim = function()
+    if not bootToMap() then return result("FAIL", "never reached the map") end
+    local name = (PLAYTEST_CHAR and PLAYTEST_CHAR ~= "") and PLAYTEST_CHAR or "prof-rbg"
+    return captureCharAnim(name)
+end
+
+-- Back-compat alias: recordrbgtest == recordanim for RBG.
 scenarios.recordrbgtest = function()
     if not bootToMap() then return result("FAIL", "never reached the map") end
-    wait(60); pokeAnimsOn()
-    local rbg = blue(RBG_PID)
-    if not rbg then return result("FAIL", "RBG not deployed -- build the ROM with TESTCH=1") end
-    local cls = ru8(ru32(rbg.addr + 0x04) + 0x04)
-    log(string.format("RBG at (%d,%d) class=0x%X (want 0x6C clone)", rbg.x, rbg.y, cls))
-    if not positionRbgForShot() then shot("rbgtest-noshot")
-        return result("FAIL", "RBG never reached firing position") end
-    shot("rbg-deploy")
-    local fired = captureAttack(rbg.addr, "rbg"); shot("rbg-after")
-    if not fired then
-        return result("FAIL", "captureAttack never reached combat -- stuck on the action/target menu") end
-    return result("PASS", string.format("RBG bow shot captured on TESTCH ROM (class 0x%X)", cls))
+    return captureCharAnim("rbg")
 end
 
 

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -13,9 +13,15 @@
 #   recordending  -- the ch01 "Rolling Cheddar" outro cutscene (frames tagged "end")
 #   recordprep    -- the Preparations + Pick Units deploy screen (frames "prep")
 #   recordrbg     -- RBG's custom battle anim ("rbg"); loads the rbgch01 checkpoint
-#   recordrbgtest -- RBG firing on a `make TESTCH=1` playtest ROM: New Game boots STRAIGHT
-#                    into the Ch1 sandbox (RBG pre-deployed + foes), so boot->fire ~30s with
-#                    no prologue grind, lord-select, or save-state. Build TESTCH=1 first.
+#   recordanim    -- ANY cast member's battle anim on a `make TESTCH=1` ROM: New Game boots
+#                    STRAIGHT into the Ch1 sandbox (whole cast + foes pre-deployed), so
+#                    boot->fire ~30s, no prologue grind / lord-select / save-state. Pick the
+#                    unit with PT_CHAR=<id> (default prof-rbg): braulo marty meesmickle wolfram
+#                    prof-rbg rootis sclorbo pinky. Frames are tagged <id>, so:
+#                      PT_CHAR=braulo tools/playtest/run.sh recordanim
+#                      tools/playtest/make_gif.py recordanim braulo --name braulo-anim --open
+#                    A staff-only unit (sclorbo) FAILs cleanly: no attack = no combat anim.
+#                    Build TESTCH=1 first. (recordrbgtest is the back-compat alias for RBG.)
 #   recordch01trail / recordlord / recordch01 / record / scenes -- other scenes
 #
 # CHECKPOINTS (fast playtest, viewable spot-check): record scenarios load a save state
@@ -70,6 +76,7 @@ PLAYTEST_LOG = "$log"
 PLAYTEST_SHOTDIR = "$out"
 PLAYTEST_STATEDIR = "$STATE_DIR"
 PLAYTEST_SEED = "${PT_SEED:-1}"
+PLAYTEST_CHAR = "${PT_CHAR:-}"
 dofile("$HERE/harness.lua")
 EOF
     rm -f "$REPO/fireemblem8u/fireemblem8.sav"   # fresh save: New Game is the default path


### PR DESCRIPTION
## What

Generalizes the #65 battle-anim capture from RBG-only to **the whole cast**. The `make TESTCH=1` sandbox already deploys every PC, so one scenario captures any of them:

```sh
PT_CHAR=braulo tools/playtest/run.sh recordanim
tools/playtest/make_gif.py recordanim braulo --name braulo-anim --open
```

## How (streamlined — minimal hand-data)

- **`positionRbgForShot` → generic `positionForShot(pid)`** that **reads the unit's actual weapon reach from `gItemData`** (`encodedRange` = min<<4|max; `ItemData` stride 0x24). So a bow parks at range 2, a melee weapon at range 1, a 1–2 weapon at either — **no per-character range table**.
- **Staff users auto-detected** (no `IA_WEAPON` attribute) → clean FAIL ("no attack weapon → no combat anim"). That's the healer case (sclorbo), handled, not crashed.
- The only hand-data is a `name→pid` `CAST` table mirroring `build_campaign` `PORTRAIT_MAP`.
- **Verdict is now `sawCombat`** (the `gProc_ekrBattle` battle proc actually ran) — robust when the attacker dies in the counter, or kills + triggers a **level-up** that outlasts a fixed frame budget. (`US_UNSELECTABLE` alone missed those — it's why braulo first read FAIL despite a real animation.)
- `PT_CHAR` rides `run.sh` like `PT_SEED`; `recordrbgtest` stays as the RBG back-compat alias; `recordrbg` (checkpoint, real-campaign RBG) unchanged.

## Verified on the sandbox

| char | weapon | result |
|---|---|---|
| `prof-rbg` | bow (range **2-2**) | **PASS** — 138 frames, 76 sizes |
| `braulo` | axe (range **1-1**, melee, levels up) | **PASS** — 200 frames, 59 sizes |
| `sclorbo` | heal staff | **FAIL (clean)** — "no attack weapon" |

Weapon range read from the game is correct (2-2 bow, 1-1 axe). `recordrbg` (checkpoint) unregressed; `lua` tests + `make` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
