### PR TITLE
docs(handoff): land stale-branch cleanup punch-list; re-probed web-env blocker

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -9,35 +9,34 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 > live pickup — its engine/tooling half is merged & inert; it's waiting only on art.** See §Wolfram + the
 > ready-to-run prompt pack at the bottom of this file. Nicolas is mobile-only the week of 2026-06-29.
 
-> **🛠 Desktop fix needed — branch cleanup + env policy (2026-06-29):** An audit on
-> `claude/audit-open-branches-5suz48` found **11 stale remote branches** the squash-merge convention
-> should have deleted (the 8 closed-unmerged PRs #67/#70/#74/#75/#76/#77/#95/#96 + the three never-PR'd
-> `claude/content-track-review-5rpjy8` / `demo/ch2-gifs` / `review/ch02-ending-bg`). The work landed on
-> `main` via separate squash-merges; the branches are leftover. **Two things to do from desktop:**
+> **🛠 Desktop fix needed — branch cleanup + env policy (2026-06-29):** An audit found **12 stale
+> remote branches** the squash-merge convention should have deleted: the 8 closed-merged PR branches
+> (#67/#70/#74/#75/#76/#77/#95/#96), the 3 never-PR'd (`claude/content-track-review-5rpjy8` /
+> `demo/ch2-gifs` / `review/ch02-ending-bg`), and the now-obsolete prior audit branch itself
+> (`claude/audit-open-branches-5suz48`, superseded by this commit). Re-probed from a fresh web session
+> 2026-06-29: blocker unchanged — `git push --delete` still HTTP 403, REST `DELETE /git/refs/...` still
+> returns `"GitHub access is not enabled for this session."` **Two things to do from desktop:**
 >
-> 1. **Delete the 11 stale branches.** From a local checkout:
+> 1. **Flip the GitHub repo setting "Automatically delete head branches"** (Settings → General →
+>    Pull Requests; mobile-reachable). That sweeps every squash-merged branch on merge so this
+>    backlog can't re-accumulate. **After flipping, squash-merging this PR will auto-delete
+>    `claude/branch-cleanup-1c1081`** — one less branch to chase manually.
+> 2. **Delete the 12 stale branches.** From a local checkout:
 >    ```sh
 >    git push origin --delete \
->      claude/content-track-review-5rpjy8 demo/ch2-gifs \
+>      claude/audit-open-branches-5suz48 claude/content-track-review-5rpjy8 demo/ch2-gifs \
 >      docs/descale-palette-guidance docs/handoff-65-mb-done \
 >      feat/19-vellynne-portrait feat/22-ch02-dialogue-reground feat/22-title-card \
 >      feat/38-chwinga-map-sprites feat/39-chwinga-portraits feat/engine-name-check \
 >      review/ch02-ending-bg
 >    ```
->    Keep `main`, `docs/handoff-ch3-map-pickup` (open PR #101), and any active audit branch.
-> 2. **Fix the Claude-Code-on-the-web env so future sessions can do this themselves.** The web env's
->    git proxy rejects ref-delete pushes with HTTP 403; the GitHub REST `DELETE /git/refs/heads/...`
->    returns `"GitHub access is not enabled for this session. An org admin must connect the Claude
->    GitHub App for this organization."` Two checks: (a) **github.com/settings/installations → Claude**
->    — confirm *Contents* is read-and-write and this repo is in the access list; (b) the env's network
->    policy in claude.com/code → this environment's settings — bump to a policy that allows full GitHub
->    write (see https://code.claude.com/docs/en/claude-code-on-the-web for policy names). Verify by
->    asking the next web session to delete a throwaway branch end-to-end.
->
-> **Convention drift to watch:** CLAUDE.md mandates *"squash-merge to `main` → delete the branch + worktree"* —
-> the 8 closed-PR branches show this step has been skipped repeatedly. Either bake it into the merge
-> step (GitHub repo setting → "Automatically delete head branches" toggle, also reachable on mobile)
-> or treat skipped deletion as a PR-checklist regression.
+>    Keep `main` and `docs/handoff-ch3-map-pickup` (open PR #101).
+> 3. **Fix the Claude-Code-on-the-web env so future sessions can do this themselves.** Two checks:
+>    (a) **github.com/settings/installations → Claude** — confirm *Contents* is read-and-write and
+>    this repo is in the access list; (b) the env's network policy in claude.com/code → this
+>    environment's settings — bump to a policy that allows full GitHub write (see
+>    https://code.claude.com/docs/en/claude-code-on-the-web for policy names). Verify by asking the
+>    next web session to delete a throwaway branch end-to-end.
 
 ## Workflow — feature-flow
 Issue → short-lived `feat/<slug>` branch off `main` → an ephemeral worktree → PR → CI + `/code-review`

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -9,6 +9,36 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 > live pickup — its engine/tooling half is merged & inert; it's waiting only on art.** See §Wolfram + the
 > ready-to-run prompt pack at the bottom of this file. Nicolas is mobile-only the week of 2026-06-29.
 
+> **🛠 Desktop fix needed — branch cleanup + env policy (2026-06-29):** An audit on
+> `claude/audit-open-branches-5suz48` found **11 stale remote branches** the squash-merge convention
+> should have deleted (the 8 closed-unmerged PRs #67/#70/#74/#75/#76/#77/#95/#96 + the three never-PR'd
+> `claude/content-track-review-5rpjy8` / `demo/ch2-gifs` / `review/ch02-ending-bg`). The work landed on
+> `main` via separate squash-merges; the branches are leftover. **Two things to do from desktop:**
+>
+> 1. **Delete the 11 stale branches.** From a local checkout:
+>    ```sh
+>    git push origin --delete \
+>      claude/content-track-review-5rpjy8 demo/ch2-gifs \
+>      docs/descale-palette-guidance docs/handoff-65-mb-done \
+>      feat/19-vellynne-portrait feat/22-ch02-dialogue-reground feat/22-title-card \
+>      feat/38-chwinga-map-sprites feat/39-chwinga-portraits feat/engine-name-check \
+>      review/ch02-ending-bg
+>    ```
+>    Keep `main`, `docs/handoff-ch3-map-pickup` (open PR #101), and any active audit branch.
+> 2. **Fix the Claude-Code-on-the-web env so future sessions can do this themselves.** The web env's
+>    git proxy rejects ref-delete pushes with HTTP 403; the GitHub REST `DELETE /git/refs/heads/...`
+>    returns `"GitHub access is not enabled for this session. An org admin must connect the Claude
+>    GitHub App for this organization."` Two checks: (a) **github.com/settings/installations → Claude**
+>    — confirm *Contents* is read-and-write and this repo is in the access list; (b) the env's network
+>    policy in claude.com/code → this environment's settings — bump to a policy that allows full GitHub
+>    write (see https://code.claude.com/docs/en/claude-code-on-the-web for policy names). Verify by
+>    asking the next web session to delete a throwaway branch end-to-end.
+>
+> **Convention drift to watch:** CLAUDE.md mandates *"squash-merge to `main` → delete the branch + worktree"* —
+> the 8 closed-PR branches show this step has been skipped repeatedly. Either bake it into the merge
+> step (GitHub repo setting → "Automatically delete head branches" toggle, also reachable on mobile)
+> or treat skipped deletion as a PR-checklist regression.
+
 ## Workflow — feature-flow
 Issue → short-lived `feat/<slug>` branch off `main` → an ephemeral worktree → PR → CI + `/code-review`
 → squash-merge → drop the branch + worktree. No fixed lanes; a feature may span engine + content

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,29 +11,29 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 > (Cynon's Mineshaft, Gray) + layout pivot to a custom Gem-Mine plan — **flattened blockout posted on #23,
 > awaiting Nicolas's OK** (see §Map (#40)). Nicolas is mobile-only the week of 2026-06-29.
 
-> **🛠 Desktop fix needed — branch cleanup + env policy (2026-06-29):** An audit found **12 stale
-> remote branches** the squash-merge convention should have deleted: the 8 closed-merged PR branches
-> (#67/#70/#74/#75/#76/#77/#95/#96), the 3 never-PR'd (`claude/content-track-review-5rpjy8` /
-> `demo/ch2-gifs` / `review/ch02-ending-bg`), and the now-obsolete prior audit branch itself
-> (`claude/audit-open-branches-5suz48`, superseded by this commit). Re-probed from a fresh web session
-> 2026-06-29: blocker unchanged — `git push --delete` still HTTP 403, REST `DELETE /git/refs/...` still
-> returns `"GitHub access is not enabled for this session."` **Two things to do from desktop:**
+> **🛠 Desktop fix needed — branch cleanup + env policy (2026-06-29; re-probed 2026-07-02):** An audit
+> found **13 stale remote branches** the squash-merge convention should have deleted. 2026-07-02 web
+> re-probe: the env can now **push to branches and squash-merge PRs via the GitHub MCP** (PR #101 was
+> conflict-resolved and merged from the web) — but **ref-deletes are still blocked** (`git push
+> --delete` hangs at the proxy; no repo-settings API either). **To do from desktop:**
 >
 > 1. **Flip the GitHub repo setting "Automatically delete head branches"** (Settings → General →
 >    Pull Requests; mobile-reachable). That sweeps every squash-merged branch on merge so this
 >    backlog can't re-accumulate. **After flipping, squash-merging this PR will auto-delete
 >    `claude/branch-cleanup-1c1081`** — one less branch to chase manually.
-> 2. **Delete the 12 stale branches.** From a local checkout:
+> 2. **Delete the stale branches.** From a local checkout:
 >    ```sh
 >    git push origin --delete \
->      claude/audit-open-branches-5suz48 claude/content-track-review-5rpjy8 demo/ch2-gifs \
->      docs/descale-palette-guidance docs/handoff-65-mb-done \
+>      claude/audit-open-branches-5suz48 claude/content-track-review-5rpjy8 \
+>      docs/descale-palette-guidance docs/handoff-65-mb-done docs/handoff-ch3-map-pickup \
 >      feat/19-vellynne-portrait feat/22-ch02-dialogue-reground feat/22-title-card \
 >      feat/38-chwinga-map-sprites feat/39-chwinga-portraits feat/engine-name-check \
 >      review/ch02-ending-bg
 >    ```
->    Keep `main` and `docs/handoff-ch3-map-pickup` (open PR #101).
-> 3. **Fix the Claude-Code-on-the-web env so future sessions can do this themselves.** Two checks:
+>    (`docs/handoff-ch3-map-pickup` joined the list when PR #101 squash-merged, 2026-07-02.)
+>    **`demo/ch2-gifs` is deliberately NOT on the list** — it still holds the only copy of the
+>    unmerged `recordch02*` cutscene-GIF scenarios; decide regenerate-vs-drop first (§Ch2), then delete.
+> 3. **Fix the Claude-Code-on-the-web env so future sessions can delete refs themselves.** Two checks:
 >    (a) **github.com/settings/installations → Claude** — confirm *Contents* is read-and-write and
 >    this repo is in the access list; (b) the env's network policy in claude.com/code → this
 >    environment's settings — bump to a policy that allows full GitHub write (see


### PR DESCRIPTION
Lands the 2026-06-29 branch-cleanup audit onto `main` so the next desktop session sees the punch-list at session start (HANDOFF is on the session-start checklist; the audit currently lives only on an orphan branch). Re-probed the cleanup blocker from a fresh web session — `git push --delete` still HTTP 403, REST `DELETE /git/refs/...` still returns `"GitHub access is not enabled for this session."` So this PR ships the **instructions**, not the deletions.

## Summary
- Cherry-picks the orphan `claude/audit-open-branches-5suz48` HANDOFF note onto `main`.
- Bumps the stale-branch count from 11 → **12** (the audit branch is itself now obsolete and on the delete list — superseded by this commit).
- Promotes the **"Automatically delete head branches"** repo toggle to step 1: mobile-reachable, prevents the backlog re-accumulating, and will auto-sweep this PR's own head on squash-merge.
- Keeps the existing env-policy / GitHub-App checks as step 3 so a future web session can do this end-to-end.

## What's still needed (desktop)
1. Flip *Settings → General → Pull Requests → Automatically delete head branches* (also mobile).
2. `git push origin --delete` the 12 listed branches.
3. Verify the env policy + GitHub App install scope per step 3 in HANDOFF.

Keep `main` and `docs/handoff-ch3-map-pickup` (PR #101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmupGxqTj5LcAwBzaCC2Dh)_