### PR TITLE
content(#17): fill NPC/recruit stub stats (Trex, Sahnar, Lupin, Basil)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/npcs/basil.yaml
+++ b/campaigns/rime-of-the-frostmaiden/npcs/basil.yaml
@@ -2,9 +2,17 @@
 # Class roster: docs/CLASSES.md (generated). Rationale: docs/decisions.md §Class Mapping.
 # Combat is vanilla FE (docs/decisions.md §Combat).
 #
-# STATUS: design record / stub. Class + role LOCKED (Nicolas, 2026-06-20) — promoted from
-# "non-combat caravan NPC" to a playable recruit. NOT yet wired into build_campaign (inert
-# until the recruit wiring lands). Full bases/growths from the donor's Priest data at wiring.
+# STATUS: design record. Class + role LOCKED (Nicolas, 2026-06-20) — promoted from
+# "non-combat caravan NPC" to a playable recruit; bases/growths below are vanilla Priest CLASS
+# data (data_classes.c [CLASS_PRIEST - 1], verbatim) -- identical to Sclorbo's, since it's the
+# same class. The "differentiated by donor" call in decisions.md (Sclorbo->Moulder durable,
+# Basil->Natasha frail-but-potent) is implemented at BUILD time, not in this design record:
+# STAT_DONOR in build_campaign.py pulls each donor's actual personal growths from vanilla
+# data_characters.c at injection time (Moulder's for Sclorbo, Natasha's for Basil once wired),
+# so the two Priests won't be stat-twins in-ROM even though this file shows the same class
+# baseline Sclorbo's shipped YAML does.
+# NOT yet wired into build_campaign (inert until the recruit wiring lands: free slot + recruit
+# logic + portrait + map sprite + a STAT_DONOR entry).
 
 id: basil
 name: Basil
@@ -28,9 +36,30 @@ dnd:
 #       survivability-floor burden — and "fragile but potent natural magic" suits a shrub.
 fe_stats:
   class: Priest
+  level: 1
+  # Vanilla FE8 Priest stats, verbatim from data_classes.c [CLASS_PRIEST - 1].
+  HP: 18
+  MAG: 1                    # FE Pow (Priest basePow) — magic attack stat
+  SKL: 1
+  SPD: 2
+  DEF: 1
+  RES: 5
+  LCK: 0                    # ClassData has no base luck
+  MOV: 5                    # Priest baseMov
+  CON: 5
 donor:
   character: Natasha        # vanilla Cleric — frail/high-magic line (distinct from Sclorbo's Moulder)
   why: glass mage-healer identity, opposite Sclorbo's durable Moulder line; Basil is no lord, so frailty costs nothing
+
+# ── Growth Rates (% per level) — vanilla Priest growths from data_classes.c ──
+growth_rates:
+  HP: 50
+  MAG: 30
+  SKL: 35
+  SPD: 32
+  DEF: 8
+  RES: 50
+  LCK: 45
 
 promotion:
   branch: [Bishop, Sage]    # vanilla FE8 Priest branch (classchg-data.c)

--- a/campaigns/rime-of-the-frostmaiden/npcs/lupin.yaml
+++ b/campaigns/rime-of-the-frostmaiden/npcs/lupin.yaml
@@ -2,9 +2,15 @@
 # Class roster: docs/CLASSES.md (generated). Rationale: docs/decisions.md §Class Mapping.
 # Combat is vanilla FE (docs/decisions.md §Combat). damage_type labels are cosmetic.
 #
-# STATUS: design record / stub. Class + role LOCKED (Nicolas, 2026-06-20) — promoted from
-# "non-combat sled NPC" to a playable recruit. NOT yet wired into build_campaign (inert
-# until the recruit wiring lands). Full bases/growths from the donor's Cavalier data at wiring.
+# STATUS: design record. Class + role LOCKED (Nicolas, 2026-06-20) — promoted from
+# "non-combat sled NPC" to a playable recruit; bases/growths below are vanilla Cavalier CLASS
+# data (data_classes.c [CLASS_CAVALIER - 1], verbatim) -- identical to Baxby's, since it's the
+# same class (the class-generic-data-in-YAML / personal-donor-growths-at-build-time split
+# every cast member uses; STAT_DONOR in build_campaign.py pulls Kyle's actual personal growths
+# at injection time, distinct from Baxby's Franz, so the two Cavaliers won't be stat-twins
+# in-ROM even though this design record shows the same class baseline for both).
+# NOT yet wired into build_campaign (inert until the recruit wiring lands: free slot + recruit
+# logic + portrait + map sprite + a STAT_DONOR entry).
 # Voice bible: ../lore/lupin.md (locked 2026-07-03 with the ch04 dialogue pass — blunt
 # pack-pragmatist; table-canon character grounded in the book's awaken magic).
 
@@ -25,9 +31,30 @@ dnd:
 # befriend-the-creatures motif. Custom map sprite + battle anim required (#38/#39).
 fe_stats:
   class: Cavalier
+  level: 1
+  # Vanilla FE8 Cavalier stats, verbatim from data_classes.c [CLASS_CAVALIER - 1].
+  HP: 20
+  STR: 5
+  SKL: 2
+  SPD: 5
+  DEF: 6
+  RES: 0
+  LCK: 0                    # ClassData has no base luck
+  MOV: 7                    # Cavalier baseMov (mounted)
+  CON: 9
 donor:
   character: Kyle           # vanilla Cavalier — bases/growths reference (Franz is Baxby's ref)
   why: fresh Cavalier = full growth runway; distinct donor from Baxby
+
+# ── Growth Rates (% per level) — vanilla Cavalier growths from data_classes.c ─
+growth_rates:
+  HP: 75
+  STR: 35
+  SKL: 40
+  SPD: 28
+  DEF: 15
+  RES: 15
+  LCK: 30
 
 promotion:
   branch: [Paladin, "Great Knight"]   # vanilla FE8 Cavalier branch (classchg-data.c [CLASS_CAVALIER])

--- a/campaigns/rime-of-the-frostmaiden/npcs/sahnar.yaml
+++ b/campaigns/rime-of-the-frostmaiden/npcs/sahnar.yaml
@@ -2,9 +2,13 @@
 # Class roster: docs/CLASSES.md (generated). Rationale: docs/decisions.md §Class Mapping.
 # Combat is vanilla FE (docs/decisions.md §Combat). damage_type labels are cosmetic.
 #
-# STATUS: design record / stub. Class + role LOCKED (Nicolas, 2026-06-20). NOT yet wired
-# into build_campaign (inert until the recruit wiring lands). Full bases/growths to be
-# authored verbatim from the donor's vanilla Myrmidon class data at wiring.
+# STATUS: design record. Class + role LOCKED (Nicolas, 2026-06-20); bases/growths below are
+# vanilla Myrmidon CLASS data (data_classes.c [CLASS_MYRMIDON - 1], verbatim) -- the same
+# class-generic-data-in-YAML / personal-donor-growths-at-build-time split every other cast
+# member uses (STAT_DONOR in build_campaign.py pulls Joshua's actual personal growths at
+# injection time; this file is the pre-wiring design record, not the final in-ROM numbers).
+# NOT yet wired into build_campaign (inert until the recruit wiring lands: free slot + recruit
+# logic + portrait + map sprite + a STAT_DONOR entry).
 
 id: sahnar
 name: Sahnar
@@ -22,9 +26,30 @@ dnd:
 # (Druid/Shaman) was the alt but we're already magic-rich, so sword is the coverage win.
 fe_stats:
   class: Myrmidon
+  level: 1
+  # Vanilla FE8 Myrmidon stats, verbatim from data_classes.c [CLASS_MYRMIDON - 1].
+  HP: 16
+  STR: 4
+  SKL: 9
+  SPD: 9
+  DEF: 2
+  RES: 0
+  LCK: 0                    # ClassData has no base luck
+  MOV: 5                    # Myrmidon baseMov
+  CON: 8
 donor:
   character: Joshua         # vanilla Myrmidon — bases/growths reference (data_classes.c)
   why: the game's crit-sword duelist archetype
+
+# ── Growth Rates (% per level) — vanilla Myrmidon growths from data_classes.c ─
+growth_rates:
+  HP: 70
+  STR: 35
+  SKL: 40
+  SPD: 40
+  DEF: 15
+  RES: 20
+  LCK: 30
 
 promotion:
   branch: [Swordmaster, Assassin]  # vanilla FE8 Myrmidon branch (classchg-data.c [CLASS_MYRMIDON])

--- a/campaigns/rime-of-the-frostmaiden/npcs/trex.yaml
+++ b/campaigns/rime-of-the-frostmaiden/npcs/trex.yaml
@@ -2,10 +2,13 @@
 # Class roster: docs/CLASSES.md (generated). Rationale: docs/decisions.md §Class Mapping.
 # Combat is vanilla FE (docs/decisions.md §Combat). damage_type labels are cosmetic.
 #
-# STATUS: design record / stub. Class + role LOCKED (Nicolas, 2026-06-20). NOT yet wired
-# into build_campaign (inert until the recruit wiring lands: free slot + recruit logic +
-# portrait + map sprite). Full bases/growths to be authored verbatim from the donor's
-# vanilla Thief class data (data_classes.c) at wiring.
+# STATUS: design record. Class + role LOCKED (Nicolas, 2026-06-20); bases/growths below are
+# vanilla Thief CLASS data (data_classes.c [CLASS_THIEF - 1], verbatim) -- the same
+# class-generic-data-in-YAML / personal-donor-growths-at-build-time split every other cast
+# member uses (STAT_DONOR in build_campaign.py pulls Colm's actual personal growths at
+# injection time; this file is the pre-wiring design record, not the final in-ROM numbers).
+# NOT yet wired into build_campaign (inert until the recruit wiring lands: free slot + recruit
+# logic + portrait + map sprite + a STAT_DONOR entry).
 
 id: trex
 name: Trex
@@ -22,9 +25,30 @@ dnd:
 # wings" are exactly that — cosmetic art, NOT a flier (Thief is a foot unit).
 fe_stats:
   class: Thief
+  level: 1
+  # Vanilla FE8 Thief stats, verbatim from data_classes.c [CLASS_THIEF - 1].
+  HP: 16
+  STR: 3
+  SKL: 1
+  SPD: 9
+  DEF: 2
+  RES: 0
+  LCK: 0                    # ClassData has no base luck
+  MOV: 6                    # Thief baseMov
+  CON: 6
 donor:
   character: Colm           # vanilla Thief — bases/growths reference (data_classes.c)
   why: the game's starter Thief = full growth runway for a fresh utility unit
+
+# ── Growth Rates (% per level) — vanilla Thief growths from data_classes.c ────
+growth_rates:
+  HP: 50
+  STR: 5
+  SKL: 45
+  SPD: 40
+  DEF: 5
+  RES: 20
+  LCK: 40
 
 promotion:
   branch: [Rogue, Assassin]  # vanilla FE8 Thief branch (classchg-data.c [CLASS_THIEF])


### PR DESCRIPTION
## Summary
- All five NPC/recruit YAMLs #17 asked for (Baxby, Trex, Sahnar, Lupin, Basil) already existed as design-record stubs; four of five (Trex, Sahnar, Lupin, Basil) were missing their `fe_stats`/`growth_rates` blocks.
- Filled each with vanilla FE8 class data verbatim from `data_classes.c` (Thief/Myrmidon/Cavalier/Priest) — matching the class-generic-in-YAML / personal-donor-growths-at-`STAT_DONOR`-build-time split every other cast member already uses.
- Clarified each file's STATUS comment so the split doesn't misread as a stat-twin bug: Lupin shares a class (and this design record) with Baxby, and Basil with Sclorbo, but they'll diverge in-ROM once `STAT_DONOR` wires their distinct personal donors (Kyle vs Franz, Natasha vs Moulder) — matching the "differentiated by donor" call already in `docs/decisions.md`.

## Test plan
- [x] `python3 tools/check.py` — drift clean
- [x] Full `tools/test_*.py` suite — all green (no schema/build regressions)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pcYsFGfMj9WpbTxgHyDWX


---
_Generated by [Claude Code](https://claude.ai/code/session_015pcYsFGfMj9WpbTxgHyDWX)_