### PR TITLE
content(#22): reground ch02 dialogue + wire the new beats

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
@@ -15,6 +15,13 @@ fe8_base_map: "FE8 Ch2 — The Protected"   # DefeatAll + defend-in-place; src/e
 parity_reference: "FE8 Ch2"   # #48 enemy-pressure parity bar — The Protected — defend-in-place breather
 balance_locked: true   # #48 (b): balance-final — CI hard-fails on a parity regression here
 
+# ── Onboarding (what this chapter first teaches) ─────────────────────────────────
+introduces:
+  - concept: fliers-vs-bows      # bows are effective vs fliers — DEBUT (player flier Pinky + the green chwinga)
+    coverage: dialogue           # C-hybrid: in-voice threat call-out (RBG→Pinky, turn 1), not a vanilla tutorial box
+    where: "turn-1 RBG→Pinky archer warning — the Chardalyn Hunter threatens flier Pinky & the chwinga"
+    status: active
+
 # ── Narrative ──────────────────────────────────────────────────────────────────
 narrative: >
   The party rolls west toward Targos in the Rolling Cheddar — their home on runners —
@@ -286,24 +293,55 @@ events:
       - beat_break: B            # Vellynne's face clears (REMA) before the party reacts on a fresh stage
       - meesmickle: "Her sled's pulled by corpses... Wonderful."
       - braulo: "If we cross it, we cross it. We've a road to make."
+      - beat_break: C            # REGROUND 2026-06-24 — fresh stage on the chwinga; Sclorbo + Marty (2 faces, clear of FE8's limit)
+      # (Just off the road, three chwinga play house in the snow — a stolen plate, pinecones
+      #  for a feast. Sclorbo, a chwinga himself, lights up and goes straight to them; the three
+      #  swarm him, masks tilting up — kin to kin. Marty crouches and pours a thimble of
+      #  Chagaccino onto their little pretend-table.)
+      - marty: "Chagaccino?"
+      # (The three abandon their pretend-feast for the real one and tumble in at the company's
+      #  heels. No one says "protect them" — the spirits are simply with us now; the threat on
+      #  the field carries the protect stakes, taught by the RBG→Pinky archer beat below.)
+  - trigger: turn_start
+    turn: 1
+    type: cutscene
+    ea_file: events/ch02-archer-warning.ea
+    description: >
+      Tutorial-parity beat (fliers-vs-bows DEBUT — see `introduces:`). The Chardalyn Hunter
+      is on the board from turn 1; RBG — a bow-user himself (Iron Bow) — warns his flier
+      "son" Pinky to keep clear of it. Teaches the player the bow→flier lesson that ALSO
+      governs shielding the flying chwinga (no one tells the player to protect them; the
+      threat does). Vanilla pairs this with the Vanessa rescue tutorial ("pegasus knights
+      ...are vulnerable to missile attacks, so watch out for archers"). RBG stays in his
+      pun-professor register — mask-drop warmth is reserved for the finale Wish — while Pinky
+      takes it to heart. LOCKED 2026-06-24 (dialogue pass, co-written with Nicolas). PENDING
+      (not wired): the eventscript + Text_BG fit (RBG's line paginates — it's a portrait
+      cutscene, not a 29-char on-map bubble); consider a proximity trigger (Pinky near bow
+      range) over turn-1 if the wiring supports it cleanly.
+    script:                     # LOCKED 2026-06-24 (dialogue pass, co-written with Nicolas)
+      # (Turn 1. The Chardalyn Hunter sits in the eastern treeline, bow strung. RBG marks it,
+      #  then glances to Pinky on the wing.)
+      - prof-rbg: "Um, actually, Pinky — mind that bowman. Wings and arrows don't mix; he'll make Swiss cheese of you. Keep well clear."
+      - pinky: "...Okay, Father. I'll be careful."
   - trigger: turn_start
     turn: 3
     type: reinforcement
     ea_file: events/ch02-rear-ambush.ea
     description: >
-      Wolves emerge from the rear (edge opposite the captain) — teach defending the
-      back line. Wolfram (the armored anchor who forged the sled in ch01 and re-plates
-      it at the inn) calls the rear: terse FE8 reinforcement-bark cadence, ends on the
-      order. LOCKED dialogue-pass text below (speaker chosen by Nicolas 2026-06-19).
-      PENDING (not wired yet): the eventscript that consumes this + on-map bubble fit —
-      "Wolves at our backs — the sled." is 31 chars, past the 29-char bubble wrap, so at
-      insertion it wraps to the bubble's 2nd line (or split with [LF]); verify the
-      right-side bubble isn't pushed offscreen by the width measure.
-    script:                     # LOCKED 2026-06-19 (dialogue pass, speaker chosen by Nicolas)
-      # (Turn 3. Two Snow Wolves drop in at the rear edge, opposite the captain, lunging
-      #  for the parked sled. Wolfram pivots to the back line and plants himself there.)
-      - wolfram: "Wolves at our backs — the sled."
-      - wolfram: "Hold here. I've got the rear."
+      Chardalyn raiders drop in at the rear (west edge, opposite the captain) and make for
+      the chwinga — teach defending the back line. Wolfram (the armored anchor) pivots to
+      the rear and plants himself between the raiders and the spirits: terse FE8
+      reinforcement-bark cadence, ends on the order. LOCKED dialogue-pass text below
+      (reground 2026-06-24; speaker chosen by Nicolas 2026-06-19). PENDING (not wired yet):
+      the eventscript that consumes this + on-map bubble fit — both lines are ≤21 chars
+      (well inside the 29-char bubble wrap); verify the right-side bubble isn't pushed
+      offscreen by the width measure.
+    script:                     # LOCKED 2026-06-24 (dialogue pass, reground; speaker chosen by Nicolas 2026-06-19)
+      # (Turn 3. Two chardalyn raiders drop in at the rear edge, opposite the captain,
+      #  flanking toward the chwinga. Wolfram pivots to the back line and plants himself
+      #  between them and the spirits.)
+      - wolfram: "Raiders at our backs."
+      - wolfram: "Get behind the plate."
   - trigger: chapter_end
     type: cutscene
     ea_file: events/ch02-targos-inn.ea
@@ -314,8 +352,8 @@ events:
       bury (a breadcrumb — he's alive and moving; no combat here; see docs/decisions.md
       §Story → Sephek arc). The inn/camp night is folded into one narration card (FE8 can't
       stage five faces and ch02 has no house-text slot yet): RBG/Marty/Meesmickle take rooms,
-      Braulo shells up, Rootis + Sclorbo camp, Wolfram re-plates the raid's battle-damage on
-      the Rolling Cheddar (plays only if the sled survived — armored since ch01). The fork: a
+      Braulo shells up, Rootis + Sclorbo camp, Wolfram re-forges the raid's battle-damage off
+      the party's dented armor (the sled is dropped — reground 2026-06-24). The fork: a
       Messie/Bremen bounty (south, money) vs the druids' trail (north, the job) — RBG calls it
       north. Seeds the Maer Monster (ch06) and the Lonelywood/druid line. LOCKED dialogue-pass
       text below (co-written with Nicolas 2026-06-19). PENDING (not this commit): ch02 host
@@ -333,9 +371,10 @@ events:
       - rootis: "Everyone here says Auril. But look — one clean cut, iced from within."
       - rootis: "That's the man Hlin warned us about. The dagger of ice."
       - beat_break: C           # nightfall; a narration card over the camp (no staged faces)
+      # card de-sledded (reground 2026-06-24): Wolfram's hammer rings on dented plate, not the sled
       - narration: >-
           Three took rooms. The rest took the cold: a shell, a drift, and Wolfram's
-          hammer ringing the sled till dawn.
+          hammer ringing on dented plate till dawn.
       - beat_break: D           # morning; the party weighs the road ahead
       - prof-rbg: "My rats whisper coin off Bremen — some lake-beast, 'Messie,' swamping boats. Very Gouda."
       - prof-rbg: >-
@@ -349,17 +388,17 @@ post_chapter:
   units_available_to_recruit: []   # Baxby is ch01; no new recruit here
   unlocks_chapter: ch03-the-termalaine-mine
 
-# ── PENDING: dialogue reground (Nicolas co-write, dialogue-pass skill) ─────────────
-# The LOCKED 2026-06-19 cutscene text above still frames the dropped SLED (Wolfram's
-# rear-bark "…the sled"; the ending narration "Wolfram's hammer ringing the sled") and
-# the reinforcements as "Snow Wolves". With the sled dropped and chwinga added, this
-# text is thematically stale and must be reground via the dialogue-pass skill WITH Nicolas:
-#   (1) opening — add a small chwinga intro beat (why the spirits are on the road / the
-#       party shielding them; a Marty line fits — the befriend-creatures diplomat);
-#   (2) rear-bark — de-sled it (chardalyn raiders at our backs, not "the sled");
-#   (3) ending — re-point Wolfram's inn payoff off the sled (he re-plates gear / the camp).
-# Left intact (not unilaterally rewritten) per feedback_show_before_committing + the
-# dialogue-pass discipline. Build wires the existing text as placeholder until then.
+# ── Dialogue reground (DONE 2026-06-24, dialogue-pass co-write with Nicolas) ───────
+# Reground from the 2026-06-19 text (which framed the dropped sled + "Snow Wolves") to the
+# merged tactical design (sled dropped, 3 green chwinga, chardalyn raiders):
+#   (1) opening — chwinga adoption beat (beat_break C): Sclorbo, a chwinga, meets his kin;
+#       Marty pours a Chagaccino. No "protect them" line — the threat on the field carries it.
+#   (1b) turn-1 tutorial beat — RBG warns flier Pinky off the archer (fliers-vs-bows DEBUT;
+#        see `introduces:`), the in-voice heads-up vanilla owes via the Vanessa rescue tutorial.
+#   (2) rear-bark — de-sledded: raiders flank the chwinga; Wolfram holds the rear ("the plate").
+#   (3) ending card — Wolfram's hammer rings on dented plate, not the sled.
+# STILL PENDING for ch02 (NOT dialogue): the .ea eventscript wiring for all four beats +
+# chwinga/Vellynne art (#38/#39/#19) + the mGBA load-test.
 
 # ── Design Notes ─────────────────────────────────────────────────────────────────
 design_notes: >

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -23,7 +23,7 @@ the tutorial never sees it) · `dialogue` = mandatory story line, shown to every
 | weapon-triangle — Weapon triangle: swords > axes > lances > swords | both | — *(pending)* |
 | magic-trinity — Trinity of magic: Light > Dark > Anima > Light | tutorial | — *(pending)* |
 | effective-weapons — Some weapons are extra-effective vs a unit type (icon glows) | tutorial | — *(pending)* |
-| fliers-vs-bows — Fliers ignore terrain but are vulnerable to bows | both | — *(pending)* |
+| fliers-vs-bows — Fliers ignore terrain but are vulnerable to bows | both | Ch 2 — dialogue (active) |
 | physical-defense — DEF reduces physical damage; armor/mercs are sturdy | tutorial | — *(pending)* |
 | magical-resistance — RES reduces magic damage; casters resist magic | tutorial | — *(pending)* |
 | criticals — Critical hits deal triple damage; chance scales with skill/weapon | tutorial | — *(pending)* |
@@ -48,7 +48,6 @@ authored, the dialogue-pass parity step should claim the ones debuting there
 - **weapon-triangle** — Weapon triangle: swords > axes > lances > swords _(vanilla: both; MSG_613)_
 - **magic-trinity** — Trinity of magic: Light > Dark > Anima > Light _(vanilla: tutorial; MSG_614)_
 - **effective-weapons** — Some weapons are extra-effective vs a unit type (icon glows) _(vanilla: tutorial; MSG_615)_
-- **fliers-vs-bows** — Fliers ignore terrain but are vulnerable to bows _(vanilla: both; MSG_96F)_
 - **physical-defense** — DEF reduces physical damage; armor/mercs are sturdy _(vanilla: tutorial; MSG_617)_
 - **magical-resistance** — RES reduces magic damage; casters resist magic _(vanilla: tutorial; MSG_618)_
 - **criticals** — Critical hits deal triple damage; chance scales with skill/weapon _(vanilla: tutorial; MSG_616)_

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -286,10 +286,11 @@ CH02_CHWINGA = (
 # Cutscene message ids -- the dead vanilla Ch3 scene/talk/turn texts our host overwrites
 # (referenced ONLY by ch3-eventscript.h scenes we replace; 0x993/0x994 are LIVE battle
 # quotes in data_battlequotes.c and are deliberately NOT in this pool -- see decisions.md
-# "Ch2 hosting"). Opening (Vellynne): card + 2 beats. Rear bark: 1. Ending (Targos): card +
-# 4 beats. Boss death quote: 1.
+# "Ch2 hosting"). Opening (Vellynne): card + 3 beats. Turn-1 archer tutorial: 2. Rear bark:
+# 1. Ending (Targos): card + 4 beats. Boss death quote: 1.
 CH02_OPENING_CARD_MSG = 0x98b
-CH02_OPENING_MSGS = (0x98c, 0x98e)            # A (Vellynne/RBG), B (Meesmickle/Braulo)
+CH02_OPENING_MSGS = (0x98c, 0x98e, 0x98d)     # A (Vellynne/RBG), B (Meesmickle/Braulo), C (chwinga: Sclorbo's kin + Marty)
+CH02_TUTORIAL_MSGS = (0x98f, 0x991)           # turn-1 fliers-vs-bows debut: RBG warns flier Pinky / Pinky
 CH02_BARK_MSG = 0x990                         # Wolfram's turn-3 rear-ambush bark (over map)
 CH02_ENDING_CARD_MSG = 0x995
 CH02_ENDING_MSGS = (0x996, 0x997, 0x998, 0x999)  # A fisher, B Rootis, C narration(#58), D RBG
@@ -3938,7 +3939,9 @@ def inject_ch02(campaign, verbose=True):
     op_card, op_beats = split_beats('chapter_start')
     end_card, end_beats = split_beats('chapter_end')
     bark = next(e for e in chap['events']
-                if e.get('trigger') == 'turn_start')['script']
+                if e.get('trigger') == 'turn_start' and e.get('turn') == 3)['script']
+    tutorial = next(e for e in chap['events']
+                    if e.get('trigger') == 'turn_start' and e.get('turn') == 1)['script']
     if len(op_beats) != len(CH02_OPENING_MSGS):
         sys.exit('ERROR: ch02 opening split into %d beats; expected %d (check '
                  'beat_break markers)' % (len(op_beats), len(CH02_OPENING_MSGS)))
@@ -4151,8 +4154,10 @@ def inject_ch02(campaign, verbose=True):
         info = f.read()
     info = _replace_brace_block(
         info, 'EventListScr_Ch3_Turn[] =',
-        '{\n    TURN(0x0, EventScr_Ch3_Turn1Npc, %d, 0, FACTION_ID_BLUE)'
-        ' /* turn-%d rear wolves + Wolfram bark */\n    END_MAIN\n}'
+        '{\n    TURN(0x0, EventScr_Ch3_Turn2Player, 1, 0, FACTION_ID_BLUE)'
+        ' /* turn-1 fliers-vs-bows: RBG warns flier Pinky off the archer */\n'
+        '    TURN(0x0, EventScr_Ch3_Turn1Npc, %d, 0, FACTION_ID_BLUE)'
+        ' /* turn-%d rear raiders + Wolfram bark */\n    END_MAIN\n}'
         % (reinf['trigger_turn'], reinf['trigger_turn']), CH3_EVENTINFO_H)
     info = _replace_brace_block(
         info, 'EventListScr_Ch3_Character[] =', '{\n    END_MAIN\n}', CH3_EVENTINFO_H)
@@ -4169,7 +4174,12 @@ def inject_ch02(campaign, verbose=True):
     op_text_calls = _scenic_beat_calls(
         CH02_OPENING_MSGS, op_beats,
         ['A -- Vellynne stops them; RBG haggles the orb job',
-         'B -- Meesmickle & Braulo react to the corpse-sled'])
+         'B -- Meesmickle & Braulo react to the corpse-sled',
+         'C -- Sclorbo meets his chwinga kin; Marty offers a Chagaccino'])
+    tut_text_calls = _scenic_beat_calls(
+        CH02_TUTORIAL_MSGS, [[ln] for ln in tutorial],
+        ['RBG warns flier Pinky off the archer (fliers-vs-bows debut)',
+         'Pinky takes it to heart'])
     end_text_calls = _scenic_beat_calls(
         CH02_ENDING_MSGS, end_beats,
         ['A -- the Targos fisher warns them off the frozen body',
@@ -4206,6 +4216,14 @@ def inject_ch02(campaign, verbose=True):
         '    TEXTSHOW(0x%X) /* Wolfram: hold the rear (rear-ambush bark) */\n'
         '    TEXTEND\n    REMA\n'
         '    EVBIT_T(7)\n    ENDA\n}' % CH02_BARK_MSG, CH3_EVENTSCRIPT_H)
+    # Turn-1 fliers-vs-bows tutorial (repurposes the dead vanilla Ch3 Turn2Player scene):
+    # RBG warns flier Pinky off the Chardalyn Hunter -- the in-voice heads-up vanilla owes
+    # via the Vanessa rescue. Portrait talk over the map; no BACG (would clobber the map).
+    script = _replace_brace_block(
+        script, 'EventScr_Ch3_Turn2Player[] =',
+        '{\n' + tut_text_calls +
+        '    REMA\n'
+        '    EVBIT_T(7)\n    ENDA\n}', CH3_EVENTSCRIPT_H)
     # Per-chwinga charm-gift: read each chwinga's survival (CHECK_ALIVE writes EVT_SLOT_C)
     # while the battle units are still loaded, BEQ past the give if it fell, else drop the
     # charm into the leader's inventory (overflow -> convoy). This is the chapter's
@@ -4265,6 +4283,10 @@ def inject_ch02(campaign, verbose=True):
         w = 28 if _beat_is_narration(beat) else 42
         set_message_body(lines, msg_id, _script_to_message(
             beat, stage(beat, op_home), width=w))
+    # Turn-1 fliers-vs-bows tutorial: one portrait box per line (RBG, then Pinky), Text_BG 42-wrap.
+    for msg_id, ln in zip(CH02_TUTORIAL_MSGS, tutorial):
+        set_message_body(lines, msg_id, _script_to_message(
+            [ln], stage([ln], op_home), width=42))
     # Wolfram's rear-ambush bark, shown over the map (29-tile bubble wrap; the 31-char
     # "Wolves at our backs -- the sled." auto-wraps via _wrap_fe_lines).
     set_message_body(lines, CH02_BARK_MSG, _script_to_message(

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -3948,6 +3948,9 @@ def inject_ch02(campaign, verbose=True):
     if len(end_beats) != len(CH02_ENDING_MSGS):
         sys.exit('ERROR: ch02 ending split into %d beats; expected %d (check '
                  'beat_break markers)' % (len(end_beats), len(CH02_ENDING_MSGS)))
+    if len(tutorial) != len(CH02_TUTORIAL_MSGS):
+        sys.exit('ERROR: ch02 turn-1 tutorial has %d lines; expected %d '
+                 '(zip would silently drop the extra)' % (len(tutorial), len(CH02_TUTORIAL_MSGS)))
 
     def cut_fid(spk):
         if spk == 'narration':                 # faceless stage-business box (#58)


### PR DESCRIPTION
## What

Co-write **dialogue reground** of ch02 "Cold Welcome" to the merged tactical design (sled dropped, 3 green chwinga, chardalyn raiders), plus the build-host wiring to render the new beats. Co-written beat-by-beat with Nicolas via the `dialogue-pass` skill; grounded in the Frostmaiden book (chwinga "Nature Spirits" p25–26, chardalyn berserkers p107) and the speaker voice bibles.

### The four beats
1. **Opening** — new 3rd beat: Sclorbo (himself a chwinga) meets his kin in the snow; Marty pours a Chagaccino. One line: **"Chagaccino?"** No "protect them" — the threat carries the stakes (show-don't-tell).
2. **Turn 1 — archer tutorial (NEW)** — RBG warns flier **Pinky** off the Chardalyn Hunter: *"…he'll make Swiss cheese of you. Keep well clear."* / *"…Okay, Father. I'll be careful."* This is the **`fliers-vs-bows` debut** (no PC flier had faced an archer before), the in-voice heads-up vanilla owes via the Vanessa rescue tutorial — recorded in the chapter's `introduces:` ledger.
3. **Turn 3 — rear bark** — de-sledded/de-wolfed: raiders flank the chwinga; Wolfram holds the rear. *"Raiders at our backs." / "Get behind the plate."*
4. **Ending card** — de-sledded: *"…Wolfram's hammer ringing on dented plate till dawn."*

### Host wiring (`build_campaign.py`)
The ch02 host hardcoded "opening = 2 beats / exactly one turn event = the bark" — stale after the reground. Updated: opening now renders 3 beats; a 2nd `TURN(...)` fires the turn-1 tutorial (repurposing the dead vanilla `Ch3_Turn2Player` scene); the bark selector keys on `turn == 3`. New message ids `0x98d / 0x98f / 0x991`.

## Gates
- `make` green (full fresh build)
- `verify_text`: **3404 messages, 0 runaway**; new ids decode correctly in-ROM
- onboarding tests **8/8**; `ONBOARDING.md` regenerated (`fliers-vs-bows` now covered)
- `check.py` drift clean

## Still open for #22 (not this PR)
- chwinga + Vellynne art (#38/#39/#19)
- mGBA load-test (ch01 → ch02 → win → chains) — and a **pacing check on the now-5 cutscene moments**, judged in motion
- The #22 issue checklist predates the reground (still says "snow-wolf / home-sled") — worth refreshing.

Refs #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
