### PR TITLE
feat(#110): mechanize the injection-ordering constraints (audit §2.6)

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -208,6 +208,65 @@ def check_chapter_deployment_schema(fail):
         fail.extend(_chapter_deployment_violations(rel, d))
 
 
+# ── Injection ordering (audit 2.6 / #110) ─────────────────────────────────────
+# The documented MUST-precede pairs in build_campaign.main(). These lived only in
+# comments ("MUST precede inject_prologue"); one reorder breaks the build at its
+# most expensive point. check_engine_guards_present pins presence; this pins order.
+INJECTION_ORDER = [
+    ('_inject_lord_select_engine', '_inject_lord_floor_engine',
+     'lord floor anchors on lord-select\'s LordSelect_GetPid'),
+    ('inject_map_sprites', 'inject_enemy_class_reskins',
+     'reskins consume the SMS ids map-sprite injection creates'),
+    ('inject_enemy_class_reskins', 'inject_ch01',
+     "ch01's goblin grunts ride the reskinned clone classes"),
+    ('inject_winter_tileset', 'inject_ch01',
+     'chapter maps register against the tileset asset-table labels'),
+    ('inject_winter_tileset', 'inject_prologue',
+     'the prologue map registers against the tileset asset-table labels'),
+    ('inject_ch01', 'inject_prologue',
+     'inject_prologue overwrites the slot-1 Seize goal template inject_ch01 copies'),
+]
+
+
+def _injection_call_sequence(text):
+    """First-call order of top-level steps in build_campaign.main(). Textual order
+    == execution order there (the only branch chooses BETWEEN later steps, never
+    hoists one earlier)."""
+    m = re.search(r'\ndef main\(\):.*', text, re.S)
+    if not m:
+        return []
+    names = re.findall(r'^\s+(?:engine_hooks\.)?(\w+)\(', m.group(0), re.M)
+    seen, order = set(), []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            order.append(n)
+    return order
+
+
+def _injection_order_violations(order):
+    msgs = []
+    pos = {n: i for i, n in enumerate(order)}
+    for before, after, why in INJECTION_ORDER:
+        missing = [n for n in (before, after) if n not in pos]
+        if missing:
+            msgs.append('injection-order constraint references unknown step(s) %s '
+                        '-- renamed/removed? update INJECTION_ORDER in check.py'
+                        % ', '.join(missing))
+        elif pos[before] > pos[after]:
+            msgs.append('build_campaign.main(): %s must run before %s -- %s'
+                        % (before, after, why))
+    return msgs
+
+
+def check_injection_order(fail):
+    """Injection steps run in a dependency order that used to live only in main()'s
+    comments (audit 2.6): pin the documented MUST-precede pairs."""
+    path = os.path.join(REPO, 'tools', 'build_campaign.py')
+    fail.extend(_injection_order_violations(
+        _injection_call_sequence(open(path, encoding='utf-8').read())))
+
+
 def check_tool_refs_exist(fail):
     pat = re.compile(r'tools/([\w-]+\.(?:py|rb))')
     for d in _docs():
@@ -520,6 +579,7 @@ def main():
     fail = []
     for check in (check_python_compiles, check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
+                  check_injection_order,
                   check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
                   check_engine_campaign_agnostic,

--- a/tools/test_check_inject_order.py
+++ b/tools/test_check_inject_order.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for the injection-ordering guard in check.py (audit 2.6 / #110).
+
+build_campaign.main() runs its injection steps in a dependency order that was
+documented only in comments ("inject_ch01 MUST precede inject_prologue", "lord
+floor after lord-select", ...). One reorder breaks the build at its most
+expensive point; the guard pins the documented MUST-precede pairs and screams
+if a constrained step is renamed away.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check  # noqa: E402
+
+GOOD = """
+def helper():
+    inject_prologue(x)   # not main(); ignored
+
+def main():
+    inject_portraits(c)
+    engine_hooks._inject_lord_select_engine()
+    engine_hooks._inject_lord_floor_engine()
+    inject_map_sprites(c)
+    inject_enemy_class_reskins(c)
+    inject_winter_tileset(c)
+    inject_ch01(c)
+    if test:
+        inject_test_chapter(c)
+    else:
+        inject_prologue(c, montage=m)
+"""
+
+
+class TestCallSequence(unittest.TestCase):
+    def test_extracts_main_calls_in_order(self):
+        order = check._injection_call_sequence(GOOD)
+        self.assertLess(order.index('inject_ch01'), order.index('inject_prologue'))
+        self.assertIn('_inject_lord_select_engine', order)   # engine_hooks. prefix stripped
+
+    def test_ignores_calls_outside_main(self):
+        # helper()'s inject_prologue must not count as the first call.
+        order = check._injection_call_sequence(GOOD)
+        self.assertGreater(order.index('inject_prologue'), order.index('inject_portraits'))
+
+    def test_no_main_yields_empty(self):
+        self.assertEqual(check._injection_call_sequence('x = 1\n'), [])
+
+
+class TestOrderViolations(unittest.TestCase):
+    def good_order(self):
+        return check._injection_call_sequence(GOOD)
+
+    def test_documented_order_passes(self):
+        self.assertEqual(check._injection_order_violations(self.good_order()), [])
+
+    def test_swapped_pair_is_flagged(self):
+        order = self.good_order()
+        a, b = order.index('inject_ch01'), order.index('inject_prologue')
+        order[a], order[b] = order[b], order[a]
+        msgs = check._injection_order_violations(order)
+        self.assertTrue(any('inject_ch01 must run before inject_prologue' in m
+                            for m in msgs))
+
+    def test_renamed_step_screams_instead_of_silently_passing(self):
+        order = [n for n in self.good_order() if n != 'inject_winter_tileset']
+        msgs = check._injection_order_violations(order)
+        self.assertTrue(any('unknown step' in m and 'inject_winter_tileset' in m
+                            for m in msgs))
+
+
+class TestRealBuildCampaign(unittest.TestCase):
+    def test_repo_main_satisfies_all_constraints(self):
+        fail = []
+        check.check_injection_order(fail)
+        self.assertEqual(fail, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #110. Audit §2.6 flagged that the injection ordering constraints lived only in `main()`'s comments — one reorder breaks the build at its most expensive point, and `check_engine_guards_present` pins presence, not order.

- `check.py check_injection_order`: parses `build_campaign.main()`'s call sequence (textual order == execution order there) and pins the six documented MUST-precede pairs, each with its *why* in the failure message.
- A renamed/removed constrained step fails loudly ("unknown step — update INJECTION_ORDER") instead of silently disabling the constraint.
- 7 unit tests (`tools/test_check_inject_order.py`); real `main()` passes; drift guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR)_