### PR TITLE
content(#23): Ch3 'The Termalaine Mine' — design lock

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
@@ -114,7 +114,10 @@ deployment:
       position: [3, 4]
       inventory: [slim-lance]
       ai_pattern: cautious        # defend, don't charge into the raid
-      gift: red-gem               # ITEM_REDGEM 0x76 — gifted at chapter end IF it survives
+      gift: hand-axe              # DEVIATION (ch02↔ch03 swap, ADR in decisions.md): vanilla Ch2's Red Gem
+                                  # moves to ch03's gem-mine chest; this slot takes ch03's Hand Axe instead.
+                                  # Net wealth + item set across ch02+ch03 = vanilla. (Useful to Braulo; a
+                                  # chwinga scavenging a discarded hatchet in Icewind Dale reads fine.)
     - id: chwinga-rime
       name: "Rime Spark"
       fe_name: "Rime"

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -5,123 +5,279 @@
 id: ch03-the-termalaine-mine
 title: "The Termalaine Mine"
 chapter_number: 3
-status: planned                # brainstorm SEED, NOT authoritative: enemy roster/levels/beats are
-                               # re-grounded against vanilla + party data when the slice is reached
-                               # (brainstorming skill digests this). Exempt from the parity gate until then.
+status: active                 # design locked + grounded (decomp + DM notes + Frostmaiden book); slice in build
 milestone: M3
-cadence: gimmick_multilevel     # see docs/CHAPTERS.md — 🟨
-fe8_base_map: "FE8 Ch3 — The Bandits of Borgo"      # Seize big-battle base
+cadence: big_battle_seize       # see docs/CHAPTERS.md — mirrors FE8 Ch3 "big battle / recruit" (Colm→Trex)
+fe8_base_map: "FE8 Ch3 — The Bandits of Borgo"      # Seize big-battle; geometry borrowed + repainted as a mine
+                                                    # interior (rooms via walls+doors), per decisions.md (ch01 rode Ch13a)
 parity_reference: "FE8 Ch3"   # #48 enemy-pressure parity bar — The Bandits of Borgo — Seize big-battle
 
+# ── Onboarding (what this chapter first teaches) ─────────────────────────────────
+# Cadence anchor = vanilla Ch3, which recruits Colm (the first thief) → the steal/chests/
+# doors lesson; our Trex (Colm-based) carries it. We ALSO move the monster foe-type debut
+# here (deviation, ADR in decisions.md): the grell is a real FE monster and chronologically
+# the party's first, one chapter before vanilla's Ch4. Moved OUT of ch04's `introduces`.
+introduces:
+  - concept: stealing-thieves    # thief utility: open chests/doors, loot — DEBUT (Trex = our only thief)
+    coverage: both               # gameplay (door/chest-gated rooms need a thief or a key) + a Trex bark
+    where: "Trex joins mid-map; the mine's locked rooms + chests reward the thief (keys drop as backup)"
+    status: active
+  - concept: monsters            # FE8's monster foe-type — DEBUT here (moved from ch04); the Grell is a real Mogall
+    coverage: dialogue           # foe-type tone shift in-scene (the Pinky shaft-scout reveal); monster-effective
+                                 # GEAR stays deferred (none on the reward curve until later) — see decisions.md
+    where: "the deep shaft — Pinky scouts the dark and the Grell is revealed (the army's first true monster)"
+    status: active
+
 # ── Narrative ──────────────────────────────────────────────────────────────────
+# Grounded: Frostmaiden book "A Beautiful Mine" (pp.93–96) + the DM notes. Termalaine's
+# tourmaline mine (a cavern in a hill NE of town) is overrun by kobolds and miners have
+# vanished; the town posts a bounty to clear it. The truth (the book's "something else
+# wrong"): a Grell — an Underdark aberration — came up the mine's central shaft "in search
+# of food" and is preying on miners AND kobolds, which is why the kobolds are agitated. Their
+# leader, Trex (a clever winged kobold — canon), defects to the party.
 narrative: >
-  Kobolds have taken over Termalaine's gemstone mine and miners are vanishing.
-  Inside, the party finds kobolds on the upper levels and Grells lurking in the
-  deep shaft. Wolfram digs out gem samples and snacks on ore; RBG executes a
-  kobold at gunpoint during a "good cop, bad cop" interrogation; the party meets
-  Trex, a clever kobold who fashioned cosmetic wings. They send Pinky to scout
-  the shaft, then slay the Grells.
+  Termalaine's tourmaline mine has been overrun by kobolds and its miners have
+  gone missing, so the town posts a bounty to clear it. Inside, the kobolds are
+  territorial but rattled — something deeper is hunting them too. Wolfram digs
+  tourmalines from the walls and snacks on raw ore; the party corners a kobold and
+  RBG executes it at gunpoint during a "good cop, bad cop" interrogation; then they
+  meet Trex, the clever winged kobold leading the warren, who throws in with them.
+  At the central shaft they send Pinky into the dark to scout — and a Grell, the
+  aberration that crawled up from the Underdark, is revealed. They take the deep
+  workings and head back to Termalaine to collect the bounty.
 
 # ── Map ────────────────────────────────────────────────────────────────────────
+# Structure: rooms-on-ONE-flat-map (FE8 has no z-levels; "multi-level" is impossible —
+# decisions.md ADR). The book's 3-level mine collapses into a horizontal sequence of walled
+# chambers joined by DOORS (TERRAIN_DOOR) and chokepoints, with one scripted "open the way
+# down" map-change (TILECHANGE) at the Pinky-scout beat. Doors make Trex (the thief) matter.
 map:
-  file: maps/ch03-termalaine-mine.tmx
-  tileset: cave-interior        # FEUniverse cave tileset, arctic palette swap
-  size: "24×24"                 # multi-level — finalize in Tiled
+  file: maps/ch03-termalaine-mine.mar    # hand-authored on the cave/interior metatiles
+  tileset: cave-interior        # vendored FE cave/dungeon tileset, arctic palette (model on the ch01/ch02 winter pipeline)
+  base_layout: Ch3Map           # vanilla Ch3 "Bandits of Borgo" geometry, repainted as a mine interior
+  size: "15×10ish"              # mirror vanilla Ch3's coordinate space (enemy tiles cite vanilla); finalize in the map tool
   description: >
-    First multi-level interior. Kobolds hold the upper galleries and the path
-    down; a vertical shaft drops to the lower workings (the seize tile) where the
-    Grells nest. Stairs/ladders are the chokepoints. Teaches vertical navigation.
+    A walled mine interior read left-to-right as a descent: a tool-room entrance →
+    kobold-held galleries (chokepoints + doors) → a river-cavern pinch → the
+    processing room → a sealed passage that a scripted map-change opens onto the
+    deep workings = the grell's lair = the seize tile. Doors/chests reward the thief.
 
 # ── Objective ──────────────────────────────────────────────────────────────────
 objective:
   type: seize
   description: >
-    Descend the shaft and seize the deep workings — the flooded lower gallery
-    where the Grells nest. Reaching it requires the full descent; the win
-    triggers on the seize tile. Slaying the Grells guarding it is incidental.
+    Fight down through the kobold-held rooms and seize the deep workings — the
+    grell's lair at the bottom of the central shaft (vanilla Ch3's seize tile,
+    14,1). The grell guards it; the way in opens after Pinky scouts the shaft.
 
 win_condition: seize_point_held
-lose_condition: all_player_units_defeated
+lose_condition: all_player_units_defeated         # FE8 lord rule
 
 difficulty_note: >
-  The single teaching goal is verticality — descending the shaft. Kobolds are a
-  normal fight on the path down (not skippable); the 2 Grells (mini-bosses) are
-  the real threat, made scary by the cramped chokepoint of the lower shaft rather
-  than by stat inflation. Lean generous: the chokepoint rewards careful play.
+  Enemy pressure mirrors vanilla FE8 Ch3 1:1 (10 slots; see enemy_units) — verified
+  on `make difficulty CH=ch03`: clear-load x0.99, threat x1.12 (within band). The
+  threat runs a touch hot because the Grell attacks with magic (Evil Eye) against
+  our melee cast's low RES — intentional: an eldritch horror should out-threaten a
+  bandit. The doors/chokepoints, not stat inflation, make the descent tense.
 
 # ── Deployment ──────────────────────────────────────────────────────────────────
 deployment:
-  note: "All 7 PCs + Baxby. Pinky (RBG's homunculus) used as a scripted scout. Positions set in Tiled."
+  # Field parity: deploy_limit = vanilla FE8 Ch3 player deploy-slot count (decisions.md §Field parity;
+  # fe8-pacing-reference §1b: Ch3 = 9, read from .size UnitDef_Event_Ch3Ally/20).
+  deploy_limit: 9               # vanilla FE8 Ch3 fields 9 — ~our whole current roster (8 PCs + Baxby)
+  note: "Pick Units fields up to deploy_limit; the chosen lord (#42) is force-deployed.
+         Pinky is used in a scripted shaft-scout beat. Positions set in the map tool."
 
 # ── Enemy Units (vanilla FE) ─────────────────────────────────────────────────────
+# 1:1 reskin of vanilla FE8 Ch3 "The Bandits of Borgo" red force (UnitDef_088B463C):
+# 10 slots = Bazba(Brig L6 boss) + 6 Brigand + 1 Mercenary + 1 Archer + 1 Thief, with
+# two key-droppers (Door Key / Chest Key). We keep the class/level/weapon mix so enemy
+# pressure mirrors vanilla (tools/difficulty.py); the ONE deliberate deviation is the boss
+# slot: Bazba's Brigand becomes the GRELL (a real FE monster — CLASS_MOGALL — since a grell
+# IS a floating tentacled eye-aberration). A same-level mogall is far frailer than a Brigand,
+# so the grell carries a level bump to hold Bazba's pressure — verified on `make difficulty
+# CH=ch03`, not faked via the class. The kobolds are agitated victims (the grell preys on
+# them too), territorial toward intruders; Trex (their leader) defects to the party mid-map.
 enemy_units:
-  - id: kobold
-    name: "Mine Kobold"
-    count: 8
-    class: brigand
-    level: 3
-    weapon: iron-axe
-    damage_type: slashing
-    ai_pattern: defensive       # guard the galleries and the path down the shaft
+  # ── BOSS SLOT (vanilla Bazba, Brigand L6 @ (14,1) GuardTile) → the GRELL ──
   - id: grell
     name: "Grell"
-    is_boss: true               # mini-boss tier
-    count: 2
-    class: mogall               # FE8 monster class (floating eye-aberration); reskinned as a Grell
-    level: 5
-    damage_type: lightning      # flavor label only
-    ai_pattern: aggressive
-    revealed_by: pinky_scout    # hidden in the dark until the shaft-mouth scout cutscene
+    fe_name: "Grell"
+    is_boss: true
+    count: 1
+    positions: [[14, 1]]        # vanilla seize tile = the deep workings / grell lair
+    class: mogall               # FE8 monster (floating eye-aberration) — the real creature, not a reskin
+    level: 12                   # BUMP over Bazba's L6: mogall bases are frail; level holds boss pressure (iterate on difficulty tool)
+    autolevel: true
+    inventory:
+      - id: evil-eye            # the mogall's innate ranged magic gaze (hits RES); flavor = lightning tentacle
+    ai_pattern: aggressive      # guards the lair; revealed by the Pinky shaft-scout (scripted spawn, not fog)
+    revealed_by: pinky_scout
     death_quote: "*a wet, clicking shriek*"
+  # ── 6 Brigand kobolds (vanilla L3-L4 brigands; 2 are key-droppers below) → Icewind kobolds ──
+  - id: kobold-axe
+    name: "Icewind Kobold"
+    count: 1                    # vanilla brigand @ (7,2) L3 iron-axe
+    positions: [[7, 2]]
+    class: brigand
+    level: 3
+    autolevel: true
+    inventory:
+      - id: iron-axe            # pick/hatchet
+    ai_pattern: defensive       # territorial; hold the galleries
+  - id: kobold-thrower-l3
+    name: "Icewind Kobold"
+    count: 1                    # vanilla brigand @ (9,8) L3 hand-axe
+    positions: [[9, 8]]
+    class: brigand
+    level: 3
+    autolevel: true
+    inventory:
+      - id: hand-axe            # throwing pick (1-2 range)
+    ai_pattern: defensive
+  - id: kobold-thrower-l4
+    name: "Icewind Kobold"
+    count: 1                    # vanilla brigand @ (14,11) L4 hand-axe
+    positions: [[14, 11]]
+    class: brigand
+    level: 4
+    autolevel: true
+    inventory:
+      - id: hand-axe
+    ai_pattern: defensive
+  - id: kobold-steel
+    name: "Icewind Brute"
+    count: 1                    # vanilla brigand @ (14,6) L3 steel-axe (the grell's nearest enforcer)
+    positions: [[14, 6]]
+    class: brigand
+    level: 3
+    autolevel: true
+    inventory:
+      - id: steel-axe           # heavy mining maul
+    ai_pattern: defensive
+  # ── 1 Mercenary (vanilla L2 merc @ (15,2)) → a blade-kobold ──
+  - id: kobold-blade
+    name: "Kobold Skirmisher"
+    count: 1
+    class: mercenary
+    level: 2
+    autolevel: true
+    inventory:
+      - id: iron-sword
+    ai_pattern: defensive
+  # ── 1 Archer (vanilla L4 archer @ (12,9)) → a kobold slinger ──
+  - id: kobold-slinger
+    name: "Kobold Slinger"
+    count: 1
+    class: archer
+    level: 4
+    autolevel: true
+    inventory:
+      - id: iron-bow            # dart/sling — the chapter's single ranged kobold
+    ai_pattern: defensive
+  # ── 1 Thief (vanilla enemy thief @ (9,11)) → a giant rat scavenger (book M3 River Cavern) ──
+  - id: giant-rat
+    name: "Giant Rat"
+    count: 1
+    class: thief
+    level: 3
+    autolevel: true
+    inventory:
+      - id: iron-sword          # claws/bite (modeled as the vanilla thief's blade)
+    ai_pattern: aggressive      # scurries the tunnels (the book's rodent tracks)
+  # ── 2 key-droppers (vanilla Door Key / Chest Key brigands) → kobolds that drop the keys ──
+  - id: kobold-keykeep-door
+    name: "Icewind Kobold"
+    count: 1
+    positions: [[5, 9]]
+    class: brigand
+    level: 3
+    autolevel: true
+    inventory:
+      - id: iron-axe
+    item_drop: door-key         # so a player who hasn't recruited Trex yet can still open doors
+    ai_pattern: defensive
+  - id: kobold-keykeep-chest
+    name: "Icewind Kobold"
+    count: 1
+    positions: [[7, 11]]
+    class: brigand
+    level: 3
+    autolevel: true
+    inventory:
+      - id: iron-axe
+    item_drop: chest-key        # backup chest access (Trex is the intended opener)
+    ai_pattern: defensive
 
 # ── Chests / Mine Loot ───────────────────────────────────────────────────────────
+# Reward footprint mirrors vanilla FE8 Ch3 (decisions.md §Reward budget; fe8-pacing-reference
+# §3): Ch3's channel is its FIRST CHESTS = basic iron-tier gear (Iron Lance/Sword + Hand Axe +
+# Javelin), opened by a thief/key. NO stat-booster (capped at parity ≥ FE8 Ch5) and NO raw gold
+# (vanilla gives none before Ch8). DEVIATION (ADR in decisions.md): one chest = a Tourmaline
+# (= a Red Gem, 2,500g) — the Hand Axe that would sit here is swapped to ch02's chwinga-mote
+# gift, and ch02's Red Gem moves here. Net wealth + item set across ch02+ch03 = vanilla; only
+# the location of the two items swaps. Thematic: it's a famous gem mine, and Trex opens the seam.
+# Trex (recruited mid-map) is the intended opener; the two key-dropper kobolds are the backup.
 chests:
-  - position: tbd               # upper side gallery — a short detour off the main descent (NOT gated behind the Grells)
+  - position: tbd               # the mine tools — reflavored basic gear (book M1 Tool Room: "racks of picks and hammers")
     contents:
-      - id: stat-booster        # FIRST stat-booster of the game (docs/fe8-pacing-reference.md §3)
-        which: energy-ring      # FE8 Energy Ring (+2 Pow); broadly useful first booster
-  - position: tbd               # deep, near the seize tile — a "while you're here" gold grab
+      - id: iron-lance          # a miner's drill-spear
+  - position: tbd
     contents:
-      - id: gem-cache
-        amount: 300             # gold value
+      - id: iron-sword          # a cutting tool
+  - position: tbd
+    contents:
+      - id: javelin             # a throwing pick (vanilla Ch3's off-on-its-own chest)
+  - position: tbd               # the deep seam, near the lair — Trex's signature pop
+    contents:
+      - id: red-gem             # a pink Tourmaline — Termalaine's signature gem (2,500g sell). DEVIATION: see ADR.
+        flavor: "a fist-sized rose-pink tourmaline, the best seam in the mine"
 
 # ── Events (pacing / cutscene placement) ─────────────────────────────────────────
+# Beat PLACEMENT only — final dialogue is written via the dialogue-pass skill (voice bibles +
+# the #58 opaque-box narration convention), gated by tools/verify_text.py. Grounded in the DM
+# notes + book "A Beautiful Mine."
 events:
   - trigger: chapter_start
     type: cutscene
     ea_file: events/ch03-opening.ea
-    description: "Termalaine; the missing miners; party enters the mine. Wolfram eyes the ore."
+    description: >
+      Termalaine; the bounty to clear the kobold-overrun gem mine; the missing
+      miners. The party enters. Wolfram eyes the tourmaline seams and the ore.
   - trigger: midmap
     type: cutscene
     ea_file: events/ch03-rbg-execution.ea
     description: >
-      Mid-map scripted beat: the kobold interrogation. RBG executes the kobold at
-      gunpoint (rbg_kobold_execution). Wolfram's ore-snacking gag plays here too
-      (wolfram_ore_snacking). Then Trex appears and the shaft to the Grells opens.
+      Mid-map scripted beat: the party corners a kobold for a "good cop, bad cop"
+      interrogation and RBG executes it at gunpoint (rbg_kobold_execution); Wolfram's
+      ore-snacking gag plays here (wolfram_ore_snacking). Then Trex — the clever
+      winged kobold leader — is met and DEFECTS to the party (trex recruited; he
+      reveals the warren is being hunted from below). Trex's thieving = the chapter's
+      thief/chests/doors lesson.
   - trigger: shaft_mouth_reached
     type: cutscene
     ea_file: events/ch03-pinky-scout.ea
     description: >
-      Scripted scout beat (pinky_scout), fires when the first unit reaches the lip
-      of the shaft. The drop is black — no one can see the bottom. RBG, only half
-      willing to send his boy into the dark, lets Pinky (the army's flier) dive to
-      scout. The camera pans down the shaft with him and the 2 Grells are REVEALED
-      here (vanilla enemy reveal — they are not visible before this). Pinky rockets
-      back up rattled ("Eyes. Big wet ones. Lots of 'em."); RBG, relieved, gives the
-      descend order with a protective line that seeds the finale Wish ("Nothing down
-      there is taking you from me."). The way down opens.
+      Scripted scout beat (pinky_scout), fires when the first unit reaches the central
+      shaft. The drop is black. RBG, only half willing to send his boy into the dark,
+      lets Pinky (the army's flier) dive to scout. The Grell is REVEALED here — a
+      scripted enemy spawn (NOT fog; Ch3 has no fog), the army's first true monster.
+      Pinky rockets back up rattled; RBG, relieved, gives the descend order with a
+      protective line that seeds the finale Wish ("Nothing down there is taking you
+      from me."). A map-change opens the way to the deep workings (the seize tile).
   - trigger: chapter_end
     type: cutscene
     ea_file: events/ch03-ending.ea
-    description: "Grells slain; party returns to Termalaine for the reward. Trex asks to come along."
+    description: "Grell slain, deep workings seized; the party returns to Termalaine to collect the bounty."
 
 # ── Post-Chapter ─────────────────────────────────────────────────────────────────
 post_chapter:
-  gold_reward: 300
-  available_shops: [termalaine]
-  units_available_to_recruit:
+  # No raw gold (vanilla gives none before FE8 Ch8); the chapter's wealth is the in-map
+  # Tourmaline chest (= Red Gem, sell for 2,500g). The town "bounty" is narrative flavor.
+  available_shops: [termalaine] # gems / mining equipment / unusual items (campaign.yaml; unlocks after ch03)
+  units_recruited_in_chapter:
     - id: trex
-      description: "Trex the winged kobold joins post-chapter"
+      where: "mid-map cutscene (rbg-execution beat) — defects, then thieves for the party"
   unlocks_chapter: ch04-the-white-moose
 
 # ── Signature Moments anchored here ──────────────────────────────────────────────
@@ -132,7 +288,12 @@ signature_moments:
     trigger: wolfram_ore_snacking
 
 design_notes: >
-  Verticality is the single teaching goal (descend the shaft to the seize tile).
-  Two PC signature beats land in the mid-map cutscene (RBG + Wolfram). The first
-  stat-booster (Energy Ring) sits in an accessible upper side gallery — an
-  exploration reward, not risk-gated. Recruit Trex post-chapter.
+  Identity: the thief/chests/doors dungeon-seize (vanilla Ch3 "big battle / recruit"),
+  reskinned as Termalaine's gem mine. Teaching goal = the thief utility, carried by Trex
+  (our Colm), made meaningful by door/chest-gated rooms. ALSO the monster foe-type debut
+  (moved here from ch04): the Grell is a real FE Mogall and chronologically the party's
+  first monster. FE8 has no multi-level maps, so the book's 3-level mine is one flat walled
+  interior + one "open the way down" map-change. Two PC signature beats (RBG execution +
+  Wolfram ore-snacking) land in the mid-map cutscene. Enemy/reward footprints both mirror
+  vanilla FE8 Ch3; the only deviations (grell=monster boss, the ch02↔ch03 gem/hand-axe swap,
+  the monster-debut move) are recorded in decisions.md and net-neutral to parity.

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
@@ -19,10 +19,9 @@ parity_reference: "FE8 Ch4"   # #48 enemy-pressure parity bar — Ancient Horror
 # Onboarding parity (see docs/ONBOARDING.md + the dialogue-pass parity step): concepts
 # making their FIRST campaign appearance here, and how WE deliver the vanilla heads-up.
 introduces:
-  - concept: monsters            # FE8 introduces its monster foe-type here (cadence: monster_debut)
-    coverage: both               # vanilla effective-weapon help + an in-scene call-out
-    where: "Lonelywood — first monster sighting in the forest hunt"
-    status: planned
+  # NOTE: the `monsters` foe-type debut MOVED to ch03 (the Grell is a real Mogall and the party's
+  # chronologically-first monster) — see decisions.md ADR. ch04 stays a monster/fog set-piece but is
+  # no longer the FIRST monster (cadence token left as a planned-seed; regrounded when this slice lands).
   - concept: fog-of-war          # the forest hunt is our first fog map (vanilla Ch4 cadence)
     coverage: dialogue
     where: "forest approach — a PC flags limited sight"

--- a/campaigns/rime-of-the-frostmaiden/onboarding-catalog.yaml
+++ b/campaigns/rime-of-the-frostmaiden/onboarding-catalog.yaml
@@ -116,7 +116,7 @@ concepts:
   - id: monsters
     concept: "Monster enemies are a distinct foe type; some weapons are effective vs them"
     vanilla_channel: both
-    vanilla_when: "First monster encounter (our ch04 monster debut, cadence: monster_debut)"
+    vanilla_when: "First monster encounter (our ch03 — the Termalaine Grell, a real Mogall; moved up from ch04 — see decisions.md ADR)"
     vanilla_text: "Effective against monsters. (item help on Slayer/monster-effective gear)"
     citation: "MSG_454-457 (monster-effective weapons); story intro: decomp sweep TBD"
 

--- a/docs/CHAPTERS.md
+++ b/docs/CHAPTERS.md
@@ -10,14 +10,14 @@ The per-chapter source of truth is the YAML in
 Forward-looking design (the promotion seam, the Act II–V scaffold, the cadence
 rules) lives in `docs/decisions.md` and `docs/fe8-pacing-reference.md`.
 
-**Cadence legend:** 🟦 tutorial / full-party intro / breather / defend · 🟨 gimmick (multi-level) / monster debut (fog) · 🟥 first boss / big battle (gray) · 🎬 marquee set-piece / scripted defeat
+**Cadence legend:** 🟦 tutorial / full-party intro / breather / defend · 🟥 big battle (seize) / first boss / big battle (gray) · 🟨 monster debut (fog) · 🎬 marquee set-piece / scripted defeat
 
 | # | Title | Cadence | Objective | Recruits | Unlocks |
 |---|---|---|---|---|---|
 | P | A Dagger of Ice | 🟦 tutorial | DefeatBoss — Defeat Sephek Kaltro | — | Ch 1 |
 | 1 | The Iron Trail | 🟦 full-party intro | Seize — Seize the goblin camp — the chief holds it and the ingots are there | baxby | Ch 2 |
 | 2 | Cold Welcome | 🟦 breather / defend | DefeatAll — Defeat the raider band; keep the chwinga alive to claim their charms | — | Ch 3 |
-| 3 | The Termalaine Mine | 🟨 gimmick (multi-level) | Seize — Descend the shaft and seize the deep workings — the flooded lower gallery where the Grells nest. Reaching it requires the full descent; the win triggers on the seize tile. Slaying the Grells guarding it is incidental. | trex | Ch 4 |
+| 3 | The Termalaine Mine | 🟥 big battle (seize) | Seize — Fight down through the kobold-held rooms and seize the deep workings — the grell's lair at the bottom of the central shaft (vanilla Ch3's seize tile, 14,1). The grell guards it; the way in opens after Pinky scouts the shaft. | — | Ch 4 |
 | 4 | The White Moose | 🟨 monster debut (fog) | DefeatAll — Rout the forest's hostile beasts and spirits | lupin +npc: lupin-pack | Ch 5 |
 | 5 | The Elven Tomb | 🟥 first boss | DefeatBoss — Defeat Ravisin, the frost druid (her guardians and the moose needn't all fall) | sahnar, basil | Ch 6 |
 | 6 | The Maer Monster | 🎬 marquee set-piece | DefeatBoss / Talk — Defeat Messie OR have Marty Talk to her while adjacent | — | Ch 7 |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -32,9 +32,9 @@ the tutorial never sees it) · `dialogue` = mandatory story line, shown to every
 | terrain-heal-tiles — Forts/gates/thrones auto-heal a unit that ends its turn there | tutorial | — *(pending)* |
 | rescue — Rescue carries a unit; mounted units can move after rescuing | tutorial | — *(pending)* |
 | status-effects — Abnormal states (sleep, poison, etc.) disable/erode a unit | tutorial | — *(pending)* |
-| monsters — Monster enemies are a distinct foe type; some weapons are effective vs them | both | Ch 4 — both (planned) |
+| monsters — Monster enemies are a distinct foe type; some weapons are effective vs them | both | Ch 3 — dialogue (active) |
 | fog-of-war — Fog of war hides enemies outside vision range | tutorial | Ch 4 — dialogue (planned) |
-| stealing-thieves — Thieves steal items; protect valuables / loot enemies | both | — *(pending)* |
+| stealing-thieves — Thieves steal items; protect valuables / loot enemies | both | Ch 3 — both (active) |
 | ballista-siege — Siege/ballista emplacements fire from long range; a unit mans them | tutorial | — *(pending)* |
 | promotion-master-seal — Master Seal promotes a unit to its advanced class (player picks the branch) | tutorial | — *(pending)* |
 | supports — Support conversations build bonuses between paired units | dialogue | — *(pending)* |
@@ -56,7 +56,6 @@ authored, the dialogue-pass parity step should claim the ones debuting there
 - **terrain-heal-tiles** — Forts/gates/thrones auto-heal a unit that ends its turn there _(vanilla: tutorial; MSG_627)_
 - **rescue** — Rescue carries a unit; mounted units can move after rescuing _(vanilla: tutorial; MSG_970-977)_
 - **status-effects** — Abnormal states (sleep, poison, etc.) disable/erode a unit _(vanilla: tutorial; MSG_61A)_
-- **stealing-thieves** — Thieves steal items; protect valuables / loot enemies _(vanilla: both; MSG_~9624 (story); Steal command tutorial: decomp sweep TBD)_
 - **ballista-siege** — Siege/ballista emplacements fire from long range; a unit mans them _(vanilla: tutorial; MSG_~5288 (siege); decomp sweep TBD)_
 - **promotion-master-seal** — Master Seal promotes a unit to its advanced class (player picks the branch) _(vanilla: tutorial; decomp sweep TBD)_
 - **supports** — Support conversations build bonuses between paired units _(vanilla: dialogue; decomp sweep TBD)_

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -465,12 +465,40 @@ Placement follows the **parity_reference, not our chapter number** — our 8-cha
 not "chapter N's." This is the item analogue of the recruit budget; per-chapter loot is authored in the
 chapter YAML (the data is the doc). Consistent with the promotion seam (Ch8→9): our MVP chapters
 (parity ≤ Ch13) sit below the Master-Seal threshold (Ch15a), so promotions stay deferred to Revel's End.
-Worked example — **ch02 (parity FE8 Ch2):** gems + premium consumables only (**Red Gem / Elixir /
-Pure Water**, the exact vanilla Ch2 village gifts) + a regular armory + one enemy consumable drop;
-**no boosters, no promos.** The three chwinga "charms" ARE those three gifts, 1:1.
+Worked example — **ch02 (parity FE8 Ch2):** gems + premium consumables only (vanilla Ch2's village
+gifts) + a regular armory + one enemy consumable drop; **no boosters, no promos.** The three chwinga
+"charms" are those gifts — **Elixir / Pure Water / Hand Axe** (the Hand Axe stands in for vanilla's
+**Red Gem**, which is lent forward to ch03's gem mine; see the Ch3-deviations ADR below — net wealth
+across ch02+ch03 is unchanged).
 _Reconstructed: 2026-06-22 (CLAUDE, decomp event-data + `events_shoplist.c` scan) — upgrades
 fe8-pacing §3 from era-buckets to a decomp-pinned curve (correcting the old "promos at Ch9–13": promos
 + boosters actually start Ch5, Master Seal/Secret Shop start ~Ch14a). Companion to the recruit budget._
+
+**Ch3 "The Termalaine Mine" — three sanctioned deviations from strict per-chapter parity.**
+ch03 reskins vanilla FE8 Ch3 "The Bandits of Borgo" (Seize big-battle; the game's first chests +
+first thief). Roster + reward footprints mirror it 1:1, with three deliberate, parity-neutral
+deviations (Nicolas-directed, this session):
+1. **The boss is a real monster.** A grell IS a floating tentacled eye-aberration, so the boss slot
+   (vanilla Bazba, Brigand L6) becomes a **CLASS_MOGALL** with the Evil Eye — NOT a frailty cheat.
+   A same-level mogall is far weaker than a Brigand, so it carries a **level bump (L12)** to hold
+   Bazba's pressure. Verified on `make difficulty CH=ch03`: clear-load ×0.99, threat ×1.12 (within
+   band; the magic Evil Eye vs our low-RES melee runs intentionally hot). Parity is *measured*, not
+   assumed — this is exactly the wiggle-room the difficulty engine exists to provide.
+2. **Monster foe-type debut moves ch04 → ch03.** The grell is chronologically the party's first
+   monster. The `introduces: monsters` ledger entry moved to ch03 (out of ch04, which stays a
+   monster/fog set-piece but is no longer the *first*). Monster-effective GEAR stays deferred (none
+   on the reward curve yet).
+3. **The ch02↔ch03 gem/hand-axe swap.** Vanilla's single early gem (the Ch2 Red Gem) is *lent
+   forward* to ch03's gem mine (it's literally a famous tourmaline mine; Trex the thief opens the
+   seam). To keep wealth on-curve, vanilla Ch3's Hand Axe chest moves *back* to ch02's chwinga-mote
+   gift. Net result: total wealth AND the exact item set across ch02+ch03 are identical to vanilla —
+   only the chapter each of the two items appears in is swapped. (We considered keeping the gem at
+   ch02 for strict per-chapter parity; chose the swap for the gem-mine payoff, since it's net-neutral
+   and the Ch2 gem money is meant for world-map shopping after the chapter anyway, not the thin Ch2 armory.)
+_Decided: 2026-06-26 (Nicolas + CLAUDE, Ch3 design-lock session; grounded in the FE8 decomp, the DM
+notes, and the Frostmaiden book "A Beautiful Mine" pp.93–96). FE8 has no multi-level maps, so the
+book's 3-level mine is authored as one flat walled interior (rooms via TERRAIN_DOOR + one TILECHANGE),
+not a verticality gimmick — the doors make the thief (Trex) matter._
 
 **Two healers, differentiated by donor (same move as the shamans).** Sclorbo and Basil are both
 Priests, so they get *distinct* vanilla donor lines to avoid stat-twins: **Sclorbo → Moulder** (the

--- a/tools/gen_chapter_index.py
+++ b/tools/gen_chapter_index.py
@@ -28,6 +28,7 @@ CADENCE = {
     'full_party_intro':   ('\U0001F7E6', 'full-party intro'),
     'breather_defend':    ('\U0001F7E6', 'breather / defend'),
     'gimmick_multilevel': ('\U0001F7E8', 'gimmick (multi-level)'),
+    'big_battle_seize':   ('\U0001F7E5', 'big battle (seize)'),
     'monster_debut':      ('\U0001F7E8', 'monster debut (fog)'),
     'first_boss':         ('\U0001F7E5', 'first boss'),
     'marquee_setpiece':   ('\U0001F3AC', 'marquee set-piece'),


### PR DESCRIPTION
## Ch3 "The Termalaine Mine" — design lock (#23)

Regrounds the ch03 brainstorm seed against the **FE8 decomp + DM notes + Frostmaiden book** ("A Beautiful Mine", pp.93–96). ch03 reskins vanilla **FE8 Ch3 "The Bandits of Borgo"** (Seize big-battle; the game's first chests + first thief) as Termalaine's kobold-overrun tourmaline mine.

This PR is **design-only** — it locks the slice's data + decisions. The build beats (dialogue, map, host, units, cutscenes, art, title card, load-test) remain open on #23.

### Locked design
- **Identity:** thief/chests/doors dungeon-seize — teaching goal is the thief utility (Trex = our Colm), made meaningful by door/chest-gated rooms. **Also the monster foe-type debut** (moved here from ch04 — the Grell is a real Mogall and the party's chronologically-first monster).
- **Structure:** rooms-on-ONE-flat-map (FE8 has no z-levels) — walls + `TERRAIN_DOOR` + one scripted "open the way down" `TILECHANGE`. The book's 3-level mine collapses to a horizontal room sequence.
- **Enemies:** 1:1 reskin of vanilla Ch3's 10-slot force — Icewind kobolds + a giant rat + the **Grell (Mogall L12, Evil Eye)** as the boss.
- **Rewards:** vanilla Ch3's first-chests (basic gear) + one pink Tourmaline (= Red Gem); the ch02↔ch03 gem/hand-axe swap keeps total wealth = vanilla.

### Three sanctioned deviations (decisions.md ADR, 2026-06-26)
1. **Boss is a real monster** — `CLASS_MOGALL` + Evil Eye, level-bumped (L12) to hold Bazba's pressure, *not* a frailty cheat.
2. **Monster debut moves ch04 → ch03** — the Grell is the party's first monster; `introduces: monsters` ledger relocated.
3. **ch02↔ch03 gem/hand-axe swap** — net-neutral to total wealth and item set; only the chapter each item appears in changes.

### Verification
- `make difficulty CH=ch03` → **PARITY** (clear-load ×0.99, threat ×1.12, within band — the magic Evil Eye runs intentionally hot vs our low-RES melee)
- `test_onboarding.py` → 8 tests OK (no double-debut)
- `make check` → **drift clean** (pre-commit hook passed)

### Files
ch03 (full regrounding) · ch02 (mote gift swap) · ch04 (monster-debut removed) · onboarding-catalog · decisions.md (ADR) · gen_chapter_index.py (cadence token) · CHAPTERS.md / ONBOARDING.md (regenerated). The `fireemblem8u` submodule pointer is intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
