### PR TITLE
feat(#63): M2 sidecar handshake + provider-agnostic policy (free local models)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,12 +4,19 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 `git log --oneline -20` + closed issues, not here. **Backlog** → GitHub issues. **Decisions** →
 `docs/decisions.md`. **Operating instructions** → `CLAUDE.md`. Run `/handoff` to refresh this file in place.
 
-> **Last session (2026-06-29):** braulo battle anim got a revised peak frame (PR #98), the Knight/lance
-> banim donor tooling landed (PR #99), and Ch3 dialogue locked (PR #97). **Wolfram's battle anim is the
-> live pickup — its engine/tooling half is merged & inert; it's waiting only on art.** See §Wolfram; the
-> ready-to-run prompt pack is in `lore/wolfram.md`. **Ch3 map (#40) also moved:** tileset decided
-> (Cynon's Mineshaft, Gray) + layout pivot to a custom Gem-Mine plan — **flattened blockout posted on #23,
-> awaiting Nicolas's OK** (see §Map (#40)). Nicolas is mobile-only the week of 2026-06-29.
+> **Last session (2026-07-02, web):** 8-item hard-queue burn-down, all merged via feature-flow —
+> chapter-deployment schema + generic injection consumers (#107, PR #109) · **#40 tileset converter +
+> vendored `cave-interior`** (PR #111 — ch03 map is now paint-ready once the blockout is OK'd) ·
+> injection-order guard + lossless GIF deltas (PR #112) · **#8 iconic matchups** (fire-vs-ice via vanilla
+> effectiveness, PR #114) · **#11 d20 nat-20 crit flourish** (PR #115) · **#60 clear-bot last-mile
+> breach** (pickMove core + the reach-window root-cause fix, PR #116; ch01 clear needs a local mGBA
+> confirm) · **#9 resolved as "vanilla IS the spell economy"** (ADR, PR #117; gray-out question to
+> Nicolas on #9) · **#63 M2 sidecar + provider-agnostic LLM policy** (PR #118 — free local
+> Llama/Gemma via Ollama one env var away, per Nicolas's cost call). **Wolfram's battle anim remains
+> art-blocked** (§Wolfram; prompts in `lore/wolfram.md`). **Ch3 blockout still awaits Nicolas's OK on
+> #23** — and ch03's `deploy_limit: 9` exceeds the 8-unit classed roster (Baxby unclassed; note on #23).
+> In-emulator verification of #60/#63 needs a local (mGBA) session: `clear_ch01`, then an `llm` record
+> run to mint `transcripts/prologue.json`.
 
 > **🛠 Desktop fix needed — branch cleanup + env policy (2026-06-29; re-probed 2026-07-02):** An audit
 > found **13 stale remote branches** the squash-merge convention should have deleted. 2026-07-02 web
@@ -87,6 +94,7 @@ ADR: `decisions.md` §Distribution.
   `inject_backgrounds`. Winter-BG catalogue: `map-review/iwd-bg-library.md`.
 - **Playtest scenarios** `tools/playtest/run.sh <scenario>` (need a built ROM + `lua`):
   - logic/stability: `win|gameover|ch01win|clear|clear_ch01|smoke|smoke_ch01|fuzz`
+  - **LLM commander (#63):** `llm` — needs the sidecar running (`llm_player.py serve`; see run.sh header).
   - **ch2 (#22):** `ch02` · `smoke_ch02` · `clear_ch02` (all load a `ch02start` checkpoint).
   - **Battle-anim capture:** `PT_CHAR=<id> tools/playtest/run.sh recordanim` on a `make TESTCH=1` ROM
     (New Game → straight to a forced battle for that unit) → `tools/playtest/make_gif.py recordanim <id>
@@ -164,11 +172,11 @@ Two decisions this session change the earlier "reskin vanilla Borgo on a winter 
   throwaway renderer assembled Cynon's own `Test Map.tmx` correctly →
   `map-review/ch03-tileset-candidates/mineshaft-testmap-gray.png` (= `docs/demo/ch03-mineshaft-tileset-demo.png`),
   proving tiles assemble. So #40 task 2 = a small converter, not a toolchain.
-- **Build order once the blockout is OK'd:** (1) write the `mapchip_config`+object-PNG → `.4bpp/.gbapal/.bin`
-  converter; vendor as tileset **`cave-interior`** under `campaigns/.../maps/tilesets/`. (2) Seed a paint
-  canvas on it from the blockout (extend `gen_map_editor` to load a vendored tileset + a custom/blank layout —
-  today it only reskins a vanilla layout on `snowy-bern`). (3) Paint against the reference →
-  `import_map_layout` → `.mar` → in-engine load-test. **Enemy/chest positions move off the old Borgo coords
+- **Build order once the blockout is OK'd:** ~~(1) converter~~ ~~(2) editor support~~ — **both LANDED
+  2026-07-02 (PR #111):** `map_tileset_tool.py import/render-tmx`, tileset **`cave-interior`** vendored
+  under `campaigns/.../maps/tilesets/` (Cynon credited in `CREDITS.md`), `gen_map_editor --tileset
+  cave-interior --blank WxH [--ref img]` seeds a blank canvas, layouts carry their tileset in `.json`.
+  Remaining: (3) Paint against the reference → `import_map_layout` → `.mar` → in-engine load-test. **Enemy/chest positions move off the old Borgo coords
   onto the new layout** (parity unchanged — same 10-unit roster, just repositioned; re-finalize in the map tool).
 - **Then (post-map, unchanged):** host on next vanilla slot (`MNC2`; model `inject_ch01`/`inject_ch02`) →
   units/objective/cutscene wiring (`inject_ch03` consumes the `script:` blocks; Brute-defeat trigger,
@@ -191,15 +199,18 @@ demo-asset task (ships nothing; v0.1.0 is Ch1-only). Scratch review images live 
   onboarding-parity #64 · faked battle anims epic #65.
 
 ### Pipeline — playtest / parity
-- **Clear-bot #60 — partial landed (#79), STILL OPEN.** BFS distance-field march + multi-range targeting +
-  stall watchdog are in; `clear` (prologue) passes fair-play. **Remaining:** the bot jams at ch01's walled
-  boss-camp with a thin 2-unit deploy — last-mile breach/unjam logic. Diagnosis on #60.
-- **LLM-player #63 — M2 next** (M1 landed): replay-only from a recorded transcript (deterministic, zero
-  cost) → M3 live policy (`PT_MODEL`) → M4 soak→curve → M5 vanilla-FE8 validation. Swap: `clearbot.lua pickTarget`.
+- **Clear-bot #60 — code complete (PR #116), needs a local `clear_ch01` mGBA confirm to close.**
+  `pickMove` march core (field-first, claimed-tile avoidance, cork-jam fallback) + the root-cause fix:
+  `selectAndReach`'s default 15×10 window clipped ch01 reach at x=14 — bounds now threaded.
+- **LLM-player #63 — M1+M2 landed (PR #118), M3 next.** Sidecar file-handshake + `llm` scenario +
+  provider-agnostic policy (`PT_PROVIDER=openai` + local Ollama = free Llama/Gemma; anthropic/Sonnet
+  default per the epic). First local run: sidecar `--record` to mint `transcripts/prologue.json`, then
+  replay is free forever. M3 = staff driving + multi-target disambiguation → M4 soak→curve → M5 vanilla-FE8.
 - **Land `balance_locked: true` on ch00/ch01** (ch02 set); the per-chapter parity gate (#48b) is enforcing
   but inert until a chapter opts in; ch00/ch01 read OK.
-- #53 tail (FE8 Ch13 → our ch08): ~11 standard weapons, informational. Other leaves: d20 crit #11,
-  spell-economy #9, iconic matchups #8.
+- #53 tail (FE8 Ch13 → our ch08): ~11 standard weapons, informational. Former leaves all landed 2026-07-02:
+  d20 crit #11 ✓ · iconic matchups #8 ✓ · spell-economy #9 = vanilla behavior (content lands per-chapter;
+  gray-out question open on #9).
 
 ## Gotchas (cross-cutting)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1026,6 +1026,40 @@ beating vanilla FE8 (so the signal isn't overfit to our maps). Locked architectu
   into the difficulty curve, M5 the vanilla-FE8 validation milestone (needs a save-state checkpoint).
 _Decided: 2026-06-20 (CLAUDE; pipeline track. Epic #63; M1 cores TDD'd green, 20 asserts in make test)_
 
+**#63 M2 = the sidecar handshake ships PROVIDER-AGNOSTIC — a free local model is one env var away.**
+Nicolas (2026-07-02) was cost-shy about the LLM-player; the happy medium is supporting free local models
+(Llama/Gemma via Ollama or llama.cpp) alongside Anthropic. Settled:
+- **Two transports, no SDK dependency.** `llm_player.py` speaks the Anthropic Messages API *or* any
+  OpenAI-compatible `/chat/completions` endpoint, both via stdlib `urllib` (~15 lines each; a new dependency
+  for two POSTs is the bigger risk, and the sidecar must run anywhere a playtester has python3). Knobs:
+  `PT_PROVIDER` (`anthropic` default per the epic's "a weak player fires FALSE balance alarms" — Sonnet;
+  `openai` = OpenAI-compatible), `PT_MODEL`, `PT_BASE_URL` (openai default = local Ollama,
+  `http://localhost:11434/v1`), `PT_API_KEY`/`ANTHROPIC_API_KEY`. **The free path is plumbing/smoke value;
+  the paid path is balance-signal value** — a Gemma-grade commander proves the loop and soaks for crashes,
+  but its losses are weak evidence about chapter difficulty. Both record into the same transcript format.
+- **Handshake = numbered files, tmp+rename both directions.** Harness writes `req-<n>.json`
+  `{seed, chapter, turn, faction, board}` into `PT_LLM_DIR` and polls (wall-clock deadline — at 240fps a
+  frame budget would be 4× too impatient); sidecar answers `resp-<n>.json` `{orders, rejected}`, lowest
+  unanswered request first, and drains pending requests before honoring its `stop` file. Every write on both
+  sides is tmp+`rename` so a poller never reads a half-written file; `run.sh llm` clears stale handshake
+  files (a leftover `resp-1.json` would satisfy the first poll instantly with last run's orders).
+- **Validation lives sidecar-side; the harness re-checks nothing.** Orders pass `validate_orders` against the
+  request's own board before they ship, so the Lua executor only sees legal orders — one that still fails to
+  commit means the board *changed under it* (logged, skipped, never soft-locks). A replay-mode transcript
+  miss writes an `{error}` response (fast, diagnosable harness FAIL) and exits non-zero — CI/replay stays
+  closed-world.
+- **Exported unit ids: blue = charId (PCs are unique), red = 1000+slot** — generic enemies *share* a charId,
+  so the slot disambiguates which brigand an attack order targets.
+- **Lua JSON is a vendored ~200-line subset (`tools/playtest/json.lua`), not a library.** mGBA's Lua has no
+  JSON; encode writes sorted keys (deterministic bytes, mirroring the serializer doctrine), decode rejects
+  trailing garbage (a truncated file must not half-parse into plausible orders). Unit-tested without mGBA
+  (`test_json.lua`, 45 asserts) + a cross-language round trip (Lua req → Python sidecar → Lua resp) verified.
+- **M2 limitations (deliberate, → M3):** `chooseAttack` fires on the UI's *default* target (unambiguous
+  whenever one enemy is in range of the strike tile); staff orders execute as Wait. In-emulator prologue
+  replay needs local mGBA (CI has none — the platform rule); the protocol itself is fully unit-tested.
+_Decided: 2026-07-02 (CLAUDE; pipeline track. Epic #63 M2 + Nicolas's free-model direction; 23 new Python
+asserts + 45 Lua asserts in make test)_
+
 **Recording a cutscene as a review GIF (the standard way to show Nicolas motion).**
 The harness fast-forwards cutscenes (mashes A), so an assert scenario's screenshots land
 on fades — to SEE a scene play, use a `record*` scenario: it drives the game to the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1034,20 +1034,31 @@ Nicolas (2026-07-02) was cost-shy about the LLM-player; the happy medium is supp
   for two POSTs is the bigger risk, and the sidecar must run anywhere a playtester has python3). Knobs:
   `PT_PROVIDER` (`anthropic` default per the epic's "a weak player fires FALSE balance alarms" — Sonnet;
   `openai` = OpenAI-compatible), `PT_MODEL`, `PT_BASE_URL` (openai default = local Ollama,
-  `http://localhost:11434/v1`), `PT_API_KEY`/`ANTHROPIC_API_KEY`. **The free path is plumbing/smoke value;
-  the paid path is balance-signal value** — a Gemma-grade commander proves the loop and soaks for crashes,
-  but its losses are weak evidence about chapter difficulty. Both record into the same transcript format.
+  `http://localhost:11434/v1`), `PT_API_KEY`/`ANTHROPIC_API_KEY` (the latter feeds ONLY the anthropic
+  transport — resolving it for the openai provider would Bearer-leak the Anthropic secret to whatever host
+  `PT_BASE_URL` names). **The free path is plumbing/smoke value; the paid path is balance-signal value** — a
+  Gemma-grade commander proves the loop and soaks for crashes, but its losses are weak evidence about chapter
+  difficulty. Both record into the same transcript format. Model output passes a non-finite gate (`NaN` /
+  `1e999`→inf orders are culled) — a one-off model hiccup must not record a transcript entry the strict
+  Lua-side JSON reader can never parse.
 - **Handshake = numbered files, tmp+rename both directions.** Harness writes `req-<n>.json`
   `{seed, chapter, turn, faction, board}` into `PT_LLM_DIR` and polls (wall-clock deadline — at 240fps a
   frame budget would be 4× too impatient); sidecar answers `resp-<n>.json` `{orders, rejected}`, lowest
-  unanswered request first, and drains pending requests before honoring its `stop` file. Every write on both
-  sides is tmp+`rename` so a poller never reads a half-written file; `run.sh llm` clears stale handshake
-  files (a leftover `resp-1.json` would satisfy the first poll instantly with last run's orders).
-- **Validation lives sidecar-side; the harness re-checks nothing.** Orders pass `validate_orders` against the
-  request's own board before they ship, so the Lua executor only sees legal orders — one that still fails to
-  commit means the board *changed under it* (logged, skipped, never soft-locks). A replay-mode transcript
-  miss writes an `{error}` response (fast, diagnosable harness FAIL) and exits non-zero — CI/replay stays
-  closed-world.
+  unanswered request first, and drains pending requests before honoring its `stop` file — **which `run.sh`
+  touches when the run ends**, so the sidecar saves its transcript and exits on its own (no Ctrl-C-dependent
+  save). Every write on both sides is tmp+`rename` so a poller never reads a half-written file; `run.sh llm`
+  clears stale handshake files (a leftover `resp-1.json` would satisfy the first poll instantly with last
+  run's orders), the sidecar tolerates a request vanishing mid-step (that cleanup can race a sidecar started
+  first) and warns at startup about pre-existing requests (usually a crashed prior run).
+- **Validation lives sidecar-side; the harness re-checks only what can change.** Orders pass
+  `validate_orders` against the request's own board before they ship — including: attack targets must be
+  foes and staff targets allies (friendly-fire "attacks" would blind-A into the Trade/Item submenu); a unit
+  the exporter gave no `range` (staff-only/weaponless) can target nothing; `seize` is gated on the board's
+  objective (the export carries no goal tile). The Lua executor re-checks just the mid-phase deltas (target
+  died to an earlier order → downgrade to wait) and backs failed menus out with a full drain (submenus are
+  also `sProc_Menu`; a fixed two-B backout can strand a unit selected). Any live-policy failure (endpoint
+  down) still answers the harness with an `{error}` response — a fast diagnosable FAIL, not a 90s timeout;
+  a replay-mode transcript miss does the same and exits non-zero — CI/replay stays closed-world.
 - **Exported unit ids: blue = charId (PCs are unique), red = 1000+slot** — generic enemies *share* a charId,
   so the slot disambiguates which brigand an attack order targets.
 - **Lua JSON is a vendored ~200-line subset (`tools/playtest/json.lua`), not a library.** mGBA's Lua has no

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -1125,6 +1125,25 @@ local function llmHandshake(n, req, timeoutSecs)
     return nil, "sidecar timeout waiting for resp-" .. n .. ".json (is llm_player.py serve running?)"
 end
 
+-- Drain every open menu level (submenus -- weapon/item lists -- are ALSO sProc_Menu,
+-- so a fixed two-B backout can strand a level), then one more B to drop a move-range
+-- selection. Restores the harness invariant: never leave a unit selected.
+local function llmBackout()
+    for _ = 1, 6 do
+        if not menuOpen() then break end
+        press(K.B) wait(8)
+    end
+    press(K.B) wait(8)
+end
+
+-- Resolve an exported unit id back to a live unit: blue = charId, red = 1000+slot
+-- (generics share charIds; see llmExportBoard).
+local function llmUnitById(id)
+    if type(id) ~= "number" then return nil end
+    if id >= LLM_RED_ID_BASE then return unitAt(SYM.gUnitArrayRed, id - LLM_RED_ID_BASE) end
+    return blue(id)
+end
+
 -- Execute one validated order with the existing primitives. M2 limitation (noted in
 -- decisions.md): chooseAttack fires on the UI's default target, which is the intended
 -- one whenever a single enemy is in range of the strike tile; multi-target
@@ -1133,15 +1152,25 @@ local function llmExecOrder(o)
     if type(o.unit) ~= "number" or type(o.move_to) ~= "table" then return false end
     local u = blue(o.unit)
     if not u or isDead(u) or (u.state & 0x2) ~= 0 then return false end
+    -- the sidecar validated against the REQUEST board; re-check what can have changed
+    -- since (an earlier order killed the target) before blind-A driving the menu --
+    -- with no live target the action menu has no Attack entry and A/A/A would walk
+    -- into the Item submenu instead
+    local action = o.action
+    if action == "attack" then
+        local tgt = llmUnitById(o.target)
+        if not tgt or isDead(tgt) then action = "wait" end
+    end
     if not moveUnit(u.x, u.y, o.move_to.x, o.move_to.y) then return false end
-    if o.action == "attack" then
+    if action == "attack" then
         chooseAttack(u.addr)
-    elseif o.action == "seize" then
+    elseif action == "seize" then
         press(K.A) wait(30)   -- Seize tops the menu for a seize-capable unit on the tile
+        if menuOpen() then llmBackout() return false end   -- no Seize here: back out fully
     else
         chooseWait()          -- wait/staff: staff driving is an M3 refinement
     end
-    if menuOpen() then press(K.B) press(K.B) return false end
+    if menuOpen() then llmBackout() return false end
     return true
 end
 

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -1046,6 +1046,167 @@ scenarios.fuzz_ch01 = function()
     return fuzzDrive(chapter())
 end
 
+-- ---- LLM-player commander (#63 M2): the sidecar file-handshake. Once per player
+-- phase the harness exports the WHOLE board as req-<n>.json into PLAYTEST_LLMDIR,
+-- blocks (polling) for resp-<n>.json from the external sidecar
+-- (`tools/playtest/llm_player.py serve`, replay-only by default -- zero LLM cost),
+-- and executes the returned orders with the existing primitives. The sidecar has
+-- already validated the orders against this exact board (validate_orders), so an
+-- illegal order arriving here means the board CHANGED under us (a kill freed a tile)
+-- -- those just fail to commit and are logged, never soft-lock. Timeout / malformed
+-- response -> FAIL, like every brick.
+local JSONF = dofile(PLAYTEST_DIR .. "/json.lua")
+local LLMDIR = (type(PLAYTEST_LLMDIR) == "string" and PLAYTEST_LLMDIR) or "/tmp/playtest-llm-handshake"
+
+-- Exported unit ids must be UNIQUE and stable across the run: blue units use charId
+-- (PCs are distinct), red units use 1000+slot (generics SHARE a charId, so the slot
+-- disambiguates which brigand an attack order targets).
+local LLM_RED_ID_BASE = 1000
+
+local function llmExportBoard(objective, maxx, maxy)
+    local units = {}
+    for i = 0, 7 do
+        local u = unitAt(SYM.gUnitArrayBlue, i)
+        if u and not isDead(u) then
+            local canAct = (u.state & 0x2) == 0
+            local reach = {}
+            if canAct then
+                local r = selectAndReach(u, maxx, maxy)
+                press(K.B) wait(6)   -- deselect: the export must not leave a unit selected
+                if r then for _, t in ipairs(r) do reach[#reach + 1] = { t.x, t.y } end end
+            end
+            local mn, mx = unitAttackRange(u)
+            units[#units + 1] = {
+                id = u.charId, faction = "blue", x = u.x, y = u.y,
+                hp = u.hp, maxhp = ru8(u.addr + 0x12), can_act = canAct,
+                boss = false, reach = reach, range = mn and { mn, mx } or nil,
+            }
+        end
+    end
+    for i = 0, 23 do
+        local u = unitAt(SYM.gUnitArrayRed, i)
+        if u and not isDead(u) then
+            local mn, mx = unitAttackRange(u)
+            units[#units + 1] = {
+                id = LLM_RED_ID_BASE + i, faction = "red", x = u.x, y = u.y,
+                hp = u.hp, maxhp = ru8(u.addr + 0x12), can_act = false,
+                boss = unitIsBoss(u), reach = {}, range = mn and { mn, mx } or nil,
+            }
+        end
+    end
+    return { objective = objective, map = { w = maxx + 1, h = maxy + 1 }, units = units }
+end
+
+-- Write req-<n>.json (tmp+rename, mirroring the sidecar, so a half-written request is
+-- never read) and poll for resp-<n>.json. Returns the decoded response table, or
+-- (nil, why). The poll is wall-clock bound (the sidecar answers in wall time; at
+-- 240fps a frame budget would be 4x too impatient).
+local function llmHandshake(n, req, timeoutSecs)
+    local reqPath = LLMDIR .. "/req-" .. n .. ".json"
+    local tmp = reqPath .. ".tmp"
+    local f, err = io.open(tmp, "w")
+    if not f then return nil, "cannot write " .. tmp .. ": " .. tostring(err) end
+    f:write(JSONF.encode(req))
+    f:close()
+    os.rename(tmp, reqPath)
+    local respPath = LLMDIR .. "/resp-" .. n .. ".json"
+    local deadline = os.time() + (timeoutSecs or 90)
+    while os.time() < deadline do
+        local rf = io.open(respPath, "r")
+        if rf then
+            local body = rf:read("a")
+            rf:close()
+            local resp, derr = JSONF.decode(body)
+            if not resp then return nil, "malformed resp-" .. n .. ".json: " .. tostring(derr) end
+            return resp
+        end
+        wait(30)
+    end
+    return nil, "sidecar timeout waiting for resp-" .. n .. ".json (is llm_player.py serve running?)"
+end
+
+-- Execute one validated order with the existing primitives. M2 limitation (noted in
+-- decisions.md): chooseAttack fires on the UI's default target, which is the intended
+-- one whenever a single enemy is in range of the strike tile; multi-target
+-- disambiguation is an M3 refinement.
+local function llmExecOrder(o)
+    if type(o.unit) ~= "number" or type(o.move_to) ~= "table" then return false end
+    local u = blue(o.unit)
+    if not u or isDead(u) or (u.state & 0x2) ~= 0 then return false end
+    if not moveUnit(u.x, u.y, o.move_to.x, o.move_to.y) then return false end
+    if o.action == "attack" then
+        chooseAttack(u.addr)
+    elseif o.action == "seize" then
+        press(K.A) wait(30)   -- Seize tops the menu for a seize-capable unit on the tile
+    else
+        chooseWait()          -- wait/staff: staff driving is an M3 refinement
+    end
+    if menuOpen() then press(K.B) press(K.B) return false end
+    return true
+end
+
+-- The LLM-commander loop body (no verdict): per player phase export the board, ask the
+-- sidecar, execute the orders, end the turn. Same terminal detection as the clear-bot.
+local function llmUntilAdvance(startChapter, objective, maxx, maxy, park)
+    local function won() return chapter() ~= startChapter end
+    local function lost() return gameOverActive() or procActive(SYM.gProcScr_TitleScreen) end
+    local budgetTurns = 18
+    local seed = math.floor(tonumber(PLAYTEST_SEED) or 1)
+    local n = 0
+    for t = 1, budgetTurns do
+        waitFor(function() return faction() == 0 and not menuOpen() end, 6000, true)
+        wait(60)              -- let the player-phase banner finish (it eats key presses)
+        press(K.B) wait(6)    -- NUDGE unstick: clear any stray menu before driving
+        n = n + 1
+        local req = { seed = seed, chapter = startChapter, turn = turn(), faction = "blue",
+                      board = llmExportBoard(objective, maxx, maxy) }
+        local resp, why = llmHandshake(n, req)
+        if not resp then return "handshake: " .. why, t end
+        if resp.error then return "sidecar: " .. tostring(resp.error), t end
+        local orders = resp.orders or {}
+        log(string.format("llm turn %d: %d orders (%d rejected sidecar-side)",
+            t, #orders, resp.rejected and #resp.rejected or 0))
+        for _, o in ipairs(orders) do
+            if won() then return "won", t end
+            if lost() then return "gameover", t end
+            if not llmExecOrder(o) then
+                log(string.format("llm: order for unit %s -> (%s,%s) did not commit",
+                    tostring(o.unit), tostring(o.move_to and o.move_to.x),
+                    tostring(o.move_to and o.move_to.y)))
+            end
+        end
+        if won() then return "won", t end
+        if lost() then return "gameover", t end
+        if runEnemyPhase(park) == "gameover" then return "gameover", t end
+    end
+    return "timeout", budgetTurns
+end
+
+local function llmDrive(startChapter, objective, maxx, maxy, park)
+    local status, t = llmUntilAdvance(startChapter, objective, maxx, maxy, park)
+    if status == "won" then shot("llm-win")
+        return result("PASS", string.format("LLM commander won by turn %d (chapter %d)", t, chapter())) end
+    if status == "gameover" then shot("llm-gameover")
+        return result("FAIL", string.format("game over on turn %d", t)) end
+    if status == "timeout" then shot("llm-timeout")
+        return result("FAIL", string.format("no win in %d turns (boss %s)",
+            t, findBoss() and "alive" or "dead")) end
+    shot("llm-fail")
+    return result("FAIL", status .. string.format(" (turn %d)", t))
+end
+
+-- llm: the prologue (DefeatBoss) driven by the sidecar commander. Replay-only run:
+--   python3 tools/playtest/llm_player.py serve --dir /tmp/playtest-llm-handshake \
+--       --transcript tools/playtest/transcripts/prologue.json     # (other terminal)
+--   tools/playtest/run.sh llm
+-- Record a fresh transcript (live model; see PT_PROVIDER/PT_MODEL/PT_BASE_URL for the
+-- free local Ollama path) by adding --record to the serve command.
+scenarios.llm = function()
+    if not bootToMap() then return result("FAIL", "never reached the map") end
+    pokeFastConfig()
+    return llmDrive(chapter(), "DefeatBoss", 14, 9)
+end
+
 -- CH01WIN: the default lord (blind A-taps pick Braulo) marches on the camp,
 -- kills the chief, and SEIZES -- in-game proof of the lord-gated Seize
 -- (CanUnitSeize hook, #42) and the win hand-off (Seize macro -> EVFLAG_WIN ->

--- a/tools/playtest/json.lua
+++ b/tools/playtest/json.lua
@@ -1,0 +1,185 @@
+-- json.lua -- minimal pure-Lua JSON encode/decode for the sidecar handshake (#63 M2).
+--
+-- The harness exports the board as `req-<n>.json` and reads the sidecar's orders back
+-- from `resp-<n>.json`; mGBA's embedded Lua ships no JSON library, so this is the pure
+-- core for both directions, unit-tested without mGBA (test_json.lua). Deliberately a
+-- SUBSET matching what the two ends of the protocol actually emit (Python `json.dumps`
+-- output on the way in): objects, arrays, strings with standard escapes (incl. \uXXXX
+-- basic-plane), numbers, true/false/null. Not a general validator -- decode returns
+-- (nil, "reason") on anything it can't parse rather than guessing.
+--
+-- Conventions:
+--   * encode() writes object keys SORTED, so the same table always produces the same
+--     bytes (mirrors the sidecar's `sort_keys` serializer -- determinism doctrine).
+--   * A table encodes as an array iff t[1] ~= nil, else as an object; the empty table
+--     encodes as [] (the protocol has empty reach LISTS but no empty objects).
+--   * decode() maps JSON null to Lua nil (the protocol never puts null inside arrays,
+--     where nil would truncate the sequence).
+
+local M = {}
+
+-- ---------------------------------------------------------------- encode
+local ESCAPES = {
+    ['"'] = '\\"', ['\\'] = '\\\\', ['\b'] = '\\b', ['\f'] = '\\f',
+    ['\n'] = '\\n', ['\r'] = '\\r', ['\t'] = '\\t',
+}
+
+local function encodeString(s)
+    return '"' .. s:gsub('[%z\1-\31"\\]', function(c)
+        return ESCAPES[c] or string.format('\\u%04x', c:byte())
+    end) .. '"'
+end
+
+local function encodeNumber(n)
+    if n ~= n or n == math.huge or n == -math.huge then
+        error("json.encode: cannot encode nan/inf")
+    end
+    if math.type(n) == "integer" then return string.format("%d", n) end
+    return string.format("%.14g", n)
+end
+
+local encodeValue
+
+local function encodeTable(t)
+    if t[1] ~= nil then                         -- array
+        local parts = {}
+        for i = 1, #t do parts[i] = encodeValue(t[i]) end
+        return "[" .. table.concat(parts, ",") .. "]"
+    end
+    local keys = {}
+    for k in pairs(t) do
+        if type(k) ~= "string" then
+            error("json.encode: object keys must be strings, got " .. type(k))
+        end
+        keys[#keys + 1] = k
+    end
+    if #keys == 0 then return "[]" end          -- empty table = empty array (see header)
+    table.sort(keys)
+    local parts = {}
+    for i, k in ipairs(keys) do
+        parts[i] = encodeString(k) .. ":" .. encodeValue(t[k])
+    end
+    return "{" .. table.concat(parts, ",") .. "}"
+end
+
+encodeValue = function(v)
+    local ty = type(v)
+    if v == nil then return "null"
+    elseif ty == "boolean" then return v and "true" or "false"
+    elseif ty == "number" then return encodeNumber(v)
+    elseif ty == "string" then return encodeString(v)
+    elseif ty == "table" then return encodeTable(v)
+    end
+    error("json.encode: cannot encode a " .. ty)
+end
+
+function M.encode(v) return encodeValue(v) end
+
+-- ---------------------------------------------------------------- decode
+-- Recursive descent over a position index. Each parser returns (value, nextPos) or
+-- raises via error(msg, 0); M.decode wraps that into the (nil, reason) convention.
+
+local function skipSpace(s, i)
+    local _, j = s:find("^[ \t\r\n]*", i)
+    return j + 1
+end
+
+local UNESCAPES = {
+    ['"'] = '"', ['\\'] = '\\', ['/'] = '/', b = '\b', f = '\f',
+    n = '\n', r = '\r', t = '\t',
+}
+
+local function parseString(s, i)               -- i sits on the opening quote
+    local out, j = {}, i + 1
+    while true do
+        local c = s:sub(j, j)
+        if c == "" then error("unterminated string at " .. i, 0) end
+        if c == '"' then return table.concat(out), j + 1 end
+        if c == "\\" then
+            local e = s:sub(j + 1, j + 1)
+            if e == "u" then
+                local hex = s:sub(j + 2, j + 5)
+                if not hex:match("^%x%x%x%x$") then
+                    error("bad \\u escape at " .. j, 0)
+                end
+                out[#out + 1] = utf8.char(tonumber(hex, 16))
+                j = j + 6
+            elseif UNESCAPES[e] then
+                out[#out + 1] = UNESCAPES[e]
+                j = j + 2
+            else
+                error("bad escape '\\" .. e .. "' at " .. j, 0)
+            end
+        else
+            out[#out + 1] = c
+            j = j + 1
+        end
+    end
+end
+
+local function parseNumber(s, i)
+    local numstr = s:match("^-?%d+%.?%d*[eE]?[+-]?%d*", i)
+    local n = numstr and tonumber(numstr)
+    if not n then error("bad number at " .. i, 0) end
+    return n, i + #numstr
+end
+
+local parseValue
+
+local function parseArray(s, i)                -- i sits on '['
+    local out, j = {}, skipSpace(s, i + 1)
+    if s:sub(j, j) == "]" then return out, j + 1 end
+    while true do
+        local v
+        v, j = parseValue(s, j)
+        out[#out + 1] = v
+        j = skipSpace(s, j)
+        local c = s:sub(j, j)
+        if c == "]" then return out, j + 1 end
+        if c ~= "," then error("expected ',' or ']' at " .. j, 0) end
+        j = skipSpace(s, j + 1)
+    end
+end
+
+local function parseObject(s, i)               -- i sits on '{'
+    local out, j = {}, skipSpace(s, i + 1)
+    if s:sub(j, j) == "}" then return out, j + 1 end
+    while true do
+        if s:sub(j, j) ~= '"' then error("expected object key at " .. j, 0) end
+        local k, v
+        k, j = parseString(s, j)
+        j = skipSpace(s, j)
+        if s:sub(j, j) ~= ":" then error("expected ':' at " .. j, 0) end
+        v, j = parseValue(s, skipSpace(s, j + 1))
+        out[k] = v
+        j = skipSpace(s, j)
+        local c = s:sub(j, j)
+        if c == "}" then return out, j + 1 end
+        if c ~= "," then error("expected ',' or '}' at " .. j, 0) end
+        j = skipSpace(s, j + 1)
+    end
+end
+
+parseValue = function(s, i)
+    local c = s:sub(i, i)
+    if c == "{" then return parseObject(s, i) end
+    if c == "[" then return parseArray(s, i) end
+    if c == '"' then return parseString(s, i) end
+    if c == "t" and s:sub(i, i + 3) == "true" then return true, i + 4 end
+    if c == "f" and s:sub(i, i + 4) == "false" then return false, i + 5 end
+    if c == "n" and s:sub(i, i + 3) == "null" then return nil, i + 4 end
+    if c == "-" or c:match("%d") then return parseNumber(s, i) end
+    error("unexpected character '" .. c .. "' at " .. i, 0)
+end
+
+-- decode(s) -> value | (nil, reason). Trailing garbage after the value is an error
+-- (a truncated/corrupt handshake file must not half-parse into plausible orders).
+function M.decode(s)
+    if type(s) ~= "string" then return nil, "not a string" end
+    local ok, v, j = pcall(parseValue, s, skipSpace(s, 1))
+    if not ok then return nil, v end
+    if skipSpace(s, j) <= #s then return nil, "trailing garbage at " .. j end
+    return v
+end
+
+return M

--- a/tools/playtest/llm_player.py
+++ b/tools/playtest/llm_player.py
@@ -23,6 +23,7 @@ Design + settled decisions: docs/decisions.md -> Playtest platform brick 4; epic
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 import sys
@@ -61,9 +62,12 @@ def validate_orders(orders, board, faction):
     (each `{order, reason}`) as a play-quality signal -- a bad LLM turn is dropped, never
     soft-locked. An order is `{unit, move_to:{x,y}, action, target?}`. Rejections, in the
     order checked: unknown unit; not the commanded faction; unit can't still act;
-    `move_to` outside the unit's reachable set; unknown action; a targeted action
-    (attack/staff) whose target is missing, unknown, dead, or out of weapon range from
-    `move_to`.
+    `move_to` outside the unit's reachable set; unknown action; `seize` when the board's
+    objective isn't Seize (the exporter carries no goal tile, so objective is the gate);
+    a targeted action (attack/staff) whose target is missing, unknown, dead, on the
+    wrong side (attack needs a foe, staff an ally), or out of range from `move_to` --
+    where a unit the exporter gave no `range` (staff-only/weaponless) can target nothing
+    at all: the blind-A executor would walk into the wrong submenu (staff driving is M3).
     """
     by_id = {u['id']: u for u in board.get('units', [])}
     accepted, rejected = [], []
@@ -91,6 +95,10 @@ def validate_orders(orders, board, faction):
             rejected.append(_reject(order, 'unknown action %r' % (action,)))
             continue
 
+        if action == 'seize' and board.get('objective') != 'Seize':
+            rejected.append(_reject(order, 'objective is not Seize'))
+            continue
+
         if action in TARGETED_ACTIONS:
             target = by_id.get(order.get('target'))
             if target is None:
@@ -99,7 +107,18 @@ def validate_orders(orders, board, faction):
             if target.get('hp', 0) <= 0:
                 rejected.append(_reject(order, 'target is already dead'))
                 continue
-            lo, hi = unit.get('range', [1, 1])
+            if action == 'attack' and target.get('faction') == faction:
+                rejected.append(_reject(order, 'attack target is a friendly unit'))
+                continue
+            if action == 'staff' and target.get('faction') != faction:
+                rejected.append(_reject(order, 'staff target is not a friendly unit'))
+                continue
+            rng = unit.get('range')
+            if not rng:
+                rejected.append(_reject(order, 'unit has no attack range '
+                                               '(staff/weaponless; staff driving is M3)'))
+                continue
+            lo, hi = rng
             dist = abs(tile[0] - target['x']) + abs(tile[1] - target['y'])
             if dist < lo or dist > hi:
                 rejected.append(_reject(order, 'target is out of weapon range'))
@@ -193,6 +212,20 @@ def build_prompt(board, faction):
     return system, user
 
 
+def _all_finite(obj):
+    """No NaN/Infinity anywhere in the parsed value (json.loads accepts them, but a
+    non-finite number would round-trip into a resp/transcript that strict JSON readers
+    -- json.lua -- cannot parse). Note `1e999` overflows to inf via the ordinary float
+    path, so this must inspect VALUES; a parse_constant hook alone misses it."""
+    if isinstance(obj, float):
+        return math.isfinite(obj)
+    if isinstance(obj, dict):
+        return all(_all_finite(v) for v in obj.values())
+    if isinstance(obj, list):
+        return all(_all_finite(v) for v in obj)
+    return True
+
+
 def parse_orders(text):
     """Model output text -> the orders list, or [] on anything unparseable.
 
@@ -220,7 +253,7 @@ def parse_orders(text):
         if isinstance(got, dict):
             got = got.get('orders')
         if isinstance(got, list):
-            return [o for o in got if isinstance(o, dict)]
+            return [o for o in got if isinstance(o, dict) and _all_finite(o)]
     return []
 
 
@@ -253,6 +286,11 @@ def _post_json(url, headers, payload, timeout=120):
     except urllib.error.HTTPError as e:
         raise RuntimeError('%s -> HTTP %d: %s'
                            % (url, e.code, e.read().decode('utf-8', 'replace')[:500]))
+    except urllib.error.URLError as e:
+        # The first failure a free-local-model user hits is "Ollama isn't running";
+        # name it instead of dying with a bare connection error.
+        raise RuntimeError('%s -> unreachable (%s); is the endpoint up? '
+                           '(free local path: `ollama serve`)' % (url, e.reason))
 
 
 def _call_anthropic(cfg, system, user):
@@ -296,11 +334,17 @@ def policy_config(env=None):
     if provider not in PROVIDERS:
         raise ValueError('PT_PROVIDER must be one of %s, got %r'
                          % ('/'.join(sorted(PROVIDERS)), provider))
+    api_key = env.get('PT_API_KEY') or None
+    if provider == 'anthropic':
+        # ANTHROPIC_API_KEY feeds ONLY the anthropic transport -- resolving it for the
+        # openai provider would Bearer-leak the Anthropic secret to whatever host
+        # PT_BASE_URL names.
+        api_key = api_key or env.get('ANTHROPIC_API_KEY') or None
     return {
         'provider': provider,
         'model': env.get('PT_MODEL') or DEFAULT_MODELS[provider],
         'base_url': env.get('PT_BASE_URL') or None,
-        'api_key': env.get('PT_API_KEY') or env.get('ANTHROPIC_API_KEY') or None,
+        'api_key': api_key,
     }
 
 
@@ -356,7 +400,10 @@ class Sidecar:
         final = os.path.join(self.dir, 'resp-%d.json' % n)
         tmp = final + '.tmp'
         with open(tmp, 'w', encoding='utf-8') as f:
-            json.dump(payload, f)
+            # allow_nan=False: json.lua is a strict reader; parse_orders already gates
+            # non-finite numbers out, this makes a future leak loud instead of shipping
+            # a resp the harness can't parse
+            json.dump(payload, f, allow_nan=False)
         os.replace(tmp, final)
 
     def step(self):
@@ -365,8 +412,14 @@ class Sidecar:
         if not pending:
             return None
         n = pending[0]
-        with open(os.path.join(self.dir, 'req-%d.json' % n), encoding='utf-8') as f:
-            req = json.load(f)
+        try:
+            with open(os.path.join(self.dir, 'req-%d.json' % n), encoding='utf-8') as f:
+                req = json.load(f)
+        except FileNotFoundError:
+            # run.sh's stale-file cleanup can race a sidecar started first (per the
+            # documented order) and delete a request between our listdir and open --
+            # a vanished request simply isn't pending anymore
+            return None
         board = req['board']
         faction = req.get('faction', self.faction)
         try:
@@ -376,6 +429,12 @@ class Sidecar:
                                             decide_fn=self.policy)
         except TranscriptMiss as e:
             self._write_resp(n, {'orders': [], 'error': 'transcript miss: %s' % e})
+            raise
+        except Exception as e:
+            # A live-policy failure (endpoint down, HTTP error) must still answer the
+            # harness -- an error response is a fast, diagnosable FAIL; silence is a
+            # 90-second timeout pointing at the wrong suspect.
+            self._write_resp(n, {'orders': [], 'error': '%s: %s' % (type(e).__name__, e)})
             raise
         accepted, rejected = validate_orders(orders, board, faction)
         self._write_resp(n, {'orders': accepted, 'rejected': rejected})
@@ -424,6 +483,13 @@ def main(argv=None):
         policy = None
         print('replay mode: %d recorded decisions' % len(transcript.entries))
     sidecar = Sidecar(args.dir, transcript, policy=policy, faction=args.faction)
+    stale = sidecar._pending()
+    if stale:
+        # run.sh clears the handshake dir when IT starts; a request already waiting
+        # when the SIDECAR starts is usually a crashed prior run about to be answered
+        # against a board that no longer exists.
+        print('WARNING: pre-existing request(s) %s in %s -- if these are from a '
+              'crashed run, stop and clear the dir' % (stale, args.dir))
     try:
         answered = sidecar.serve(log=lambda s: print(s, flush=True))
     finally:

--- a/tools/playtest/llm_player.py
+++ b/tools/playtest/llm_player.py
@@ -7,14 +7,28 @@ the harness exports the board to a file and blocks, this process decides, writes
 orders back. Per the platform doctrine -- pure core, driver owns I/O -- everything here
 is plain Python, unit-testable on CI with no emulator (test_llm_player.py).
 
-M1 ships the three pure cores only, no LLM calls yet:
-  * serialize_board  -- FE board state -> compact, deterministic JSON (prompt + hash key)
-  * (M1 continues with the order validator + transcript, added below as TDD proceeds)
+M1 shipped the three pure cores (serialize_board, validate_orders, Transcript). M2 adds
+the sidecar itself: the request/response FILE loop (`Sidecar`, `serve` CLI) plus the
+provider-agnostic live policy -- prompt builder, robust order parsing, and two urllib
+transports (Anthropic Messages API, or ANY OpenAI-compatible /chat/completions endpoint,
+which is how a FREE local model plays: Ollama or llama.cpp serving Llama/Gemma). Replay
+from a recorded transcript stays the default -- CI and re-soaks never call a model.
+
+Handshake (epic #63): the harness writes `req-<n>.json` {seed, chapter, turn, faction,
+board} and polls for `resp-<n>.json` {orders, rejected, reasoning?}; all writes on both
+sides are tmp+rename so a half-written file is never read.
 
 Design + settled decisions: docs/decisions.md -> Playtest platform brick 4; epic #63.
 """
+import argparse
 import hashlib
 import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
 
 
 def serialize_board(board):
@@ -144,3 +158,282 @@ class Transcript:
     def load(cls, path, mode='replay'):
         with open(path, encoding='utf-8') as f:
             return cls(entries=json.load(f), mode=mode)
+
+
+# ---------------------------------------------------------------- prompt + parse (pure)
+
+SYSTEM_PROMPT = """\
+You are the commander of the %(faction)s army in a Fire Emblem (GBA) tactics battle.
+Each turn you receive the full board as JSON and must order your units.
+
+Rules:
+- Order ONLY units of your faction with "can_act": true.
+- "move_to" MUST be one of that unit's "reach" tiles (listed as [x, y] pairs).
+- "attack" needs a "target" (an enemy unit id) whose Manhattan distance from your
+  "move_to" tile is within the unit's weapon "range" [min, max].
+- Units act in the order you list them. A unit not ordered simply stays put.
+- Play to WIN without losing units: gang up to secure kills, keep the wounded out of
+  enemy reach, and press toward the objective.
+
+Reply with ONLY a JSON object, no other text:
+{"orders": [{"unit": <id>, "move_to": {"x": <x>, "y": <y>},
+             "action": "attack"|"wait"|"seize"|"staff", "target": <enemy id, if attacking>}]}
+"""
+
+
+def build_prompt(board, faction):
+    """(system, user) prompt pair for one per-turn commander decision.
+
+    Pure: the user half embeds `serialize_board` (the same bytes the transcript keys
+    on), so a prompt is reproducible from the request file alone.
+    """
+    system = SYSTEM_PROMPT % {'faction': faction}
+    user = 'Objective: %s\nBoard:\n%s\nGive your orders.' % (
+        board.get('objective', 'defeat the boss'), serialize_board(board))
+    return system, user
+
+
+def parse_orders(text):
+    """Model output text -> the orders list, or [] on anything unparseable.
+
+    LLMs wrap JSON in prose or code fences despite instructions; a free local model
+    (Llama/Gemma) does so more than most. Extraction ladder: whole text as JSON -> the
+    first ```-fenced block -> the outermost {...} or [...] slice. Accepts either a bare
+    orders array or an object with an "orders" key. Never raises -- a garbage turn
+    returns [] and plays as all-wait (the soft-lock guard is the harness's timeout).
+    """
+    if not isinstance(text, str):
+        return []
+    candidates = [text.strip()]
+    fence = re.search(r'```(?:json)?\s*(.*?)```', text, re.DOTALL)
+    if fence:
+        candidates.append(fence.group(1).strip())
+    for opener, closer in (('{', '}'), ('[', ']')):
+        start, end = text.find(opener), text.rfind(closer)
+        if 0 <= start < end:
+            candidates.append(text[start:end + 1])
+    for cand in candidates:
+        try:
+            got = json.loads(cand)
+        except ValueError:
+            continue
+        if isinstance(got, dict):
+            got = got.get('orders')
+        if isinstance(got, list):
+            return [o for o in got if isinstance(o, dict)]
+    return []
+
+
+# ---------------------------------------------------------------- live policy (urllib)
+# No SDK dependency on purpose: this repo's tooling is stdlib+{numpy,pillow,pyyaml} only,
+# and the sidecar must run anywhere a playtester has python3. Both transports are thin
+# enough that urllib is the smaller risk (vs. a new dep for two POSTs).
+
+ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
+ANTHROPIC_VERSION = '2023-06-01'
+OLLAMA_BASE_URL = 'http://localhost:11434/v1'   # OpenAI-compatible; llama.cpp/vLLM too
+DEFAULT_MODELS = {
+    # Epic #63 locked "Sonnet default" -- a weak player fires FALSE balance alarms.
+    'anthropic': 'claude-sonnet-5',
+    # The free happy medium (Nicolas 2026-07-02): a local model via Ollama. Weaker play
+    # = plumbing/smoke value more than balance-signal value; see decisions.md.
+    'openai': 'llama3.1',
+}
+
+
+def _post_json(url, headers, payload, timeout=120):
+    """POST a JSON payload, return the parsed JSON response. Raises RuntimeError with
+    the response body on an HTTP error (the body carries the useful message)."""
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode('utf-8'),
+        headers=dict(headers, **{'content-type': 'application/json'}), method='POST')
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+    except urllib.error.HTTPError as e:
+        raise RuntimeError('%s -> HTTP %d: %s'
+                           % (url, e.code, e.read().decode('utf-8', 'replace')[:500]))
+
+
+def _call_anthropic(cfg, system, user):
+    resp = _post_json(
+        cfg.get('base_url') or ANTHROPIC_URL,
+        {'x-api-key': cfg['api_key'], 'anthropic-version': ANTHROPIC_VERSION},
+        {'model': cfg['model'], 'max_tokens': 2048, 'system': system,
+         'messages': [{'role': 'user', 'content': user}]})
+    return ''.join(b.get('text', '') for b in resp.get('content', [])
+                   if b.get('type') == 'text')
+
+
+def _call_openai(cfg, system, user):
+    base = (cfg.get('base_url') or OLLAMA_BASE_URL).rstrip('/')
+    resp = _post_json(
+        base + '/chat/completions',
+        # Ollama/llama.cpp ignore the key but the header keeps real OpenAI-compatible
+        # hosts happy; "ollama" is the conventional placeholder.
+        {'authorization': 'Bearer ' + (cfg.get('api_key') or 'ollama')},
+        {'model': cfg['model'],
+         'messages': [{'role': 'system', 'content': system},
+                      {'role': 'user', 'content': user}]})
+    return resp['choices'][0]['message']['content'] or ''
+
+PROVIDERS = {'anthropic': _call_anthropic, 'openai': _call_openai}
+
+
+def policy_config(env=None):
+    """Resolve the live-policy knobs from the environment.
+
+    PT_PROVIDER  anthropic (default; epic: Sonnet plays well enough to trust the signal)
+                 | openai = any OpenAI-compatible endpoint -- Ollama/llama.cpp serving
+                 Llama or Gemma is the FREE local soak.
+    PT_MODEL     model id (defaults per provider, see DEFAULT_MODELS)
+    PT_BASE_URL  endpoint override (openai default: OLLAMA_BASE_URL, localhost:11434)
+    PT_API_KEY   key for openai-compatible hosts (unneeded for local Ollama);
+                 anthropic reads ANTHROPIC_API_KEY.
+    """
+    env = os.environ if env is None else env
+    provider = env.get('PT_PROVIDER', 'anthropic').lower()
+    if provider not in PROVIDERS:
+        raise ValueError('PT_PROVIDER must be one of %s, got %r'
+                         % ('/'.join(sorted(PROVIDERS)), provider))
+    return {
+        'provider': provider,
+        'model': env.get('PT_MODEL') or DEFAULT_MODELS[provider],
+        'base_url': env.get('PT_BASE_URL') or None,
+        'api_key': env.get('PT_API_KEY') or env.get('ANTHROPIC_API_KEY') or None,
+    }
+
+
+def make_policy(faction, env=None, transport=None):
+    """A `decide_fn(board) -> orders` closure over the env-configured provider.
+
+    `transport` (tests) replaces the HTTP call: (cfg, system, user) -> response text.
+    """
+    cfg = policy_config(env)
+    if cfg['provider'] == 'anthropic' and not cfg['api_key'] and transport is None:
+        raise ValueError('anthropic provider needs ANTHROPIC_API_KEY (or PT_API_KEY); '
+                         'for a free local model: PT_PROVIDER=openai + an Ollama serve')
+    call = transport or PROVIDERS[cfg['provider']]
+
+    def decide(board):
+        system, user = build_prompt(board, faction)
+        return parse_orders(call(cfg, system, user))
+    return decide
+
+
+# ---------------------------------------------------------------- sidecar file loop
+
+REQ_RE = re.compile(r'^req-(\d+)\.json$')
+
+
+class Sidecar:
+    """The request/response file loop the harness's `llm` scenario talks to.
+
+    One `step()` answers the lowest-numbered unanswered request (testable without any
+    filesystem watching or threads); `serve()` polls until a `stop` file appears. Every
+    response is written tmp+rename so the polling harness never reads a partial file.
+    Orders pass through `validate_orders` before they ship: the harness only ever sees
+    legal orders in `orders`, with the culls in `rejected` (a play-quality signal it
+    logs). A replay-mode transcript miss writes an error response (fast, diagnosable
+    FAIL on the harness side) and then re-raises -- CI/replay is closed-world.
+    """
+
+    def __init__(self, dirpath, transcript, policy=None, faction='blue'):
+        self.dir = dirpath
+        self.transcript = transcript
+        self.policy = policy
+        self.faction = faction
+
+    def _pending(self):
+        reqs = []
+        for name in os.listdir(self.dir):
+            m = REQ_RE.match(name)
+            if m and not os.path.exists(os.path.join(self.dir, 'resp-%s.json' % m.group(1))):
+                reqs.append(int(m.group(1)))
+        return sorted(reqs)
+
+    def _write_resp(self, n, payload):
+        final = os.path.join(self.dir, 'resp-%d.json' % n)
+        tmp = final + '.tmp'
+        with open(tmp, 'w', encoding='utf-8') as f:
+            json.dump(payload, f)
+        os.replace(tmp, final)
+
+    def step(self):
+        """Answer one pending request; returns its number, or None when idle."""
+        pending = self._pending()
+        if not pending:
+            return None
+        n = pending[0]
+        with open(os.path.join(self.dir, 'req-%d.json' % n), encoding='utf-8') as f:
+            req = json.load(f)
+        board = req['board']
+        faction = req.get('faction', self.faction)
+        try:
+            orders = self.transcript.decide(board, seed=req.get('seed'),
+                                            chapter=req.get('chapter'),
+                                            turn=req.get('turn'),
+                                            decide_fn=self.policy)
+        except TranscriptMiss as e:
+            self._write_resp(n, {'orders': [], 'error': 'transcript miss: %s' % e})
+            raise
+        accepted, rejected = validate_orders(orders, board, faction)
+        self._write_resp(n, {'orders': accepted, 'rejected': rejected})
+        return n
+
+    def serve(self, poll_interval=0.25, log=None):
+        """Answer requests until `<dir>/stop` exists (pending requests are drained
+        before the stop is honored). Returns the number of requests answered."""
+        stop = os.path.join(self.dir, 'stop')
+        answered = 0
+        while True:
+            n = self.step()
+            if n is not None:
+                answered += 1
+                if log:
+                    log('answered req-%d' % n)
+                continue
+            if os.path.exists(stop):
+                return answered
+            time.sleep(poll_interval)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = p.add_subparsers(dest='cmd', required=True)
+    s = sub.add_parser('serve', help='answer harness requests from a handshake dir')
+    s.add_argument('--dir', required=True, help='handshake dir (harness PT_LLM_DIR)')
+    s.add_argument('--transcript', required=True,
+                   help='transcript JSON path (created in --record mode)')
+    s.add_argument('--record', action='store_true',
+                   help='record mode: cache miss -> live model call (env knobs: '
+                        'PT_PROVIDER/PT_MODEL/PT_BASE_URL); default is replay-only')
+    s.add_argument('--faction', default='blue')
+    args = p.parse_args(argv)
+
+    os.makedirs(args.dir, exist_ok=True)
+    if args.record:
+        transcript = (Transcript.load(args.transcript, mode='record')
+                      if os.path.exists(args.transcript) else Transcript(mode='record'))
+        policy = make_policy(args.faction)
+        cfg = policy_config()
+        print('record mode: %(provider)s %(model)s (base %(base_url)s)'
+              % dict(cfg, base_url=cfg['base_url'] or 'default'))
+    else:
+        transcript = Transcript.load(args.transcript, mode='replay')
+        policy = None
+        print('replay mode: %d recorded decisions' % len(transcript.entries))
+    sidecar = Sidecar(args.dir, transcript, policy=policy, faction=args.faction)
+    try:
+        answered = sidecar.serve(log=lambda s: print(s, flush=True))
+    finally:
+        if args.record:
+            transcript.save(args.transcript)
+            print('transcript saved: %s (%d entries)'
+                  % (args.transcript, len(transcript.entries)))
+    print('served %d requests' % answered)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -14,6 +14,15 @@
 #                           chwinga charm-gifts (CHECK_ALIVE -> GIVEITEMTO) reach leader/convoy (#22)
 #   fuzz  | fuzz_ch01    -- SEEDED random-input soak (#49); set PT_SEED=N (default 1) to
 #                           pick the seed; a FAIL prints the seed so PT_SEED=N replays it
+#   llm                  -- LLM-player commander on the prologue (#63): the harness
+#                           handshakes with an EXTERNAL sidecar over PT_LLM_DIR (default
+#                           /tmp/playtest-llm-handshake). Start the sidecar first:
+#                             python3 tools/playtest/llm_player.py serve \
+#                                 --dir /tmp/playtest-llm-handshake \
+#                                 --transcript tools/playtest/transcripts/prologue.json
+#                           Replay-only by default (zero LLM cost); add --record + env
+#                           knobs (PT_PROVIDER=openai for a free local Ollama model,
+#                           PT_MODEL, PT_BASE_URL) to record a fresh transcript.
 # Recording scenarios (drop motion frames for a review GIF):
 #   recordending  -- the ch01 "Rolling Cheddar" outro cutscene (frames tagged "end")
 #   recordprep    -- the Preparations + Pick Units deploy screen (frames "prep")
@@ -53,6 +62,14 @@ KEEP_OPEN="${2:-}"
 STATE_DIR="$HERE/states"
 mkdir -p "$STATE_DIR"
 
+# LLM-player handshake dir (#63): fresh req/resp files per run -- a stale resp-1.json
+# from the last run would satisfy the first poll instantly with old orders.
+LLM_DIR="${PT_LLM_DIR:-/tmp/playtest-llm-handshake}"
+if [ "$SCENARIO" = "llm" ]; then
+    mkdir -p "$LLM_DIR"
+    rm -f "$LLM_DIR"/req-*.json "$LLM_DIR"/resp-*.json "$LLM_DIR"/*.tmp "$LLM_DIR/stop"
+fi
+
 if [ ! -x "$APP" ]; then
     echo "mGBA dev build missing; downloading nightly..."
     curl -fsSL -o /tmp/mgba-nightly.dmg "https://s3.amazonaws.com/mgba/mGBA-build-latest-macos.dmg"
@@ -82,6 +99,7 @@ PLAYTEST_SHOTDIR = "$out"
 PLAYTEST_STATEDIR = "$STATE_DIR"
 PLAYTEST_SEED = "${PT_SEED:-1}"
 PLAYTEST_CHAR = "${PT_CHAR:-}"
+PLAYTEST_LLMDIR = "$LLM_DIR"
 dofile("$HERE/harness.lua")
 EOF
     rm -f "$REPO/fireemblem8u/fireemblem8.sav"   # fresh save: New Game is the default path
@@ -137,9 +155,9 @@ fi
 # record* now LOADS a checkpoint (no grind), so its deadline is short.
 FPS=240; VSYNC=0; DEADLINE_S=420
 case "$SCENARIO" in record*) FPS=60; VSYNC=1; DEADLINE_S=300 ;; esac
-# smoke_* / fuzz_* / clear_ch02 play a full chapter (lead-in + a long idle/random/clear soak)
-# -> longer wall.
-case "$SCENARIO" in smoke*|fuzz*|clear_ch02) DEADLINE_S=600 ;; esac
+# smoke_* / fuzz_* / clear_ch02 / llm play a full chapter (lead-in + a long soak; the
+# llm handshake also waits wall-clock on the sidecar each turn) -> longer wall.
+case "$SCENARIO" in smoke*|fuzz*|clear_ch02|llm) DEADLINE_S=600 ;; esac
 # PT_FPS overrides the rate. 60fps+videoSync is only needed to capture smooth cutscene
 # FADES; verification captures of static text/boxes (sign, death quote) read fine at top
 # speed, so `PT_FPS=240 ... recordfix` runs ~4x faster.

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -22,7 +22,9 @@
 #                                 --transcript tools/playtest/transcripts/prologue.json
 #                           Replay-only by default (zero LLM cost); add --record + env
 #                           knobs (PT_PROVIDER=openai for a free local Ollama model,
-#                           PT_MODEL, PT_BASE_URL) to record a fresh transcript.
+#                           PT_MODEL, PT_BASE_URL) to record a fresh transcript. When
+#                           the run ends this script touches <dir>/stop: the sidecar
+#                           drains, saves its transcript, and exits on its own.
 # Recording scenarios (drop motion frames for a review GIF):
 #   recordending  -- the ch01 "Rolling Cheddar" outro cutscene (frames tagged "end")
 #   recordprep    -- the Preparations + Pick Units deploy screen (frames "prep")
@@ -155,12 +157,18 @@ fi
 # record* now LOADS a checkpoint (no grind), so its deadline is short.
 FPS=240; VSYNC=0; DEADLINE_S=420
 case "$SCENARIO" in record*) FPS=60; VSYNC=1; DEADLINE_S=300 ;; esac
-# smoke_* / fuzz_* / clear_ch02 / llm play a full chapter (lead-in + a long soak; the
-# llm handshake also waits wall-clock on the sidecar each turn) -> longer wall.
-case "$SCENARIO" in smoke*|fuzz*|clear_ch02|llm) DEADLINE_S=600 ;; esac
+# smoke_* / fuzz_* / clear_ch02 play a full chapter (lead-in + a long soak) -> longer
+# wall. llm waits wall-clock on the sidecar EVERY turn (18 turns x 90s handshake
+# budget), and a --record run against a slow local model legitimately uses it -- so its
+# deadline covers the harness's own worst case instead of killing a healthy run.
+case "$SCENARIO" in smoke*|fuzz*|clear_ch02) DEADLINE_S=600 ;; llm) DEADLINE_S=2100 ;; esac
 # PT_FPS overrides the rate. 60fps+videoSync is only needed to capture smooth cutscene
 # FADES; verification captures of static text/boxes (sign, death quote) read fine at top
 # speed, so `PT_FPS=240 ... recordfix` runs ~4x faster.
 if [ -n "${PT_FPS:-}" ]; then FPS="$PT_FPS"; [ "$PT_FPS" -ge 240 ] && VSYNC=0; fi
 run_mgba "$SCENARIO" "$FPS" "$VSYNC" "$DEADLINE_S"
+# Tell the sidecar the run is over: serve() drains any pending request, saves its
+# transcript (record mode), and exits -- without this it polls forever and a recorded
+# transcript would only be saved by a clean Ctrl-C.
+if [ "$SCENARIO" = "llm" ]; then touch "$LLM_DIR/stop"; fi
 case "$VERDICT" in *PASS*) exit 0 ;; *) exit 1 ;; esac

--- a/tools/playtest/test_json.lua
+++ b/tools/playtest/test_json.lua
@@ -1,0 +1,100 @@
+-- Tests for json.lua -- the sidecar-handshake JSON encode/decode core (no emulator).
+-- Run: lua tools/playtest/test_json.lua
+local here = (arg[0]:match("(.*/)")) or "./"
+local J = dofile(here .. "json.lua")
+
+local tests, fails = 0, 0
+local function check(got, want, msg)
+    tests = tests + 1
+    if got ~= want then
+        fails = fails + 1
+        print(string.format("FAIL: %s\n  got  %s\n  want %s", msg, tostring(got), tostring(want)))
+    end
+end
+
+-- ---- encode -----------------------------------------------------------------
+check(J.encode(nil), "null", "encode nil")
+check(J.encode(true), "true", "encode true")
+check(J.encode(false), "false", "encode false")
+check(J.encode(42), "42", "encode integer")
+check(J.encode(-7), "-7", "encode negative integer")
+check(J.encode(1.5), "1.5", "encode float")
+check(J.encode("hi"), '"hi"', "encode plain string")
+check(J.encode('a"b\\c\nd'), '"a\\"b\\\\c\\nd"', "encode escapes")
+check(J.encode({}), "[]", "empty table encodes as empty array")
+check(J.encode({ 1, 2, 3 }), "[1,2,3]", "encode array")
+check(J.encode({ { 3, 4 }, { 5, 4 } }), "[[3,4],[5,4]]", "encode nested array (reach list)")
+
+-- object keys come out SORTED, so identical tables give identical bytes
+check(J.encode({ b = 1, a = 2 }), '{"a":2,"b":1}', "object keys are sorted")
+check(J.encode({ move_to = { x = 5, y = 4 }, unit = 17 }),
+    '{"move_to":{"x":5,"y":4},"unit":17}', "encode a nested order shape")
+
+-- deterministic: two insertion orders, same bytes
+do
+    local a = { seed = 1, turn = 2, faction = "blue" }
+    local b = { faction = "blue", seed = 1, turn = 2 }
+    check(J.encode(a), J.encode(b), "encode is insertion-order independent")
+end
+
+-- non-encodable values fail loudly, not silently
+check(pcall(J.encode, { f = print }), false, "encoding a function errors")
+check(pcall(J.encode, { [1.5] = "x", x = 1 }), false, "non-string object key errors")
+check(pcall(J.encode, 0 / 0), false, "encoding nan errors")
+
+-- ---- decode -----------------------------------------------------------------
+do
+    local v = J.decode('{"orders":[{"unit":17,"move_to":{"x":5,"y":4},"action":"attack","target":104}]}')
+    check(v ~= nil, true, "decode a response shape")
+    check(v.orders[1].unit, 17, "decode order unit id")
+    check(v.orders[1].move_to.x, 5, "decode nested move_to.x")
+    check(v.orders[1].action, "attack", "decode action string")
+    check(v.orders[1].target, 104, "decode target id")
+end
+
+check(J.decode("[]")[1], nil, "decode empty array")
+check(#J.decode("[1,2,3]"), 3, "decode array length")
+check(J.decode("-12"), -12, "decode negative number")
+check(J.decode("2.5e2"), 250.0, "decode exponent float")
+check(J.decode('"a\\nb"'), "a\nb", "decode newline escape")
+check(J.decode('"\\u0041"'), "A", "decode unicode escape")
+check(J.decode('  { "a" : [ 1 , 2 ] }  ').a[2], 2, "whitespace tolerated everywhere")
+check(J.decode('{"a":null,"b":1}').a, nil, "null decodes to nil object value")
+check(J.decode('{"a":null,"b":1}').b, 1, "sibling of a null survives")
+check(J.decode('{"a":true,"b":false}').b, false, "decode booleans")
+
+-- round trip: encode -> decode reproduces the structure
+do
+    local board = {
+        map = { w = 15, h = 10 },
+        units = {
+            { id = 17, x = 3, y = 4, hp = 18, can_act = true, reach = { { 3, 4 }, { 4, 4 } } },
+            { id = 1104, x = 6, y = 4, hp = 22, can_act = false, boss = true, reach = {} },
+        },
+    }
+    local rt = J.decode(J.encode(board))
+    check(rt.map.w, 15, "round trip map width")
+    check(rt.units[1].reach[2][1], 4, "round trip nested reach pair")
+    check(rt.units[2].boss, true, "round trip boolean")
+    check(#rt.units[2].reach, 0, "round trip empty reach")
+    check(J.encode(rt), J.encode(board), "re-encode is byte-identical")
+end
+
+-- corrupt input -> (nil, reason), never a half-parsed value
+do
+    local v, err = J.decode('{"orders":[{"unit":17')
+    check(v, nil, "truncated JSON returns nil")
+    check(err ~= nil, true, "truncated JSON returns a reason")
+end
+do
+    local v, err = J.decode('{"a":1} trailing')
+    check(v, nil, "trailing garbage returns nil")
+    check(err and err:match("trailing") ~= nil, true, "trailing garbage names the reason")
+end
+check(J.decode("nope"), nil, "non-JSON text returns nil")
+check(J.decode(nil), nil, "non-string input returns nil")
+check(J.decode('{"a" 1}'), nil, "missing colon returns nil")
+check(J.decode("[1,2,"), nil, "unclosed array returns nil")
+
+print(string.format("json: %d tests, %d failures", tests, fails))
+os.exit(fails == 0 and 0 or 1)

--- a/tools/playtest/test_json.lua
+++ b/tools/playtest/test_json.lua
@@ -96,5 +96,9 @@ check(J.decode(nil), nil, "non-string input returns nil")
 check(J.decode('{"a" 1}'), nil, "missing colon returns nil")
 check(J.decode("[1,2,"), nil, "unclosed array returns nil")
 
-print(string.format("json: %d tests, %d failures", tests, fails))
-os.exit(fails == 0 and 0 or 1)
+if fails == 0 then
+    print(string.format("ok -- %d assertions", tests))
+    os.exit(0)
+end
+print(string.format("%d/%d FAILED", fails, tests))
+os.exit(1)

--- a/tools/playtest/transcripts/README.md
+++ b/tools/playtest/transcripts/README.md
@@ -1,0 +1,17 @@
+# Playtest LLM-player transcripts (#63)
+
+Recorded per-turn decisions for the LLM-player sidecar, keyed by
+`hash(serialize_board) + seed + chapter + turn` (see `tools/playtest/llm_player.py`).
+
+- **Recording** (local, needs a model): run the sidecar with `--record` while
+  `tools/playtest/run.sh llm` plays — cache misses call the configured model
+  (`PT_PROVIDER` / `PT_MODEL` / `PT_BASE_URL`; `PT_PROVIDER=openai` against a local
+  Ollama serve is the free path) and append here.
+- **Replaying** (default, zero cost, deterministic): the sidecar serves recorded
+  decisions only; a miss is a hard FAIL. Commit a transcript once a recorded run is
+  worth replaying — it is the fixture that makes the `llm` scenario reproducible.
+
+The board hash keys on the serialized board, so a transcript survives only as long as
+the chapter's starting state does — a rebalanced enemy or moved deploy slot invalidates
+the affected turns (by design: replaying stale orders against a changed board would be
+noise, not signal).

--- a/tools/test_llm_player.py
+++ b/tools/test_llm_player.py
@@ -381,8 +381,8 @@ class TestSidecar(unittest.TestCase):
                 resp = json.load(f)
             self.assertEqual(resp['orders'], self.GOOD)      # the bad order was culled
             self.assertEqual(len(resp['rejected']), 1)
-            self.assertEqual(os.listdir(d), sorted(os.listdir(d)))  # no .tmp left over
-            self.assertNotIn('resp-1.json.tmp', os.listdir(d))
+            # atomic write: only the rename target remains, no .tmp left behind
+            self.assertEqual([f for f in os.listdir(d) if f.endswith('.tmp')], [])
 
     def test_step_is_idle_when_nothing_is_pending(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tools/test_llm_player.py
+++ b/tools/test_llm_player.py
@@ -138,6 +138,54 @@ class TestOrderValidator(unittest.TestCase):
         self.assertEqual(accepted, [])
         self.assertIn('target', rejected[0]['reason'])
 
+    def test_rejects_attacking_a_friendly_unit(self):
+        board = sample_board()
+        board['units'].append({'id': 2, 'name': 'Marty', 'faction': 'blue',
+                               'class': 'Fighter', 'x': 4, 'y': 5, 'hp': 20,
+                               'maxhp': 20, 'range': [1, 1], 'can_act': True,
+                               'boss': False, 'reach': []})
+        orders = [{'unit': 1, 'move_to': {'x': 4, 'y': 4},
+                   'action': 'attack', 'target': 2}]
+        accepted, rejected = llm_player.validate_orders(orders, board, 'blue')
+        self.assertEqual(accepted, [])
+        self.assertIn('friendly', rejected[0]['reason'])
+
+    def test_staff_needs_a_friendly_target(self):
+        board = sample_board()
+        board['units'].append({'id': 2, 'name': 'Marty', 'faction': 'blue',
+                               'class': 'Fighter', 'x': 4, 'y': 5, 'hp': 20,
+                               'maxhp': 20, 'range': [1, 1], 'can_act': True,
+                               'boss': False, 'reach': []})
+        heal = [{'unit': 1, 'move_to': {'x': 3, 'y': 5}, 'action': 'staff', 'target': 2}]
+        accepted, rejected = llm_player.validate_orders(heal, board, 'blue')
+        self.assertEqual(len(accepted), 1)
+        zap = [{'unit': 1, 'move_to': {'x': 5, 'y': 4}, 'action': 'staff', 'target': 104}]
+        accepted, rejected = llm_player.validate_orders(zap, board, 'blue')
+        self.assertEqual(accepted, [])
+        self.assertIn('friendly', rejected[0]['reason'])
+
+    def test_rejects_an_attack_from_a_rangeless_unit(self):
+        # the exporter omits 'range' for staff-only/weaponless units: they can target
+        # NOTHING (a defaulted melee range would send the blind-A executor into the
+        # wrong submenu)
+        board = sample_board()
+        del board['units'][0]['range']
+        orders = [{'unit': 1, 'move_to': {'x': 5, 'y': 4},
+                   'action': 'attack', 'target': 104}]
+        accepted, rejected = llm_player.validate_orders(orders, board, 'blue')
+        self.assertEqual(accepted, [])
+        self.assertIn('range', rejected[0]['reason'])
+
+    def test_seize_is_gated_on_the_objective(self):
+        board = sample_board()                               # objective: DefeatBoss
+        orders = [{'unit': 1, 'move_to': {'x': 4, 'y': 4}, 'action': 'seize'}]
+        accepted, rejected = llm_player.validate_orders(orders, board, 'blue')
+        self.assertEqual(accepted, [])
+        self.assertIn('objective', rejected[0]['reason'])
+        board['objective'] = 'Seize'
+        accepted, rejected = llm_player.validate_orders(orders, board, 'blue')
+        self.assertEqual(len(accepted), 1)
+
     def test_keeps_the_good_order_and_drops_the_bad_one(self):
         board = sample_board()
         orders = [
@@ -268,6 +316,19 @@ class TestParseOrders(unittest.TestCase):
         text = json.dumps({'orders': [self.ORDERS[0], 'retreat!', 7]})
         self.assertEqual(llm_player.parse_orders(text), self.ORDERS)
 
+    def test_non_finite_numbers_are_rejected(self):
+        # json.loads accepts NaN/Infinity by default (and 1e999 overflows to inf via
+        # the ordinary float path); letting one through would write a resp/transcript
+        # the strict Lua-side reader cannot parse -- permanently
+        self.assertEqual(llm_player.parse_orders(
+            '{"orders": [{"unit": 1, "move_to": {"x": NaN, "y": 0}}]}'), [])
+        self.assertEqual(llm_player.parse_orders(
+            '{"orders": [{"unit": 1e999, "move_to": {"x": 3, "y": 0}}]}'), [])
+        # a finite sibling order survives the cull
+        got = llm_player.parse_orders(
+            '{"orders": [{"unit": 1e999}, {"unit": 1, "action": "wait"}]}')
+        self.assertEqual(got, [{'unit': 1, 'action': 'wait'}])
+
 
 class TestPolicyConfig(unittest.TestCase):
     def test_defaults_to_anthropic_sonnet(self):
@@ -296,6 +357,21 @@ class TestPolicyConfig(unittest.TestCase):
     def test_anthropic_without_a_key_fails_loudly(self):
         with self.assertRaises(ValueError):
             llm_player.make_policy('blue', env={})
+
+    def test_anthropic_key_never_feeds_the_openai_provider(self):
+        # ANTHROPIC_API_KEY as the openai fallback would Bearer-leak the Anthropic
+        # secret to whatever host PT_BASE_URL names
+        cfg = llm_player.policy_config(env={
+            'PT_PROVIDER': 'openai', 'ANTHROPIC_API_KEY': 'sk-ant-secret'})
+        self.assertIsNone(cfg['api_key'])
+        cfg = llm_player.policy_config(env={'ANTHROPIC_API_KEY': 'sk-ant-secret'})
+        self.assertEqual(cfg['api_key'], 'sk-ant-secret')    # anthropic still gets it
+
+    def test_anthropic_with_an_injected_transport_needs_no_key(self):
+        # the keyless-test carve-out: a stub transport must bypass the key check
+        policy = llm_player.make_policy(
+            'blue', env={}, transport=lambda cfg, s, u: '{"orders": [{"unit": 1}]}')
+        self.assertEqual(policy(sample_board()), [{'unit': 1}])
 
 
 class TestTransports(unittest.TestCase):
@@ -443,6 +519,74 @@ class TestSidecar(unittest.TestCase):
             sidecar = self._replay_sidecar(d, self.GOOD)
             open(os.path.join(d, 'stop'), 'w').close()
             self.assertEqual(sidecar.serve(poll_interval=0.01), 1)
+
+    def test_a_half_written_request_is_not_pending(self):
+        # the harness writes tmp+rename; the .tmp must never be read as a request
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'req-1.json.tmp'), 'w', encoding='utf-8') as f:
+                f.write('{"seed": 7, "chap')
+            sidecar = self._replay_sidecar(d, self.GOOD)
+            self.assertIsNone(sidecar.step())
+
+    def test_a_request_vanishing_mid_step_is_tolerated(self):
+        # run.sh's stale-file cleanup can delete a request between the sidecar's
+        # listdir and open (documented startup order starts the sidecar first)
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+            sidecar = self._replay_sidecar(d, self.GOOD)
+            real_pending = sidecar._pending()
+            self.assertEqual(real_pending, [1])
+            os.unlink(os.path.join(d, 'req-1.json'))
+            sidecar._pending = lambda: real_pending          # listdir already happened
+            self.assertIsNone(sidecar.step())
+
+    def test_a_policy_failure_still_answers_the_harness(self):
+        # endpoint down (Ollama not running) must be a fast diagnosable FAIL on the
+        # harness side, not a silent 90s handshake timeout
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+
+            def broken_policy(board):
+                raise RuntimeError('http://localhost:11434/v1 -> unreachable')
+            sidecar = llm_player.Sidecar(
+                d, llm_player.Transcript(mode='record'), policy=broken_policy)
+            with self.assertRaises(RuntimeError):
+                sidecar.step()
+            with open(os.path.join(d, 'resp-1.json'), encoding='utf-8') as f:
+                resp = json.load(f)
+            self.assertEqual(resp['orders'], [])
+            self.assertIn('unreachable', resp['error'])
+
+
+class TestPostJson(unittest.TestCase):
+    """_post_json's error wrapping (the diagnostic text is the product here)."""
+
+    def _patch_urlopen(self, exc):
+        import urllib.request as ur
+        orig = ur.urlopen
+
+        def fake(req, timeout=None):
+            raise exc
+        ur.urlopen = fake
+        self.addCleanup(setattr, ur, 'urlopen', orig)
+
+    def test_http_error_carries_the_body(self):
+        import io
+        import urllib.error
+        self._patch_urlopen(urllib.error.HTTPError(
+            'http://x/v1', 401, 'unauthorized', {}, io.BytesIO(b'{"error":"bad key"}')))
+        with self.assertRaises(RuntimeError) as cm:
+            llm_player._post_json('http://x/v1', {}, {})
+        self.assertIn('bad key', str(cm.exception))
+        self.assertIn('401', str(cm.exception))
+
+    def test_connection_error_names_the_ollama_hint(self):
+        import urllib.error
+        self._patch_urlopen(urllib.error.URLError('connection refused'))
+        with self.assertRaises(RuntimeError) as cm:
+            llm_player._post_json('http://localhost:11434/v1/chat/completions', {}, {})
+        self.assertIn('unreachable', str(cm.exception))
+        self.assertIn('ollama serve', str(cm.exception))
 
 
 if __name__ == '__main__':

--- a/tools/test_llm_player.py
+++ b/tools/test_llm_player.py
@@ -223,5 +223,227 @@ class TestTranscriptRecord(unittest.TestCase):
         self.assertEqual(got, orders)
 
 
+class TestBuildPrompt(unittest.TestCase):
+    def test_prompt_carries_faction_board_and_schema(self):
+        system, user = llm_player.build_prompt(sample_board(), 'blue')
+        self.assertIn('blue army', system)
+        self.assertIn('"orders"', system)                     # the reply schema
+        self.assertIn('DefeatBoss', user)                     # the objective
+        self.assertIn(llm_player.serialize_board(sample_board()), user)
+
+    def test_prompt_is_reproducible(self):
+        self.assertEqual(llm_player.build_prompt(sample_board(), 'blue'),
+                         llm_player.build_prompt(sample_board(), 'blue'))
+
+
+class TestParseOrders(unittest.TestCase):
+    """parse_orders never raises: prose-wrapped, fenced, or garbage model output all
+    resolve to a (possibly empty) list of dict orders."""
+
+    ORDERS = [{'unit': 1, 'move_to': {'x': 5, 'y': 4}, 'action': 'attack', 'target': 104}]
+
+    def test_bare_object_with_orders_key(self):
+        self.assertEqual(llm_player.parse_orders(json.dumps({'orders': self.ORDERS})),
+                         self.ORDERS)
+
+    def test_bare_array(self):
+        self.assertEqual(llm_player.parse_orders(json.dumps(self.ORDERS)), self.ORDERS)
+
+    def test_json_inside_a_code_fence(self):
+        text = 'Here is my plan:\n```json\n%s\n```\nGood luck!' % json.dumps(
+            {'orders': self.ORDERS})
+        self.assertEqual(llm_player.parse_orders(text), self.ORDERS)
+
+    def test_json_wrapped_in_prose(self):
+        text = 'I will attack. %s That is all.' % json.dumps({'orders': self.ORDERS})
+        self.assertEqual(llm_player.parse_orders(text), self.ORDERS)
+
+    def test_garbage_returns_empty(self):
+        self.assertEqual(llm_player.parse_orders('I surrender.'), [])
+        self.assertEqual(llm_player.parse_orders(''), [])
+        self.assertEqual(llm_player.parse_orders(None), [])
+        self.assertEqual(llm_player.parse_orders('{"orders": "all of them"}'), [])
+
+    def test_non_dict_entries_are_dropped(self):
+        text = json.dumps({'orders': [self.ORDERS[0], 'retreat!', 7]})
+        self.assertEqual(llm_player.parse_orders(text), self.ORDERS)
+
+
+class TestPolicyConfig(unittest.TestCase):
+    def test_defaults_to_anthropic_sonnet(self):
+        cfg = llm_player.policy_config(env={})
+        self.assertEqual(cfg['provider'], 'anthropic')
+        self.assertEqual(cfg['model'], 'claude-sonnet-5')
+
+    def test_openai_provider_defaults_to_a_free_local_model(self):
+        cfg = llm_player.policy_config(env={'PT_PROVIDER': 'openai'})
+        self.assertEqual(cfg['provider'], 'openai')
+        self.assertEqual(cfg['model'], 'llama3.1')
+        self.assertIsNone(cfg['base_url'])   # transport falls back to OLLAMA_BASE_URL
+
+    def test_env_knobs_override(self):
+        cfg = llm_player.policy_config(env={
+            'PT_PROVIDER': 'openai', 'PT_MODEL': 'gemma3:12b',
+            'PT_BASE_URL': 'http://gpubox:8080/v1', 'PT_API_KEY': 'k'})
+        self.assertEqual(cfg['model'], 'gemma3:12b')
+        self.assertEqual(cfg['base_url'], 'http://gpubox:8080/v1')
+        self.assertEqual(cfg['api_key'], 'k')
+
+    def test_unknown_provider_fails_loudly(self):
+        with self.assertRaises(ValueError):
+            llm_player.policy_config(env={'PT_PROVIDER': 'skynet'})
+
+    def test_anthropic_without_a_key_fails_loudly(self):
+        with self.assertRaises(ValueError):
+            llm_player.make_policy('blue', env={})
+
+
+class TestTransports(unittest.TestCase):
+    """The two HTTP transports, with _post_json stubbed -- asserts each provider's wire
+    shape (URL, auth header, payload) and response extraction."""
+
+    def _capture(self, response):
+        calls = []
+
+        def fake_post(url, headers, payload, timeout=120):
+            calls.append({'url': url, 'headers': headers, 'payload': payload})
+            return response
+        return calls, fake_post
+
+    def test_anthropic_wire_shape(self):
+        calls, fake = self._capture(
+            {'content': [{'type': 'text', 'text': '{"orders": []}'}]})
+        orig = llm_player._post_json
+        llm_player._post_json = fake
+        try:
+            got = llm_player._call_anthropic(
+                {'model': 'claude-sonnet-5', 'api_key': 'sk-test', 'base_url': None},
+                'sys', 'user')
+        finally:
+            llm_player._post_json = orig
+        self.assertEqual(got, '{"orders": []}')
+        self.assertEqual(calls[0]['url'], llm_player.ANTHROPIC_URL)
+        self.assertEqual(calls[0]['headers']['x-api-key'], 'sk-test')
+        self.assertEqual(calls[0]['payload']['system'], 'sys')
+        self.assertEqual(calls[0]['payload']['messages'][0]['content'], 'user')
+
+    def test_openai_wire_shape_defaults_to_ollama(self):
+        calls, fake = self._capture(
+            {'choices': [{'message': {'content': '{"orders": []}'}}]})
+        orig = llm_player._post_json
+        llm_player._post_json = fake
+        try:
+            got = llm_player._call_openai(
+                {'model': 'llama3.1', 'api_key': None, 'base_url': None}, 'sys', 'user')
+        finally:
+            llm_player._post_json = orig
+        self.assertEqual(got, '{"orders": []}')
+        self.assertEqual(calls[0]['url'],
+                         llm_player.OLLAMA_BASE_URL + '/chat/completions')
+        self.assertEqual(calls[0]['headers']['authorization'], 'Bearer ollama')
+        self.assertEqual(calls[0]['payload']['messages'][0]['role'], 'system')
+
+    def test_make_policy_runs_prompt_through_transport_and_parse(self):
+        board = sample_board()
+
+        def transport(cfg, system, user):
+            self.assertIn(llm_player.serialize_board(board), user)
+            return 'Sure! ```json\n{"orders": [{"unit": 1}]}\n```'
+        policy = llm_player.make_policy(
+            'blue', env={'PT_PROVIDER': 'openai'}, transport=transport)
+        self.assertEqual(policy(board), [{'unit': 1}])
+
+
+class TestSidecar(unittest.TestCase):
+    """The file handshake, played from the harness's side of the directory."""
+
+    GOOD = [{'unit': 1, 'move_to': {'x': 5, 'y': 4}, 'action': 'attack', 'target': 104}]
+    BAD = [{'unit': 999, 'move_to': {'x': 0, 'y': 0}, 'action': 'wait'}]
+
+    def _write_req(self, d, n, board=None, turn=2):
+        req = {'seed': 7, 'chapter': 'ch00', 'turn': turn, 'faction': 'blue',
+               'board': board or sample_board()}
+        with open(os.path.join(d, 'req-%d.json' % n), 'w', encoding='utf-8') as f:
+            json.dump(req, f)
+        return req
+
+    def _replay_sidecar(self, d, orders, turn=2):
+        key = llm_player.transcript_key(sample_board(), seed=7, chapter='ch00', turn=turn)
+        t = llm_player.Transcript(entries={key: orders}, mode='replay')
+        return llm_player.Sidecar(d, t)
+
+    def test_step_answers_a_request_with_validated_orders(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+            sidecar = self._replay_sidecar(d, self.GOOD + self.BAD)
+            self.assertEqual(sidecar.step(), 1)
+            with open(os.path.join(d, 'resp-1.json'), encoding='utf-8') as f:
+                resp = json.load(f)
+            self.assertEqual(resp['orders'], self.GOOD)      # the bad order was culled
+            self.assertEqual(len(resp['rejected']), 1)
+            self.assertEqual(os.listdir(d), sorted(os.listdir(d)))  # no .tmp left over
+            self.assertNotIn('resp-1.json.tmp', os.listdir(d))
+
+    def test_step_is_idle_when_nothing_is_pending(self):
+        with tempfile.TemporaryDirectory() as d:
+            sidecar = self._replay_sidecar(d, self.GOOD)
+            self.assertIsNone(sidecar.step())
+
+    def test_step_skips_already_answered_requests(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+            sidecar = self._replay_sidecar(d, self.GOOD)
+            self.assertEqual(sidecar.step(), 1)
+            self.assertIsNone(sidecar.step())                # 1 is answered; nothing new
+
+    def test_lowest_numbered_request_goes_first(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 2, turn=3)
+            self._write_req(d, 1, turn=2)
+            key2 = llm_player.transcript_key(sample_board(), seed=7, chapter='ch00', turn=3)
+            key1 = llm_player.transcript_key(sample_board(), seed=7, chapter='ch00', turn=2)
+            t = llm_player.Transcript(entries={key1: self.GOOD, key2: []}, mode='replay')
+            sidecar = llm_player.Sidecar(d, t)
+            self.assertEqual(sidecar.step(), 1)
+            self.assertEqual(sidecar.step(), 2)
+
+    def test_replay_miss_writes_an_error_response_then_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+            sidecar = llm_player.Sidecar(d, llm_player.Transcript(mode='replay'))
+            with self.assertRaises(llm_player.TranscriptMiss):
+                sidecar.step()
+            with open(os.path.join(d, 'resp-1.json'), encoding='utf-8') as f:
+                resp = json.load(f)
+            self.assertEqual(resp['orders'], [])
+            self.assertIn('transcript miss', resp['error'])
+
+    def test_record_mode_calls_policy_and_fills_the_transcript(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+            calls = []
+
+            def policy(board):
+                calls.append(1)
+                return self.GOOD
+            t = llm_player.Transcript(mode='record')
+            sidecar = llm_player.Sidecar(d, t, policy=policy)
+            self.assertEqual(sidecar.step(), 1)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(len(t.entries), 1)              # the decision was recorded
+            # replaying the SAME board from the filled transcript needs no policy
+            self._write_req(d, 2, turn=2)
+            replay = llm_player.Sidecar(d, llm_player.Transcript(
+                entries=t.entries, mode='replay'))
+            self.assertEqual(replay.step(), 2)
+
+    def test_serve_stops_on_the_stop_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_req(d, 1)
+            sidecar = self._replay_sidecar(d, self.GOOD)
+            open(os.path.join(d, 'stop'), 'w').close()
+            self.assertEqual(sidecar.serve(poll_interval=0.01), 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Epic #63 **M2**: the LLM-player's sidecar file-handshake loop + the `llm` harness scenario — **plus** the provider-agnostic policy layer from Nicolas's free-model direction (2026-07-02): the sidecar speaks the Anthropic Messages API *or* any OpenAI-compatible endpoint, so **a free local Llama/Gemma via Ollama is one env var away** (`PT_PROVIDER=openai`), with no new Python dependencies (stdlib `urllib`, ~15 lines per transport).

## How it works

- **Protocol** (per the epic): harness writes `req-<n>.json` `{seed, chapter, turn, faction, board}` into `PT_LLM_DIR`, polls (wall-clock deadline) for `resp-<n>.json` `{orders, rejected}`. Every write on both sides is tmp+`rename` — a poller never reads a half-written file. `run.sh llm` clears stale handshake files, and touches `<dir>/stop` when the run ends so the sidecar drains, saves its transcript, and exits on its own.
- **Replay is the default everywhere.** The sidecar serves recorded transcript decisions (zero LLM cost, deterministic); a replay miss writes an `{error}` response (fast, diagnosable harness FAIL) and exits non-zero — closed-world, per the platform rule. `--record` + `PT_PROVIDER`/`PT_MODEL`/`PT_BASE_URL` records fresh decisions.
- **Validation lives sidecar-side** (`validate_orders`, the M1 core): the Lua executor only ever sees legal orders; it re-checks just the mid-phase deltas (target died to an earlier order → downgrade to wait). An order that still fails to commit means the board changed under it (logged, skipped, never soft-locks).
- **`json.lua`**: vendored minimal JSON for mGBA's Lua (none exists there) — sorted-key encode (deterministic bytes), decode rejects trailing garbage so a truncated file can't half-parse into plausible orders.
- **Unit ids**: blue = charId (PCs unique); red = 1000+slot (generic enemies *share* charIds — the slot disambiguates which brigand an attack order targets).

## Adversarial review hardening (3-angle pass, all findings fixed)

- **Validator gates**: attack targets must be foes / staff targets allies (a friendly-fire "attack" would blind-A into the Trade/Item submenu); a unit the exporter gave no `range` (staff-only/weaponless) can target nothing; `seize` gated on the board objective.
- **Key-leak guard**: `ANTHROPIC_API_KEY` feeds ONLY the anthropic transport — the openai fallback would have Bearer-leaked the secret to whatever host `PT_BASE_URL` names.
- **Non-finite gate**: `NaN` *and* `1e999`→inf orders are culled in `parse_orders` (the float path bypasses `parse_constant`), so a one-off model hiccup can't record a transcript entry `json.lua` can never parse; `allow_nan=False` on the resp writer as belt.
- **Lifecycle**: any live-policy failure (Ollama down) still answers the harness with an `{error}` resp + the `ollama serve` hint — a fast diagnosable FAIL, not a 90s timeout; vanished-request race with run.sh's cleanup tolerated; startup warning for crashed-run leftovers; llm deadline 2100s (18 turns × 90s handshake budget — 600s killed healthy record runs against slow local models).
- **Harness backout**: full menu drain (submenus are also `sProc_Menu`; two blind B presses could strand a unit selected, desyncing the whole turn).

## Verification

- `make test` green: **35 new Python asserts (55 total)** — protocol round-trip through real files, prompt/parse ladder incl. fenced/prose/garbage/non-finite output, stubbed-transport wire shapes for both providers, key-leak guard, replay-miss/policy-failure error responses, record-mode + drain-then-stop semantics, `_post_json` error wraps — plus **45 Lua asserts** (`test_json.lua`).
- **Cross-language round trip verified**: board encoded by `json.lua` → parsed + answered by the Python `Sidecar` → response decoded by `json.lua`, with the illegal order correctly culled into `rejected`.
- CLI smoke-tested (`serve` replay mode answers a real request dir and exits on `stop`).
- `luac -p` clean on `harness.lua`/`json.lua`; `bash -n` clean on `run.sh`; `tools/check.py` clean.
- **Not verified here**: the in-emulator prologue run (this environment has no mGBA — the platform's standing caveat). Local commands are in the `run.sh` header; M2's "prologue end-to-end from a recorded transcript" needs one local `--record` run first to mint `transcripts/prologue.json`.

## Deliberate M2 limitations (→ M3)

`chooseAttack` fires on the UI's default target (unambiguous when one enemy is in range of the strike tile); staff orders are rejected by the validator until the export carries staff range. Both noted in the ADR.

Also carries the end-of-session `HANDOFF.md` refresh (8 queue items merged 2026-07-02).

ADR: `docs/decisions.md` → "#63 M2 = the sidecar handshake ships PROVIDER-AGNOSTIC". Checks off M2 on epic #63 (M3–M5 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR