### PR TITLE
feat(#65): Knight/lance battle-anim donor + per-donor melee cadence

### DIFF
--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -2410,9 +2410,14 @@ def enemy_class_reskins(campaign):
 # donor 'clone_from' -> (FE donor class enum, the AnimConf weapon entry to repoint in the
 # clone, the cadence the faked motion.s is built with: 'ranged' draw-and-fire / 'melee'
 # lunge-and-swing). The cadence is studied from the donor class's own vanilla motion.s.
+# clone_from: (donor_class, weapon_type, motion, melee_cadence). `motion` picks the mode
+# SHAPE (ranged draw-and-fire vs melee lunge-and-swing); `melee_cadence` picks the per-donor
+# sound/FX punctuation within a melee body (ref_to_battleframe._MELEE_CADENCE) -- None for
+# ranged donors, which never run a melee body.
 BANIM_DONORS = {
-    'archer': ('CLASS_ARCHER', '0x0100 | ITYPE_BOW', 'ranged'),
-    'pirate': ('CLASS_PIRATE', '0x0100 | ITYPE_AXE', 'melee'),
+    'archer': ('CLASS_ARCHER',       '0x0100 | ITYPE_BOW',   'ranged', None),
+    'pirate': ('CLASS_PIRATE',       '0x0100 | ITYPE_AXE',   'melee',  'axe'),
+    'knight': ('CLASS_ARMOR_KNIGHT', '0x0100 | ITYPE_LANCE', 'melee',  'lance'),
 }
 
 
@@ -2542,13 +2547,15 @@ def inject_battle_anims(campaign, verbose=True):
         clone_from = cfg['clone_from']
         if clone_from not in BANIM_DONORS:
             sys.exit('ERROR: battle_anim %s: unsupported clone_from %r' % (uid, clone_from))
-        donor_class, wtype, motion = BANIM_DONORS[clone_from]
+        donor_class, wtype, motion, cadence = BANIM_DONORS[clone_from]
         motion = cfg.get('motion', motion)            # YAML may override the donor default
+        cadence = cfg.get('cadence', cadence)         # ...and its melee cadence
         abbr = cfg.get('abbr') or (uid.replace('-', '').replace('prof', '')[:5] + '_ar1')
         frame_imgs = [Image.open(os.path.join(anim_dir, p)).convert('RGBA')
                       for p in cfg['frames']]
         palette = _banim_palette(frame_imgs)
-        res = ref_to_battleframe.build_battle_anim(abbr, frame_imgs, palette, motion=motion)
+        res = ref_to_battleframe.build_battle_anim(abbr, frame_imgs, palette, motion=motion,
+                                                   cadence=cadence or 'axe')
 
         # 1. assets into the decomp (motion.s, per-frame sheet PNGs, agbpal blob)
         with open(os.path.join(BANIM_DATA_DIR, 'banim_%s_motion.s' % abbr), 'w',

--- a/tools/ref_to_battleframe.py
+++ b/tools/ref_to_battleframe.py
@@ -204,25 +204,51 @@ def _mode_order(motion):
     return list(_MODE_ORDER)
 
 
-def _melee_mode_body(abbr, kind):
-    """One mode's script for the 3-beat MELEE fake (cadence from FE8 Pirate axe).
+# Per-donor MELEE sound/effect cadence. Both share the 3-beat lunge SHAPE (ready -> coil ->
+# lunge & hold through the hit -> ease back); only the audio/FX punctuation differs, studied
+# from each donor's decomp script. "axe" = FE8 Pirate (banim_pirm_ax1); "lance" = FE8 Armor
+# Knight (banim_armm_sp1) -- heavy armored steps + an armored leap + a thrust whoosh + the
+# heavy-weight screen shake, and the lighter hit-sound variant (no '_durandal').
+_MELEE_CADENCE = {
+    "axe": {
+        "windup": ["\tbanim_code_sound_axe_swing_short"],
+        "swing":  ["\tbanim_code_sound_axe_swing_long", "\tbanim_code_effect_dirt_kick"],
+        "hit":    ["\tbanim_code_sound_hit_eliwood_promoted_durandal"],
+        "impact": [],
+        "back":   [],
+    },
+    "lance": {
+        "windup": ["\tbanim_code_sound_step_heavy_quick"],
+        "swing":  ["\tbanim_code_sound_armor_leap", "\tbanim_code_shake_screnn_slightly"],
+        "hit":    ["\tbanim_code_sound_sword_slash_air",
+                   "\tbanim_code_sound_hit_eliwood_promoted"],
+        "impact": ["\tbanim_code_shake_screnn_slightly"],
+        "back":   ["\tbanim_code_sound_step_heavy_quick"],
+    },
+}
 
-    Cadence matched to the FE8 Pirate axe (banim_pirm_ax1): ready -> wind up (frame 1, held
+
+def _melee_mode_body(abbr, kind, cadence="axe"):
+    """One mode's script for the 3-beat MELEE fake.
+
+    Cadence SHAPE matched to the FE8 Pirate axe (banim_pirm_ax1): ready -> wind up (frame 1, held
     longest, coiled back) -> lunge into the swing (frame 2, the peak holds its forward dx
     through the hit, mirroring the Pirate's frames 2/3/5 ~7 ticks at dx ~-45) -> hit_normal on
     contact -> ease back over a 6-tick return (the Pirate's frames 7/8) and turn. No projectile:
     the hit IS the contact. Dodge hops backward (dodge_to_back). The forward step is the OAM
-    lunge baked by build_battle_anim (MELEE_LUNGE_DX), held here by keeping frame 2 on-screen."""
+    lunge baked by build_battle_anim (MELEE_LUNGE_DX), held here by keeping frame 2 on-screen.
+    `cadence` swaps only the per-donor sound/FX punctuation (see _MELEE_CADENCE); the lance
+    cadence (FE8 Armor Knight banim_armm_sp1) reads as a heavy armored thrust, not an axe swing."""
+    c = _MELEE_CADENCE[cadence]
     if kind == "attack":   # ready -> wind up -> lunge & HOLD forward through the hit -> ease back
         return ["\tbanim_code_start_attack_1", "\tbanim_code_start_attack_2",
-                _frame_cmd(abbr, 1, 0), "\tbanim_code_sound_axe_swing_short",
-                _frame_cmd(abbr, 20, 1), "\tbanim_code_sound_axe_swing_long",
-                "\tbanim_code_effect_dirt_kick", _frame_cmd(abbr, 3, 2),
-                "\tbanim_code_prepare_hp_deplete", _frame_cmd(abbr, 3, 2),
-                "\tbanim_code_sound_hit_eliwood_promoted_durandal",
-                "\tbanim_code_hit_normal", _frame_cmd(abbr, 1, 2),   # hold the lunge through the hit
+                _frame_cmd(abbr, 1, 0)] + c["windup"] + [
+                _frame_cmd(abbr, 20, 1)] + c["swing"] + [
+                _frame_cmd(abbr, 3, 2),
+                "\tbanim_code_prepare_hp_deplete", _frame_cmd(abbr, 3, 2)] + c["hit"] + [
+                "\tbanim_code_hit_normal", _frame_cmd(abbr, 1, 2)] + c["impact"] + [
                 "\tbanim_code_wait_hp_deplete", "\tbanim_code_start_opposite_turn",
-                _frame_cmd(abbr, 3, 0), _frame_cmd(abbr, 3, 0),      # ease back (Pirate f7+f8, 6 ticks)
+                _frame_cmd(abbr, 3, 0)] + c["back"] + [_frame_cmd(abbr, 3, 0),
                 "\tbanim_code_end_dodge", "\tbanim_code_end_mode"]
     if kind == "dodge":    # hop backward: ready -> wind-up -> ready
         return ["\tbanim_code_dodge_to_back", _frame_cmd(abbr, 1, 0),
@@ -234,19 +260,19 @@ def _melee_mode_body(abbr, kind):
                 "\tbanim_code_end_mode"]
     # miss: lunge and swing through, hold the forward beat (like the hit), but no contact lands
     return ["\tbanim_code_start_attack_1", "\tbanim_code_start_attack_2",
-            _frame_cmd(abbr, 1, 0), "\tbanim_code_sound_axe_swing_short",
-            _frame_cmd(abbr, 20, 1), "\tbanim_code_sound_axe_swing_long",
-            "\tbanim_code_effect_dirt_kick", _frame_cmd(abbr, 3, 2),
+            _frame_cmd(abbr, 1, 0)] + c["windup"] + [
+            _frame_cmd(abbr, 20, 1)] + c["swing"] + [
+            _frame_cmd(abbr, 3, 2),
             _frame_cmd(abbr, 4, 2),                                 # hold forward (matches the hit beat)
             "\tbanim_code_wait_hp_deplete", "\tbanim_code_start_opposite_turn",
             _frame_cmd(abbr, 3, 0), _frame_cmd(abbr, 3, 0), "\tbanim_code_end_dodge",
             "\tbanim_code_end_mode"]
 
 
-def _mode_body(abbr, kind, motion="ranged"):
+def _mode_body(abbr, kind, motion="ranged", cadence="axe"):
     """Emit one mode's script lines for the 3-beat (Ready/Wind-up/Peak) fake."""
     if motion == "melee":
-        return _melee_mode_body(abbr, kind)
+        return _melee_mode_body(abbr, kind, cadence)
     if kind == "attack":   # draw (0->1 held) -> peak (2) + loose arrow -> recover
         return ["\tbanim_code_start_attack_1", "\tbanim_code_start_attack_2",
                 _frame_cmd(abbr, 3, 0), "\tbanim_code_sound_pull_bow",
@@ -271,7 +297,7 @@ def _oam_line(e):
             % (e["attr0"], e["attr1"], e["attr2"], e["dx"], e["dy"]))
 
 
-def emit_motion_s(abbr, frames, motion="ranged"):
+def emit_motion_s(abbr, frames, motion="ranged", cadence="axe"):
     """Assemble the full banim motion.s text for `abbr` from 3 frames' OAM.
 
     `frames` is a list of {"oam_r": [...], "oam_l": [...]} (Ready/Wind-up/Peak). `motion`
@@ -303,7 +329,7 @@ def emit_motion_s(abbr, frames, motion="ranged"):
     order = _mode_order(motion)
     for name, kind in order:
         L.append("banim_%s_mode_%s:" % (abbr, name))
-        L += _mode_body(abbr, kind, motion)
+        L += _mode_body(abbr, kind, motion, cadence)
 
     L.append("\t.section .data.modes")
     for name, _ in order:
@@ -331,7 +357,7 @@ def _lunge(entries, dx):
     return [dict(e, dx=e["dx"] + dx) for e in entries]
 
 
-def build_battle_anim(abbr, frame_imgs, palette, center_px=None, motion="ranged"):
+def build_battle_anim(abbr, frame_imgs, palette, center_px=None, motion="ranged", cadence="axe"):
     """Drive the whole faked-anim build: 3 frames -> sheets + agbpal + motion.s text.
 
     Per frame: tile -> merge filled cells into OBJs -> pack to oam_r + 2D placements ->
@@ -362,7 +388,7 @@ def build_battle_anim(abbr, frame_imgs, palette, center_px=None, motion="ranged"
         sheets.append(build_sheet_from_placements(im, placements, palette))
         frames.append({"oam_r": entries, "oam_l": mirror_oam(entries)})
     return {"sheets": sheets, "pal": agbpal_bytes(palette),
-            "motion_s": emit_motion_s(abbr, frames, motion)}
+            "motion_s": emit_motion_s(abbr, frames, motion, cadence)}
 
 
 def _cell_is_empty(im, ox, oy):

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -245,6 +245,21 @@ class CharacterUniqueBanim(unittest.TestCase):
                '    AnimConf_Unused_LuciusPromoted,\n'
                '};\n')
 
+    def test_knight_donor_maps_to_armor_knight_lance_cadence(self):
+        # wolfram et al. ride CLASS_ARMOR_KNIGHT (display "Knight") with a lance and the
+        # heavy armored thrust cadence (decomp banim_armm_sp1), not the Pirate axe.
+        donor_class, wtype, motion, cadence = bc.BANIM_DONORS['knight']
+        self.assertEqual(donor_class, 'CLASS_ARMOR_KNIGHT')
+        self.assertIn('ITYPE_LANCE', wtype)
+        self.assertEqual(motion, 'melee')
+        self.assertEqual(cadence, 'lance')
+
+    def test_every_melee_donor_names_a_known_cadence(self):
+        from ref_to_battleframe import _MELEE_CADENCE
+        for name, (_dc, _wt, motion, cadence) in bc.BANIM_DONORS.items():
+            if motion == 'melee':
+                self.assertIn(cadence, _MELEE_CADENCE, name)
+
     def test_unique_append_returns_next_index_and_appends_the_symbol(self):
         new, idx = bc.banim_unique_append(self.CONFIGS, 'AnimConf_brau_ax1')
         self.assertEqual(idx, 3)                       # NULL + 2 existing -> new is index 3

--- a/tools/test_ref_to_battleframe.py
+++ b/tools/test_ref_to_battleframe.py
@@ -316,6 +316,35 @@ class TestMeleeMotionS(unittest.TestCase):
         self.assertNotIn("banim_code_start_attack_1", body)     # no lunge
         self.assertNotIn("banim_code_hit_normal", body)         # no hit at range
 
+    def test_lance_cadence_uses_armored_thrust_not_axe_swing(self):
+        # Knight (Armor Knight, decomp banim_armm_sp1) lance cadence: heavy armored steps +
+        # an armored leap into the thrust + a thrust whoosh + heavy-weight screen shake --
+        # NOT the Pirate's axe swing / dirt kick. Verified against the decomp armm_sp1 script.
+        s = rb.emit_motion_s("wolf_ln1", self._frames(), motion="melee", cadence="lance")
+        body = self._mode(s, "attack_close", abbr="wolf_ln1")
+        self.assertIn("banim_code_sound_step_heavy_quick", body)   # heavy armored step
+        self.assertIn("banim_code_sound_armor_leap", body)         # the armored lunge
+        self.assertIn("banim_code_shake_screnn_slightly", body)    # heavy-weight screen shake
+        self.assertIn("banim_code_sound_sword_slash_air", body)    # the thrust whoosh
+        self.assertIn("banim_code_hit_normal", body)               # melee contact (shared)
+        self.assertNotIn("banim_code_sound_axe_swing_long", body)  # not the axe swing
+        self.assertNotIn("banim_code_effect_dirt_kick", body)      # not the axe's dirt kick
+
+    def test_lance_miss_also_uses_armored_cadence_not_axe(self):
+        # a missed lance attack swings the same armored thrust (no contact) -- still no axe sounds.
+        s = rb.emit_motion_s("wolf_ln1", self._frames(), motion="melee", cadence="lance")
+        body = self._mode(s, "attack_miss", abbr="wolf_ln1")
+        self.assertIn("banim_code_sound_armor_leap", body)
+        self.assertNotIn("banim_code_sound_axe_swing_long", body)
+        self.assertNotIn("banim_code_hit_normal", body)            # a miss lands no hit
+
+    def test_axe_cadence_is_still_the_melee_default(self):
+        # default melee cadence stays the Pirate axe (braulo) -- a new donor must opt in.
+        body = self._mode(rb.emit_motion_s("brau_an1", self._frames(), motion="melee"),
+                          "attack_close")
+        self.assertIn("banim_code_sound_axe_swing_long", body)
+        self.assertNotIn("banim_code_sound_armor_leap", body)
+
     def test_ranged_motion_is_still_the_default(self):
         s = rb.emit_motion_s("rbg_ar1", self._frames())         # no motion= -> ranged
         self.assertIn("banim_code_call_spell_anim", s)


### PR DESCRIPTION
Adds the **Knight/lance battle-anim donor** so the next PC anims (wolfram, pinky) can ride a lance-thrust cadence instead of the Pirate axe.

- New `knight → (CLASS_ARMOR_KNIGHT, ITYPE_LANCE, melee, lance)` row in `BANIM_DONORS`.
- `_MELEE_CADENCE` makes the sound/FX punctuation **per-donor** (`axe` | `lance`) while all melee donors share the same 3-beat lunge *shape*. The `lance` cadence is studied from the vanilla Armor Knight script (`banim_armm_sp1`): heavy armored steps + armored leap + thrust whoosh + heavy-weight screen shake.
- Cadence threaded through `build_battle_anim` / `emit_motion_s`.

**Campaign-agnostic tooling only** — no unit opts in yet (`clone_from: knight`); inert until wolfram's art lands. TDD'd: lance-cadence + donor-mapping tests, **81 green**.

Part of #65 Milestone B (unblocks the 6 remaining PC anims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
