### PR TITLE
docs: vanilla boundary, final form — ALL mechanical data is vanilla (donor inheritance)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1197,12 +1197,19 @@ _Decided: 2026-07-02 (CLAUDE; resolves #9's engine half as already-vanilla; gray
 The #8 implementation (Fire/Elfire flagged `effective` vs the ice-monster classes, PR #114) used only
 FE8's native effectiveness system — but Nicolas ruled (2026-07-02) that the vanilla-combat principle
 extends to item *data*: stock weapons must behave exactly as a vanilla FE8 player expects, and vanilla
-Fire/Elfire carry no effectiveness. The precise boundary (Nicolas, same day): **character-level data is
-ours; class data and stock-item data stay verbatim vanilla.** Our cast and enemy rosters ride unmodified
-vanilla classes exactly the way FE8's own cast does — custom names, portraits, personal bases/growths,
-levels, and placements are the same kind of data FE8 layers on its own characters (Franz has personal
-stats on the Cavalier class; so does Baxby). Nothing about a *class* or a *stock item* changes — no
-custom classes, no stat/effectiveness/might edits to stock weapons. PR #114 was reverted wholesale (injector, campaign.yaml
+Fire/Elfire carry no effectiveness. The precise boundary (Nicolas, same day, sharpened once more when he
+caught that even "personal bases/growths are ours" overstates it): **ALL mechanical data is vanilla —
+class data verbatim, character data inherited from a class-matched vanilla DONOR, item data stock.**
+`patch_character_data` copies each cast slot's growths and weapon ranks verbatim from its vanilla donor
+(`GROWTH_DONOR`/`STAT_DONOR`) and lands its personal bases on the donor's own statline (an FE-strict unit
+IS its donor mechanically — Rootis fights on Lute's Mage line, Wolfram on Gilliam's Knight line, renamed
+and re-drawn; Baxby's YAML names Franz as his donor for when his wiring lands); enemy class clones
+inherit the same way. What is genuinely ours: the donor/class *choice* per character, identity cosmetics
+(names, portraits, sprites, dialogue), levels, roster composition, and placements. Nothing about a *class*
+or a *stock item* changes — no custom classes, no stat/effectiveness/might edits to stock weapons. (The
+YAML `fe_stats` mechanism CAN stack a deliberate divergence on the donor line; the FE-strict default is
+divergence-free, and any future use of it is a per-unit balance decision, not a principle change.)
+PR #114 was reverted wholesale (injector, campaign.yaml
 `iconic_matchups:` block, elfire weapon model, class tags, tests, and its ADR); the 2026-05-28/06-04
 "iconic matchups via effectiveness" carve-outs above are annotated superseded. Fire-vs-ice survives as
 **flavor only** — item names, dialogue, and battle-anim art. Issue #8 closes as not-planned.

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -1110,11 +1110,15 @@ def inject_crit_flourish(campaign, verbose=True):
 
 # --- Milestone B: character stats / class -----------------------------------------
 # Write each cast unit's vanilla-class identity into its portrait slot's
-# gCharacterData[] entry: defaultClass, affinity (Anima, cosmetic), baseLevel,
-# personal base stats = (YAML fe_stats - class base), the class's weapon-type rank,
-# and zeroed personal growths (so the unit grows at its pure class rate). When
-# fe_stats match the class verbatim (the FE-strict default) the personal bases come
-# out 0; any deliberate YAML divergence is still honored so displayed stats ==
+# gCharacterData[] entry: defaultClass, affinity (Anima, cosmetic), baseLevel --
+# and the MECHANICAL character layer inherited from a class-matched VANILLA DONOR
+# (STAT_DONOR / GROWTH_DONOR): personal bases = (YAML fe_stats - class base) + the
+# donor's personal bases, growths copied verbatim from the growth donor, weapon
+# ranks from the rank donor. So an FE-strict unit (fe_stats == class base, the
+# default) lands exactly on its donor's statline -- vanilla character data under a
+# new identity, not "naked class" frailty (decisions.md: even character-level
+# mechanical data is vanilla; ours is the donor CHOICE + cosmetics + levels).
+# Any deliberate YAML divergence still stacks on top so displayed stats ==
 # fe_stats. portraitId, attributes (gender), and pSupportData are left as the
 # vanilla slot's -- gender/supports are a later YAML-driven pass.
 


### PR DESCRIPTION
## What

Nicolas's second sharpening of the #8-reversal boundary: even *character-level* mechanical data is vanilla. The code already works this way — `patch_character_data` copies each cast slot's **growths and weapon ranks verbatim from a class-matched vanilla donor** (`GROWTH_DONOR`/`STAT_DONOR`) and lands its **personal bases on the donor's own statline**, so an FE-strict unit *is* its donor mechanically (Rootis fights on Lute's Mage line, Wolfram on Gilliam's Knight line — renamed and re-drawn). Enemy class clones inherit the same way.

- **ADR updated** to its final form: *all mechanical data is vanilla — class data verbatim, character data donor-inherited, item data stock. Ours: the donor/class choice, identity cosmetics, levels, roster composition, placements.* (The `fe_stats` divergence mechanism is noted as existing-but-unused under the FE-strict default.)
- **Fixes the stale Milestone B header comment** in `build_campaign.py` ("zeroed personal growths", no mention of donor bases) that contradicted the donor-inheritance implementation right below it — the comment that misled the previous ADR wording in #120.

Comment + docs only, no behavior change; `tools/check.py` clean, `ast.parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR)_