### PR TITLE
refactor(#107): normalize chapter deployment schema + finish the injection-scaffolding hoist

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
@@ -70,16 +70,17 @@ difficulty_note: >
 # ── Player Units ──────────────────────────────────────────────────────────────
 # Whole cast is RECRUITED (Northlook scene); the field obeys vanilla Ch1: 4 slots.
 # Pick Units (prep flow) chooses which 4; the chosen lord (#42) is force-deployed.
-deploy_limit: 4                          # vanilla Ch1: Eirika+Seth + Franz+Gilliam = 4
-deploy_slots:                            # [col, row] — west edge, trail mouth
-  - [3, 8]
-  - [3, 9]
-  - [2, 8]
-  - [2, 9]
-# Vanilla fields these 4 as 2 starters + 2 turn-2 arrivals (Franz/Gilliam). We field
-# all 4 from turn 1: the staggered arrival was a story beat for fixed characters and
-# doesn't survive a player-picked party; 4-at-start is the gentler read of the same
-# total (lean generous, feedback_fe-level-design).
+deployment:
+  deploy_limit: 4                        # vanilla Ch1: Eirika+Seth + Franz+Gilliam = 4
+  deploy_slots:                          # [col, row] — west edge, trail mouth
+    - [3, 8]
+    - [3, 9]
+    - [2, 8]
+    - [2, 9]
+  # Vanilla fields these 4 as 2 starters + 2 turn-2 arrivals (Franz/Gilliam). We field
+  # all 4 from turn 1: the staggered arrival was a story beat for fixed characters and
+  # doesn't survive a player-picked party; 4-at-start is the gentler read of the same
+  # total (lean generous, feedback_fe-level-design).
 
 # ── Enemy Units ────────────────────────────────────────────────────────────────
 # Vanilla Ch1 enemy table, goblin-skinned: 3 Soldiers (lances) + 3 Fighters (axes)

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
@@ -84,18 +84,18 @@ difficulty_note: >
 # player deploy-slot count = 5 (Eirika/Seth/Franz/Gilliam/Moulder). Our 8-strong cast does
 # NOT widen the field — the prep screen (Pick Units) chooses which 5 take it; the chosen
 # lord (#42) is force-deployed. This models our difficulty to vanilla's despite the bigger cast.
-deploy_limit: 5
-# [col, row] — the NW entry corner, ringing the parked sled. FIRST PASS (parity intent
-# only): vanilla Ch2's ally tiles land on walls/peaks in Nicolas's hand-retiled paint, so
-# these are authored against THIS map's actual walkable tiles (plains/forest), not vanilla
-# coords. The party rolls in NW; the raid converges from the E/SE. Nicolas to adjust on the paint.
-deploy_slots:
-  - [0, 3]
-  - [0, 4]
-  - [0, 5]
-  - [1, 5]
-  - [2, 4]
 deployment:
+  deploy_limit: 5
+  # [col, row] — the NW entry corner, ringing the parked sled. FIRST PASS (parity intent
+  # only): vanilla Ch2's ally tiles land on walls/peaks in Nicolas's hand-retiled paint, so
+  # these are authored against THIS map's actual walkable tiles (plains/forest), not vanilla
+  # coords. The party rolls in NW; the raid converges from the E/SE. Nicolas to adjust on the paint.
+  deploy_slots:
+    - [0, 3]
+    - [0, 4]
+    - [0, 5]
+    - [1, 5]
+    - [2, 4]
   note: "Pick Units fields 5 of {7 PCs + Baxby} (vanilla Ch2 fields 5). The party rolls in NW; 3 green chwinga sit just ahead, in the raid's path."
   # ── Protected: 3 GREEN chwinga (replaces the dropped sled) ──────────────────────
   # Harmless gift-spirits (book: "Starting Quest: Nature Spirits", p25–26) on the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -98,6 +98,23 @@ gate built main's ROM and the refactor's ROM against the same mock base ROM -- e
 normalization across chapter YAML + a generic YAML-driven `inject_chapter()` entry point.
 _Decided: 2026-07-02_
 
+**Chapter deployment schema: ONE shape, gated (#107).**
+All deployment data lives inside the chapter YAML's `deployment:` block -- `deploy_limit`,
+`deploy_slots`, prose `note`, `green_allies`. `player_units:` is the single alternative,
+only for a fixed-roster chapter with no prep screen (the prologue). Kills the audit-2.2 drift
+(four incompatible shapes across 9 files; three different access paths in code). ch01/ch02
+migrated; consumers (`inject_ch01`/`inject_ch02`, `difficulty.py chapter_deploy_limit`) read
+only the block. Gate: `check.py check_chapter_deployment_schema` (CI + pre-commit) --
+top-level `deploy_limit`/`deploy_slots` are rejected, slots must match the limit (the slot
+list IS the cap template), an `active` chapter needs a machine-readable `deploy_limit`
+(prose caps are for `planned` seeds), `green_allies` entries need id/class/level/position.
+The #105 hoist also finished here: `_split_event_beats`, `_require_beat_count`, `_make_fid`,
+`_emit_scene_beats`, `_classed_cast`, `_deploy_cap_entries`, and `_ally_unit_entry`
+parameterized over allegiance/autolevel/ai (ch02's `green_entry` copy retired). Verified:
+old-vs-new injection into a clean submodule against the same mock base ROM diffs empty
+(byte-identical generated sources), full test suite + drift guard green.
+_Decided: 2026-07-02 (CLAUDE; audit 2.1/2.2 follow-through)_
+
 ---
 
 ## Documentation Model

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -3528,21 +3528,19 @@ def _split_script_beats(script, card_required=True):
     return card, beats
 
 
-def _split_event_beats(chap, trigger, err_label, card_required=True):
+def _split_event_beats(chap, trigger, err_label, msg_ids=None, card_required=True):
     """Locate the chapter event with `trigger` and split its locked `script:` into
-    (location_card, beats) (cf. _split_script_beats)."""
+    (location_card, beats) (cf. _split_script_beats). Passing the scene's reserved
+    `msg_ids` block guards the split against it -- a count mismatch means a
+    beat_break drifted in the YAML and a zip would silently drop the extra."""
     ev = next((e for e in chap['events'] if e.get('trigger') == trigger), None)
     if ev is None:
         sys.exit('ERROR: %s: no %r event in the chapter YAML' % (err_label, trigger))
-    return _split_script_beats(ev['script'], card_required=card_required)
-
-
-def _require_beat_count(beats, msg_ids, label):
-    """Guard a beat split against its reserved message-id block: a mismatch means a
-    beat_break drifted in the YAML and zip would silently drop the extra."""
-    if len(beats) != len(msg_ids):
+    card, beats = _split_script_beats(ev['script'], card_required=card_required)
+    if msg_ids is not None and len(beats) != len(msg_ids):
         sys.exit('ERROR: %s split into %d beats; expected %d (check beat_break '
-                 'markers in the YAML)' % (label, len(beats), len(msg_ids)))
+                 'markers in the YAML)' % (err_label, len(beats), len(msg_ids)))
+    return card, beats
 
 
 def _cutscene_fid(spk, special, err_label, fallback=None):
@@ -3583,11 +3581,16 @@ def _emit_scene_beats(lines, msg_ids, beats, fid, home, overrides=None,
     the opaque, auto-centered SOLOTEXTBOXSTART box (#58) wrapped at the on-map 28
     (42 overflows the centered box); faced beats use the full-screen scenic 42.
     A fixed width (e.g. 42) overrides for scenes with no narration beats."""
-    for i, (msg_id, beat) in enumerate(zip(msg_ids, beats)):
+    overrides = overrides or [None] * len(beats)
+    preloads = preloads or [None] * len(beats)
+    if not (len(overrides) == len(preloads) == len(beats)):
+        sys.exit('ERROR: scene staging lists out of step with its %d beats '
+                 '(%d overrides, %d preloads) for msgs %s' %
+                 (len(beats), len(overrides), len(preloads), msg_ids))
+    for msg_id, beat, override, preload in zip(msg_ids, beats, overrides, preloads):
         w = width if width is not None else (28 if _beat_is_narration(beat) else 42)
         set_message_body(lines, msg_id, _script_to_message(
-            beat, _stage_beat(beat, fid, home, overrides[i] if overrides else None),
-            width=w, preload=preloads[i] if preloads else None))
+            beat, _stage_beat(beat, fid, home, override), width=w, preload=preload))
 
 
 def _register_chapter_map(maps_dir, layout, comment):
@@ -3649,6 +3652,9 @@ def _classed_cast(campaign):
         cast.append((unit_id, slot, class_enum, deploy_class_for(unit),
                      int(unit.get('fe_stats', {}).get('level', 1))))
         names.append(display_name(unit))
+    if not cast:
+        sys.exit('ERROR: no classed cast -- every PORTRAIT_MAP unit is missing a '
+                 'class mapping (check the pcs/*.yaml fe_stats blocks)')
     return cast, names
 
 
@@ -3657,35 +3663,38 @@ def _ally_unit_entry(leader, slot, class_enum, level, x, y, items, comment,
     """One non-RED UnitDefinition row (events_udefs.c) for a chapter join/deploy/
     green-ally table. leader=None omits the leaderCharIndex field; autolevel/ai
     toggle their optional lines (GREEN allies use all three)."""
-    return ('    {\n'
-            '        .charIndex = CHARACTER_%s,%s\n'
-            '        .classIndex = %s,\n'
-            '%s'
-            '%s'
-            '        .allegiance = FACTION_ID_%s,\n'
-            '        .level = %d,\n'
-            '        .xPosition = %d,\n'
-            '        .yPosition = %d,\n'
-            '        .redaCount = 0,\n'
-            '        .items = { %s },\n'
-            '%s'
-            '    },' % (slot.upper(), comment, class_enum,
-                       '        .leaderCharIndex = %s,\n' % leader if leader else '',
-                       '        .autolevel = 1,\n' if autolevel else '',
-                       allegiance, level, x, y, items,
-                       '        .ai = %s,\n' % ai if ai else ''))
+    fields = ['.charIndex = CHARACTER_%s,%s' % (slot.upper(), comment),
+              '.classIndex = %s,' % class_enum]
+    if leader:
+        fields.append('.leaderCharIndex = %s,' % leader)
+    if autolevel:
+        fields.append('.autolevel = 1,')
+    fields += ['.allegiance = FACTION_ID_%s,' % allegiance,
+               '.level = %d,' % level,
+               '.xPosition = %d,' % x,
+               '.yPosition = %d,' % y,
+               '.redaCount = 0,',
+               '.items = { %s },' % items]
+    if ai:
+        fields.append('.ai = %s,' % ai)
+    return '    {\n' + ''.join('        %s\n' % f for f in fields) + '    },'
 
 
 def _deploy_cap_entries(chap, cast, leader, label):
     """The ally deploy "cap template" rows from the chapter's `deployment:` block
     (#107 schema): never LOADed -- the prep flow reads the table's entry count as
-    the field cap and its coords as the deploy tiles. classIndex rides the DEPLOY
-    class (the Archer-clone for RBG, #65), like the actual fielded units."""
+    the field cap and its coords as the deploy tiles. classIndex rides
+    deploy_class_for (today == the plain vanilla class; custom anims need no clone
+    class since the per-character _u25 path, #65 M-B)."""
     dep = chap.get('deployment') or {}
     slots, limit = dep.get('deploy_slots'), dep.get('deploy_limit')
-    if not slots or len(slots) != limit:
-        sys.exit('ERROR: %s deployment.deploy_slots (%s) != deploy_limit (%s)'
-                 % (label, len(slots or []), limit))
+    if not slots:
+        sys.exit('ERROR: %s has no deployment.deploy_slots -- a hosted chapter '
+                 'needs its deploy tiles authored (they land with the map paint)'
+                 % label)
+    if len(slots) != limit:
+        sys.exit('ERROR: %s deployment.deploy_slots (%d) != deploy_limit (%s)'
+                 % (label, len(slots), limit))
     if len(cast) < limit:
         sys.exit('ERROR: %d classed cast < %s deploy_limit %d'
                  % (len(cast), label, limit))
@@ -3774,8 +3783,8 @@ def inject_ch01(campaign, verbose=True):
     #    instead of empty air, and the haggle puts Hruna across from RBG. Hlin's final
     #    "who leads?" line stays in the scene (end of beat E, at the Northlook); the
     #    lord-select menu then plays over its own scenic BG (not the battle map).
-    b1_card, b1_beats = _split_event_beats(chap, 'chapter_start', 'ch01 Beat 1')
-    _require_beat_count(b1_beats, CH01_BEAT1_MSGS, 'ch01 Beat 1')
+    b1_card, b1_beats = _split_event_beats(chap, 'chapter_start', 'ch01 Beat 1',
+                                           CH01_BEAT1_MSGS)
 
     b1_guests = {'hlin': _fid_tag(PROLOGUE_HLIN_SLOT),
                  'scramsax': _fid_tag(PROLOGUE_SCRAMSAX_SLOT),
@@ -3815,8 +3824,8 @@ def inject_ch01(campaign, verbose=True):
     #     budget resets per beat. Duvessa (the host, Speaker of Bryn Shander) anchors the
     #     mid-right podium throughout; the party speaks from mid-left, with the other beat
     #     speaker(s) staged as clean two-shots opposite her (cf. Beat 1 podium geometry).
-    end_card, end_beats = _split_event_beats(chap, 'chapter_end', 'ch01 ending')
-    _require_beat_count(end_beats, CH01_ENDING_MSGS, 'ch01 ending')
+    end_card, end_beats = _split_event_beats(chap, 'chapter_end', 'ch01 ending',
+                                             CH01_ENDING_MSGS)
 
     # narration = faceless stage-business box (no portrait); the fallback covers
     # the duvessa/hruna/baxby cutscene faces (GUEST_PORTRAIT_MAP).
@@ -4539,15 +4548,13 @@ def inject_ch02(campaign, verbose=True):
 
     # 0. Cutscene beat splits, consumed from the locked chapter YAML (cf. inject_ch01).
     op_card, op_beats = _split_event_beats(chap, 'chapter_start', 'ch02 opening',
-                                           card_required=False)
+                                           CH02_OPENING_MSGS, card_required=False)
     end_card, end_beats = _split_event_beats(chap, 'chapter_end', 'ch02 ending',
-                                             card_required=False)
+                                             CH02_ENDING_MSGS, card_required=False)
     bark = next(e for e in chap['events']
                 if e.get('trigger') == 'turn_start' and e.get('turn') == 3)['script']
     tutorial = next(e for e in chap['events']
                     if e.get('trigger') == 'turn_start' and e.get('turn') == 1)['script']
-    _require_beat_count(op_beats, CH02_OPENING_MSGS, 'ch02 opening')
-    _require_beat_count(end_beats, CH02_ENDING_MSGS, 'ch02 ending')
     if len(tutorial) != len(CH02_TUTORIAL_MSGS):
         sys.exit('ERROR: ch02 turn-1 tutorial has %d lines; expected %d '
                  '(zip would silently drop the extra)' % (len(tutorial), len(CH02_TUTORIAL_MSGS)))
@@ -4636,11 +4643,13 @@ def inject_ch02(campaign, verbose=True):
         True, hx, hy, steel, CH02_AI['hold_position'],
         ' /* Halvar the Raider Captain -- boss, steel axe (Bazba slot) */'))
 
-    # 2b. GREEN chwinga (088B4718) -- the protect layer; positions + per-survivor gift
-    #     come from the YAML deployment.green_allies (id order matches CH02_CHWINGA).
-    #     autolevel leans on the pegasus class curve (bases = tuning checkpoint).
+    # 2b. GREEN chwinga (088B4718) -- the protect layer; class + level + positions +
+    #     per-survivor gift come from the YAML deployment.green_allies (id order
+    #     matches CH02_CHWINGA). autolevel leans on the class curve (bases = tuning
+    #     checkpoint).
     chwinga_by_id = {g['id']: g for g in chap['deployment']['green_allies']}
-    chwinga = [_ally_unit_entry(None, slot, CH02_CLASS_IDS['pegasus_knight'],
+    chwinga = [_ally_unit_entry(None, slot,
+                                CH02_CLASS_IDS[chwinga_by_id[uid]['class']],
                                 chwinga_by_id[uid]['level'],
                                 chwinga_by_id[uid]['position'][0],
                                 chwinga_by_id[uid]['position'][1],

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -3528,6 +3528,23 @@ def _split_script_beats(script, card_required=True):
     return card, beats
 
 
+def _split_event_beats(chap, trigger, err_label, card_required=True):
+    """Locate the chapter event with `trigger` and split its locked `script:` into
+    (location_card, beats) (cf. _split_script_beats)."""
+    ev = next((e for e in chap['events'] if e.get('trigger') == trigger), None)
+    if ev is None:
+        sys.exit('ERROR: %s: no %r event in the chapter YAML' % (err_label, trigger))
+    return _split_script_beats(ev['script'], card_required=card_required)
+
+
+def _require_beat_count(beats, msg_ids, label):
+    """Guard a beat split against its reserved message-id block: a mismatch means a
+    beat_break drifted in the YAML and zip would silently drop the extra."""
+    if len(beats) != len(msg_ids):
+        sys.exit('ERROR: %s split into %d beats; expected %d (check beat_break '
+                 'markers in the YAML)' % (label, len(beats), len(msg_ids)))
+
+
 def _cutscene_fid(spk, special, err_label, fallback=None):
     """Speaker id -> face tag for a chapter cutscene: the chapter's `special` speakers
     first (guest slots, faceless `narration` -> None), then the PC PORTRAIT_MAP, then
@@ -3541,6 +3558,14 @@ def _cutscene_fid(spk, special, err_label, fallback=None):
     sys.exit('ERROR: %s %r' % (err_label, spk))
 
 
+def _make_fid(special, err_label, fallback=None):
+    """A chapter's speaker->face function (a closure over _cutscene_fid), the shape
+    _stage_beat/_emit_scene_beats consume."""
+    def fid(spk):
+        return _cutscene_fid(spk, special, err_label, fallback=fallback)
+    return fid
+
+
 def _stage_beat(beat, fid, home, overrides=None):
     """Podium staging for one scenic beat: speaker -> (podium, face tag). Speakers
     default to the mid-left podium; `home` anchors recurring speakers (quest-givers),
@@ -3549,6 +3574,20 @@ def _stage_beat(beat, fid, home, overrides=None):
     ov = overrides or {}
     return {k: (ov.get(k, home.get(k, '[OpenMidLeft]')), fid(k))
             for e in beat for k in e}
+
+
+def _emit_scene_beats(lines, msg_ids, beats, fid, home, overrides=None,
+                      preloads=None, width=None):
+    """Write one message per scenic beat (staging via _stage_beat, body via
+    _script_to_message). width=None picks per beat: faceless-narration beats ride
+    the opaque, auto-centered SOLOTEXTBOXSTART box (#58) wrapped at the on-map 28
+    (42 overflows the centered box); faced beats use the full-screen scenic 42.
+    A fixed width (e.g. 42) overrides for scenes with no narration beats."""
+    for i, (msg_id, beat) in enumerate(zip(msg_ids, beats)):
+        w = width if width is not None else (28 if _beat_is_narration(beat) else 42)
+        set_message_body(lines, msg_id, _script_to_message(
+            beat, _stage_beat(beat, fid, home, overrides[i] if overrides else None),
+            width=w, preload=preloads[i] if preloads else None))
 
 
 def _register_chapter_map(maps_dir, layout, comment):
@@ -3596,19 +3635,64 @@ def _retarget_host_chapter(host_index, goal_slot, goal_type, goal_err, indices,
     return host
 
 
-def _ally_unit_entry(leader, slot, class_enum, level, x, y, items, comment):
-    """One ally UnitDefinition row (events_udefs.c) for a chapter join/deploy table."""
+def _classed_cast(campaign):
+    """The classed cast in PORTRAIT_MAP order: (unit_id, slot, class_enum,
+    deploy_class_enum, level) per unit, plus a parallel display-name list.
+    Units with no class mapping (non-combat NPCs) are skipped."""
+    cast, names = [], []
+    for unit_id, slot in PORTRAIT_MAP.items():
+        unit = load_unit(campaign, unit_id)
+        unit.setdefault('id', unit_id)
+        class_enum = class_enum_for(unit)
+        if class_enum is None:
+            continue
+        cast.append((unit_id, slot, class_enum, deploy_class_for(unit),
+                     int(unit.get('fe_stats', {}).get('level', 1))))
+        names.append(display_name(unit))
+    return cast, names
+
+
+def _ally_unit_entry(leader, slot, class_enum, level, x, y, items, comment,
+                     allegiance='BLUE', autolevel=False, ai=None):
+    """One non-RED UnitDefinition row (events_udefs.c) for a chapter join/deploy/
+    green-ally table. leader=None omits the leaderCharIndex field; autolevel/ai
+    toggle their optional lines (GREEN allies use all three)."""
     return ('    {\n'
             '        .charIndex = CHARACTER_%s,%s\n'
             '        .classIndex = %s,\n'
-            '        .leaderCharIndex = %s,\n'
-            '        .allegiance = FACTION_ID_BLUE,\n'
+            '%s'
+            '%s'
+            '        .allegiance = FACTION_ID_%s,\n'
             '        .level = %d,\n'
             '        .xPosition = %d,\n'
             '        .yPosition = %d,\n'
             '        .redaCount = 0,\n'
             '        .items = { %s },\n'
-            '    },' % (slot.upper(), comment, class_enum, leader, level, x, y, items))
+            '%s'
+            '    },' % (slot.upper(), comment, class_enum,
+                       '        .leaderCharIndex = %s,\n' % leader if leader else '',
+                       '        .autolevel = 1,\n' if autolevel else '',
+                       allegiance, level, x, y, items,
+                       '        .ai = %s,\n' % ai if ai else ''))
+
+
+def _deploy_cap_entries(chap, cast, leader, label):
+    """The ally deploy "cap template" rows from the chapter's `deployment:` block
+    (#107 schema): never LOADed -- the prep flow reads the table's entry count as
+    the field cap and its coords as the deploy tiles. classIndex rides the DEPLOY
+    class (the Archer-clone for RBG, #65), like the actual fielded units."""
+    dep = chap.get('deployment') or {}
+    slots, limit = dep.get('deploy_slots'), dep.get('deploy_limit')
+    if not slots or len(slots) != limit:
+        sys.exit('ERROR: %s deployment.deploy_slots (%s) != deploy_limit (%s)'
+                 % (label, len(slots or []), limit))
+    if len(cast) < limit:
+        sys.exit('ERROR: %d classed cast < %s deploy_limit %d'
+                 % (len(cast), label, limit))
+    return [_ally_unit_entry(leader, slot, dce, lv, x, y, '0',
+                             ' /* deploy slot %d (cap template, never LOADed) */' % i)
+            for i, ((uid, slot, ce, dce, lv), (x, y))
+            in enumerate(zip(cast[:limit], slots))]
 
 
 def _enemy_unit_entry(char, class_enum, level, autolevel, x, y, items, ai, comment,
@@ -3690,19 +3774,13 @@ def inject_ch01(campaign, verbose=True):
     #    instead of empty air, and the haggle puts Hruna across from RBG. Hlin's final
     #    "who leads?" line stays in the scene (end of beat E, at the Northlook); the
     #    lord-select menu then plays over its own scenic BG (not the battle map).
-    b1_script = next(e for e in chap['events']
-                     if e['trigger'] == 'chapter_start')['script']
-    b1_card, b1_beats = _split_script_beats(b1_script)
-    if len(b1_beats) != len(CH01_BEAT1_MSGS):
-        sys.exit('ERROR: ch01 Beat 1 split into %d beats; expected %d (check '
-                 'beat_break markers in the YAML)' % (len(b1_beats), len(CH01_BEAT1_MSGS)))
+    b1_card, b1_beats = _split_event_beats(chap, 'chapter_start', 'ch01 Beat 1')
+    _require_beat_count(b1_beats, CH01_BEAT1_MSGS, 'ch01 Beat 1')
 
     b1_guests = {'hlin': _fid_tag(PROLOGUE_HLIN_SLOT),
                  'scramsax': _fid_tag(PROLOGUE_SCRAMSAX_SLOT),
                  'hruna': _fid_tag('VILLAGER_WOMAN')}
-
-    def b1_fid(spk):
-        return _cutscene_fid(spk, b1_guests, 'ch01 Beat 1 unknown speaker')
+    b1_fid = _make_fid(b1_guests, 'ch01 Beat 1 unknown speaker')
     # Podium geometry (gTalkFaceHPosLut, scene.c, px = x*8; faces are 96px = 12 tiles):
     # FarLeft 24 | MidLeft 48 | Left 72 | Right 168 | MidRight 192 | FarRight 216.
     # Two faces only avoid overlap when >=96px apart, so the clean "two-shot" is
@@ -3737,18 +3815,13 @@ def inject_ch01(campaign, verbose=True):
     #     budget resets per beat. Duvessa (the host, Speaker of Bryn Shander) anchors the
     #     mid-right podium throughout; the party speaks from mid-left, with the other beat
     #     speaker(s) staged as clean two-shots opposite her (cf. Beat 1 podium geometry).
-    end_script = next(e for e in chap['events']
-                      if e['trigger'] == 'chapter_end')['script']
-    end_card, end_beats = _split_script_beats(end_script)
-    if len(end_beats) != len(CH01_ENDING_MSGS):
-        sys.exit('ERROR: ch01 ending split into %d beats; expected %d (check '
-                 'beat_break markers in the YAML)' % (len(end_beats), len(CH01_ENDING_MSGS)))
+    end_card, end_beats = _split_event_beats(chap, 'chapter_end', 'ch01 ending')
+    _require_beat_count(end_beats, CH01_ENDING_MSGS, 'ch01 ending')
 
-    def end_fid(spk):
-        # narration = faceless stage-business box (no portrait); the fallback covers
-        # the duvessa/hruna/baxby cutscene faces (GUEST_PORTRAIT_MAP).
-        return _cutscene_fid(spk, {'narration': None}, 'ch01 ending unknown speaker',
-                             fallback=GUEST_PORTRAIT_MAP)
+    # narration = faceless stage-business box (no portrait); the fallback covers
+    # the duvessa/hruna/baxby cutscene faces (GUEST_PORTRAIT_MAP).
+    end_fid = _make_fid({'narration': None}, 'ch01 ending unknown speaker',
+                        fallback=GUEST_PORTRAIT_MAP)
     # Duvessa hosts from mid-right (like Hlin in Beat 1); everyone else defaults mid-left.
     # Per-beat overrides put the OTHER speaker opposite her for a clean two-shot: Hruna
     # (C) and Meesmickle (D) take mid-right; in E, Baxby takes mid-right -- evicting
@@ -3790,19 +3863,11 @@ def inject_ch01(campaign, verbose=True):
     #      Northlook; the engine benches everyone past the cap).
     #    - UnitDef_088B4344: the 7 initial goblins. UnitDef_088B44AC: the 3 west
     #      reinforcements (turn 3).
-    cast = []
-    cast_names = []  # parallel to cast: lord-select menu/confirm display names (#42)
-    for unit_id, slot in PORTRAIT_MAP.items():
-        unit = load_unit(campaign, unit_id)
-        unit.setdefault('id', unit_id)
-        class_enum = class_enum_for(unit)
-        if class_enum is None:
-            continue
+    # cast_names is parallel to cast: lord-select menu/confirm display names (#42)
+    cast, cast_names = _classed_cast(campaign)
+    for unit_id, _, class_enum, _, _ in cast:
         if class_enum not in CLASS_LOADOUT:
             sys.exit('ERROR: no loadout for %s (unit %s)' % (class_enum, unit_id))
-        cast.append((unit_id, slot, class_enum, deploy_class_for(unit),
-                     int(unit.get('fe_stats', {}).get('level', 1))))
-        cast_names.append(display_name(unit))
     if len(cast) > len(LORDSEL_CONFIRM_MSGS):
         sys.exit('ERROR: %d lord candidates > %d reserved confirm text ids'
                  % (len(cast), len(LORDSEL_CONFIRM_MSGS)))
@@ -3816,13 +3881,7 @@ def inject_ch01(campaign, verbose=True):
     join = [_ally_unit_entry(leader, slot, dce, lv, x, y,
                              ', '.join(CLASS_LOADOUT[ce]), ' /* %s */' % uid)
             for (uid, slot, ce, dce, lv), (x, y) in zip(cast, CH01_JOIN_POSITIONS)]
-    deploy = [_ally_unit_entry(leader, slot, dce, lv, x, y, '0',
-                               ' /* deploy slot %d (cap template, never LOADed) */' % i)
-              for i, ((uid, slot, ce, dce, lv), (x, y))
-              in enumerate(zip(cast[:len(chap['deploy_slots'])], chap['deploy_slots']))]
-    if len(deploy) != chap['deploy_limit']:
-        sys.exit('ERROR: deploy_slots (%d) != deploy_limit (%d) in ch01 YAML'
-                 % (len(deploy), chap['deploy_limit']))
+    deploy = _deploy_cap_entries(chap, cast, leader, 'ch01')
 
     by_eid = {e['id']: e for e in chap['enemy_units']}
     spear, axe = by_eid['goblin-spear'], by_eid['goblin-axe']
@@ -4314,23 +4373,15 @@ def inject_ch01(campaign, verbose=True):
     # placeholder line -- DEV_PLACEHOLDER_MSG; the ingot recovery is told in beat A.)
     set_message_body(lines, DEV_PLACEHOLDER_MSG, dev_placeholder_message())
     set_message_body(lines, CH01_ENDING_CARD_MSG, name_message_body(end_card))
-    for i, (msg_id, beat) in enumerate(zip(CH01_ENDING_MSGS, end_beats)):
-        # Faceless-narration beats ride the opaque, auto-centered SOLOTEXTBOXSTART box
-        # (#58): wrap at the on-map width so the centered box fits the 240px screen (42
-        # overflows it); faced beats use the full-screen scenic wrap.
-        w = 28 if _beat_is_narration(beat) else 42
-        set_message_body(lines, msg_id, _script_to_message(
-            beat, _stage_beat(beat, end_fid, end_home, end_overrides[i]),
-            width=w, preload=end_preload[i]))
+    _emit_scene_beats(lines, CH01_ENDING_MSGS, end_beats, end_fid, end_home,
+                      end_overrides, end_preload)
     # Beat 1 (#21): the Northlook opening. Card + one message per beat (A-E), rendered
     # from the chapter YAML's locked script with the scenic full-screen wrap width and
     # the per-beat two-sided staging + silent listeners built in step 0. Each beat rides
     # its own Text()/REMA, so the 4-face budget resets per beat.
     set_message_body(lines, CH01_BEAT1_CARD_MSG, name_message_body(b1_card))
-    for i, (msg_id, beat) in enumerate(zip(CH01_BEAT1_MSGS, b1_beats)):
-        set_message_body(lines, msg_id, _script_to_message(
-            beat, _stage_beat(beat, b1_fid, b1_home, b1_overrides[i]),
-            width=42, preload=b1_preload[i]))
+    _emit_scene_beats(lines, CH01_BEAT1_MSGS, b1_beats, b1_fid, b1_home,
+                      b1_overrides, b1_preload, width=42)
     # Lord select (#42): Hlin's "who leads?" already lands in beat E (at the Northlook),
     # so the menu opens directly over its scenic BG -- no separate prompt. Per-candidate
     # confirm texts keep the vanilla route-split shape (cf. MSG_C14/C17/C18) incl. the
@@ -4487,22 +4538,16 @@ def inject_ch02(campaign, verbose=True):
     chap = _load_chapter_yaml(campaign, CH02_CHAPTER_YAML)
 
     # 0. Cutscene beat splits, consumed from the locked chapter YAML (cf. inject_ch01).
-    def split_beats(trigger):
-        scr = next(e for e in chap['events'] if e.get('trigger') == trigger)['script']
-        return _split_script_beats(scr, card_required=False)
-
-    op_card, op_beats = split_beats('chapter_start')
-    end_card, end_beats = split_beats('chapter_end')
+    op_card, op_beats = _split_event_beats(chap, 'chapter_start', 'ch02 opening',
+                                           card_required=False)
+    end_card, end_beats = _split_event_beats(chap, 'chapter_end', 'ch02 ending',
+                                             card_required=False)
     bark = next(e for e in chap['events']
                 if e.get('trigger') == 'turn_start' and e.get('turn') == 3)['script']
     tutorial = next(e for e in chap['events']
                     if e.get('trigger') == 'turn_start' and e.get('turn') == 1)['script']
-    if len(op_beats) != len(CH02_OPENING_MSGS):
-        sys.exit('ERROR: ch02 opening split into %d beats; expected %d (check '
-                 'beat_break markers)' % (len(op_beats), len(CH02_OPENING_MSGS)))
-    if len(end_beats) != len(CH02_ENDING_MSGS):
-        sys.exit('ERROR: ch02 ending split into %d beats; expected %d (check '
-                 'beat_break markers)' % (len(end_beats), len(CH02_ENDING_MSGS)))
+    _require_beat_count(op_beats, CH02_OPENING_MSGS, 'ch02 opening')
+    _require_beat_count(end_beats, CH02_ENDING_MSGS, 'ch02 ending')
     if len(tutorial) != len(CH02_TUTORIAL_MSGS):
         sys.exit('ERROR: ch02 turn-1 tutorial has %d lines; expected %d '
                  '(zip would silently drop the extra)' % (len(tutorial), len(CH02_TUTORIAL_MSGS)))
@@ -4513,8 +4558,7 @@ def inject_ch02(campaign, verbose=True):
         'targos-fisher': CH02_FISHER_FID,          # generic villager mug
     }
 
-    def cut_fid(spk):
-        return _cutscene_fid(spk, cut_special, 'ch02 unknown cutscene speaker')
+    cut_fid = _make_fid(cut_special, 'ch02 unknown cutscene speaker')
 
     # Vellynne anchors mid-right (the quest-giver, cf. Hlin/Duvessa); everyone else
     # speaks from mid-left. The ending beats are single-speaker each, so mid-left is
@@ -4544,43 +4588,9 @@ def inject_ch02(campaign, verbose=True):
     #      was vanilla Colm's green table). Distinct NPC slots so CHECK_ALIVE tracks each.
     #    - UnitDef_088B4758: the turn-3 RED reinforcement pair (the empty vanilla table;
     #      088B4718 is now the chwinga). Vanilla 088B4470 mix = one L2 + one L3 brigand.
-    cast = []
-    for unit_id, slot in PORTRAIT_MAP.items():
-        unit = load_unit(campaign, unit_id)
-        unit.setdefault('id', unit_id)
-        class_enum = class_enum_for(unit)
-        if class_enum is None:
-            continue
-        cast.append((unit_id, slot, class_enum,
-                     int(unit.get('fe_stats', {}).get('level', 1))))
-    if len(cast) < chap['deploy_limit']:
-        sys.exit('ERROR: %d classed cast < ch02 deploy_limit %d'
-                 % (len(cast), chap['deploy_limit']))
+    cast, _ = _classed_cast(campaign)
     leader = 'CHARACTER_%s' % cast[0][1].upper()
-
-    deploy_slots = chap['deploy_slots']
-    if len(deploy_slots) != chap['deploy_limit']:
-        sys.exit('ERROR: ch02 deploy_slots (%d) != deploy_limit (%d)'
-                 % (len(deploy_slots), chap['deploy_limit']))
-    deploy = [_ally_unit_entry(leader, slot, ce, lv, x, y, '0',
-                               ' /* deploy slot %d (cap template, never LOADed) */' % i)
-              for i, ((uid, slot, ce, lv), (x, y))
-              in enumerate(zip(cast[:chap['deploy_limit']], deploy_slots))]
-
-    def green_entry(slot, level, x, y, items, ai, comment):
-        return ('    {\n'
-                '        .charIndex = CHARACTER_%s,%s\n'
-                '        .classIndex = %s,\n'
-                '        .autolevel = 1,\n'          # lean on the pegasus class curve (bases = tuning checkpoint)
-                '        .allegiance = FACTION_ID_GREEN,\n'
-                '        .level = %d,\n'
-                '        .xPosition = %d,\n'
-                '        .yPosition = %d,\n'
-                '        .redaCount = 0,\n'
-                '        .items = { %s },\n'
-                '        .ai = %s,\n'
-                '    },' % (slot.upper(), comment, CH02_CLASS_IDS['pegasus_knight'],
-                           level, x, y, items, ai))
+    deploy = _deploy_cap_entries(chap, cast, leader, 'ch02')
 
     by_eid = {e['id']: e for e in chap['enemy_units']}
     raider = by_eid['chardalyn-raider']            # 2x L3 generic brigand (vanilla #1 + #5)
@@ -4628,10 +4638,15 @@ def inject_ch02(campaign, verbose=True):
 
     # 2b. GREEN chwinga (088B4718) -- the protect layer; positions + per-survivor gift
     #     come from the YAML deployment.green_allies (id order matches CH02_CHWINGA).
+    #     autolevel leans on the pegasus class curve (bases = tuning checkpoint).
     chwinga_by_id = {g['id']: g for g in chap['deployment']['green_allies']}
-    chwinga = [green_entry(slot, chwinga_by_id[uid]['level'],
-                           chwinga_by_id[uid]['position'][0], chwinga_by_id[uid]['position'][1],
-                           lance, CH02_AI['cautious'], ' /* chwinga %s (%s) */' % (uid, gift))
+    chwinga = [_ally_unit_entry(None, slot, CH02_CLASS_IDS['pegasus_knight'],
+                                chwinga_by_id[uid]['level'],
+                                chwinga_by_id[uid]['position'][0],
+                                chwinga_by_id[uid]['position'][1],
+                                lance, ' /* chwinga %s (%s) */' % (uid, gift),
+                                allegiance='GREEN', autolevel=True,
+                                ai=CH02_AI['cautious'])
                for uid, slot, gift in CH02_CHWINGA]
 
     # 2c. RED reinforcements (088B4758) -- vanilla 088B4470 mix: one L2 + one L3, turn 3.
@@ -4785,10 +4800,7 @@ def inject_ch02(campaign, verbose=True):
     set_message_body(lines, host['goal']['windowTextId'],
                      name_message_body('Rout the enemy'))
     set_message_body(lines, CH02_OPENING_CARD_MSG, name_message_body(op_card))
-    for msg_id, beat in zip(CH02_OPENING_MSGS, op_beats):
-        w = 28 if _beat_is_narration(beat) else 42
-        set_message_body(lines, msg_id, _script_to_message(
-            beat, _stage_beat(beat, cut_fid, op_home), width=w))
+    _emit_scene_beats(lines, CH02_OPENING_MSGS, op_beats, cut_fid, op_home)
     # Turn-1 fliers-vs-bows tutorial: one portrait box per line (RBG, then Pinky), Text_BG 42-wrap.
     for msg_id, ln in zip(CH02_TUTORIAL_MSGS, tutorial):
         set_message_body(lines, msg_id, _script_to_message(
@@ -4799,10 +4811,7 @@ def inject_ch02(campaign, verbose=True):
         bark, {'wolfram': ('[OpenMidLeft]', _fid_tag(PORTRAIT_MAP['wolfram'].upper()))},
         width=29))
     set_message_body(lines, CH02_ENDING_CARD_MSG, name_message_body(end_card))
-    for msg_id, beat in zip(CH02_ENDING_MSGS, end_beats):
-        w = 28 if _beat_is_narration(beat) else 42
-        set_message_body(lines, msg_id, _script_to_message(
-            beat, _stage_beat(beat, cut_fid, {}), width=w))
+    _emit_scene_beats(lines, CH02_ENDING_MSGS, end_beats, cut_fid, {})
     set_message_body(lines, CH02_BOSS_DEATH_MSG, _script_to_message(
         [{'halvar': halvar['death_quote']}],
         {'halvar': ('[OpenMidRight]', _fid_tag(CH02_BOSS_SLOT))}, width=29))

--- a/tools/check.py
+++ b/tools/check.py
@@ -91,14 +91,7 @@ def check_chapter_status(fail):
     with grounded combat data. Invariant: a `planned` chapter must NOT be `balance_locked: true`
     -- you cannot lock the parity of a chapter whose enemies are an ungrounded sketch (that
     half-state is exactly what makes the difficulty curve and readers treat a seed as truth)."""
-    import yaml
-    for f in sorted(glob.glob(os.path.join(
-            REPO, 'campaigns/*/chapters/ch*.yaml'))):
-        rel = os.path.relpath(f, REPO)
-        try:
-            d = yaml.safe_load(open(f, encoding='utf-8')) or {}
-        except Exception:
-            continue                       # parse errors are check_yaml_parses' job
+    for rel, d in _chapters():
         status = d.get('status')
         if status not in ('active', 'planned'):
             fail.append('%s: missing/invalid `status` (must be active|planned, got %r)'
@@ -108,12 +101,52 @@ def check_chapter_status(fail):
                         'chapter is an ungrounded seed; ground it and flip to active first' % rel)
 
 
+def _chapters():
+    """Yield (relpath, parsed_dict) for every chapter YAML. THE chapter iterator --
+    per-chapter gates consume this so the glob + parse-error policy (parse errors
+    are check_yaml_parses' job) lives in one place."""
+    import yaml
+    for f in sorted(glob.glob(os.path.join(REPO, 'campaigns/*/chapters/ch*.yaml'))):
+        try:
+            d = yaml.safe_load(open(f, encoding='utf-8')) or {}
+        except Exception:
+            continue
+        yield os.path.relpath(f, REPO), d
+
+
+def _int_pair(v):
+    """True for a [col, row] coordinate pair of real ints (bool is an int subtype
+    but a YAML `yes` is never a coordinate)."""
+    return (isinstance(v, list) and len(v) == 2
+            and all(isinstance(c, int) and not isinstance(c, bool) for c in v))
+
+
+def _unit_entry_violations(rel, kind, entries):
+    """Entries of a roster list (player_units / green_allies) must be mappings
+    carrying what the injectors index: id/class/level/position ([col, row])."""
+    msgs = []
+    for g in entries or []:
+        if not isinstance(g, dict):
+            msgs.append('%s: %s entry %r must be a mapping (id/class/level/'
+                        'position ...)' % (rel, kind, g))
+            continue
+        missing = [k for k in ('id', 'class', 'level', 'position') if k not in g]
+        if missing:
+            msgs.append('%s: %s entry %r missing %s'
+                        % (rel, kind, g.get('id', '?'), ', '.join(missing)))
+        elif not _int_pair(g['position']):
+            msgs.append('%s: %s entry %r position must be a [col, row] int pair '
+                        '(got %r)' % (rel, kind, g['id'], g['position']))
+    return msgs
+
+
 def _chapter_deployment_violations(rel, d):
     """Schema violations for one parsed chapter YAML (pure; unit-tested in
     test_check_chapter_schema.py). The normalized shape (#107, audit 2.2): ALL
     deployment data lives under the `deployment:` block (deploy_limit,
-    deploy_slots, note, green_allies); `player_units:` is the one alternative
-    (a fixed-roster chapter with no prep screen, i.e. the prologue)."""
+    deploy_slots, note, green_allies); `player_units:` is the one alternative,
+    reserved for a fixed-roster chapter with no prep screen (`is_prologue: true`
+    gates it structurally, not by convention)."""
     msgs = []
     for legacy in ('deploy_limit', 'deploy_slots'):
         if legacy in d:
@@ -124,6 +157,12 @@ def _chapter_deployment_violations(rel, d):
         msgs.append('%s: a chapter expresses its roster as EITHER `player_units:` '
                     '(fixed roster, no prep screen) OR a `deployment:` block -- '
                     'found %s' % (rel, 'both' if has_pu else 'neither'))
+    if has_pu:
+        if not d.get('is_prologue'):
+            msgs.append('%s: `player_units:` is the fixed-roster prologue shape -- '
+                        'a prep-screen chapter takes a `deployment:` block '
+                        '(is_prologue: true gates the exception)' % rel)
+        msgs.extend(_unit_entry_violations(rel, 'player_units', d['player_units']))
     if not has_dep:
         return msgs
     dep = d.get('deployment')
@@ -131,18 +170,23 @@ def _chapter_deployment_violations(rel, d):
         msgs.append('%s: `deployment:` must be a mapping' % rel)
         return msgs
     limit = dep.get('deploy_limit')
-    if limit is not None and (not isinstance(limit, int) or limit <= 0):
+    limit_ok = isinstance(limit, int) and not isinstance(limit, bool) and limit > 0
+    if limit is not None and not limit_ok:
         msgs.append('%s: deployment.deploy_limit must be a positive int (got %r)'
                     % (rel, limit))
-        limit = None
     slots = dep.get('deploy_slots')
+    if slots is not None and not isinstance(slots, list):
+        msgs.append('%s: deployment.deploy_slots must be a list of [col, row] '
+                    'pairs (got %r)' % (rel, slots))
+        slots = None
     if slots is not None:
-        bad = [s for s in slots if not (isinstance(s, list) and len(s) == 2
-                                        and all(isinstance(c, int) for c in s))]
+        bad = [s for s in slots if not _int_pair(s)]
         if bad:
             msgs.append('%s: deployment.deploy_slots entries must be [col, row] '
                         'int pairs (first bad: %r)' % (rel, bad[0]))
-        if len(slots) != limit:
+        # One typo shouldn't cascade: the match rule only fires when the limit
+        # itself parsed clean (missing limit still counts as a mismatch).
+        if (limit is None or limit_ok) and len(slots) != limit:
             msgs.append('%s: deployment.deploy_slots (%d) must match '
                         'deployment.deploy_limit (%r) -- the slot list IS the cap '
                         'template' % (rel, len(slots), limit))
@@ -150,11 +194,8 @@ def _chapter_deployment_violations(rel, d):
         msgs.append('%s: an active chapter with a `deployment:` block needs a '
                     'machine-readable deployment.deploy_limit (prose notes are for '
                     'planned seeds)' % rel)
-    for g in dep.get('green_allies') or []:
-        missing = [k for k in ('id', 'class', 'level', 'position') if k not in g]
-        if missing:
-            msgs.append('%s: deployment.green_allies entry %r missing %s'
-                        % (rel, g.get('id', '?'), ', '.join(missing)))
+    msgs.extend(_unit_entry_violations(rel, 'deployment.green_allies',
+                                       dep.get('green_allies')))
     return msgs
 
 
@@ -163,13 +204,7 @@ def check_chapter_deployment_schema(fail):
     where no two chapters expressed their roster the same way (four shapes across
     9 files). The injectors and difficulty.py read ONE shape; this gate keeps new
     chapters on it."""
-    import yaml
-    for f in sorted(glob.glob(os.path.join(REPO, 'campaigns/*/chapters/ch*.yaml'))):
-        rel = os.path.relpath(f, REPO)
-        try:
-            d = yaml.safe_load(open(f, encoding='utf-8')) or {}
-        except Exception:
-            continue                       # parse errors are check_yaml_parses' job
+    for rel, d in _chapters():
         fail.extend(_chapter_deployment_violations(rel, d))
 
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -108,6 +108,71 @@ def check_chapter_status(fail):
                         'chapter is an ungrounded seed; ground it and flip to active first' % rel)
 
 
+def _chapter_deployment_violations(rel, d):
+    """Schema violations for one parsed chapter YAML (pure; unit-tested in
+    test_check_chapter_schema.py). The normalized shape (#107, audit 2.2): ALL
+    deployment data lives under the `deployment:` block (deploy_limit,
+    deploy_slots, note, green_allies); `player_units:` is the one alternative
+    (a fixed-roster chapter with no prep screen, i.e. the prologue)."""
+    msgs = []
+    for legacy in ('deploy_limit', 'deploy_slots'):
+        if legacy in d:
+            msgs.append('%s: top-level `%s` -- deployment data lives under the '
+                        '`deployment:` block (#107 normalized schema)' % (rel, legacy))
+    has_pu, has_dep = 'player_units' in d, 'deployment' in d
+    if has_pu == has_dep:
+        msgs.append('%s: a chapter expresses its roster as EITHER `player_units:` '
+                    '(fixed roster, no prep screen) OR a `deployment:` block -- '
+                    'found %s' % (rel, 'both' if has_pu else 'neither'))
+    if not has_dep:
+        return msgs
+    dep = d.get('deployment')
+    if not isinstance(dep, dict):
+        msgs.append('%s: `deployment:` must be a mapping' % rel)
+        return msgs
+    limit = dep.get('deploy_limit')
+    if limit is not None and (not isinstance(limit, int) or limit <= 0):
+        msgs.append('%s: deployment.deploy_limit must be a positive int (got %r)'
+                    % (rel, limit))
+        limit = None
+    slots = dep.get('deploy_slots')
+    if slots is not None:
+        bad = [s for s in slots if not (isinstance(s, list) and len(s) == 2
+                                        and all(isinstance(c, int) for c in s))]
+        if bad:
+            msgs.append('%s: deployment.deploy_slots entries must be [col, row] '
+                        'int pairs (first bad: %r)' % (rel, bad[0]))
+        if len(slots) != limit:
+            msgs.append('%s: deployment.deploy_slots (%d) must match '
+                        'deployment.deploy_limit (%r) -- the slot list IS the cap '
+                        'template' % (rel, len(slots), limit))
+    if d.get('status') == 'active' and limit is None:
+        msgs.append('%s: an active chapter with a `deployment:` block needs a '
+                    'machine-readable deployment.deploy_limit (prose notes are for '
+                    'planned seeds)' % rel)
+    for g in dep.get('green_allies') or []:
+        missing = [k for k in ('id', 'class', 'level', 'position') if k not in g]
+        if missing:
+            msgs.append('%s: deployment.green_allies entry %r missing %s'
+                        % (rel, g.get('id', '?'), ', '.join(missing)))
+    return msgs
+
+
+def check_chapter_deployment_schema(fail):
+    """The normalized chapter deployment schema (#107): kills the audit-2.2 drift
+    where no two chapters expressed their roster the same way (four shapes across
+    9 files). The injectors and difficulty.py read ONE shape; this gate keeps new
+    chapters on it."""
+    import yaml
+    for f in sorted(glob.glob(os.path.join(REPO, 'campaigns/*/chapters/ch*.yaml'))):
+        rel = os.path.relpath(f, REPO)
+        try:
+            d = yaml.safe_load(open(f, encoding='utf-8')) or {}
+        except Exception:
+            continue                       # parse errors are check_yaml_parses' job
+        fail.extend(_chapter_deployment_violations(rel, d))
+
+
 def check_tool_refs_exist(fail):
     pat = re.compile(r'tools/([\w-]+\.(?:py|rb))')
     for d in _docs():
@@ -419,7 +484,8 @@ def check_lane_ownership(fail):
 def main():
     fail = []
     for check in (check_python_compiles, check_tests_pass, check_yaml_parses,
-                  check_chapter_status, check_tool_refs_exist, check_no_dead_concepts,
+                  check_chapter_status, check_chapter_deployment_schema,
+                  check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
                   check_engine_campaign_agnostic,
                   check_save_layout_stable, check_lane_ownership):

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -548,8 +548,15 @@ def chapter_path(campaign, ch):
 def chapter_deploy_limit(chap, default):
     """The chapter's field cap from its `deployment:` block (#107 normalized schema);
     chapters without one (the fixed-roster prologue, prose-only seeds) fall back to
-    `default` (= whole roster)."""
-    return int((chap.get('deployment') or {}).get('deploy_limit', default))
+    `default` (= whole roster). The retired top-level shape is rejected loudly --
+    silently modeling a mis-placed cap as "whole roster" would bake wrong parity
+    numbers into a tuning session before the pre-commit gate ever runs."""
+    if 'deploy_limit' in chap or 'deploy_slots' in chap:
+        sys.exit('ERROR: %s: top-level deploy_limit/deploy_slots -- move under the '
+                 '`deployment:` block (#107 schema; check.py explains)'
+                 % chap.get('id', 'chapter'))
+    limit = (chap.get('deployment') or {}).get('deploy_limit')
+    return int(limit) if limit is not None else int(default)
 
 
 def load_field(campaign, ch):

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -545,6 +545,13 @@ def chapter_path(campaign, ch):
     return hits[0]
 
 
+def chapter_deploy_limit(chap, default):
+    """The chapter's field cap from its `deployment:` block (#107 normalized schema);
+    chapters without one (the fixed-roster prologue, prose-only seeds) fall back to
+    `default` (= whole roster)."""
+    return int((chap.get('deployment') or {}).get('deploy_limit', default))
+
+
 def load_field(campaign, ch):
     """Assemble (roster, line_enemies, bosses, deploy_limit, enemy_labels) for a chapter."""
     with open(chapter_path(campaign, ch), encoding='utf-8') as f:
@@ -558,7 +565,7 @@ def load_field(campaign, ch):
         labels.append('%dx %s (%s l%s)' % (count, ed.get('name', ed.get('id', '?')),
                                            kind, ed.get('level', 1)))
         (bosses if ed.get('is_boss') else line).extend(units)
-    return chap, roster, line, bosses, int(chap.get('deploy_limit', len(roster))), labels
+    return chap, roster, line, bosses, chapter_deploy_limit(chap, len(roster)), labels
 
 
 def _metrics(party, line, bosses):
@@ -663,7 +670,7 @@ def _chapter_pressure(chap, band=0.25):
     """Enemy-pressure parity for one loaded chapter dict: our force vs its parity_reference's
     vanilla force, threat/slot + clear-load/slot, with a verdict. `vanilla` is None when the
     reference isn't curated yet (#48 registry)."""
-    deploy_cap = int(chap.get('deploy_limit', len(ROSTER)))
+    deploy_cap = chapter_deploy_limit(chap, len(ROSTER))
     ours_force = chapter_enemy_force(chap)
     ours = enemy_pressure(ours_force, deploy_cap)
     ref = chap.get('parity_reference')

--- a/tools/test_check_chapter_schema.py
+++ b/tools/test_check_chapter_schema.py
@@ -7,17 +7,12 @@ pins the ONE normalized shape (`deployment:` block owns deploy_limit/deploy_slot
 green_allies; `player_units:` only for the fixed-roster prologue) so the shared injector
 machinery and difficulty.py can read a single access path.
 """
-import glob
 import os
 import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import check  # noqa: E402
-
-import yaml  # noqa: E402
-
-REPO = check.REPO
 
 
 def violations(d):
@@ -47,7 +42,9 @@ class TestNormalizedShapePasses(unittest.TestCase):
 
     def test_prologue_player_units(self):
         self.assertEqual(
-            violations({'status': 'active', 'player_units': [{'id': 'hlin'}]}), [])
+            violations({'status': 'active', 'is_prologue': True,
+                        'player_units': [{'id': 'hlin', 'class': 'fighter',
+                                          'level': 3, 'position': [8, 5]}]}), [])
 
     def test_green_allies_complete_entries(self):
         d = valid_active()
@@ -111,14 +108,64 @@ class TestDriftShapesFail(unittest.TestCase):
         self.assertTrue(any('green_allies' in m and 'class' in m for m in msgs))
 
 
+class TestMalformedYamlIsAViolationNotACrash(unittest.TestCase):
+    # A typo'd chapter must produce a per-file message, never a traceback that
+    # aborts check.py and skips every later gate.
+
+    def test_scalar_deploy_slots(self):
+        d = valid_active()
+        d['deployment']['deploy_slots'] = 5     # confused slots with the limit
+        self.assertTrue(any('must be a list' in m for m in violations(d)))
+
+    def test_string_green_ally_entry(self):
+        d = valid_active()
+        d['deployment']['green_allies'] = ['chwinga-mote']   # bare id, no mapping
+        self.assertTrue(any('must be a mapping' in m for m in violations(d)))
+
+    def test_boolean_deploy_limit_rejected(self):
+        # YAML `deploy_limit: yes` parses to True; isinstance(True, int) is True,
+        # so an explicit bool exclusion keeps a typo from becoming a cap of 1.
+        d = valid_active()
+        d['deployment']['deploy_limit'] = True
+        d['deployment']['deploy_slots'] = [[3, 8]]
+        self.assertTrue(any('positive int' in m for m in violations(d)))
+
+    def test_green_ally_position_shape_checked(self):
+        # inject_ch02 indexes position[0]/position[1]; the gate must reject what
+        # the consumer would crash on.
+        d = valid_active()
+        d['deployment']['green_allies'] = [{'id': 'chwinga-mote',
+                                            'class': 'pegasus_knight',
+                                            'level': 1, 'position': 7}]
+        self.assertTrue(any('position' in m and '[col, row]' in m
+                            for m in violations(d)))
+
+    def test_one_bad_limit_does_not_cascade(self):
+        # A single typo'd limit reports ONCE; the slots-match and
+        # machine-readable rules stay quiet (same root cause).
+        d = valid_active()
+        d['deployment']['deploy_limit'] = 'five'
+        msgs = violations(d)
+        self.assertEqual(len(msgs), 1, msgs)
+        self.assertIn('positive int', msgs[0])
+
+    def test_player_units_requires_is_prologue(self):
+        # The fixed-roster escape hatch is tied to is_prologue structurally --
+        # a prep-screen chapter can't dodge deployment validation by switching
+        # roster shapes.
+        d = {'status': 'active',
+             'player_units': [{'id': 'x', 'class': 'fighter', 'level': 1,
+                               'position': [1, 1]}]}
+        self.assertTrue(any('is_prologue' in m for m in violations(d)))
+
+
 class TestRealChapters(unittest.TestCase):
     def test_all_repo_chapters_pass(self):
-        for f in sorted(glob.glob(os.path.join(
-                REPO, 'campaigns/*/chapters/ch*.yaml'))):
-            with open(f, encoding='utf-8') as fh:
-                d = yaml.safe_load(fh) or {}
-            self.assertEqual(
-                check._chapter_deployment_violations(os.path.relpath(f, REPO), d), [])
+        # Exercise the PUBLIC gate exactly as CI runs it (glob + parse policy
+        # included), not a hand-rolled copy of its loop.
+        fail = []
+        check.check_chapter_deployment_schema(fail)
+        self.assertEqual(fail, [])
 
 
 if __name__ == '__main__':

--- a/tools/test_check_chapter_schema.py
+++ b/tools/test_check_chapter_schema.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for the chapter deployment-schema gate in check.py (#107).
+
+The 2026-07-02 audit (2.2) found four incompatible roster shapes across the 9 chapter
+YAMLs -- invisible only because each built chapter had a hand-written injector. The gate
+pins the ONE normalized shape (`deployment:` block owns deploy_limit/deploy_slots/note/
+green_allies; `player_units:` only for the fixed-roster prologue) so the shared injector
+machinery and difficulty.py can read a single access path.
+"""
+import glob
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check  # noqa: E402
+
+import yaml  # noqa: E402
+
+REPO = check.REPO
+
+
+def violations(d):
+    return check._chapter_deployment_violations('chNN.yaml', d)
+
+
+def valid_active():
+    """A minimal active chapter in the normalized shape."""
+    return {
+        'status': 'active',
+        'deployment': {
+            'deploy_limit': 2,
+            'deploy_slots': [[3, 8], [3, 9]],
+        },
+    }
+
+
+class TestNormalizedShapePasses(unittest.TestCase):
+    def test_active_with_limit_and_slots(self):
+        self.assertEqual(violations(valid_active()), [])
+
+    def test_planned_prose_only_deployment(self):
+        # ch04-ch08 seeds: a deployment block with only a prose note is fine
+        # while status is planned.
+        self.assertEqual(
+            violations({'status': 'planned', 'deployment': {'note': 'cap TBD'}}), [])
+
+    def test_prologue_player_units(self):
+        self.assertEqual(
+            violations({'status': 'active', 'player_units': [{'id': 'hlin'}]}), [])
+
+    def test_green_allies_complete_entries(self):
+        d = valid_active()
+        d['deployment']['green_allies'] = [{
+            'id': 'chwinga-mote', 'class': 'pegasus_knight',
+            'level': 1, 'position': [3, 4],
+        }]
+        self.assertEqual(violations(d), [])
+
+
+class TestDriftShapesFail(unittest.TestCase):
+    def test_top_level_deploy_limit_rejected(self):
+        d = valid_active()
+        d['deploy_limit'] = 4                       # the old ch01 shape
+        self.assertTrue(any('top-level `deploy_limit`' in m for m in violations(d)))
+
+    def test_top_level_deploy_slots_rejected(self):
+        d = valid_active()
+        d['deploy_slots'] = [[1, 1]]                # the old ch01/ch02 shape
+        self.assertTrue(any('top-level `deploy_slots`' in m for m in violations(d)))
+
+    def test_both_roster_shapes_rejected(self):
+        d = valid_active()
+        d['player_units'] = [{'id': 'x'}]
+        self.assertTrue(any('EITHER' in m for m in violations(d)))
+
+    def test_neither_roster_shape_rejected(self):
+        self.assertTrue(any('EITHER' in m
+                            for m in violations({'status': 'planned'})))
+
+    def test_slots_must_match_limit(self):
+        d = valid_active()
+        d['deployment']['deploy_slots'].append([2, 8])   # 3 slots, limit 2
+        self.assertTrue(any('must match' in m for m in violations(d)))
+
+    def test_slots_without_limit_fail_the_match(self):
+        d = {'status': 'planned',
+             'deployment': {'deploy_slots': [[1, 1]]}}
+        self.assertTrue(any('must match' in m for m in violations(d)))
+
+    def test_malformed_slot_rejected(self):
+        d = valid_active()
+        d['deployment']['deploy_slots'] = [[3, 8], [3]]  # not a [col, row] pair
+        self.assertTrue(any('[col, row]' in m for m in violations(d)))
+
+    def test_active_needs_machine_readable_limit(self):
+        # An active chapter can't hide its cap in prose (the ch04-08 seed shape
+        # is only legal while planned).
+        d = {'status': 'active', 'deployment': {'note': 'fields 5'}}
+        self.assertTrue(any('machine-readable' in m for m in violations(d)))
+
+    def test_non_int_limit_rejected(self):
+        d = valid_active()
+        d['deployment']['deploy_limit'] = 'five'
+        self.assertTrue(any('positive int' in m for m in violations(d)))
+
+    def test_incomplete_green_ally_rejected(self):
+        d = valid_active()
+        d['deployment']['green_allies'] = [{'id': 'chwinga-mote', 'level': 1}]
+        msgs = violations(d)
+        self.assertTrue(any('green_allies' in m and 'class' in m for m in msgs))
+
+
+class TestRealChapters(unittest.TestCase):
+    def test_all_repo_chapters_pass(self):
+        for f in sorted(glob.glob(os.path.join(
+                REPO, 'campaigns/*/chapters/ch*.yaml'))):
+            with open(f, encoding='utf-8') as fh:
+                d = yaml.safe_load(fh) or {}
+            self.assertEqual(
+                check._chapter_deployment_violations(os.path.relpath(f, REPO), d), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #107. Completes the audit §2.1/§2.2 top recommendation ("do before Ch3's map build") beyond #105.

## What
- **One deployment shape:** everything lives in the `deployment:` block (`deploy_limit`, `deploy_slots`, `note`, `green_allies`); `player_units:` stays legal only for the fixed-roster prologue. ch01/ch02 YAML migrated (ch03–08 already point this way).
- **Schema gate:** `check.py check_chapter_deployment_schema` (CI + pre-commit) — rejects top-level `deploy_limit`/`deploy_slots`, enforces slots↔limit match, requires a machine-readable cap on `active` chapters, validates `green_allies` entries. 15 unit tests in `tools/test_check_chapter_schema.py`.
- **Consumers updated:** `inject_ch01`/`inject_ch02` and `difficulty.py` (`chapter_deploy_limit`) now read one access path.
- **Scaffolding hoist finished:** `_split_event_beats`, `_require_beat_count`, `_make_fid`, `_emit_scene_beats`, `_classed_cast`, `_deploy_cap_entries`; `_ally_unit_entry` parameterized over allegiance/autolevel/ai, retiring ch02's parallel `green_entry` copy. `inject_ch03` can now be thin.

## Verification
- Old-code vs new-code injection into a clean submodule against the same mock base ROM: **generated sources diff empty (byte-identical)** — tracked-file patch, untracked-file hashes, and injection logs all equal.
- Full Python test suite + `tools/check.py` drift guard green locally; CI runs the mock-ROM `make` + `verify_text` + difficulty gate.
- Dated ADR added to `docs/decisions.md` (follows the #104/#105 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR)_