### PR TITLE
Comment-drift guard + full comment-vs-code sweep (50+ stale claims, 4 real code bugs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ cd fireemblem8u
 - Match the existing file and function naming conventions in `fireemblem8u/src/`
 - New engine behavior ships as string-patch hooks in `tools/inject/engine_hooks.py` — never hand-edits
   to `fireemblem8u/src/` (our decomp edits are build artifacts, restored on every build)
+- Comments say **why**; the **what** lives in code + tests. When a change retires a mechanism or term,
+  register its key phrases in `tools/check.py` `DEAD_CONCEPTS` in the same commit — the drift lint scans
+  docs AND hand-written code comments (`docs/decisions.md` → "Comments are testimony").
 
 ## Engine / Content Boundary Rule
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,9 +84,10 @@ Rationale + long form: `docs/decisions.md` → Coordination model. The operating
   PR + issue, not a file glob.
 - **Concurrent agents each get their own worktree** (two ROM builds in one tree corrupt each other;
   a single writer may work the provisioned main tree — see `HANDOFF.md`).
-- **Engine/content invariant is a HARD gate** (the Boundary Rule above + the 5 engine hooks in
-  `tools/inject/`, guarded by `check.py check_engine_guards_present`). Desk ownership is a review
-  judgment (`check_lane_ownership` is advisory).
+- **Engine/content invariant is a HARD gate** (the Boundary Rule above + the engine hooks in
+  `tools/inject/`, guarded by `check.py check_engine_guards_present` — its tuple is the
+  authoritative hook list, don't cite a count). Desk ownership is a review judgment
+  (`check_lane_ownership` is advisory).
 - Never commit the `fireemblem8u` submodule pointer.
 
 ## Design placement test ("not my job" / "no need to know")

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -207,8 +207,9 @@ demo-asset task (ships nothing; v0.1.0 is Ch1-only). Scratch review images live 
   provider-agnostic policy (`PT_PROVIDER=openai` + local Ollama = free Llama/Gemma; anthropic/Sonnet
   default per the epic). First local run: sidecar `--record` to mint `transcripts/prologue.json`, then
   replay is free forever. M3 = staff driving + multi-target disambiguation → M4 soak→curve → M5 vanilla-FE8.
-- **Land `balance_locked: true` on ch00/ch01** (ch02 set); the per-chapter parity gate (#48b) is enforcing
-  but inert until a chapter opts in; ch00/ch01 read OK.
+- **`balance_locked: true` is LIVE on ch00/ch01/ch02** — the per-chapter parity gate (#48b,
+  `make difficulty-gate`, in CI) actively enforces all three; new chapters opt in as their enemy
+  inventories are authored and playtested.
 - #53 tail (FE8 Ch13 → our ch08): ~11 standard weapons, informational. Former leaves settled 2026-07-02:
   d20 crit #11 ✓ · iconic matchups #8 **reverted + closed not-planned** (vanilla principle covers item
   data; flavor only) · spell-economy #9 = vanilla behavior incl. break-and-rebuy (content lands per-chapter).

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ else
 	@python3 tools/difficulty.py --campaign $(CAMPAIGN) --chapter $(CH)
 endif
 
-# Enforcing form of the campaign curve (#48 (b)): non-zero exit if any referenced chapter
-# is off-parity or unreliably measured. CI runs the informative `difficulty` today and flips
-# to this target once the content track authors the Ch2+ enemy inventories (until then our
-# side is 0.0 and this is RED by design).
+# Enforcing form of the campaign curve (#48 (b)): per-chapter OPT-IN gate -- non-zero
+# exit only for chapters marked `balance_locked: true` in their YAML that read
+# off-parity or unreliably measured (with zero locks the gate passes). CI runs this
+# target; chapters opt in as their enemy inventories are authored and playtested.
 difficulty-gate:
 	@python3 tools/difficulty.py --campaign $(CAMPAIGN) --curve --check
 

--- a/campaigns/rime-of-the-frostmaiden/maps/README.md
+++ b/campaigns/rime-of-the-frostmaiden/maps/README.md
@@ -87,7 +87,8 @@ way; its test-map render is pinned pixel-exact against
    (so `mar_to_map`'s `>>3` yields the `.bin` value `metatile_index × 4`); the `atlas`
    subcommand renders which metatile is which.
 3. Register + wire it in `build_campaign.py`: `_register_tileset(campaign, '<name>', '<Stem>', …)`
-   once per tileset + `_register_chapter_map(…, tileset_stem='<Stem>')` per chapter, then
+   once per tileset; per chapter, `_register_chapter_map(maps_dir, layout, comment)` reads the
+   tileset from the layout's own `.json` `tileset` stamp (resolved via `TILESET_STEMS`), then
    `_retarget_host_chapter` sets the chapter's `chapter_settings.json` map indices. The winter
    tileset rides `inject_winter_tileset`; `cave-interior` registers with the ch03 injector (#23).
 4. `make CAMPAIGN=rime-of-the-frostmaiden fireemblem8.gba` and load-test in mGBA.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1215,6 +1215,28 @@ PR #114 was reverted wholesale (injector, campaign.yaml
 **flavor only** — item names, dialogue, and battle-anim art. Issue #8 closes as not-planned.
 _Decided: 2026-07-02 (Nicolas; supersedes the 2026-05-28 iconic-matchup carve-out)_
 
+**Comments are testimony, code is evidence — the comment-drift guard (post-mortem of the "zeroed growths" incident).**
+A stale `build_campaign.py` section header claimed "zeroed personal growths / pure class rate" long after
+donor-parity replaced that mechanism; an ADR then cited the comment as fact and had to be corrected twice
+(PRs #120/#121) — while the *tests* pinning the real donor behavior were green the whole time. Root cause:
+comments restating WHAT code does are unverified duplication (a single-source-of-truth violation), and the
+existing dead-concepts lint scanned docs only, with patterns too narrow for the comment's phrasing. Settled:
+- **The dead-concepts lint scans hand-written CODE comments too** (`check.py` `CODE_GLOBS`: tools py/lua/sh,
+  engine C, Makefile — decomp submodule, generated files, `check.py` itself, and `test_*` fixtures exempt),
+  and `check_tool_refs_exist` now also catches dangling `tools/…`/`docs/…` pointers in code comments
+  (gitignored targets = declared build artifacts, not rot). Regression-pinned by
+  `tools/test_check_comment_drift.py`, including the exact incident line.
+- **Registry discipline:** a change that RETIRES a mechanism or term registers its key phrases in
+  `DEAD_CONCEPTS` in the same commit — that registration is what makes the lint effective; the incident's
+  phrases were registered but too narrowly (now broadened). This joins the Definition of Done.
+- **Write rules:** a comment says WHY; the WHAT belongs to the code and its tests. An ADR asserting a
+  mechanical fact must be verified against the implementing symbol (cite it), never against nearby prose.
+  Semantic drift the lint can't see is caught by the same rule in review: header comments of touched
+  sections are in scope for every diff review.
+- A full 7-agent comment-vs-code sweep of the hand-written tree ran with this change; findings fixed in the
+  same PR.
+_Decided: 2026-07-02 (CLAUDE after Nicolas caught the propagated stale comment; guard + sweep in one PR)_
+
 **MVP weapons = stock FE weapons (no custom Might); personal weapons are post-MVP**
 PCs carry plain vanilla FE weapons whose stats (Mt/Hit/Crit/Wt/uses) come verbatim from a stock
 FE8 item, named in each inventory entry's `fe_base` field — there is **no custom Might authoring**.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -127,7 +127,9 @@ against a reviewed render -- `cave-interior` (Cynon's Mineshaft, Gray; CC, cross
 endorsed in its CREDITS) reproduces `docs/demo/ch03-mineshaft-tileset-demo.png` pixel-exact,
 gated in `tools/test_map_tileset.py`. Engine seam: `_register_tileset(campaign, name, Stem,
 comment)` registers any vendored tileset's asset-table entries (winter now rides it);
-`_register_chapter_map(..., tileset_stem=)` points a chapter map at any registered tileset.
+`_register_chapter_map(maps_dir, layout, comment)` points a chapter map at whichever registered
+tileset the layout's own `.json` `tileset` stamp names (resolved via `TILESET_STEMS` -- no
+per-call tileset argument).
 Layout JSONs (editor export + compiled `<map>.json`) now stamp their `tileset`, so
 `import_map_layout.py` compiles + previews on the right one. The map editor gained the
 custom-canvas mode for non-reskin chapters: `gen_map_editor.py --tileset=cave-interior
@@ -306,7 +308,8 @@ and got welded onto the same `inst/<track>` worktree, forcing work to partition 
   the reactions (my job / I can help / no impact / no need to know). Review is where ownership is decided,
   replacing the pre-commit glob block.
 - **Engine/content stays a HARD invariant.** The Engine/Content Boundary Rule (no character/chapter/plot
-  in `.c`/`.s`) + the 5 engine hooks in `tools/inject/` (`check_engine_guards_present`) are genuine
+  in `.c`/`.s`) + the engine hooks in `tools/inject/` (`check_engine_guards_present`; its guarded tuple
+  is the authoritative list — the count here read "5" long after it grew) are genuine
   decision-hiding and remain gates. The character-name half is now mechanized
   (`check_engine_campaign_agnostic` scans the hand-written engine sources for any campaign id);
   chapter-number / plot-event references stay a review-judgment call.

--- a/tools/autoframe.py
+++ b/tools/autoframe.py
@@ -7,7 +7,7 @@ with transparent headroom on top and small side margins (verified against
 vanilla Eirika: opaque rows 11-79, cols 21-88). A reference where the subject
 fills its own frame edge-to-edge therefore reads "zoomed in" when converted
 directly. This tool detects the subject, then composites it onto a flat-bg
-canvas at ~1.2 aspect — bottom-anchored, ~16% headroom, ~12% side margins — so
+canvas at ~1.2 aspect — bottom-anchored, ~10% headroom, ~5% side margins (SUBJ_H_FRAC/SUBJ_W_FRAC = 0.90) — so
 `ref_to_bust.py` produces Braulo-style framing.
 
 Usage:

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -9,12 +9,15 @@ restore vanilla with `git -C fireemblem8u checkout <path>`.
 Engine/Content boundary (CLAUDE.md): the GENERATOR knows character/chapter names;
 the C/asm it EMITS is just data. No campaign name is ever hardcoded in engine C.
 
---- Milestone A (current): PORTRAITS ---------------------------------------------
+--- Milestone A (landed first; the file has since grown far past it): PORTRAITS --
 For each named cast member, run the bust through portrait_tool.generate (4 decomp
 assets) and overwrite a vanilla portrait slot's source files in
 graphics/portrait/. The decomp's generic gbagfx pattern rules rebuild the
-.4bpp/.4bpp.fk/.4bpp.lz on the next `make`; data_portrait[] is untouched, so the
-mapped vanilla character simply wears our face. Zero C changes, fully reversible.
+.4bpp/.4bpp.fk/.4bpp.lz on the next `make`; patch_portrait_geometry also rewrites
+the slot's mouth/eye FaceData in src/portrait_data.c (a PATCHED_DECOMP_FILES
+build artifact, restored each build) so our faces blink/talk in the right place.
+Milestones B+ (names, class/stats, battle anims, full chapter codegen) live
+further down this file -- main() is the authoritative pass list.
 
 Milestones B+ (characters, chapter, dialogue codegen) hang off the same CLI.
 """
@@ -69,7 +72,8 @@ PORTRAIT_DATA_C = os.path.join(DECOMP, 'src', 'portrait_data.c')
 PORTRAIT_GEOMETRY = '2, 6, 3, 4'   # xMouth, yMouth, xEyes, yEyes
 # Test-chapter spawn (Milestone B step 3): we hijack the vanilla Ch1 ally roster to
 # stand up our classed cast on one real map -- the first in-engine confirmation of
-# names + portraits + classes + stats together. These are the only two files it touches.
+# names + portraits + classes + stats together. It touches the three ch1-event files
+# below (udefs + eventinfo + eventscript).
 CH1_UDEFS_H = os.path.join(DECOMP, 'src', 'events', 'ch1-eventudefs.h')
 CH1_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'ch1-eventinfo.h')
 CH1_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch1-eventscript.h')
@@ -194,8 +198,9 @@ CH01_CLASS_IDS = {'soldier': 'CLASS_SOLDIER', 'fighter': 'CLASS_FIGHTER',
 # 0xF0 block is ours. Engine hooks: _inject_lord_select_engine.
 # Lord survivability floor (#45 3c) "applied" flag: one permanent flag, just above the
 # 0xF0..0xF9 candidate-pick block (LORDSEL_CONFIRM_MSGS caps the cast at 10), so the floor
-# bakes into the chosen lead's saved stats exactly once. Permanent flags span 100..299
-# (GetPermanentFlagBitsSize = 0x19 bytes), so 0xFA is in range and free.
+# bakes into the chosen lead's saved stats exactly once. Permanent flags span 101..300
+# (SetPermanentFlag rejects <= 100, then indexes flag-101 into 0x19 bytes = 200 bits),
+# so 0xFA is in range and free.
 LORDSEL_PROMPT_MSG = 0x957   # dead vanilla slot-2 scene text (cf. inject_ch01 step 6)
 LORDSEL_CONFIRM_MSGS = (0x959, 0x95A, 0x95B, 0x95C, 0x95D, 0x95E, 0x95F,
                         0x962, 0x963, 0x964)  # same dead pool, one per candidate
@@ -203,8 +208,9 @@ LORDSEL_CONFIRM_MSGS = (0x959, 0x95A, 0x95B, 0x95C, 0x95D, 0x95E, 0x95F,
 # PARALLEL to LORDSEL_CONFIRM_MSGS (same 10-cap), drawn by lord_select_screen.c as the
 # cursor lands on each candidate. Plus a one-time explainer box shown before the screen
 # ("(a) explain", feedback #4). Pool vetting (the "msg-id vetting is treacherous" gotcha):
-# 0x966-0x970 are referenced ONLY by the vanilla Ch1 (slot-2) tutorial event scripts our
-# prologue host strips -> never displayed in our ROM; checked clean of live data_battlequotes.c
+# 0x966-0x970 are referenced ONLY by vanilla Ch2's slot-2 event scripts
+# (ch2-eventscript.h) -- dead because inject_ch01 replaces the slot-2 events (NOT
+# because of the prologue host); checked clean of live data_battlequotes.c
 # refs (the 0x993/0x994 false-negative lesson) and of the lone live use in the range (0x980,
 # bmdifficulty.c), which is excluded.
 LORDSEL_EXPLAINER_MSG = 0x966
@@ -224,19 +230,23 @@ LORDSEL_EXPLAINER_TEXT = (
 CH01_BEAT1_CARD_MSG = 0x945
 CH01_BEAT1_MSGS = (0x940, 0x941, 0x942, 0x943, 0x944)  # A,B,C,D,E (0x945 = card)
 # ch01 ending "The Rolling Cheddar" (#21): a "Bryn Shander" location card + one message
-# per beat (A-F), on the same dead vanilla Ch1-tutorial slot-2 pool as Beat 1 (the
-# prologue host strips Ch1's event lists, so these ids never display in our ROM).
+# per beat (A-F), on the dead slot-2 pool (see Beat 1). CAVEAT (comment audit
+# 2026-07-02): 0x949/0x94A/0x94B/0x94C are ALSO TEXTSHOWn by the tutorial-mode trade
+# demo compiled into src/bmtrade.c, which nothing patches -- if tutorial mode's trade
+# demo ever runs in our ROM, these ending-scene bodies would display there (same
+# false-negative class as the 0x993/0x994 lesson; needs an emulator repro to size).
 CH01_ENDING_CARD_MSG = 0x94C
 # AB,C,D,E1,E2(narration),E2b(Marty/Baxby),F. 0x93D is a dead vanilla Ch1-tutorial
 # slot-2 id (weapon-triangle blurb, stripped by the prologue host) reused for the
 # faceless "Marty leans in..." narration that #58 split into its own opaque box.
 CH01_ENDING_MSGS = (0x946, 0x947, 0x948, 0x949, 0x93D, 0x94A, 0x94B)
-CH01_BODY_MSG = 0x956    # the dismembered sled-driver, found just past the road sign
-CH01_TAUNT_MSG = 0x960   # Izobai's turn-1 boss taunt (both dead vanilla Ch1-tutorial slots)
+CH01_BODY_MSG = 0x956    # the dismembered sled-driver (dead vanilla Ch2 slot-2 scene id)
+CH01_TAUNT_MSG = 0x960   # Izobai's turn-1 boss taunt (no vanilla event-script ref at all)
 # Per-PC death quotes (#6, dialogue pass 2026-06-17): one universal dying line per
 # deployable cast member, shown with their bust when they fall in ANY chapter. Each
-# rides a dead vanilla Ch1-tutorial slot-2 message id (the prologue host strips Ch1's
-# tutorial event lists, so these never display in our ROM -> safe campaign-wide).
+# rides a dead slot-2 message id: 0x94D-0x953 are Ch1-tutorial ids (stripped by the
+# prologue host); pinky's 0x958 is a vanilla Ch2 scene id, dead because inject_ch01
+# replaces the slot-2 events. All vetted unreferenced elsewhere -> safe campaign-wide.
 # Keyed by cast unit_id; the PC rides its PORTRAIT_MAP slot, so pid/FID = CHARACTER_<slot>.
 PC_DEATH_QUOTE_MSGS = {
     'braulo':     0x94D,
@@ -488,7 +498,8 @@ GROWTH_DONOR = dict(STAT_DONOR, meesmickle='CHARACTER_EWAN')
 
 # our cast bust  ->  vanilla portrait slot whose graphic files we overwrite.
 # Slots are FE8's earliest-available cast so one early chapter shows many faces.
-# (portrait-only mapping; class/stat mapping comes in Milestone B.)
+# (Started as the portrait mapping; it is now the general character-slot key --
+# names, class/stats/growths/gender, death quotes, and map sprites all ride it.)
 PORTRAIT_MAP = {
     'braulo':     'Eirika',    # the prologue lord -- first face the player sees
     'marty':      'Seth',
@@ -1119,8 +1130,9 @@ def inject_crit_flourish(campaign, verbose=True):
 # new identity, not "naked class" frailty (decisions.md: even character-level
 # mechanical data is vanilla; ours is the donor CHOICE + cosmetics + levels).
 # Any deliberate YAML divergence still stacks on top so displayed stats ==
-# fe_stats. portraitId, attributes (gender), and pSupportData are left as the
-# vanilla slot's -- gender/supports are a later YAML-driven pass.
+# fe_stats. Gender IS driven from YAML (_set_gender rewrites .attributes CA_FEMALE);
+# only portraitId and pSupportData are left as the vanilla slot's -- supports are a
+# later YAML-driven pass.
 
 def _set_field(block, field, value, path, marker):
     """Replace `.field = ...,` within `block`. Errors if the field isn't present."""
@@ -1335,8 +1347,9 @@ def patch_character_data(campaign, verbose=True):
 #     nothing references removed units or fires a win/lose condition,
 #   * cut the boot attract reel + redirect prologue->Ch1 so a fresh boot lands on the
 #     title and New Game drops straight onto the map (dev loop).
-# Result: New Game -> Ch1 map with the 8 cast, no cutscene, no game over -- a pure
-# look-test (no enemies, no objective; reset when done). Each cast unit rides its
+# Result: New Game -> Ch1 map with the 8 cast, no cutscene, no game over -- a
+# combat-ready sandbox (the vanilla foes stay, reskinned; no objective -- reset when
+# done; battle-anim capture fires on them). Each cast unit rides its
 # PORTRAIT_MAP slot's CHARACTER_ id, so its injected name/portrait/class/stats show.
 # redaCount=0 places a unit statically at xPosition/yPosition (eventscr.c sub_800F8A8).
 # All edits are restorable build artifacts (PATCHED_DECOMP_FILES). Authored chapters
@@ -1417,8 +1430,10 @@ def _redirect_new_game(chapter_index):
     """Redirect the prologue slot -> `chapter_index` at the authoritative map-load point,
     StartBattleMap (feeds gPlaySt.chapterIndex into InitChapterMap/fog/weather): if
     (chapterIndex == 0) chapterIndex = N. chapterIndex == 0 there can only be a fresh
-    game's prologue (skirmishes use PLAY_FLAGs; later chapters nonzero). Only the test
-    sandbox needs this; the real prologue IS chapter 0, so it doesn't redirect."""
+    game's prologue (skirmishes use PLAY_FLAGs; later chapters nonzero). BOTH boot
+    modes ride this: the sandbox redirects 0 -> the Ch1 slot, and the real game
+    redirects 0 -> PROLOGUE_HOST_INDEX (slot 1, where the prologue is hosted --
+    main() calls _configure_boot on every non-sandbox build)."""
     with open(BMIO_C, encoding='utf-8') as f:
         bmio = f.read()
     bmio, n = re.subn(
@@ -1833,8 +1848,11 @@ def inject_test_chapter(campaign, verbose=True, lord_boot=False):
 # FE8 draws map sprites by class (GetUnitSMSId -> pClassData->SMSId). To give each
 # cast member a distinct overworld sprite without touching stock classes or vanilla
 # enemies, we add a custom SMS slot per cast member (ids CUSTOM_SMS_BASE+) and a
-# per-CHARACTER override in GetUnitSMSId. Colours come from the one shared cast
-# palette (unit_icon_pal_player.agbpal) -- map sprites can't carry their own.
+# per-CHARACTER override in GetUnitSMSId. Colours come from the bespoke cast OBJ
+# palette (map_sprites/cast_palette.png -> gCastMapPalette via _inject_cast_palette;
+# the shared player blue bank stays untouched) -- a map sprite still can't carry its
+# OWN palette, they all share the cast bank. Cold-open guests render through the
+# vanilla unit_icon_pal_player.agbpal.
 
 
 def classed_cast(campaign):
@@ -2000,7 +2018,9 @@ def _inject_mu_override_hook():
 
 def _read_cast_palette(path):
     """Read cast_palette.png (indexed) -> 16 GBA15 u16 colours (index 0 transparent).
-    Pads short palettes with black; errors if it carries more than 16 entries."""
+    Pads short palettes with black; errors if any pixel USES an index above 15 (a
+    carried-but-unused longer palette, e.g. PIL's padded 256, is tolerated -- only
+    the first 16 entries are read)."""
     im = Image.open(path)
     if im.mode != 'P':
         sys.exit('ERROR: %s must be indexed (mode P) so it defines the cast palette' % path)
@@ -2515,10 +2535,12 @@ def enemy_class_reskins(campaign):
 # Give a unit a custom battle anim from 1-3 static frames + the engine's effects, with
 # NO hand-drawn motion. ref_to_battleframe generates the assets (sheets + agbpal + motion.s)
 # cloning a donor class's timing; this injects them ADDITIVELY: append a banim_data[] row
-# (-> a new animId), then -- so generic/enemy archers stay vanilla -- give the unit a
-# stat-identical CLONE of the donor class (clone_into) whose private AnimConf selects the new
-# animId, and deploy the unit as that clone (deploy_class_for). Nothing vanilla is overwritten
-# (donor class + AnimConf byte-unchanged). Reversible: the patched files restore each build.
+# (-> a new animId), then -- so generic/enemy units of the class stay vanilla -- register a
+# PRIVATE AnimConf for the CHARACTER in gUnitSpecificBanimConfigs and point its _u25 at it
+# (the per-character path; _patch_banim_character_unique routes combat through
+# GetBattleAnimationId_WithUnique). No class clone: the unit deploys as its plain vanilla
+# class (deploy_class_for). Nothing vanilla is overwritten (donor class + AnimConf
+# byte-unchanged). Reversible: the patched files restore each build.
 
 # donor 'clone_from' -> (FE donor class enum, the AnimConf weapon entry to repoint in the
 # clone, the cadence the faked motion.s is built with: 'ranged' draw-and-fire / 'melee'
@@ -2629,21 +2651,23 @@ def inject_battle_anims(campaign, verbose=True):
 
     ADDING A UNIT (the repeatable how): give its YAML a `battle_anim:` block --
         clone_from: archer                  # donor class: timing/effects/modes + the weapon slot
-        clone_into: CLASS_<FREE_SLOT>       # a FREE class enum -> this unit's PRIVATE clone class
         abbr: <stem>                        # banim asset stem (<=12 chars)
         frames: [<unit>/ready.png, <unit>/windup.png, <unit>/peak.png]  # 1-3, Ready->Windup->Peak
+        # (+ optional motion/cadence per BANIM_DONORS; no class key -- see below)
     Frames: BOX-descale the hi-res (e.g. 1920x1080) source poses onto a ~88x64 canvas with a COMMON
     feet-anchor + a protected ~15-colour palette. NEVER re-shrink an already-small frame (non-integer
     re-shrink looks muddy) -- to rescale a unit, re-descale from the hi-res master.
 
-    This APPENDS a banim_data[] row (table self-sizes) and CLONES the donor class into clone_into with
-    its OWN AnimConf, so the donor class + generic/enemy units of it stay byte-vanilla -- only this
-    unit (deployed AS the clone via deploy_class_for) shows the custom anim. Stats ride STAT_DONOR/
+    This APPENDS a banim_data[] row (table self-sizes) and registers a PRIVATE AnimConf for the
+    CHARACTER (gUnitSpecificBanimConfigs + the character's _u25, routed by
+    _patch_banim_character_unique) -- the donor class, its AnimConf, and every generic/enemy unit
+    of it stay byte-vanilla, and the unit deploys as its PLAIN vanilla class (deploy_class_for;
+    the earlier clone-class approach is retired). Stats ride STAT_DONOR/
     BASE_DONOR/GROWTH_DONOR; PORTRAIT_MAP ties the unit id -> its vanilla character slot.
 
-    !! OFF-BY-ONE: the clone's AnimConf `.index` MUST be `anim_id + 1` (GetBattleAnimationId returns
+    !! OFF-BY-ONE: the private AnimConf `.index` MUST be `anim_id + 1` (GetBattleAnimationId returns
        idx - 1). Get it wrong and a PURPLE DRAGON renders instead of the unit.
-    Decisions/rationale: decisions.md (Art & Audio, the additive clone-class call).
+    Decisions/rationale: decisions.md (Art & Audio, the per-character _u25 call).
     """
     from PIL import Image
     units = units_with_battle_anim(campaign)
@@ -3201,7 +3225,8 @@ def inject_prologue(campaign, verbose=True, montage=False):
     maps_dir = os.path.join(REPO, 'campaigns', campaign, 'maps')
     # Cold-open guests ride non-PORTRAIT_MAP vanilla slots (PROLOGUE_*_SLOT). Classes mirror
     # the ch00 YAML: a strong promoted "Jeigan" (Scramsax/Hero) + the frail must-survive lead
-    # (Hlin/Warrior) -- the vanilla Prologue Seth+Eirika dynamic. (Difficulty lives in the
+    # (Hlin/Fighter, UNPROMOTED -- the frailty is the point) -- the vanilla Prologue
+    # Seth+Eirika dynamic. (Difficulty lives in the
     # roster levels/items below + the guest stat patch in step 4b.)
     hlin_slot, scram_slot, sephek_slot = (
         PROLOGUE_HLIN_SLOT, PROLOGUE_SCRAMSAX_SLOT, PROLOGUE_SEPHEK_SLOT)
@@ -3244,8 +3269,9 @@ def inject_prologue(campaign, verbose=True, montage=False):
         json.dump(settings, f, indent=2)
 
     # 2. Rewrite the two prologue rosters. redaCount=0 places units statically at
-    #    xPosition/yPosition (like inject_test_chapter); the boss rides the ONEILL slot so
-    #    its CA_BOSS attribute makes DefeatBoss fire on death. Positions/levels/items from
+    #    xPosition/yPosition (like inject_test_chapter); the boss rides the ONEILL slot
+    #    (CA_BOSS marks it a boss for autolevel/UI -- the DefeatBoss EVENT flag comes from
+    #    the flagged defeat quote in step 5, not from CA_BOSS). Positions/levels/items from
     #    the chapter YAML (0-indexed x,y). AI: boss = Breguet's stationary-aggressive bytes
     #    {AI_A_03 ActionStanding, AI_B_03 NeverMove, config} (cp_data.c gAi1/2ScriptTable) --
     #    NOT O'Neill's {0x6,0x3} "DoNothing", which only works because the vanilla tutorial
@@ -3325,8 +3351,8 @@ def inject_prologue(campaign, verbose=True, montage=False):
     #    empty the Turn/Character/Location lists and null the tutorial list, then replace the
     #    beginning scene with a bare deploy of both rosters. The Misc list keeps the win/lose
     #    machinery in the vanilla Prologue's shape (prologue-eventinfo.h): DefeatBoss = AFEV
-    #    on EVFLAG_DEFEAT_BOSS, which the engine sets when a CA_BOSS unit (Sephek, on the
-    #    ONEILL slot) dies -> runs the ending scene; CauseGameOverIfLordDies = AFEV on
+    #    on EVFLAG_DEFEAT_BOSS, which Sephek's FLAGGED DEFEAT QUOTE sets on his death
+    #    (step 5; CA_BOSS alone sets nothing) -> runs the ending scene; CauseGameOverIfLordDies = AFEV on
     #    EVFLAG_GAMEOVER, which Hlin's flagged defeat quote sets (step 5).
     with open(CH1_EVENTINFO_H, encoding='utf-8') as f:
         info = f.read()
@@ -3908,7 +3934,7 @@ def inject_ch01(campaign, verbose=True):
     #    chapter_start `script:` and staged below (step 4) as a scenic off-map scene
     #    (BACG bg_Fireplace) at the head of EventScr_Ch2_BeginningScene. The script
     #    splits on `beat_break` sentinels into 5 messages (A-E); each rides one `Text()`
-    #    whose trailing REMA clears all faces (scene.c sub_800E640) -> a fresh 4-face
+    #    whose trailing REMA clears all faces (eventscr.c sub_800E640) -> a fresh 4-face
     #    budget per beat. TWO SIDES: the quest-givers stand on the RIGHT (Hlin mid-right,
     #    Scramsax far-right, Hruna right) and the party on the LEFT. The roll-call rotates
     #    one PC at a time through the mid-left spotlight (eviction); monologue beats PRELOAD
@@ -4018,8 +4044,9 @@ def inject_ch01(campaign, verbose=True):
                  % (len(cast), len(CH01_JOIN_POSITIONS)))
     leader = 'CHARACTER_%s' % cast[0][1].upper()
 
-    # classIndex rides the DEPLOY class (dce -- the Archer-clone for RBG, #65); items/loadout
-    # still come from the real vanilla class (ce). For most units dce == ce.
+    # classIndex rides the DEPLOY class (dce) -- which today equals the real vanilla class
+    # (ce) for EVERY unit: the #65 clone-class approach is retired (custom anims ride the
+    # per-character _u25 path; see deploy_class_for). The split survives only as a seam.
     join = [_ally_unit_entry(leader, slot, dce, lv, x, y,
                              ', '.join(CLASS_LOADOUT[ce]), ' /* %s */' % uid)
             for (uid, slot, ce, dce, lv), (x, y) in zip(cast, CH01_JOIN_POSITIONS)]
@@ -4423,10 +4450,9 @@ def inject_ch01(campaign, verbose=True):
     # bodies + staging are built in step 0b/step 6. The scene plays over the vanilla
     # BG_NORMAL_VILLAGE (we tried winterizing it but a palette swap just washes it out and
     # no clean FE8 snow-village BG was available, so we use it as-is; Nicolas 2026-06-17).
-    # ch02 isn't hosted yet, so instead of MNC2'ing onto a leftover vanilla map the
-    # ending lands on the reusable dev placeholder (dev_placeholder_scene): RBG's
-    # "still under construction" cheese pun, then back to title. Swap to MNC2(ch02 slot)
-    # when ch02 lands.
+    # The ending MNC2s into ch02 "Cold Welcome" (hosted on chapter slot 3 by
+    # inject_ch02; see the generated EventScr_Ch2_EndingScene below). Before ch02 landed
+    # it parked on the dev placeholder instead.
     end_text_calls = _scenic_beat_calls(
         CH01_ENDING_MSGS, end_beats,
         ['A+B -- Duvessa thanks them, commissions them, grants the sled, points west',
@@ -4549,7 +4575,8 @@ def inject_ch01(campaign, verbose=True):
               else '[A]' if (j + 1) % 2 == 0 else '[LF]')
         for j, ln in enumerate(expl))
     set_message_body(lines, LORDSEL_EXPLAINER_MSG, _term_pad(expl_body + '[X]'))
-    # Prep-screen header (#46): "Choose your lead" replaces "Pick N Units Left" in lord mode.
+    # Lord-select screen title (#46): "Choose your lead", drawn by the generated
+    # CallLordSelectMenu title box (the prep screen's own "Pick N Units Left" is untouched).
     set_message_body(lines, LORDSEL_HEADER_MSG, _term_pad('Choose your lead[X]'))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
@@ -4809,7 +4836,7 @@ def inject_ch02(campaign, verbose=True):
     with open(EVENTS_UDEFS_C, 'w', encoding='utf-8') as f:
         f.write(udefs)
 
-    # 3. Event lists (ch3-eventinfo.h). Turn: the rear wolves on turn 3 (FACTION_ID_BLUE
+    # 3. Event lists (ch3-eventinfo.h). Turn: the rear raiders on turn 3 (FACTION_ID_BLUE
     #    appear-at-player-phase idiom, cf. inject_ch01). Character/Location cleared: no
     #    talks, and DROP the vanilla Seize(14,1) + chests/doors so DefeatAll (CountRedUnits)
     #    is the only win path. Misc keeps its vanilla CauseGameOverIfLordDies untouched.
@@ -4947,8 +4974,8 @@ def inject_ch02(campaign, verbose=True):
     for msg_id, ln in zip(CH02_TUTORIAL_MSGS, tutorial):
         set_message_body(lines, msg_id, _script_to_message(
             [ln], _stage_beat([ln], cut_fid, op_home), width=42))
-    # Wolfram's rear-ambush bark, shown over the map (29-tile bubble wrap; the 31-char
-    # "Wolves at our backs -- the sled." auto-wraps via _wrap_fe_lines).
+    # Wolfram's rear-ambush bark, shown over the map (29-tile bubble wrap via
+    # _wrap_fe_lines; the current YAML lines fit unwrapped).
     set_message_body(lines, CH02_BARK_MSG, _script_to_message(
         bark, {'wolfram': ('[OpenMidLeft]', _fid_tag(PORTRAIT_MAP['wolfram'].upper()))},
         width=29))

--- a/tools/check.py
+++ b/tools/check.py
@@ -20,6 +20,7 @@ Exit 0 = clean, 1 = drift found. Run from the repo root.
 import glob
 import os
 import re
+import subprocess
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -27,17 +28,31 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Docs that carry prose facts (decisions.md is handled specially per-check).
 DOC_GLOBS = ['docs/**/*.md', 'CLAUDE.md', 'README.md', 'HANDOFF.md']
 
-# Terms that are NEVER legitimate in vision/ops docs: abandoned tools, dead code
-# symbols, retired implementation phrases. decisions.md is EXEMPT (its ADRs record
-# what we abandoned, e.g. "supersedes the flat-E placeholder"). Context-dependent
-# terms (Event Assembler / devkitARM / "damage-type") are intentionally NOT here --
-# they appear legitimately in negation ("no Event Assembler").
+# Terms that are NEVER legitimate in vision/ops docs OR hand-written code comments:
+# abandoned tools, dead code symbols, retired implementation phrases. decisions.md
+# and this file are EXEMPT (the ADR log records what we dropped; this list names it).
+# Context-dependent terms (Event Assembler / devkitARM / "damage-type") are
+# intentionally NOT here -- they appear legitimately in negation ("no Event
+# Assembler").
+#
+# REGISTRY DISCIPLINE (decisions.md 2026-07-02 "Comments are testimony"): when a
+# change RETIRES a mechanism or term, add its key phrases here in the same commit.
+# The 2026-07-02 stale-comment incident ("zeroed personal growths" surviving in a
+# build_campaign.py header long after donor-parity replaced it, then leaking into
+# an ADR) happened because this scan covered docs only and the growth patterns were
+# too narrow to match the comment's phrasing -- both fixed below.
 DEAD_CONCEPTS = [
     r'build-campaign\.ts', r'build-events\.ts', r'pull-srd', r'map-class\.ts',
     r'srd-snapshot', r'open5e-snapshot', r'CLASS_WEAPON', r'WPN_EXP_E',
-    r'zeroed.{0,3}growth', r'flat-?E rank', r'pure[- ]class growth',
+    r'zeroed.{0,24}growths?', r'flat-?E rank', r'pure[- ]class (?:growth|rate)',
     r'gen-chapter-index\.rb', r'gen-class-index\.rb',  # ported to Python 2026-06-09
 ]
+
+# Hand-written source whose comments carry doctrine -- the same drift surface as
+# docs. The decomp submodule, generated artifacts, and caches are not ours to lint.
+CODE_GLOBS = ['tools/*.py', 'tools/inject/*.py', 'tools/playtest/*.py',
+              'tools/playtest/*.lua', 'tools/*.sh', 'tools/playtest/*.sh',
+              'engine/**/*.c', 'engine/**/*.h', 'Makefile']
 
 
 def _docs():
@@ -45,6 +60,18 @@ def _docs():
     for g in DOC_GLOBS:
         out += glob.glob(os.path.join(REPO, g), recursive=True)
     return [d for d in out if os.path.isfile(d)]
+
+
+def _handwritten_sources():
+    out = []
+    for g in CODE_GLOBS:
+        out += glob.glob(os.path.join(REPO, g), recursive=True)
+    # check.py hosts the DEAD_CONCEPTS registry and test_* files quote dead phrases
+    # as regression fixtures -- both exempt, like decisions.md.
+    me = os.path.abspath(__file__)
+    return [p for p in out
+            if os.path.isfile(p) and os.path.abspath(p) != me
+            and not os.path.basename(p).startswith('test_')]
 
 
 def check_python_compiles(fail):
@@ -268,17 +295,34 @@ def check_injection_order(fail):
 
 
 def check_tool_refs_exist(fail):
-    pat = re.compile(r'tools/([\w-]+\.(?:py|rb))')
-    for d in _docs():
-        for m in pat.findall(open(d, encoding='utf-8').read()):
-            if not os.path.isfile(os.path.join(REPO, 'tools', m)):
-                fail.append('%s references tools/%s which does not exist'
-                            % (os.path.relpath(d, REPO), m))
+    """A doc or code comment naming tools/<x>.py|rb, or a docs/<x>.md path, must
+    point at a file that exists -- dangling pointers are the cheapest-to-catch form
+    of comment rot (2026-07-02 comment-drift ADR)."""
+    # (?<![\w/]) keeps "texttools/x.py" or "fireemblem8u/tools/..." from reading as
+    # our tools/; a missing-but-gitignored target is a declared build artifact
+    # (e.g. playtest/symbols.lua), not a dangling pointer.
+    tool_pat = re.compile(r'(?<![\w/])tools/([\w./-]*[\w-]\.(?:py|rb|lua|sh))')
+    doc_pat = re.compile(r'(?<![\w/])docs/([\w./-]*[\w-]\.md)')
+
+    def _gitignored(rel):
+        return subprocess.run(['git', 'check-ignore', '-q', rel], cwd=REPO).returncode == 0
+
+    for d in _docs() + _handwritten_sources():
+        text = open(d, encoding='utf-8').read()
+        rel = os.path.relpath(d, REPO)
+        for prefix, pat in (('tools', tool_pat), ('docs', doc_pat)):
+            for m in pat.findall(text):
+                target = '%s/%s' % (prefix, m)
+                if not os.path.isfile(os.path.join(REPO, target)) and not _gitignored(target):
+                    fail.append('%s references %s which does not exist' % (rel, target))
 
 
 def check_no_dead_concepts(fail):
+    """Retired terms/mechanisms must not survive in docs OR hand-written code
+    comments (the 2026-07-02 incident: a superseded mechanism lived on in a
+    build_campaign.py header and got copied into an ADR as fact)."""
     pat = re.compile('|'.join(DEAD_CONCEPTS), re.I)
-    for d in _docs():
+    for d in _docs() + _handwritten_sources():
         if os.path.basename(d) == 'decisions.md':
             continue
         for i, line in enumerate(open(d, encoding='utf-8'), 1):

--- a/tools/check.py
+++ b/tools/check.py
@@ -2,13 +2,14 @@
 """Repo drift guard. ONE source of check logic, run by CI, the git pre-commit hook,
 and `make check`. Keeps doc/plan drift from landing.
 
-Catches:
-  1. Python tooling that doesn't compile.
-  2. Campaign YAML that doesn't parse.
-  3. Docs referencing a tools/<x>.py|rb that doesn't exist.
-  4. Resurrected "dead concepts" -- abandoned tool names, dead code symbols, retired
-     implementation phrases -- in any doc except decisions.md (the ADR log that is
-     *supposed* to record what we dropped).
+Catches (main() is the authoritative list -- one check_* per gate): compile/parse
+gates (Python tooling, unit tests, campaign YAML), doc/comment drift (dangling
+tools/docs references, resurrected "dead concepts" -- abandoned tool names, dead
+symbols, retired implementation phrases -- everywhere except decisions.md, the ADR
+log that is *supposed* to record what we dropped, and test_* fixtures), generated
+indexes freshness, chapter status/deployment schema, injection order, the
+engine-hook guards, the engine/content boundary, save-layout stability, and
+advisory lane ownership.
 
 What it does NOT catch: arbitrary prose that contradicts the code without using a
 known-dead term. The defense there is single source of truth (link, don't restate)
@@ -46,6 +47,10 @@ DEAD_CONCEPTS = [
     r'srd-snapshot', r'open5e-snapshot', r'CLASS_WEAPON', r'WPN_EXP_E',
     r'zeroed.{0,24}growths?', r'flat-?E rank', r'pure[- ]class (?:growth|rate)',
     r'gen-chapter-index\.rb', r'gen-class-index\.rb',  # ported to Python 2026-06-09
+    # retired by the 2026-07-02 comment sweep:
+    r'clone_into',                     # #65 clone-class approach -> per-character _u25
+    r'tileset_stem\s*=',               # _register_chapter_map reads the layout's stamp
+    r'BATTLE_FOLLOWUP_THRESHOLD',      # misnomer; real: BATTLE_FOLLOWUP_SPEED_THRESHOLD
 ]
 
 # Hand-written source whose comments carry doctrine -- the same drift surface as
@@ -356,7 +361,8 @@ def check_engine_guards_present(fail):
     "lord" rides a non-LORD-class slot: FE8's chapter-start cursor centering derefs a NULL
     leader unit, parks the cursor off-map, and an out-of-bounds terrain read runs the text
     decoder away into gBmSt. Our whole cast uses non-lord slots, so EVERY chapter needs
-    these two campaign-agnostic guards in build_campaign.py. Removing either silently
+    these two campaign-agnostic guards (defined in tools/inject/engine_hooks.py, called
+    from build_campaign.py). Removing either silently
     re-introduces the crash, so guard their presence here. (The patches themselves also
     fail the build if the decomp source form changes -- see their `if orig not in text`.)
     The campaign-engine hooks below are likewise build-time string-replaces that leave no
@@ -456,7 +462,8 @@ def check_engine_campaign_agnostic(fail):
 
 # ── Save-layout stability (so testers can carry their .sav across builds) ──────────
 # A battery .sav is accepted on a new build iff its validity magics + checksum still
-# match (bmsave-lib.c:125-128, ReadSaveBlockInfo). Those magics are constant, so a
+# match (bmsave-lib.c ReadGlobalSaveInfo, the magic16/magic32/checksum condition; the
+# per-block form is ReadSaveBlockInfo). Those magics are constant, so a
 # rebuild alone never invalidates a save -- the ONLY thing that can is the save-block
 # LAYOUT shifting, which moves the old bytes to wrong offsets and fails the checksum.
 # struct GameSaveBlock's size is driven by two array dims; pin them (and the magics) so
@@ -616,7 +623,8 @@ def check_lane_ownership(fail):
     sawed such a feature in half. So this no longer fails -- it just surfaces, on a legacy
     `inst/<track>` branch, that a change touches the other desk's historical files, so the PR
     review names the cross-desk contract. The HARD invariant is now check_engine_guards_present
-    (the 5 engine hooks); desk ownership is reviewed at the PR. The glob map (above) is the seed
+    (every hook in its guarded tuple -- count-free on purpose, the tuple is the truth); desk
+    ownership is reviewed at the PR. The glob map (above) is the seed
     of the desk map. Dormant on `feat/*` branches (no lane), which is the steady state."""
     for path, owner in _lane_violations(_current_lane(), _changed_files()):
         print('  note: %s is historically %s-side -- if this PR spans desks, name the contract in review'

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -77,7 +77,8 @@ def _class_growths(class_enum):
 
 def autolevel(base, growths, level):
     """Project class-base stats up `level` (FE generic-enemy autolevel on class growths,
-    bmunit.c:792). Per stat: base + round-half-up((level-1) * growth%). Con/Mov don't grow."""
+    UnitAutolevelCore, bmunit.c:776-786, applied with level-1 by UnitAutolevel). Per
+    stat: base + round-half-up((level-1) * growth%). Con/Mov don't grow."""
     out = dict(base)
     gains = level - 1
     for gf in bc.GROWTH_FIELDS:
@@ -426,7 +427,8 @@ def carry(boss, party, terrain_avoid=0):
 # A fixed, campaign-neutral reference attacker/defender. enemy_pressure measures every
 # enemy against THIS unit, so a chapter's pressure is comparable to its vanilla reference's
 # on the same scale; the yardstick's exact stats cancel in an ours-vs-vanilla ratio. Chosen
-# as a plain mid-game footsoldier (iron sword, no triangle bias, modest bulk/offense).
+# as a plain mid-game footsoldier (iron sword -- triangle-ACTIVE like any sword, so it
+# reads +1Mt/+15Hit vs axe foes and -1/-15 vs lances; modest bulk/offense).
 YARDSTICK = fc.Combatant('yardstick', hp=24, pow=8, skl=8, spd=8, df=6, res=4, lck=4,
                          con=10, weapon=fc.W['iron-sword'])
 
@@ -831,8 +833,9 @@ def main():
     ap.add_argument('--curve', action='store_true',
                     help='emit the campaign-wide enemy-pressure curve (all chapters)')
     ap.add_argument('--check', action='store_true',
-                    help='with --curve: exit non-zero if any referenced chapter is off-parity '
-                         'or unreliably measured (the hard CI gate, #48 (b))')
+                    help='with --curve: the hard CI gate (#48 (b)) -- exit non-zero if any '
+                         'balance_locked chapter is off-parity, unreliably measured, or '
+                         'missing its reference (UNLOCKED chapters never gate)')
     ap.add_argument('--lord-floor', action='store_true',
                     help='emit the per-lord survivability-floor table instead of the parity report')
     ap.add_argument('--target', type=float, default=3.5, help='floor: target bulk rounds-to-down')

--- a/tools/fe_combat.py
+++ b/tools/fe_combat.py
@@ -12,9 +12,10 @@ Combat model (bmbattle.c line cites):
   Hit     = Skl*2 + wpnHit + Lck//2 + triangleHit          (l.578)
   Avoid   = AS*2 + terrainAvoid + Lck                       (l.582)
   HitShown= clamp(atkHit - defAvoid, 0, 100)               (l.600-603)
-  Atk     = Pow + wpnMt + triangleDmg   (x3 whole if effective, l.531)
+  Atk     = Pow + (wpnMt + triangleDmg)  (the Mt+tri HALF x3 if effective, l.527-556:
+            battleAttack = Mt + tri, tripled on effectiveness, THEN += Pow)
   Damage  = max(0, Atk - (Def | Res))                       Res for magic
-  Double  if (atkAS - defAS) >= 4                           (BATTLE_FOLLOWUP_THRESHOLD)
+  Double  if (atkAS - defAS) >= 4                     (BATTLE_FOLLOWUP_SPEED_THRESHOLD)
 Triangle (GBA FE8): advantage +1 Mt / +15 Hit, disadvantage -1 Mt / -15 Hit.
 """
 from dataclasses import dataclass, field
@@ -50,7 +51,7 @@ W = {
     'killing-edge': Weapon('killing-edge', 9, 75, 30, 7,  'sword'),
     'iron-axe':     Weapon('iron-axe',     8, 75,  0, 10, 'axe'),
     'steel-axe':    Weapon('steel-axe',    11, 65, 0, 15, 'axe'),
-    'hand-axe':     Weapon('hand-axe',     7, 60,  0, 11, 'axe',   rng=(1, 2)),
+    'hand-axe':     Weapon('hand-axe',     7, 60,  0, 12, 'axe',   rng=(1, 2)),
     'iron-bow':     Weapon('iron-bow',     6, 85,  0, 5,  'bow',   rng=(2, 2),
                            effective=frozenset({'flier'})),
     'fire':         Weapon('fire',         5, 90,  0, 4,  'magic', rng=(1, 2)),
@@ -99,7 +100,7 @@ def attack_speed(c):
     return max(0, c.spd - max(0, c.weapon.wt - c.con))
 
 
-# A 4-point attack-speed lead earns a follow-up attack (BATTLE_FOLLOWUP_THRESHOLD).
+# A 4-point attack-speed lead earns a follow-up attack (BATTLE_FOLLOWUP_SPEED_THRESHOLD).
 FOLLOWUP_THRESHOLD = 4
 
 
@@ -124,14 +125,17 @@ def triangle(atk_kind, def_kind):
 
 def damage(atk, dfn):
     """Damage atk deals to dfn on a single connecting hit (max 0). Magic resolves
-    against Res, everything else against Def; an effective weapon triples the whole
-    attack (Pow + Mt + triangle) before the defence is subtracted."""
+    against Res, everything else against Def; an effective weapon triples the WEAPON
+    half only (Mt + triangle) -- Pow is added after, per the decomp
+    (bmbattle.c ComputeBattleUnitAttack: battleAttack = Mt + tri, x3 on
+    effectiveness, then += Pow; the sacred-twins x2 special case is not modeled)."""
     if atk.weapon is None:                # a weaponless support unit can't attack
         return 0
     tri = triangle(atk.weapon.kind, dfn.weapon.kind) if dfn.weapon else 0
-    raw = atk.pow + atk.weapon.mt + tri
+    raw = atk.weapon.mt + tri
     if atk.weapon.effective & dfn.tags:
         raw *= 3
+    raw += atk.pow
     defence = dfn.res if atk.weapon.kind == 'magic' else dfn.df
     return max(0, raw - defence)
 

--- a/tools/gen_subtitle_cards.py
+++ b/tools/gen_subtitle_cards.py
@@ -12,7 +12,7 @@ seven slides from the campaign YAML.
 Style is matched to the vanilla cards, measured off the shipped PNGs: slate
 background (palette index 0), cream text quantized into the vanilla 16-color
 ramp (the warm antialiasing browns come from the quantization), 24px line
-pitch, text block centered on (120, 80), <= 214px line width. Letterforms are
+pitch, text block centered on (120, 80), <= 220px line width (MAX_LINE_W). Letterforms are
 Georgia 13px with +1px tracking -- side-by-side closest to vanilla's serif
 (see the 2026-06-10 decisions.md entry).
 

--- a/tools/import_map_layout.py
+++ b/tools/import_map_layout.py
@@ -4,7 +4,9 @@ campaigns/.../maps/ and render a confirmation preview to map-review/.
 
 Usage: import_map_layout.py <map-stem> [src-json]
 e.g.   import_map_layout.py ch01-the-iron-trail ~/Downloads/ch01-layout.json
-       (src defaults to ~/Downloads/<map-stem>-layout.json, then ~/Downloads/prologue-layout.json)"""
+       (src defaults to ~/Downloads/<map-stem>-layout.json; ch00/prologue stems also try
+        ~/Downloads/prologue-layout.json and ch01 stems ~/Downloads/ch01-layout.json --
+        any other stem has no second fallback)"""
 import sys, os, json
 ROOT=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # repo root (worktree-aware)
 sys.path.insert(0, os.path.join(ROOT,'tools'))

--- a/tools/inject/engine_hooks.py
+++ b/tools/inject/engine_hooks.py
@@ -11,7 +11,9 @@ from inject.decomp import (
     DECOMP, _replace_brace_block,
     BATTLEQUOTES_C, BMUNIT_C, LORDSEL_FLAG_BASE)
 
-# Decomp source files patched ONLY by the engine hooks below.
+# Decomp source files the engine hooks read or patch. One exception to "patched
+# here": BANIM_DATA_C is only READ by the hooks (_vanilla_banim_count); the content
+# side appends its rows (build_campaign.py inject_battle_anims).
 BANIM_EKRBATTLEINTRO_C = os.path.join(DECOMP, 'src', 'banim-ekrbattleintro.c')
 BANIM_EKRMAIN_C = os.path.join(DECOMP, 'src', 'banim-ekrmain.c')
 BANIM_DATA_C = os.path.join(DECOMP, 'src', 'banim_data.c')

--- a/tools/map_sprite_editor.py
+++ b/tools/map_sprite_editor.py
@@ -17,7 +17,8 @@ The idle preview follows the FE8 decomp exactly (src/bmudisp.c sub_8026FF4 / the
 GetGameClock() % 72 ladder): standing sprites animate frames 0,1,2 only, held
 32 / 4 / 32 / 4 ticks (frame 0, 1, 2, 1) at 60fps -- a slow two-pose bob.
 
-It is deliberately stdlib-only (http.server) -- no pip installs, no framework, no network
+It is deliberately framework-free (stdlib http.server + the repo's existing Pillow
+dep for image IO) -- no new installs, no web framework, no network
 calls, nothing leaves the machine. Sheet-agnostic by design (frame geometry from
 map_sprite_tool.sheet_info, --fw/--fh override), so the painting surface carries over to
 battle-animation frames later (the anim *scripting* is a separate problem).

--- a/tools/map_tileset_tool.py
+++ b/tools/map_tileset_tool.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Map tileset helpers (#40 task 2): render a GBAFE tileset's metatiles so maps can
-be authored by metatile index, and compile a hand-authored layout grid -> the decomp
-layout .bin (and matching .json).
+be authored by metatile index, and compile a hand-authored layout grid -> the
+FEBuilder-format .mar the decomp build consumes (+ the matching .json); the decomp's
+own scripts/mar_to_map.py turns that into the layout .bin at ROM-build time (writing
+the .bin directly scrambles the map -- see compile_layout).
 
 A GBAFE tileset is 3 raw pieces (the decomp/FEBuilder format, see maps/README.md):
   <name>.4bpp    1024 8x8 tiles, 4bpp (32768 B)

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -2,9 +2,14 @@
 --
 -- Launched by run.sh via a generated wrapper that sets:
 --   PLAYTEST_DIR      -- this directory (for dofile of symbols.lua)
---   PLAYTEST_SCENARIO -- "win" | "gameover" | "retreat" | "titlecard"
+--   PLAYTEST_SCENARIO -- which `scenarios.<name>` to run (the table below is the
+--                        authoritative list; run.sh's header groups the main ones)
 --   PLAYTEST_LOG      -- log file path (runner polls it for "RESULT:")
 --   PLAYTEST_SHOTDIR  -- screenshot directory for milestone/debug captures
+--   PLAYTEST_STATEDIR -- save-state checkpoint dir (ckpt_*/record* scenarios)
+--   PLAYTEST_SEED     -- fuzz/llm seed (PT_SEED)
+--   PLAYTEST_CHAR     -- recordanim unit id (PT_CHAR)
+--   PLAYTEST_LLMDIR   -- #63 sidecar handshake dir (PT_LLM_DIR)
 --
 -- Design: one coroutine resumed once per emulated frame; every wait is a
 -- yield loop over real memory state (closed loop, no frame-perfect timing).
@@ -44,7 +49,7 @@ end
 local nshot = 0
 local function shot(tag)
     nshot = nshot + 1
-    local p = string.format("%s/%02d-%s.png", PLAYTEST_SHOTDIR, nshot, tag)
+    local p = string.format("%s/%04d-%s.png", PLAYTEST_SHOTDIR, nshot, tag)
     pcall(function() emu:screenshot(p) end)
     log("screenshot: " .. p)
 end
@@ -358,8 +363,9 @@ local scenarios = {}
 -- clean terminal: the point is to exercise load + every phase/event path to a clean
 -- end as content lands, not to win (winning is the next brick). The verdict is the
 -- pure classifier in liveness.lua (unit-tested without an emulator). PASS = clean
--- terminal, FAIL = soft-lock, INCONCLUSIVE = alive past the turn budget (run.sh treats
--- INCONCLUSIVE as exit 0 + WARN; a wedged emulator is run.sh's wall-clock deadline).
+-- terminal OR alive past the turn budget (an idle party usually can't force a terminal,
+-- so budget-survival is the healthy outcome); FAIL = soft-lock. A wedged emulator is
+-- caught by run.sh's wall-clock deadline.
 local LIVENESS = dofile(PLAYTEST_DIR .. "/liveness.lua")
 
 local function hpSum()
@@ -537,7 +543,8 @@ local function smokeDrive(startChapter)
 end
 
 -- smoke: prologue is reachable straight from New Game (bootToMap). Later chapters need
--- their own "reach the map" lead-in (smoke_ch01) or a save-state checkpoint (deferred).
+-- their own "reach the map" lead-in (smoke_ch01) or a save-state checkpoint
+-- (smoke_ch02 loads the ch02start state).
 scenarios.smoke = function()
     if not bootToMap() then return result("FAIL", "never reached the map") end
     return smokeDrive(chapter())
@@ -783,8 +790,9 @@ local CH01_PARK = { x = 24, y = 15 } -- empty far corner; ch01 map is 25x16
 -- -- each player phase, march/attack every unit toward the boss; once the boss is dead, if the
 -- chapter hasn't already advanced (DefeatBoss objective), send a unit onto the boss's old tile
 -- to SEIZE (Seize objective). Returns a status ("noboss"|"won"|"gameover"|"timeout") and the
--- turn it ended on. clearDrive wraps this with a PASS/FAIL verdict; reachCh02Map (#22) uses it
--- to clear ch01 and then keep driving into the ch02 cutscene chain. maxx/maxy = map bounds;
+-- turn it ended on. clearDrive (its only caller) wraps this with a PASS/FAIL verdict.
+-- (reachCh02Map (#22) does NOT ride it -- the generic bot is too slow to seize ch01
+-- reliably, so it uses the directed seizeCh01ToCh02.) maxx/maxy = map bounds;
 -- park = the end-turn empty tile. The completability brick (#60).
 local function clearUntilAdvance(startChapter, maxx, maxy, park)
     maxx, maxy = maxx or 14, maxy or 9
@@ -895,7 +903,8 @@ local function clearUntilAdvance(startChapter, maxx, maxy, park)
     return "timeout", budgetTurns
 end
 
--- The verdict wrapper, shared by every clear_* scenario. Win = the chapter advances. FAIL =
+-- The verdict wrapper for clear + clear_ch01 (clear_ch02 has its own rout loop +
+-- verdicts). Win = the chapter advances. FAIL =
 -- game over (incl. a loss kicking back to the title) / no progress (stuck) / turn budget.
 local function clearDrive(startChapter, maxx, maxy, park)
     local status, t = clearUntilAdvance(startChapter, maxx, maxy, park)
@@ -1226,7 +1235,8 @@ end
 
 -- llm: the prologue (DefeatBoss) driven by the sidecar commander. Replay-only run:
 --   python3 tools/playtest/llm_player.py serve --dir /tmp/playtest-llm-handshake \
---       --transcript tools/playtest/transcripts/prologue.json     # (other terminal)
+--       --transcript tools/playtest/transcripts/prologue.json     # (other terminal;
+--       the transcript file is MINTED by the first --record run -- see the README there)
 --   tools/playtest/run.sh llm
 -- Record a fresh transcript (live model; see PT_PROVIDER/PT_MODEL/PT_BASE_URL for the
 -- free local Ollama path) by adding --record to the serve command.
@@ -1239,8 +1249,8 @@ end
 -- CH01WIN: the default lord (blind A-taps pick Braulo) marches on the camp,
 -- kills the chief, and SEIZES -- in-game proof of the lord-gated Seize
 -- (CanUnitSeize hook, #42) and the win hand-off (Seize macro -> EVFLAG_WIN ->
--- ending scene -> dev placeholder -> MNTS back to the title screen, since ch02 is
--- not hosted yet). (CH01_PARK is defined up by the clear-bot.)
+-- ending scene -> MNC2 into the hosted ch02). (CH01_PARK is defined up by the
+-- clear-bot.)
 scenarios.ch01win = function()
     if not winCh00() then return end
     if not waitFor(function() return chapter() == 2 end, 1800) then
@@ -1325,8 +1335,8 @@ scenarios.ch01win = function()
                 shot("ch01win-seize-menu")
                 press(K.A) -- Seize
             end
-            -- generous budget: post-seize plays the full ending cutscene + the dev
-            -- placeholder before MNTS reaches the title (longer than the old 3600).
+            -- generous budget: post-seize plays the full ending cutscene before
+            -- MNC2 chains into the hosted ch02 (longer than the old 3600).
             local won = waitFor(function()
                 return chapter() ~= 2 or procActive(SYM.gProcScr_TitleScreen)
             end, 9000, true)
@@ -1940,9 +1950,9 @@ scenarios.recordending = function()
     pokeNormalConfig() -- normal text speed so the typewriter + face fades animate
     press(K.A) -- Seize (the menu was saved open) -> the ending hand-off
     wait(40)
-    -- ch02 isn't hosted, so the ending runs the dev placeholder (RBG's cheese pun over
-    -- the campfire) and MNTS's back to the title screen -- record through all of it until
-    -- gProcScr_TitleScreen comes up.
+    -- the ending plays the full outro then MNC2s into the hosted ch02 -- record
+    -- through all of it until the chapter advances (the title-screen check below is
+    -- the legacy pre-ch02 exit, kept as a harmless backstop).
     local fr, atTitle = 0, false
     while fr < 9000 do
         fr = fr + 1
@@ -2348,9 +2358,10 @@ scenarios.record = function()
     return result("PASS", "video frames recorded (op + bt)")
 end
 
--- (The boot title screen is captured by `recordending` -- it ends on the title via the
--- dev placeholder's MNTS, and shoots a "title" frame once gProcScr_TitleScreen draws.
--- A standalone boot-capture is unreliable: the attract reel races past the title.)
+-- (A dedicated title-screen capture used to ride recordending's post-ending MNTS,
+-- but ch02 is hosted now -- the ch01 ending MNC2s onward instead of returning to the
+-- title. A standalone boot-capture is unreliable: the attract reel races past the
+-- title; bootobserve below is the tool for boot-sequence questions.)
 
 -- BOOTOBSERVE: screenshot the natural boot sequence with NO input, to see whether the
 -- title screen actually appears at boot (diagnostic).
@@ -2910,7 +2921,7 @@ local function collectedItems()
         if u then for s = 0, 4 do items[#items + 1] = ru16(u.addr + 0x1E + s * 2) & 0xFF end end
     end
     local n = ru8(SYM.gConvoyItemCount)
-    if n > 0x57 then n = 0x57 end   -- convoy cap (supplyItems[0xB0/2])
+    if n > 100 then n = 100 end     -- convoy cap (CONVOY_ITEM_COUNT, bmcontainer.h)
     for i = 0, n - 1 do items[#items + 1] = ru16(SYM.gConvoyItemArray + i * 2) & 0xFF end
     return items
 end

--- a/tools/playtest/liveness.lua
+++ b/tools/playtest/liveness.lua
@@ -1,8 +1,8 @@
 -- liveness.lua -- pure stability classifier for the playtest smoke net (#49).
 --
 -- NO emulator calls: a function over a series of state snapshots, so it is unit-tested
--- without mGBA (tools/playtest/test_liveness.lua). The smoke driver (smoke.lua) samples
--- real memory into snapshots and asks classify() what to do each cycle.
+-- without mGBA (tools/playtest/test_liveness.lua). The smoke driver (smokeDrive in
+-- harness.lua) samples real memory into snapshots and asks classify() what to do each cycle.
 --
 -- A snapshot is a table:
 --   frame             monotonic emulated-frame counter at sample time
@@ -20,8 +20,9 @@
 --   cfg.softlock_frames: frames with no change in {turn,faction,hpsum,procfp} => SOFTLOCK.
 --
 -- There is deliberately no budget/HANG state: exhausting the in-game turn budget while
--- still LIVE is the driver's call (-> INCONCLUSIVE), and a wedged emulator is caught by
--- run.sh's wall-clock deadline -- both outside this pure verdict.
+-- still LIVE is the driver's call (smokeDrive PASSes it -- an idle party usually can't
+-- force a terminal), and a wedged emulator is caught by run.sh's wall-clock deadline --
+-- both outside this pure verdict.
 
 local M = {}
 

--- a/tools/playtest/make_gif.py
+++ b/tools/playtest/make_gif.py
@@ -43,10 +43,17 @@ REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 
 def collect_frames(shotdir, tag):
-    """Frames are `NN-<tag>.png`; NN is a zero-padded global counter, so lexical
-    sort == capture order. Filter to the tag (substring after the NN- prefix)."""
-    return sorted(f for f in glob.glob(os.path.join(shotdir, '*.png'))
-                  if tag in os.path.basename(f).split('-', 1)[-1])
+    """Frames are `NN-<tag>.png`; NN is the harness's global shot counter. Sort
+    NUMERICALLY on it -- the counter's zero padding (%02d) runs out at 99 while a
+    record run shoots hundreds of frames, so a lexical sort would splice '100-'
+    before '99-' and scramble the capture order mid-scene."""
+
+    def shot_no(path):
+        head = os.path.basename(path).split('-', 1)[0]
+        return int(head) if head.isdigit() else -1
+
+    return sorted((f for f in glob.glob(os.path.join(shotdir, '*.png'))
+                   if tag in os.path.basename(f).split('-', 1)[-1]), key=shot_no)
 
 
 def mp4_cmd(in_pattern, out, fps, scale):

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -4,6 +4,8 @@
 #   tools/playtest/run.sh <scenario> [--keep-open]
 #
 # Logic scenarios (assert PASS/FAIL):  win | gameover | retreat | ch01win | titlecard
+#   also: ch01 (entry asserts) | ch01lord | lordfloor | goodberry | clearprobe
+#   (harness.lua's `scenarios` table is the authoritative full list)
 #   ch02   -- ch2 (#22) ENTRY assertions off the ch02start checkpoint: 3 green chwinga on the
 #             field, party at the deploy cap, the archer (fliers-vs-bows debut) + boss present.
 # Stability scenarios (PASS/FAIL liveness over a run):
@@ -20,6 +22,8 @@
 #                             python3 tools/playtest/llm_player.py serve \
 #                                 --dir /tmp/playtest-llm-handshake \
 #                                 --transcript tools/playtest/transcripts/prologue.json
+#                           (prologue.json is MINTED by the first --record run; until then
+#                           replay mode has nothing to serve -- see transcripts/README.md.)
 #                           Replay-only by default (zero LLM cost); add --record + env
 #                           knobs (PT_PROVIDER=openai for a free local Ollama model,
 #                           PT_MODEL, PT_BASE_URL) to record a fresh transcript. When
@@ -38,7 +42,9 @@
 #                      tools/playtest/make_gif.py recordanim braulo --name braulo-anim --open
 #                    A staff-only unit (sclorbo) FAILs cleanly: no attack = no combat anim.
 #                    Build TESTCH=1 first. (recordrbgtest is the back-compat alias for RBG.)
-#   recordch01trail / recordlord / recordch01 / record / scenes -- other scenes
+#   recordch01trail / recordlord / recordlordfast / recordch01 / recordopening /
+#   record / scenes / scenesch01 / bootobserve -- other scenes (no checkpoint: these
+#   replay their full lead-in at 60fps, so they are the slowest captures)
 #
 # CHECKPOINTS (fast playtest, viewable spot-check): record scenarios load a save state
 # built ONCE at top speed (240fps) by a ckpt_* scenario, then replay JUST that section
@@ -154,7 +160,8 @@ if [ -n "$BUILDER" ]; then
 fi
 
 # Main run: record* at 60fps (faithful motion); everything else at 240fps (top speed).
-# record* now LOADS a checkpoint (no grind), so its deadline is short.
+# The checkpoint-backed record* scenarios (table above) skip the grind; the rest replay
+# their full lead-in and simply have to fit the record deadline.
 FPS=240; VSYNC=0; DEADLINE_S=420
 case "$SCENARIO" in record*) FPS=60; VSYNC=1; DEADLINE_S=300 ;; esac
 # smoke_* / fuzz_* / clear_ch02 play a full chapter (lead-in + a long soak) -> longer

--- a/tools/portrait_tool.py
+++ b/tools/portrait_tool.py
@@ -209,8 +209,9 @@ def generate(bust, xmouth=2, ymouth=6, static_portrait=False):
     by hand is infeasible for custom art, so instead we defeat the animation:
       * bake the WHOLE neutral face (eyes + mouth) into the tileset — do NOT blank
         the mouth window the way animated vanilla portraits do;
-      * emit an all-transparent (index 0) frames file, so every overlay frame the
-        engine paints is empty and the static face underneath always shows through.
+      * fill every mouth/blink frame slot with the NEUTRAL mouth/eye crop (opaque --
+        NOT transparent), so each overlay frame the engine paints repaints the same
+        neutral pixels that are already there.
     Net effect: the engine "animates", but nothing ever moves — a locked still.
     """
     mouth_bx = (xmouth - 4) * 8 + 32   # bust x of the 32x16 mouth window
@@ -326,7 +327,7 @@ def main():
         parser.add_argument('--ymouth', type=int, default=6,
                             help='mouth tile-row offset (default 6)')
         parser.add_argument('--static', action='store_true',
-                            help='non-animated bust: full face in tileset, transparent frames')
+                            help='non-animated bust: full face in tileset, neutral-crop frames')
         args = parser.parse_args(sys.argv[2:])
 
         im = Image.open(args.bust)

--- a/tools/setup-toolchain.sh
+++ b/tools/setup-toolchain.sh
@@ -6,8 +6,10 @@
 # decomp quickstart.sh does not handle (Homebrew deps, a python >= 3.10 with
 # numpy/pillow, agbcc, and a few Linux-only shebangs in the submodule scripts).
 #
-# After this completes, `make` from the repo root produces a byte-identical
-# vanilla FE8 ROM (verify with `make verify`).
+# After this completes, `make` from the repo root builds the campaign-injected
+# fireemblem8.gba (we diverge from vanilla on purpose -- no sha1 match; `make
+# verify` runs the text-decode regression instead). To prove the BASE decomp
+# builds clean, use the decomp's own quickstart (see CLAUDE.md Build Command).
 #
 # Usage: tools/setup-toolchain.sh
 set -euo pipefail

--- a/tools/test_check_comment_drift.py
+++ b/tools/test_check_comment_drift.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for the comment-drift guards in tools/check.py (2026-07-02 ADR "Comments
+are testimony, code is evidence").
+
+The incident being pinned: a stale build_campaign.py header ("zeroed personal
+growths ... pure class rate") outlived the donor-parity code that replaced it and
+got copied into an ADR as fact. Two gaps let it survive: check_no_dead_concepts
+scanned docs only (never code comments), and the registered growth patterns were
+too narrow to match the comment's actual phrasing. These tests hold both fixes.
+
+Run: python3 tools/test_check_comment_drift.py
+"""
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check
+
+
+DEAD_PAT = re.compile('|'.join(check.DEAD_CONCEPTS), re.I)
+
+# The exact stale comment text from the incident (build_campaign.py pre-fix).
+INCIDENT_LINE = ('# and zeroed personal growths (so the unit grows at its pure '
+                 'class rate). When')
+
+
+class DeadConceptPatterns(unittest.TestCase):
+    def test_the_incident_comment_is_now_caught(self):
+        # both retired phrasings in the one line; either alone must fire
+        self.assertIsNotNone(DEAD_PAT.search(INCIDENT_LINE))
+        self.assertIsNotNone(DEAD_PAT.search('zeroed personal growths'))
+        self.assertIsNotNone(DEAD_PAT.search('grows at its pure class rate'))
+
+    def test_the_original_narrow_phrasings_still_fire(self):
+        self.assertIsNotNone(DEAD_PAT.search('zeroed growths'))
+        self.assertIsNotNone(DEAD_PAT.search('pure-class growth'))
+
+    def test_live_donor_vocabulary_is_not_flagged(self):
+        for ok in ('growths copied verbatim from the growth donor',
+                   'the donor personal bases',
+                   'class growths from data_classes.c',):
+            self.assertIsNone(DEAD_PAT.search(ok), ok)
+
+
+class HandwrittenSourceScan(unittest.TestCase):
+    """check_no_dead_concepts must scan code comments, not just docs."""
+
+    def _with_planted_file(self, contents, suffix='.py'):
+        tmp = tempfile.NamedTemporaryFile('w', suffix=suffix, delete=False,
+                                          dir=os.path.dirname(os.path.abspath(__file__)))
+        tmp.write(contents)
+        tmp.close()
+        return tmp.name
+
+    def test_dead_concept_in_a_code_comment_is_flagged(self):
+        path = self._with_planted_file('# legacy: zeroed personal growths here\n')
+        try:
+            orig_docs, orig_src = check._docs, check._handwritten_sources
+            check._docs = lambda: []
+            check._handwritten_sources = lambda: [path]
+            fail = []
+            check.check_no_dead_concepts(fail)
+            self.assertEqual(len(fail), 1)
+            self.assertIn('zeroed personal growths', fail[0])
+        finally:
+            check._docs, check._handwritten_sources = orig_docs, orig_src
+            os.unlink(path)
+
+    def test_the_repo_scan_globs_cover_the_incident_file(self):
+        sources = [os.path.relpath(p, check.REPO) for p in check._handwritten_sources()]
+        self.assertIn('tools/build_campaign.py', sources)
+        self.assertIn('tools/playtest/harness.lua', sources)
+        self.assertNotIn('tools/check.py', sources)   # hosts the registry; exempt
+
+    def test_the_live_repo_is_clean(self):
+        fail = []
+        check.check_no_dead_concepts(fail)
+        self.assertEqual(fail, [])
+
+
+class DanglingRefs(unittest.TestCase):
+    def _run_on(self, contents):
+        tmp = tempfile.NamedTemporaryFile('w', suffix='.py', delete=False,
+                                          dir=os.path.dirname(os.path.abspath(__file__)))
+        tmp.write(contents)
+        tmp.close()
+        try:
+            orig_docs, orig_src = check._docs, check._handwritten_sources
+            check._docs = lambda: []
+            check._handwritten_sources = lambda: [tmp.name]
+            fail = []
+            check.check_tool_refs_exist(fail)
+            return fail
+        finally:
+            check._docs, check._handwritten_sources = orig_docs, orig_src
+            os.unlink(tmp.name)
+
+    def test_a_dangling_tool_ref_in_a_comment_is_flagged(self):
+        fail = self._run_on('# see tools/zzz-does-not-exist.py for the old flow\n')
+        self.assertEqual(len(fail), 1)
+        self.assertIn('tools/zzz-does-not-exist.py', fail[0])
+
+    def test_a_dangling_doc_ref_is_flagged(self):
+        fail = self._run_on('# rationale: docs/zzz-retired-plan.md\n')
+        self.assertEqual(len(fail), 1)
+        self.assertIn('docs/zzz-retired-plan.md', fail[0])
+
+    def test_a_real_tool_and_doc_pass(self):
+        self.assertEqual(self._run_on(
+            '# see tools/build_campaign.py + docs/decisions.md\n'), [])
+
+    def test_decomp_internal_paths_do_not_false_positive(self):
+        # "texttools/textdecoder.py" must not read as tools/textdecoder.py
+        # (the FP that surfaced the moment the scan was extended to code)
+        self.assertEqual(self._run_on(
+            '# decodes via scripts/texttools/textdecoder.py in the decomp\n'), [])
+
+    def test_gitignored_generated_targets_are_declared_artifacts(self):
+        # symbols.lua is generated by gen_symbols.py and gitignored -- a reference
+        # to it is a build-artifact pointer, not rot
+        self.assertEqual(self._run_on('# emits tools/playtest/symbols.lua\n'), [])
+
+    def test_the_live_repo_is_clean(self):
+        fail = []
+        check.check_tool_refs_exist(fail)
+        self.assertEqual(fail, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_fe_combat.py
+++ b/tools/test_fe_combat.py
@@ -99,12 +99,14 @@ class Damage(unittest.TestCase):
         atk = attacker(5, fc.W['lightning'])             # 5 + 4 mt, vs Res 0
         self.assertEqual(fc.damage(atk, defender(df=9, res=0)), 9)
 
-    def test_effective_weapon_triples_whole_attack(self):
+    def test_effective_weapon_triples_the_weapon_half(self):
         # Vanilla Eirika rapier (sword) vs the Armor boss with a lance (Def 9): sword
-        # is at a triangle DISADVANTAGE to lance (-1), so (4 + 7 - 1) x3 - 9 = 21.
+        # is at a triangle DISADVANTAGE to lance (-1); the decomp triples the WEAPON
+        # half only, then adds Pow (bmbattle.c ComputeBattleUnitAttack):
+        # (7 - 1) x3 + 4 - 9 = 13. (The old model tripled the whole sum -> 21.)
         eirika = attacker(4, fc.W['rapier'])
         boss = defender(df=9, weapon=fc.W['iron-lance'], tags=frozenset({'armor'}))
-        self.assertEqual(fc.damage(eirika, boss), 21)
+        self.assertEqual(fc.damage(eirika, boss), 13)
 
     def test_damage_never_negative(self):
         atk = attacker(1, fc.W['iron-sword'])            # 1 + 5 mt vs Def 20
@@ -234,7 +236,7 @@ class CanonicalMatchup(unittest.TestCase):
                               con=5, weapon=fc.W['rapier'])
         boss = fc.Combatant('Izobai', hp=20, pow=8, skl=2, spd=1, df=9, res=0, lck=2,
                             con=13, weapon=fc.W['iron-lance'], tags=frozenset({'armor'}))
-        self.assertEqual(fc.damage(eirika, boss), 21)        # effective rapier, -1 triangle
+        self.assertEqual(fc.damage(eirika, boss), 13)        # (7-1)x3 + 4 - 9; x3 on Mt+tri only
         self.assertEqual(fc.hit_chance(eirika, boss), 94)
         self.assertTrue(fc.doubles(eirika, boss))            # AS 9 vs 1
         self.assertEqual(fc.kills_per_round(eirika, boss), 1.0)


### PR DESCRIPTION
## Why

Post-mortem of the "zeroed personal growths" incident: a stale `build_campaign.py` header outlived the donor-parity code, got cited into an ADR as fact, and took two correcting PRs — while the tests pinning the real behavior were green the whole time. Nicolas asked for a comprehensive sweep plus a durable fix.

## The durable fix (commit 1)

The repo already had the right mechanism — `check.py`'s dead-concepts lint — and the incident's phrases were *already registered*. It failed for two reasons, both fixed:

- **The scan covered docs only.** `check_no_dead_concepts` and `check_tool_refs_exist` now also scan hand-written code comments (`CODE_GLOBS`: tools py/lua/sh, engine C, Makefile; decomp submodule, generated files, `check.py` itself, and `test_*` fixtures exempt). Dangling `tools/…`/`docs/…` pointers in comments are caught too (path-boundary guard against `texttools/x.py`; gitignored targets = declared build artifacts).
- **The patterns were too narrow** for the comment's phrasing — broadened, with the exact incident line pinned as a regression fixture in `tools/test_check_comment_drift.py` (12 tests).

Process rules (ADR "Comments are testimony, code is evidence" + CLAUDE.md): comments say **why**, the **what** lives in code + tests; retiring a mechanism registers its key phrases in `DEAD_CONCEPTS` same-commit; an ADR asserting a mechanical fact cites the implementing symbol.

## The sweep (commit 2)

Seven parallel audit agents covered every doctrine-bearing comment in the hand-written tree; every finding was re-verified against code (and the decomp) before fixing. **~50 confirmed stale claims fixed across 22 files** — and four were **code** bugs hiding behind comments that claimed fidelity:

| Bug | Fix | Blast radius |
|---|---|---|
| `fe_combat.py` effective damage tripled the whole sum; the decomp triples only (Mt+tri) then adds Pow | Formula corrected to `bmbattle.c ComputeBattleUnitAttack`; canonical Eirika-vs-armor-boss per-hit 21→13 (the one-round outcome holds via doubling) | **Parity gate re-run: all three locked chapters still OK** |
| hand-axe weight 11 vs decomp's 12 | Corrected | folded into the same gate re-run |
| GIF frames sorted lexically while the shot counter pads `%02d` — order scrambles past frame 99 | `make_gif.py` sorts numerically on the counter; harness `shot()` widened to `%04d` | long `record*` GIFs |
| Convoy clamp `0x57` justified by a wrong struct cite | `100` (`CONVOY_ITEM_COUNT`, bmcontainer.h) | ch02 charm check |

Notable comment fixes: the `inject_battle_anims` docstring (the doc CLAUDE.md names as the add-a-unit how-to) still taught the retired clone-class recipe; four "ch02 isn't hosted / dev placeholder" comments; message-id provenance corrections **including a documented latent risk** (ending-scene ids 0x949–0x94C are also TEXTSHOWn by tutorial-mode's trade demo in unpatched `bmtrade.c` — needs an emulator repro to size); hardcoded hook counts made count-free; `difficulty-gate`/setup-toolchain claims; a dozen tool docstrings. `DEAD_CONCEPTS` += `clone_into`, `tileset_stem=`, `BATTLE_FOLLOWUP_THRESHOLD`.

## Verification

`make test` green (22 suites, incl. the 12 new guard tests + corrected combat pins), `tools/check.py` clean **with the extended scan live**, `make difficulty-gate` all locked chapters at parity, `luac -p`/`bash -n`/`ast.parse` clean on everything touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTEKqFqEvJKsz1t874oxcR)_