### PR TITLE
fix(worktree): repoint decomp gfx-script shebangs to env python3

### DIFF
--- a/tools/worktree-setup.sh
+++ b/tools/worktree-setup.sh
@@ -105,6 +105,18 @@ fi
 echo ">> initialising the fireemblem8u submodule in the worktree (from local objects)"
 ( cd "$WT_PATH" && git submodule update --init fireemblem8u )
 
+# A fresh decomp checkout's graphics scripts hard-code `#!/bin/python3`, which doesn't exist
+# on macOS (python3 lives at /usr/bin/python3). The Makefile runs them via their shebang, so a
+# fresh worktree fails to REGENERATE graphics (the primary checkout already has them built, so
+# it never hits this). Repoint to `env python3` (portable; the submodule is a build artifact,
+# so this local edit is never committed). Only act where /bin/python3 is actually missing.
+if [ ! -e /bin/python3 ]; then
+    echo ">> repointing decomp gfx-script shebangs to env python3 (no /bin/python3 on this host)"
+    grep -rl '#!/bin/python3' "$WT_PATH/fireemblem8u/scripts" 2>/dev/null | while IFS= read -r f; do
+        perl -i -pe 's{\A#!/bin/python3$}{#!/usr/bin/env python3}' "$f"
+    done
+fi
+
 echo ">> symlinking the build toolchain from the primary checkout (shared, read-only)"
 M="$REPO/fireemblem8u"
 W="$WT_PATH/fireemblem8u"


### PR DESCRIPTION
## Problem
A fresh worktree must **regenerate** the decomp graphics (the primary checkout already has them built, so it never hits this). But the decomp gfx scripts hard-code `#!/bin/python3`, which does not exist on macOS (`python3` is `/usr/bin/python3`). The Makefile runs them via their shebang, so a fresh worktree dies at the first graphics target:

```
scripts/gfxtools/tsa_generator.py: /bin/python3: bad interpreter: No such file or directory
make[1]: *** [graphics/efxdragon/DemonLightBg_Close_10.fetsa1.bin] Error 126
```

Hit this live while building the ch02 dialogue worktree (#70).

## Fix
`worktree-setup.sh` now repoints those shebangs to `#!/usr/bin/env python3` right after the submodule init, **guarded on `/bin/python3` being absent** so Linux/CI is untouched. The `fireemblem8u` submodule is a build artifact, so the edit is local-to-the-worktree and never committed.

## Validation
Mechanism verified by hand during the ch02 build: the fresh worktree failed pre-patch and went fully green (ROM + `verify_text` 0 runaway) after the exact same `sed`/`perl` repoint. Shell `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)