### PR TITLE
docs(#9): ADR — vanilla FE8 IS the spell economy; remaining work is content

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1141,6 +1141,23 @@ layer (the whole party shops, scavenges, rations). Flavor the restock per charac
 scribe / pray); mechanically these are vanilla FE tomes/staves.
 _Decided: 2026-05-29 (supersedes the May 2026 "free chapter-refill, cantrips infinite, slots not buyable")_
 
+**Decision B needs (almost) no code — vanilla FE8 IS the spell economy (#9 delta audit).**
+Decomp-grounded findings (issue #9 has the full table): tome depletion (`bmitem.c
+GetItemAfterUse`, high-byte uses counter), the uses/maxUses display on BOTH the item menu and
+the stat screen, and gold-restock shops (`bmshop.c` sells fresh full-uses items at
+`costPerUse × uses`; vanilla Ch5's vendor already stocks Fire + Lightning tomes) are ALL stock
+behavior — and the primary-cantrip counts already sit in decision B's band (Fire 40, Flux 45,
+Thunder/Lightning 35, Elfire/Shine 30). **"Gray out depleted" conflicts with vanilla**: a
+spent tome breaks and vanishes like an iron sword; we accept break-and-rebuy (it IS the
+decision-B economy) unless Nicolas asks for a persistent grayed slot (question posted on #9).
+What remains is CONTENT, landing with its first consumer per the no-dead-code rule: a
+`shops:` block + `ShopList_Event_*` injection when the first shop chapter is authored
+(vanilla cadence: ~Ch5), per-PC `inventory:` → loadout wiring (today `CLASS_LOADOUT` ships
+class-stock items; changing it alters playtested ch01 balance, so it rides a chapter slice
+with an emulator pass), and secondary-cantrip `maxUses` overrides once the per-PC spell kits
+assign them (same string-patch idiom as #8's effectiveness injection).
+_Decided: 2026-07-02 (CLAUDE; resolves #9's engine half as already-vanilla)_
+
 **MVP weapons = stock FE weapons (no custom Might); personal weapons are post-MVP**
 PCs carry plain vanilla FE weapons whose stats (Mt/Hit/Crit/Wt/uses) come verbatim from a stock
 FE8 item, named in each inventory entry's `fe_base` field — there is **no custom Might authoring**.


### PR DESCRIPTION
Records the #9 delta audit (full table on the issue): **tome depletion, uses display (item menu + stat screen), and gold-restock shops are all stock FE8 behavior**, and the primary cantrip counts already sit in decision B's 30–50 band (Fire 40, Flux 45). The one conflict — "gray out depleted" vs vanilla break-and-rebuy — is flagged as a question for Nicolas on #9; we proceed on the vanilla reading.

The remaining pieces are content, deliberately NOT landed as inert tooling (the same no-dead-code rule today's reviews enforced twice): `shops:` injection lands with the first shop chapter (~ch05 by vanilla cadence), per-PC inventory→loadout wiring rides a chapter slice (it changes playtested ch01 balance), and `maxUses` overrides wait for the per-PC spell kits to assign secondary cantrips.

Doc-only; keeps #9 open as a content tracker with the engine half resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR)_