### PR TITLE
feat(#8): iconic matchups via vanilla FE effectiveness — fire vs ice

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/campaign.yaml
+++ b/campaigns/rime-of-the-frostmaiden/campaign.yaml
@@ -103,6 +103,20 @@ item_names:
 item_icons:
   ITEM_VULNERARY: goodberry
 
+# Iconic matchups (#8): flag weapons `effective` vs enemy CLASSES via FE8's native
+# effectiveness (x3 damage, decisions.md §Combat "Iconic matchups" -- class-keyed,
+# no resistance tables, use SPARINGLY). Injected by build_campaign.inject_iconic_matchups:
+# each entry appends one ItemEffectiveness_* class list to the decomp and points the
+# named weapons' .pEffectiveness at it. Weapon keys = WEAPON_ITEM_ENUM names; class
+# tokens = decomp CLASS_ enums lowercased (cyclops -> CLASS_CYCLOPS).
+iconic_matchups:
+  - id: fire-vs-ice
+    weapons: [fire, elfire]           # the fire-line anima tomes
+    effective_vs: [cyclops, druid]    # ice trolls (ch08 cyclops reskin) + frost
+                                      # druids (Ravisin, ch05). cyclops-2 unused by
+                                      # our chapters; add it here if that changes.
+    note: "Fire bites Icewind's ice-creatures -- the campaign's one elemental truth."
+
 # D&D content sources (frozen snapshots committed at data/)
 data_sources:
   srd: data/srd/srd-snapshot.json

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -460,6 +460,21 @@ vanilla FE under the hood"). So:
   its D&D inspiration); see Weapon & Magic §.
 _Decided: 2026-05-28 (resistance dropped); 2026-06-04 (labels/enum/icon dropped too — vestigial)_
 
+**The campaign's one iconic matchup ships (#8): fire-line tomes ×3 vs ice trolls + frost druids.**
+`campaign.yaml iconic_matchups:` is the source of truth (weapons by `WEAPON_ITEM_ENUM` key,
+targets by class token → `CLASS_` enum); `build_campaign.inject_iconic_matchups` appends one
+`ItemEffectiveness_*` class list per matchup to `data_itemuse.c` and points each weapon's
+`.pEffectiveness` at it — pure vanilla ×3 math, and a weapon already carrying vanilla
+effectiveness is refused (never silently overwritten). First (and for now only) entry:
+`fire`/`elfire` vs `cyclops` (the ch08 Ice Troll reskin) + `druid` (Ravisin, ch05) —
+"fire bites Icewind's ice-creatures." The difficulty model mirrors it (`fe_combat.W`
+effective sets + `CLASS_TAGS` cyclops/druid tags), and `test_iconic_matchups.py` pins
+YAML ↔ model consistency so a matchup can't exist in the ROM but not the balance math
+(or vice versa). Vanilla parity references are unaffected (their yardstick targets carry
+no matchup tag). In-emulator verification (fire vs an ice troll on a built map) rides the
+ch05/ch08 slice load-tests — those chapters aren't hosted yet.
+_Decided: 2026-07-02 (CLAUDE; closes #8's build half)_
+
 **Hit-rate tuning: vanilla FE, no special floor needed**
 With vanilla FE hit/avoid restored, FE8's native 70–95% hit norms apply directly —
 the old d20-variance problem and the "skill floor" mitigation are moot. Tune

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -372,6 +372,8 @@ PATCHED_DECOMP_FILES = ['texts/texts.txt', 'src/data_characters.c', 'src/portrai
                         # battle_terrain_table + the terrain->ground remap (snow chapters)
                         'src/banim_terrain_data.c', 'data/data_banim_terrain.s',
                         'src/data_terrains.c', 'src/banim-battleparse.c', 'include/variables.h',
+                        # iconic matchups (#8): appended effectiveness lists + repointed weapons
+                        'src/data_items.c', 'src/data_itemuse.c',
                         # Goodberry (#21): vulnerary icon swapped by inject_item_icons
                         'graphics/item_icon/item_icon_vulnerary.png',
                         'data/const_data_unit_icon_wait.s', 'data/const_data_unit_icon_move.s',
@@ -997,6 +999,88 @@ def inject_item_names(campaign, verbose=True):
             print('  %-18s -> MSG_%03X: %s' % (item_enum, text_id, name))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
+
+
+ITEMUSE_C = os.path.join(DECOMP, 'src', 'data_itemuse.c')
+
+
+def _matchup_class_list(matchup, classes_h):
+    """The C definition of one iconic matchup's ItemEffectiveness_* class list:
+    (identifier, C snippet). Class tokens resolve like enemy YAML classes
+    ('cyclops' -> CLASS_CYCLOPS) and must exist in the decomp's classes.h."""
+    ident = 'ItemEffectiveness_Iconic_%s' % re.sub(r'[^A-Za-z0-9]', '_',
+                                                   str(matchup['id']))
+    rows = []
+    for tok in matchup['effective_vs']:
+        enum = 'CLASS_' + str(tok).upper().replace('-', '_')
+        if not re.search(r'\b%s\b' % enum, classes_h):
+            sys.exit('ERROR: iconic matchup %r: no %s in the decomp classes.h'
+                     % (matchup['id'], enum))
+        rows.append('    %s,\n' % enum)
+    return ident, ('\n/* Manchego Stars iconic matchup (#8): %s */\n'
+                   'CONST_DATA u8 %s[] = {\n%s    0,\n};\n'
+                   % (matchup['id'], ident, ''.join(rows)))
+
+
+def inject_iconic_matchups(campaign, verbose=True):
+    """Iconic matchups (#8): flag weapons `effective` vs enemy CLASSES using FE8's
+    native effectiveness (x3 damage; decisions.md §Combat "Iconic matchups" --
+    class-keyed, sparse, no resistance tables). campaign.yaml `iconic_matchups:`
+    is the source of truth; each entry appends one ItemEffectiveness_* class list
+    to data_itemuse.c and points the named weapons' .pEffectiveness at it. A
+    weapon that already carries vanilla effectiveness is refused: overwriting it
+    would silently drop vanilla behavior (pick another weapon or fold the vanilla
+    classes into the matchup deliberately)."""
+    cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
+    with open(cfg, encoding='utf-8') as f:
+        matchups = (yaml.safe_load(f) or {}).get('iconic_matchups') or []
+    if not matchups:
+        return
+    classes_h = open(os.path.join(DECOMP, 'include', 'constants', 'classes.h'),
+                     encoding='utf-8').read()
+    with open(ITEMS_C, encoding='utf-8') as f:
+        items_src = f.read()
+    lists, externs = [], []
+    for m in matchups:
+        ident, snippet = _matchup_class_list(m, classes_h)
+        lists.append(snippet)
+        externs.append('extern CONST_DATA u8 %s[];\n' % ident)
+        for wkey in m['weapons']:
+            item = WEAPON_ITEM_ENUM.get(wkey)
+            if item is None:
+                sys.exit('ERROR: iconic matchup %r: unknown weapon %r (add it to '
+                         'WEAPON_ITEM_ENUM)' % (m['id'], wkey))
+            marker = '[%s] = {' % item
+            if items_src.count(marker) != 1:
+                sys.exit('ERROR: %s entry not found in data_items.c' % item)
+            at = items_src.index(marker)
+            end = items_src.index('\n\t},', at)
+            if '.pEffectiveness' in items_src[at:end]:
+                sys.exit('ERROR: %s already carries vanilla effectiveness -- '
+                         'refusing to overwrite it for matchup %r' % (item, m['id']))
+            # vanilla field order puts pEffectiveness right after .attributes
+            attr_end = items_src.index('\n', items_src.index('.attributes', at))
+            items_src = (items_src[:attr_end]
+                         + '\n\t\t.pEffectiveness = %s,' % ident
+                         + items_src[attr_end:])
+        if verbose:
+            print('  %s: %s -> x3 vs %s' % (m['id'], ', '.join(m['weapons']),
+                                            ', '.join(m['effective_vs'])))
+    with open(ITEMS_C, 'w', encoding='utf-8') as f:
+        f.write(items_src)
+    with open(ITEMUSE_C, 'a', encoding='utf-8') as f:
+        f.write(''.join(lists))
+    # data_items.c sees the lists through variables.h (where the vanilla
+    # ItemEffectiveness_* externs live).
+    with open(VARIABLES_H, encoding='utf-8') as f:
+        var_h = f.read()
+    anchor = 'extern CONST_DATA u8 ItemEffectiveness_Monsters[];'
+    if var_h.count(anchor) != 1:
+        sys.exit('ERROR: ItemEffectiveness_Monsters extern not in expected form '
+                 'in variables.h')
+    var_h = var_h.replace(anchor, anchor + '\n' + ''.join(externs).rstrip('\n'))
+    with open(VARIABLES_H, 'w', encoding='utf-8') as f:
+        f.write(var_h)
 
 
 # --- Milestone B: character stats / class -----------------------------------------
@@ -5186,6 +5270,8 @@ def main():
         inject_item_names(args.campaign)
         print('item icons:')
         inject_item_icons(args.campaign)
+        print('iconic matchups (#8):')
+        inject_iconic_matchups(args.campaign)
         print('characters:')
         patch_character_data(args.campaign)
         print('portrait geometry:')

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -37,6 +37,10 @@ CLASS_TAGS = {
     'CLASS_PEGASUS_KNIGHT': frozenset({'flier'}),
     'CLASS_FALCON_KNIGHT': frozenset({'flier'}),
     'CLASS_WYVERN_RIDER': frozenset({'flier'}),
+    # iconic-matchup targets (#8): fire-line tomes are x3 vs these (fe_combat.W)
+    'CLASS_CYCLOPS': frozenset({'cyclops'}),
+    'CLASS_CYCLOPS_2': frozenset({'cyclops'}),
+    'CLASS_DRUID': frozenset({'druid'}),
 }
 
 # The engine models VANILLA, so every decomp read is the committed (HEAD) source, never

--- a/tools/fe_combat.py
+++ b/tools/fe_combat.py
@@ -53,7 +53,13 @@ W = {
     'hand-axe':     Weapon('hand-axe',     7, 60,  0, 11, 'axe',   rng=(1, 2)),
     'iron-bow':     Weapon('iron-bow',     6, 85,  0, 5,  'bow',   rng=(2, 2),
                            effective=frozenset({'flier'})),
-    'fire':         Weapon('fire',         5, 90,  0, 4,  'magic', rng=(1, 2)),
+    # fire-line tomes carry the campaign's ONE iconic matchup (#8, campaign.yaml
+    # iconic_matchups): x3 vs ice trolls (cyclops reskin) + frost druids. Vanilla
+    # parity-reference forces are unaffected (their targets carry neither tag).
+    'fire':         Weapon('fire',         5, 90,  0, 4,  'magic', rng=(1, 2),
+                           effective=frozenset({'cyclops', 'druid'})),
+    'elfire':       Weapon('elfire',       10, 85, 0, 10, 'magic', rng=(1, 2),
+                           effective=frozenset({'cyclops', 'druid'})),
     'lightning':    Weapon('lightning',    4, 95,  5, 6,  'magic', rng=(1, 2)),
     'flux':         Weapon('flux',         7, 80,  0, 8,  'magic', rng=(1, 2)),
     # Extended vanilla weapons carried only by enemy parity-reference forces (FE8 Ch4/Ch6),

--- a/tools/inject/decomp.py
+++ b/tools/inject/decomp.py
@@ -31,6 +31,7 @@ WEAPON_ITEM_ENUM = {
     'iron-axe': 'ITEM_AXE_IRON', 'steel-axe': 'ITEM_AXE_STEEL',
     'hand-axe': 'ITEM_AXE_HANDAXE',
     'iron-bow': 'ITEM_BOW_IRON', 'fire': 'ITEM_ANIMA_FIRE', 'flux': 'ITEM_DARK_FLUX',
+    'elfire': 'ITEM_ANIMA_ELFIRE',
 }
 
 

--- a/tools/test_iconic_matchups.py
+++ b/tools/test_iconic_matchups.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for the iconic-matchup injection (#8).
+
+One campaign flavor decision -- fire bites Icewind's ice-creatures -- expressed as
+vanilla FE8 class-keyed effectiveness (x3, decisions.md §Combat "Iconic matchups").
+campaign.yaml `iconic_matchups:` is the source of truth; these tests pin (a) the
+generated C list shape, (b) the x3 math in the difficulty model, and (c) that the
+YAML and the model can't silently drift apart.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import build_campaign as bc  # noqa: E402
+import difficulty as df      # noqa: E402
+import fe_combat as fc       # noqa: E402
+
+import yaml  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CAMPAIGN_YAML = os.path.join(REPO, 'campaigns/rime-of-the-frostmaiden/campaign.yaml')
+
+CLASSES_H = 'enum { CLASS_CYCLOPS = 0x5A, CLASS_DRUID = 0x2F, };'
+
+
+class TestMatchupClassList(unittest.TestCase):
+    def test_snippet_shape(self):
+        ident, snippet = bc._matchup_class_list(
+            {'id': 'fire-vs-ice', 'effective_vs': ['cyclops', 'druid']}, CLASSES_H)
+        self.assertEqual(ident, 'ItemEffectiveness_Iconic_fire_vs_ice')
+        self.assertIn('CONST_DATA u8 ItemEffectiveness_Iconic_fire_vs_ice[]', snippet)
+        self.assertIn('    CLASS_CYCLOPS,\n', snippet)
+        self.assertIn('    CLASS_DRUID,\n', snippet)
+        self.assertTrue(snippet.rstrip().endswith('0,\n};'))   # 0-terminated list
+
+    def test_unknown_class_rejected(self):
+        with self.assertRaises(SystemExit):
+            bc._matchup_class_list(
+                {'id': 'x', 'effective_vs': ['ice-weasel']}, CLASSES_H)
+
+
+class TestEffectiveMath(unittest.TestCase):
+    def _target(self, tags):
+        return fc.Combatant('t', hp=30, pow=0, skl=0, spd=0, df=0, res=5, lck=0,
+                            con=10, weapon=None, tags=frozenset(tags))
+
+    def _mage(self, weapon):
+        return fc.Combatant('m', hp=20, pow=6, skl=8, spd=8, df=2, res=6, lck=4,
+                            con=6, weapon=fc.W[weapon])
+
+    def test_fire_triples_vs_cyclops_tag(self):
+        # (Pow 6 + Fire Mt 5) x3 - Res 5 = 28, vs 6 plain
+        self.assertEqual(fc.damage(self._mage('fire'), self._target({'cyclops'})), 28)
+        self.assertEqual(fc.damage(self._mage('fire'), self._target(set())), 6)
+
+    def test_elfire_triples_vs_druid_tag(self):
+        self.assertEqual(fc.damage(self._mage('elfire'), self._target({'druid'})),
+                         (6 + 10) * 3 - 5)
+
+    def test_flux_is_not_effective(self):
+        self.assertEqual(fc.damage(self._mage('flux'), self._target({'cyclops'})),
+                         6 + 7 - 5)
+
+
+class TestYamlModelConsistency(unittest.TestCase):
+    """campaign.yaml drives the ROM; fe_combat/difficulty drive the balance math.
+    If one gains a matchup the other doesn't know, parity reads go silently wrong."""
+
+    def setUp(self):
+        with open(CAMPAIGN_YAML, encoding='utf-8') as f:
+            self.matchups = (yaml.safe_load(f) or {}).get('iconic_matchups') or []
+
+    def test_campaign_declares_the_matchup(self):
+        self.assertTrue(self.matchups, 'campaign.yaml lost its iconic_matchups block')
+
+    def test_model_mirrors_every_yaml_matchup(self):
+        for m in self.matchups:
+            target_tags = set()
+            for tok in m['effective_vs']:
+                enum = 'CLASS_' + str(tok).upper().replace('-', '_')
+                tags = df.CLASS_TAGS.get(enum)
+                self.assertTrue(tags, '%s: CLASS_TAGS has no tags for %s -- the '
+                                'difficulty model would miss this matchup' % (m['id'], enum))
+                target_tags |= set(tags)
+            for wkey in m['weapons']:
+                w = fc.W.get(wkey)
+                self.assertIsNotNone(w, '%s: fe_combat.W has no %r' % (m['id'], wkey))
+                self.assertTrue(set(w.effective) & target_tags,
+                                '%s: fe_combat.W[%r].effective misses the matchup '
+                                'tags %s' % (m['id'], wkey, sorted(target_tags)))
+
+    def test_yaml_weapons_resolve_to_items(self):
+        from inject.decomp import WEAPON_ITEM_ENUM
+        for m in self.matchups:
+            for wkey in m['weapons']:
+                self.assertIn(wkey, WEAPON_ITEM_ENUM)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #8 (build half — in-emulator verification rides the ch05/ch08 slice load-tests, since those chapters aren't hosted yet).

## What
- **`campaign.yaml iconic_matchups:`** is the source of truth (per the decisions.md doctrine: class-keyed vanilla ×3 effectiveness, used sparingly, no resistance tables). First and only entry: `fire`/`elfire` ×3 vs `cyclops` (ch08's Ice Troll reskin) + `druid` (Ravisin, ch05).
- **`inject_iconic_matchups`**: appends one `ItemEffectiveness_*` class list per matchup to `data_itemuse.c`, points each weapon's `.pEffectiveness` at it (inserted in vanilla field position), externs via `variables.h`; **refuses to overwrite a weapon that already carries vanilla effectiveness**. All three decomp files added to the restore list.
- **Difficulty model mirrors the ROM**: `fe_combat.W` fire/elfire effective sets + `CLASS_TAGS` cyclops/druid; `elfire` added to `W` and `WEAPON_ITEM_ENUM` (the #53 pattern). Vanilla parity references unaffected (yardstick targets carry no tag) — parity gate green.
- **`test_iconic_matchups.py`** (8 tests): generated C shape, ×3 math, and a YAML↔model consistency gate so a matchup can't exist in the ROM but not the balance math (or vice versa).

## Verification
- Injection run: list + both `.pEffectiveness` repoints + extern verified in generated sources; full suite + drift guard + `make difficulty-gate` green. CI compiles the patched C in the mock-ROM build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR)_