### PR TITLE
test(#22): automate the structural ch02 load-test in the playtest harness

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -31,7 +31,7 @@ ADR: `decisions.md` §Distribution.
 
 ## Now / Next
 
-### Content — Ch2 "Cold Welcome" (#22): build-complete; only the mGBA load-test (c) remains
+### Content — Ch2 "Cold Welcome" (#22): build-complete; structural load-test automated, only the human PACING pass (c) remains
 - **(a) Dialogue reground** — ✅ DONE, merged in #70 (`37f327c`): opening chwinga-adoption beat
   (Sclorbo's kin + Marty's Chagaccino), turn-1 RBG→Pinky archer tutorial (fliers-vs-bows debut),
   de-sledded rear bark + ending card. Host wired (3 opening beats + turn-1 tutorial scene reusing the
@@ -47,10 +47,13 @@ ADR: `decisions.md` §Distribution.
   (prologue/ch1 prefixed style). Added C/W/d/m + the "Ch.2:" prefix to the `gen_chapter_title` atlas;
   `_load` now reads source cards from git HEAD (vanilla), so inject_ch01 overwriting `chap_title_2.png`
   before ch02 composes no longer corrupts the "Ch.2:" cut.
-- **(c) mGBA load-test** — THE ONLY #22 ITEM LEFT (needs Nicolas at the emulator): ch01→ch02→win→chains
-  (chwinga LOAD, archer threatens pegasi, survivors deliver charms) + a pacing check on the 5 cutscene
-  moments + see the chwinga/Vellynne faces, names, and the new title card in motion. Fast via
-  `make TESTCH=1` (wire a ch02 sandbox) or the `recordrbg`/checkpoint path.
+- **(c) load-test** — STRUCTURAL half ✅ AUTOMATED (this branch): three playtest scenarios off a
+  `ch02start` checkpoint (real ch00→ch01→ch02 chain, paid once), all PASS — `ch02` (entry: 3 green
+  chwinga + 5 deployed + archer + boss), `smoke_ch02` (loads/no soft-lock through the cutscenes),
+  `clear_ch02` (DefeatAll rout → chains → all 3 chwinga charms delivered, CHECK_ALIVE→GIVEITEMTO).
+  Run: `tools/playtest/run.sh ch02|smoke_ch02|clear_ch02` (builds the checkpoint on first run).
+  **PACING half still needs Nicolas at mGBA**: judge the 5 cutscene moments in motion + see the
+  chwinga/Vellynne faces, names, and the new title card. ADR in decisions.md (Working Conventions tail).
 - Per-unit art/anim follows the **convention homes** — `inject_battle_anims` / `inject_battle_platforms`
   docstrings (how) + `decisions.md` Art & Audio (why) + the **`custom_unit` issue template** (per-unit
   checklist); open one issue per remaining cast/enemy.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -266,6 +266,26 @@ _Decided: 2026-06-24_
 
 ---
 
+**Ch2 load-test: automate the STRUCTURAL half in the harness; the PACING half stays human.**
+The only open #22 item was the in-emulator load-test. It splits in two: *structural* (does ch02
+LOAD off the real `MNC2(0x3)` chain, not soft-lock, and is it winnable — chwinga load green, the
+archer present, surviving chwinga deliver charms) and *pacing* (judging the 5 cutscenes in motion).
+The structural half is now machine-verified by the playtest harness; the pacing half is left a
+human-at-mGBA pass. **Reached via the REAL chain, not a ch02 sandbox** — a `TESTCH=2`-style boot
+would skip the `MNC2(0x3)` transition the load-test most needs to prove, so `reachCh02Map` clears
+ch00 + ch01 with the clear-bot and A-mashes through the ending→opening→prep onto the ch02 map. That
+deep chain is paid **once** into a `ch02start` save-state checkpoint (`ckpt_ch02start`, like
+`rbgch01`); `ch02` (entry assertions), `smoke_ch02` (soft-lock net), and `clear_ch02` load it. The
+3 green chwinga are kept alive during `clear_ch02` (direct HP/def poke) so the charm-gift path
+(`CHECK_ALIVE → GIVEITEMTO`) runs deterministically — whether they survive under real play is a
+balance question for the human pass, not the wiring test. Charm delivery is verified by scanning
+all blue inventories + the convoy (`gConvoyItemArray`) for the three charm ids; the pure membership
+core is unit-tested in `test_ch02check.lua`. `clearDrive` was split into a non-terminating
+`clearUntilAdvance` (the loop) + a verdict wrapper so the chain helper can keep driving past a win.
+_Decided: 2026-06-25 (CLAUDE; brainstormed-then-TDD; assert depth "Core + charm delivery" — Nicolas)_
+
+---
+
 ## Combat System
 
 > **2026-05-28 — Combat resolution reverted to vanilla FE.** The earlier "Hybrid

--- a/tools/playtest/ch02check.lua
+++ b/tools/playtest/ch02check.lua
@@ -1,0 +1,22 @@
+-- ch02check.lua -- pure helpers for the ch02 structural load-test (#22), kept free of any
+-- emulator dependency so they unit-test without a ROM (cf. clearbot.lua). The harness reads
+-- the bytes (leader inventory + convoy) and hands this module a flat list of item ids.
+local M = {}
+
+-- Given a flat list of collected item ids and the set of charm item ids to look for, return
+-- the charm ids that are present -- de-duplicated and in charmIds order (deterministic), with
+-- empty 0x00 slots ignored. Used to verify the per-chwinga charm-gifts (Red Gem / Elixir /
+-- Pure Water) actually landed in the leader's inventory or the convoy after the ending scene.
+function M.deliveredCharms(items, charmIds)
+    local present = {}
+    for _, id in ipairs(items) do
+        if id ~= 0 then present[id] = true end
+    end
+    local out = {}
+    for _, charm in ipairs(charmIds) do
+        if present[charm] then out[#out + 1] = charm end
+    end
+    return out
+end
+
+return M

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -19,6 +19,11 @@ WANTED = [
     'gBmSt',                    # live map cursor (include/types.h)
     'gUnitArrayBlue',           # player units (include/bmunit.h)
     'gUnitArrayRed',            # enemy units
+    'gUnitArrayGreen',          # green (ally/NPC) units (include/bmunit.h) -- the ch02 chwinga
+                                # protect layer rides this array (FACTION_ID_GREEN).
+    'gConvoyItemArray',         # the convoy (extern u16[]; include/variables.h). Low byte of
+                                # each entry is the item id -- where an overflow charm-gift lands.
+    'gConvoyItemCount',         # u8 count of live convoy entries (include/bmcontainer.h).
     'gItemData',                # struct ItemData[] (include/bmitem.h): per-item attributes
                                 # (IA_WEAPON/IA_STAFF @ +0x08) + encodedRange (min<<4|max @ +0x19).
                                 # Lets the harness read a unit's weapon reach generically.

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -375,6 +375,7 @@ end
 -- ---- greedy clear-bot (#60): real-combat chapter completion. Generic boss detection
 -- (no hardcoded char ids) + the pure pickTarget core; the scenario owns the driving.
 local CLEARBOT = dofile(PLAYTEST_DIR .. "/clearbot.lua")
+local CH02 = dofile(PLAYTEST_DIR .. "/ch02check.lua")   -- pure charm-delivery check (#22)
 local CA_BOSS = (1 << 15)   -- include/bmunit.h:326 (character/class attribute)
 local FUZZRNG = dofile(PLAYTEST_DIR .. "/fuzzrng.lua")   -- seeded PRNG + input policy (#49)
 
@@ -723,16 +724,17 @@ end
 
 local CH01_PARK = { x = 24, y = 15 } -- empty far corner; ch01 map is 25x16
 
--- The clear loop, shared by every clear_* scenario: actually PLAY the chapter with real
--- combat (no pokeFrail) -- each player phase, march/attack every unit toward the boss; once
--- the boss is dead, if the chapter hasn't already advanced (DefeatBoss objective), send a
--- unit onto the boss's old tile to SEIZE (Seize objective). Win = the chapter advances (or
--- the title screen -- ch01's ch02 isn't hosted yet). FAIL = game over / turn budget. The
--- completability brick (#60). maxx/maxy = map bounds; park = the end-turn empty tile.
-local function clearDrive(startChapter, maxx, maxy, park)
+-- The clear loop body (no verdict): actually PLAY the chapter with real combat (no pokeFrail)
+-- -- each player phase, march/attack every unit toward the boss; once the boss is dead, if the
+-- chapter hasn't already advanced (DefeatBoss objective), send a unit onto the boss's old tile
+-- to SEIZE (Seize objective). Returns a status ("noboss"|"won"|"gameover"|"timeout") and the
+-- turn it ended on. clearDrive wraps this with a PASS/FAIL verdict; reachCh02Map (#22) uses it
+-- to clear ch01 and then keep driving into the ch02 cutscene chain. maxx/maxy = map bounds;
+-- park = the end-turn empty tile. The completability brick (#60).
+local function clearUntilAdvance(startChapter, maxx, maxy, park)
     maxx, maxy = maxx or 14, maxy or 9
     local boss = findBoss()
-    if not boss then return result("FAIL", "no boss found to clear toward") end
+    if not boss then return "noboss", 0 end
     log(string.format("clear: boss char=0x%02X at (%d,%d) hp=%d on a %dx%d map",
         boss.charId, boss.x, boss.y, boss.hp, maxx + 1, maxy + 1))
     local seizeTile = { x = boss.x, y = boss.y }   -- killed boss's tile = the seize point
@@ -742,8 +744,7 @@ local function clearDrive(startChapter, maxx, maxy, park)
         waitFor(function() return faction() == 0 and not menuOpen() end, 6000, true)
         wait(60) -- let the player-phase banner finish (it eats key presses)
         for i = 0, 7 do
-            if won() then shot("clear-win")
-                return result("PASS", string.format("won by turn %d (chapter %d)", t, chapter())) end
+            if won() then return "won", t end
             local u = unitAt(SYM.gUnitArrayBlue, i)
             if u and not isDead(u) and (u.state & 0x2) == 0 then   -- live, not yet acted
                 local b = findBoss()
@@ -755,21 +756,29 @@ local function clearDrive(startChapter, maxx, maxy, park)
                     -- seize; for any other unit A just Waits, so we back out and try the next.
                     shot("clear-seize-try")
                     press(K.A)
-                    if waitFor(won, 9000, true) then shot("clear-seized")
-                        return result("PASS", string.format("seized by turn %d", t)) end
+                    if waitFor(won, 9000, true) then return "won", t end
                     press(K.B); press(K.B)
                 end
             end
         end
-        if won() then shot("clear-win")
-            return result("PASS", string.format("won by turn %d (chapter %d)", t, chapter())) end
-        local phase = runEnemyPhase(park)
-        if phase == "gameover" then shot("clear-gameover")
-            return result("FAIL", string.format("game over on turn %d -- bot lost units", t)) end
+        if won() then return "won", t end
+        if runEnemyPhase(park) == "gameover" then return "gameover", t end
     end
+    return "timeout", budgetTurns
+end
+
+-- The verdict wrapper, shared by every clear_* scenario. Win = the chapter advances (or the
+-- title screen -- e.g. a not-yet-hosted next chapter). FAIL = game over / turn budget.
+local function clearDrive(startChapter, maxx, maxy, park)
+    local status, t = clearUntilAdvance(startChapter, maxx, maxy, park)
+    if status == "won" then shot("clear-win")
+        return result("PASS", string.format("won by turn %d (chapter %d)", t, chapter())) end
+    if status == "noboss" then return result("FAIL", "no boss found to clear toward") end
+    if status == "gameover" then shot("clear-gameover")
+        return result("FAIL", string.format("game over on turn %d -- bot lost units", t)) end
     shot("clear-timeout")
     return result("FAIL", string.format("could not clear in %d turns (boss %s)",
-        budgetTurns, findBoss() and "alive" or "dead"))
+        t, findBoss() and "alive" or "dead"))
 end
 
 -- clear: the prologue (DefeatBoss), reachable straight from New Game.
@@ -2409,6 +2418,291 @@ scenarios.recordrbgtest = function()
     return captureCharAnim("rbg")
 end
 
+
+-- ================================================================ ch02 load-test (#22)
+-- The structural half of the Ch2 "Cold Welcome" load-test: does ch02 LOAD off the real
+-- ch01->ch02 chain (MNC2(0x3)), not soft-lock, and is it winnable -- with the 3 GREEN chwinga
+-- protect layer present and their per-survivor charm-gifts (CHECK_ALIVE -> GIVEITEMTO) actually
+-- landing. The PACING half (judging the 5 cutscenes in motion) stays a human-at-mGBA pass.
+-- Built on a "ch02start" save-state checkpoint (ckpt_ch02start plays the whole chain ONCE at
+-- top speed); ch02 / smoke_ch02 / clear_ch02 LOAD it so each is fast. Char/class/item ids from
+-- the decomp + the ch02 build (CH02_CHWINGA / CH02_ITEM_IDS in tools/build_campaign.py).
+local CH02_CHWINGA_PIDS = { 0xCA, 0xC9, 0xC8 }   -- DARA/KLIMT/MANSEL = Mote/Rime/Glimmer (green)
+local CH02_CHARMS = { 0x76, 0x6D, 0x6E }         -- Red Gem / Elixir / Pure Water (the gifts)
+local CLASS_ARCHER = 0x19                          -- the fliers-vs-bows debut enemy (CH02_CLASS_IDS)
+local CH02_CHAPTER = 3                             -- ch02 hosts on chapter slot 3 (ch01 -> MNC2(0x3))
+local CH02_PARK = { x = 0, y = 0 }                -- NW corner end-turn tile (15x15 map; deploy is row 3+)
+
+-- Directed ch01 seize (the generic clear-bot is too slow to seize ch01's 25x16 map reliably):
+-- march the lord onto the chief's throne, poking the chief + escort frail/harmless so the march
+-- can't be blocked or killed. Modeled on scenarios.ch01win; reachCh02Map only needs to REACH
+-- ch02, not fairly test ch01 balance. Returns "won" once ch01 hands off, else "timeout"/"gameover".
+local CH01_CHIEF, CH01_LORD = CHAR_CHIEF, 0x01   -- ch01 boss (BREGUET slot) + Braulo (default lord)
+local function seizeCh01ToCh02()
+    pokeFastConfig()   -- 10-goblin enemy phases: map combat + fast speed
+    local chief = red(CH01_CHIEF)
+    if not chief then return "noboss" end
+    local goal = { x = chief.x, y = chief.y }   -- the chief holds the seize tile
+    pokeFrail(chief)
+    log(string.format("ch01 seize: chief frail on (%d,%d); marching the lord", goal.x, goal.y))
+    for t = 1, 18 do
+        if chapter() ~= 2 then return "won" end
+        waitFor(function() return faction() == 0 and not menuOpen() end, 6000, true)
+        wait(100)   -- let the player-phase banner finish (it eats key presses)
+        for i = 0, 23 do   -- the escort dies to the first counter and deals no damage
+            local r = unitAt(SYM.gUnitArrayRed, i)
+            if r and r.charId ~= CH01_CHIEF and not isDead(r) then pokeFrail(r); pokeHarmless(r) end
+        end
+        local lord = blue(CH01_LORD)
+        if not lord or isDead(lord) then return "gameover" end
+        chief = red(CH01_CHIEF)
+        if chief and not isDead(chief) then
+            if math.abs(lord.x - chief.x) + math.abs(lord.y - chief.y) == 1 then
+                if moveUnit(lord.x, lord.y, lord.x, lord.y) then chooseAttack(lord.addr) end
+            else
+                marchToward(lord, goal.x, goal.y + 1, 24, 15)
+            end
+        else
+            if moveUnit(lord.x, lord.y, goal.x, goal.y) then press(K.A) end   -- Seize tops the menu here
+            if waitFor(function() return chapter() ~= 2 end, 9000, true) then return "won" end
+            press(K.B); press(K.B)
+        end
+        if runEnemyPhase(CH01_PARK) == "gameover" then return "gameover" end
+    end
+    return "timeout"
+end
+
+-- Reach the ch02 map off the REAL chain: clear ch00, seize ch01, then A-mash through the ch01
+-- ending + ch02 opening cutscenes + prep onto the map. This is the chain (MNC2(0x3)) the load-test
+-- most needs to prove. Returns true once on the ch02 map (faction 0, turn >= 1).
+local function reachCh02Map()
+    if not reachCh01Map() then return false end
+    log("seizing ch01 to chain into ch02 (slot 3)")
+    local status = seizeCh01ToCh02()
+    log(string.format("ch01 seize status=%s chapter=%d faction=0x%02X turn=%d title=%s",
+        status, chapter(), faction(), turn(), tostring(procActive(SYM.gProcScr_TitleScreen))))
+    if status ~= "won" then
+        result("FAIL", "ch01 seize did not complete (" .. status .. ") -- can't reach ch02"); return false end
+    -- A-mash the ch01 ending cutscene + post-chapter save menu (they gate the MNC2(0x3)
+    -- transition) until ch02 (slot 3) actually loads.
+    local loaded = false
+    for i = 1, 400 do
+        if chapter() == CH02_CHAPTER then loaded = true break end
+        if i % 20 == 0 then log(string.format("await ch02: chapter=%d faction=0x%02X turn=%d title=%s",
+            chapter(), faction(), turn(), tostring(procActive(SYM.gProcScr_TitleScreen)))) end
+        press(K.A, 4); wait(36)
+    end
+    if not loaded then
+        shot("ch02-never-loaded")
+        result("FAIL", "ch02 (slot 3) never loaded after the ch01 win"); return false end
+    log("in ch02 (slot 3); A-mashing the opening cutscene to the prep (Pick Units) screen")
+    -- The ch02 opening (title card + 3 beats) precedes prep. A-mash until Pick Units opens.
+    local prep = false
+    for i = 1, 400 do
+        if procActive(SYM.gProcScr_SALLYCURSOR) then prep = true break end
+        if i % 20 == 0 then log(string.format("ch02 wait prep: chapter=%d faction=0x%02X turn=%d",
+            chapter(), faction(), turn())) end
+        press(K.A, 4); wait(36)
+    end
+    if prep then
+        wait(180)
+        for i = 1, 40 do
+            if not procActive(SYM.gProcScr_SALLYCURSOR) then break end
+            press(K.B, 4); wait(10); press(K.START, 4); wait(40)
+            if i % 4 == 0 and procActive(SYM.gProcScr_SALLYCURSOR) then press(K.A, 4); wait(20) end
+        end
+    end
+    -- A-mash the beginning scene (+ turn-1 tutorial) until the map is fully LIVE: enemies loaded,
+    -- the party deployed, player control, no cutscene. Units/enemies/green chwinga load here -- the
+    -- earlier "faction 0 + turn 1" fired during the opening cutscene, before any of them existed.
+    local function partyDeployed()
+        for j = 0, 7 do local u = unitAt(SYM.gUnitArrayBlue, j)
+            if u and (u.state & 0x9) == 0 and u.x ~= 0xFF then return true end end
+        return false
+    end
+    local onmap = false
+    for i = 1, 400 do
+        if chapter() == CH02_CHAPTER and faction() == 0 and turn() >= 1
+            and unitAt(SYM.gUnitArrayRed, 0) ~= nil and partyDeployed()
+            and not procActive(SYM.ProcScr_StdEventEngine) and not procActive(SYM.gProcScr_SALLYCURSOR)
+            and not menuOpen() then onmap = true break end
+        if i % 20 == 0 then log(string.format(
+            "await ch02 map: chapter=%d faction=0x%02X turn=%d red0=%s deployed=%s evt=%s",
+            chapter(), faction(), turn(), tostring(unitAt(SYM.gUnitArrayRed, 0) ~= nil),
+            tostring(partyDeployed()), tostring(procActive(SYM.ProcScr_StdEventEngine)))) end
+        press(K.A, 4); wait(36)
+    end
+    if not onmap then
+        shot("ch02-map-not-live")
+        result("FAIL", "ch02 map never became live (party/enemies never loaded)"); return false end
+    wait(120)
+    shot("ch02-map")
+    return true
+end
+
+-- ckpt_ch02start: build the ch02start checkpoint once (run.sh runs this at 240fps when the
+-- state is missing/stale), so the deep ch00->ch01->ch02 chain is paid once per ROM build.
+scenarios.ckpt_ch02start = function()
+    if not reachCh02Map() then return end   -- reachCh02Map already set a FAIL verdict
+    saveState("ch02start")
+    result("PASS", "ch02start checkpoint saved (on the ch02 map, turn 1)")
+end
+
+-- Read every collected item id (low byte) from all blue inventories + the convoy -- where a
+-- charm-gift lands (leader's inventory, overflow -> convoy).
+local function collectedItems()
+    local items = {}
+    for i = 0, 7 do
+        local u = unitAt(SYM.gUnitArrayBlue, i)
+        if u then for s = 0, 4 do items[#items + 1] = ru16(u.addr + 0x1E + s * 2) & 0xFF end end
+    end
+    local n = ru8(SYM.gConvoyItemCount)
+    if n > 0x57 then n = 0x57 end   -- convoy cap (supplyItems[0xB0/2])
+    for i = 0, n - 1 do items[#items + 1] = ru16(SYM.gConvoyItemArray + i * 2) & 0xFF end
+    return items
+end
+
+-- Keep the 3 green chwinga alive so the gift path (CHECK_ALIVE -> GIVEITEMTO) is exercised
+-- deterministically -- whether they survive UNDER REAL PLAY is a balance/pacing question for
+-- the human pass, not the wiring test.
+local function protectChwinga()
+    for _, pid in ipairs(CH02_CHWINGA_PIDS) do
+        local g = findUnit(SYM.gUnitArrayGreen, 20, pid)
+        if g and not isDead(g) then
+            emu:write8(g.addr + 0x13, 60)   -- curHP
+            emu:write8(g.addr + 0x17, 30)   -- def
+            emu:write8(g.addr + 0x18, 30)   -- res
+        end
+    end
+end
+
+-- ch02: entry assertions on the ch02 map (mirrors scenarios.ch01). The 3 green chwinga are on
+-- the field, the party deploys to the cap, and the archer + boss are present.
+scenarios.ch02 = function()
+    wait(30)
+    if not loadState("ch02start") then return result("FAIL", "no ch02start checkpoint (run.sh builds it)") end
+    wait(90)
+    -- diagnostic: dump every non-null green slot (and the blue/red char ids) so a missing-chwinga
+    -- failure shows whether they are absent, on another faction, or under unexpected char ids.
+    for i = 0, 19 do
+        local g = unitAt(SYM.gUnitArrayGreen, i)
+        if g then log(string.format("green[%02d] char=0x%02X pos=(%d,%d) hp=%d state=0x%08X",
+            i, g.charId, g.x, g.y, g.hp, g.state)) end
+    end
+    local blueids, redids = {}, {}
+    for i = 0, 7 do local u = unitAt(SYM.gUnitArrayBlue, i); if u then blueids[#blueids+1] = string.format("0x%02X", u.charId) end end
+    for i = 0, 23 do local r = unitAt(SYM.gUnitArrayRed, i); if r then redids[#redids+1] = string.format("0x%02X", r.charId) end end
+    log("blue=" .. table.concat(blueids, ",") .. " | red=" .. table.concat(redids, ","))
+    local chwinga = 0
+    for _, pid in ipairs(CH02_CHWINGA_PIDS) do
+        local g = findUnit(SYM.gUnitArrayGreen, 20, pid)
+        if g and not isDead(g) then chwinga = chwinga + 1
+            log(string.format("chwinga 0x%02X at (%d,%d) hp=%d", pid, g.x, g.y, g.hp)) end
+    end
+    local deployed = 0
+    for i = 0, 7 do
+        local u = unitAt(SYM.gUnitArrayBlue, i)
+        if u and (u.state & 0x9) == 0 and u.x ~= 0xFF then deployed = deployed + 1 end
+    end
+    local archer, boss = false, false
+    for i = 0, 23 do
+        local r = unitAt(SYM.gUnitArrayRed, i)
+        if r and not isDead(r) then
+            if ru8(ru32(r.addr + 0x04) + 0x04) == CLASS_ARCHER then archer = true end
+            if unitIsBoss(r) then boss = true end
+        end
+    end
+    log(string.format("ch02 entry: chwinga=%d deployed=%d archer=%s boss=%s",
+        chwinga, deployed, tostring(archer), tostring(boss)))
+    shot("ch02-entry")
+    if chwinga ~= 3 then return result("FAIL", string.format("want 3 green chwinga, found %d", chwinga)) end
+    if deployed ~= 5 then return result("FAIL", string.format("deploy cap broken: %d on field (want 5)", deployed)) end
+    if not archer then return result("FAIL", "no enemy archer (fliers-vs-bows debut) on the field") end
+    if not boss then return result("FAIL", "no boss on the field") end
+    result("PASS", string.format("ch02 entered: 3 chwinga green, %d deployed, archer + boss present", deployed))
+end
+
+-- smoke_ch02: stability net on the ch02 map -- idle-drive to a clean terminal, catching a
+-- crash / soft-lock on load or during the 5 cutscenes.
+scenarios.smoke_ch02 = function()
+    wait(30)
+    if not loadState("ch02start") then return result("FAIL", "no ch02start checkpoint (run.sh builds it)") end
+    wait(90)
+    return smokeDrive(chapter())
+end
+
+-- clear_ch02: the completability + chain + charm-delivery proof. Rout the raider band (DefeatAll)
+-- while keeping the chwinga alive, then watch the ending scene gift all 3 charms to the leader /
+-- convoy. PASS = routed, chained, and all 3 chwinga charms delivered.
+scenarios.clear_ch02 = function()
+    wait(30)
+    if not loadState("ch02start") then return result("FAIL", "no ch02start checkpoint (run.sh builds it)") end
+    wait(90)
+    pokeFastConfig()
+    local start = chapter()
+    local function advanced() return chapter() ~= start or procActive(SYM.gProcScr_TitleScreen) end
+    local best = {}
+    local function snapCharms()
+        local d = CH02.deliveredCharms(collectedItems(), CH02_CHARMS)
+        if #d > #best then best = d end
+    end
+    -- Deterministic rout: the generic clear-bot is unreliable on ch02 (fumbles into item menus),
+    -- so each player phase we frail+harmless every enemy (1 HP, no power) and teleport a party unit
+    -- adjacent to each live foe to one-shot it via REAL combat -- the kill goes through the death
+    -- hook that fires the DefeatAll win check (a raw US_DEAD poke would NOT). clear_ch02 verifies the
+    -- win->ending->charm WIRING, not ch02 balance (that's the human pacing pass + the difficulty gate).
+    local routed = false
+    for t = 1, 12 do
+        if advanced() then break end
+        waitFor(function() return faction() == 0 and not menuOpen() end, 6000, true)
+        wait(60)
+        protectChwinga()
+        for i = 0, 23 do
+            local r = unitAt(SYM.gUnitArrayRed, i)
+            if r and not isDead(r) then pokeFrail(r); pokeHarmless(r) end
+        end
+        for i = 0, 7 do
+            if advanced() or #liveEnemies() == 0 then break end
+            local u = unitAt(SYM.gUnitArrayBlue, i)
+            if u and not isDead(u) and (u.state & 0x2) == 0 then
+                local mn, mx = unitAttackRange(u)
+                if mn and teleportToFiringTile(u, mn, mx) then
+                    u = blue(u.charId)   -- refresh after the teleport relocates it
+                    if u and moveUnit(u.x, u.y, u.x, u.y) then
+                        chooseAttack(u.addr)
+                        waitFor(function() return faction() == 0 and not menuOpen()
+                            and not procActive(SYM.gProc_ekrBattle) end, 600)   -- let the kill resolve
+                    end
+                end
+            end
+        end
+        log(string.format("clear_ch02 turn %d: liveEnemies=%d chapter=%d", t, #liveEnemies(), chapter()))
+        if #liveEnemies() == 0 then routed = true; break end
+        if advanced() then break end
+        if runEnemyPhase(CH02_PARK) == "gameover" then
+            shot("clear-ch02-gameover")
+            return result("FAIL", string.format("game over on turn %d -- party lost", t)) end
+        snapCharms()
+    end
+    shot("clear-ch02-routed")
+    log(string.format("rout=%s; ending the turn to fire the DefeatAll win check", tostring(routed)))
+    -- Routed: force the phase-end DefeatAll check, then FINE-GRAINED poll the ending scene so the
+    -- charm-gifts (CHECK_ALIVE -> GIVEITEMTO) are captured before the ch03 placeholder/title clears
+    -- the convoy/inventory. (Coarse polling skipped the charm window last time.)
+    if routed and not advanced() then endTurn() end
+    for _ = 1, 1200 do
+        snapCharms()
+        if #best >= 3 then break end
+        if procActive(SYM.gProcScr_TitleScreen) then snapCharms(); break end
+        press(K.A, 2); wait(8)
+    end
+    shot("clear-ch02-ending")
+    log(string.format("charms delivered: %d/3", #best))
+    if #best < 3 then
+        return result("FAIL", string.format(
+            "ch02 charm-gift broken: only %d/3 chwinga charms reached the leader/convoy", #best)) end
+    result("PASS", "ch02 routed + chained; all 3 chwinga charms delivered (CHECK_ALIVE -> GIVEITEMTO)")
+end
 
 -- ---------------------------------------------------------------- runner
 local co = coroutine.create(function()

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -4,9 +4,14 @@
 #   tools/playtest/run.sh <scenario> [--keep-open]
 #
 # Logic scenarios (assert PASS/FAIL):  win | gameover | retreat | ch01win | titlecard
+#   ch02   -- ch2 (#22) ENTRY assertions off the ch02start checkpoint: 3 green chwinga on the
+#             field, party at the deploy cap, the archer (fliers-vs-bows debut) + boss present.
 # Stability scenarios (PASS/FAIL liveness over a run):
 #   smoke | smoke_ch01   -- idle the party; catch crashes/soft-locks (#49)
+#   smoke_ch02           -- the same net on ch02 (loads ch02start; catches a cutscene soft-lock)
 #   clear | clear_ch01   -- greedy clear-bot plays to a win (#60)
+#   clear_ch02           -- rout ch02 (DefeatAll) keeping the chwinga alive, then verify all 3
+#                           chwinga charm-gifts (CHECK_ALIVE -> GIVEITEMTO) reach leader/convoy (#22)
 #   fuzz  | fuzz_ch01    -- SEEDED random-input soak (#49); set PT_SEED=N (default 1) to
 #                           pick the seed; a FAIL prints the seed so PT_SEED=N replays it
 # Recording scenarios (drop motion frames for a review GIF):
@@ -112,11 +117,13 @@ case "$SCENARIO" in
     recordtrade)  BUILDER=ckpt_prep;      CKPT=prep ;;
     recordfix)    BUILDER=ckpt_prep;      CKPT=prep ;;
     recordrbg)    BUILDER=ckpt_rbgch01;   CKPT=rbgch01 ;;
+    # ch02 (#22) scenarios LOAD the ch02start state (the real ch00->ch01->ch02 chain, paid once).
+    ch02|smoke_ch02|clear_ch02) BUILDER=ckpt_ch02start; CKPT=ch02start ;;
 esac
 if [ -n "$BUILDER" ]; then
     if [ ! -f "$STATE_DIR/$CKPT.ss" ] || [ "$(cat "$STATE_DIR/$CKPT.romhash" 2>/dev/null || true)" != "$ROMHASH" ]; then
         echo "== checkpoint '$CKPT' missing/stale -> building at top speed (240fps) =="
-        run_mgba "$BUILDER" 240 0 600
+        run_mgba "$BUILDER" 240 0 900   # ch02start plays the whole ch00->ch01->ch02 chain
         case "$VERDICT" in
             *PASS*) echo "$ROMHASH" > "$STATE_DIR/$CKPT.romhash" ;;
             *) echo "checkpoint build FAILED -- aborting"; exit 1 ;;
@@ -130,8 +137,9 @@ fi
 # record* now LOADS a checkpoint (no grind), so its deadline is short.
 FPS=240; VSYNC=0; DEADLINE_S=420
 case "$SCENARIO" in record*) FPS=60; VSYNC=1; DEADLINE_S=300 ;; esac
-# smoke_* / fuzz_* play a full chapter (lead-in + a long idle/random soak) -> longer wall.
-case "$SCENARIO" in smoke*|fuzz*) DEADLINE_S=600 ;; esac
+# smoke_* / fuzz_* / clear_ch02 play a full chapter (lead-in + a long idle/random/clear soak)
+# -> longer wall.
+case "$SCENARIO" in smoke*|fuzz*|clear_ch02) DEADLINE_S=600 ;; esac
 # PT_FPS overrides the rate. 60fps+videoSync is only needed to capture smooth cutscene
 # FADES; verification captures of static text/boxes (sign, death quote) read fine at top
 # speed, so `PT_FPS=240 ... recordfix` runs ~4x faster.

--- a/tools/playtest/test_ch02check.lua
+++ b/tools/playtest/test_ch02check.lua
@@ -1,0 +1,55 @@
+-- Tests for ch02check.lua -- the pure charm-delivery check (no emulator).
+-- Run: lua tools/playtest/test_ch02check.lua
+local here = (arg[0]:match("(.*/)")) or "./"
+local C = dofile(here .. "ch02check.lua")
+
+local tests, fails = 0, 0
+local function check(got, want, msg)
+    tests = tests + 1
+    if got ~= want then
+        fails = fails + 1
+        print(string.format("FAIL: %s\n  got  %s\n  want %s", msg, tostring(got), tostring(want)))
+    end
+end
+
+-- The 3 chwinga charms (real decomp item ids): Red Gem 0x76, Elixir 0x6D, Pure Water 0x6E.
+local CHARMS = { 0x76, 0x6D, 0x6E }
+
+-- No charms anywhere in the collected items -> empty result.
+do
+    local got = C.deliveredCharms({ 0x01, 0x02, 0x03 }, CHARMS)
+    check(#got, 0, "no charms present -> none delivered")
+end
+
+-- A single charm in the item list is reported.
+do
+    local got = C.deliveredCharms({ 0x01, 0x76, 0x02 }, CHARMS)
+    check(#got, 1, "one charm present -> one delivered")
+    check(got[1], 0x76, "the present charm id is reported")
+end
+
+-- All three charms present (e.g. all chwinga survived) -> all three reported.
+do
+    local got = C.deliveredCharms({ 0x76, 0x6D, 0x6E, 0x01 }, CHARMS)
+    check(#got, 3, "all three charms present -> three delivered")
+end
+
+-- A charm appearing twice (leader inventory AND convoy) is reported once, not double-counted.
+do
+    local got = C.deliveredCharms({ 0x76, 0x76, 0x01 }, CHARMS)
+    check(#got, 1, "duplicate charm id reported once")
+    check(got[1], 0x76, "the de-duplicated charm id is correct")
+end
+
+-- An empty 0x00 item slot is ignored (FE8 packs empty inventory slots as 0x00).
+do
+    local got = C.deliveredCharms({ 0x00, 0x00, 0x6D, 0x00 }, CHARMS)
+    check(#got, 1, "empty 0x00 slots ignored, charm still found")
+    check(got[1], 0x6D, "charm found amid empty slots")
+end
+
+if fails > 0 then
+    print(string.format("\n%d/%d FAILED", fails, tests)); os.exit(1)
+else
+    print(string.format("ok -- %d assertions", tests))
+end


### PR DESCRIPTION
## What

Automates the **structural half** of the Ch2 "Cold Welcome" load-test (#22), the only open item on that (closed, build-complete) chapter. The **pacing half** — judging the 5 cutscenes in motion + seeing the chwinga/Vellynne faces, names, and title card — stays a human-at-mGBA pass.

Reached via the **real chain** (not a ch02 sandbox, which would skip the `MNC2(0x3)` transition the load-test most needs to prove): `reachCh02Map` clears ch00 + seizes ch01 (directed lord-march, frail escort), then A-mashes the ending/opening/prep onto the ch02 map. That deep chain is paid **once** into a `ch02start` save-state checkpoint (like `rbgch01`); three scenarios load it:

| scenario | proves |
|---|---|
| `ch02` | entry: 3 green chwinga on the field, party at the deploy cap (5), the archer (fliers-vs-bows debut) + boss present |
| `smoke_ch02` | loads / no soft-lock through the cutscenes (clean terminal) |
| `clear_ch02` | DefeatAll rout to chain to ch03, then all 3 chwinga charm-gifts (`CHECK_ALIVE -> GIVEITEMTO`) reach the leader/convoy |

Run: `tools/playtest/run.sh ch02|smoke_ch02|clear_ch02` (builds the checkpoint on first run).

## How
- `clearDrive` split into a non-terminating `clearUntilAdvance` + a thin verdict wrapper (so the chain helper can drive past a win). `clear` (prologue) re-verified PASS — refactor is behavior-preserving.
- `clear_ch02` rout is **deterministic** (frail enemies + teleport-adjacent one-shots via real combat, which fires the death-hook so DefeatAll triggers); it verifies the win→ending→charm **wiring**, not ch02 balance (that is the human pacing pass + the difficulty gate). Chwinga are kept alive so the gift path runs.
- Pure charm-membership check extracted to `ch02check.lua`, unit-tested in `test_ch02check.lua` (TDD).
- New ELF symbols: `gUnitArrayGreen`, `gConvoyItemArray`, `gConvoyItemCount`.
- ADR in `docs/decisions.md`.

## Verification
All three scenarios verified **PASS** locally (`clear_ch02`: routed in 3 turns, 3/3 charms delivered). Drift guard clean; full Python + Lua unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
