### PR TITLE
docs(#125): resolve msg-id collision as unreachable — no code change needed

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1974,6 +1974,24 @@ _Decided 2026-06-19 with Nicolas (interactive story + dialogue pass for ch02-tar
 
 ---
 
+**#125 msg-id collision (ch01 ending vs. the tutorial trade demo) — RESOLVED unreachable, no emulator
+needed.** `CH01_ENDING_MSGS` (0x949-0x94C) are also `TEXTSHOW`n by vanilla's tutorial-mode trade demo
+compiled into `src/bmtrade.c`, which nothing patches — flagged as a live risk needing an mGBA repro to
+size (#122 comment-sweep). Traced instead: that demo only runs behind `CheckTradeTutorial()` ->
+`CheckFlag(0x87)`, and flag `0x87` has **exactly one setter in the whole decomp** — `ENUT(0x87)` inside
+`EventScr_Ch1Tut_TradeSelectGalliamEnd` (`events/ch1-tutorials.h`), part of vanilla's real Ch1 chapter
+slot (`Ch1Events` in `data_8B363C.s`) — a **separate ROM asset from `PrologueEvents`**, the only slot our
+chapter progression ever loads (New Game redirects to `PROLOGUE_HOST_INDEX`; `_redirect_new_game` in
+`build_campaign.py`). Vanilla's real Ch1 never loads in our build (our "ch01" rides the Prologue slot
+instead), so flag `0x87` can never be set, `CheckTradeTutorial()` always returns false, and the trade
+demo — and this msg-id collision — is unreachable by construction. General lesson for the msg-id-vetting
+gotcha (below): reachability isn't just "is this id referenced elsewhere" (the 0x993/0x994 lesson) — a
+referencing event can ALSO be dead if its own trigger condition (a flag, in this case) can never be set
+in our build's actual chapter-load graph. Static trace of the flag's setter(s) resolves it without mGBA.
+_Decided: 2026-07-05 (CLAUDE; pipeline track. #125, closed not-planned — no code change, comment-only)._
+
+---
+
 ## Operational Gotchas (durable)
 
 _Moved here from `HANDOFF.md` 2026-07-02 (audit): these are durable engineering constraints, not

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -230,11 +230,17 @@ LORDSEL_EXPLAINER_TEXT = (
 CH01_BEAT1_CARD_MSG = 0x945
 CH01_BEAT1_MSGS = (0x940, 0x941, 0x942, 0x943, 0x944)  # A,B,C,D,E (0x945 = card)
 # ch01 ending "The Rolling Cheddar" (#21): a "Bryn Shander" location card + one message
-# per beat (A-F), on the dead slot-2 pool (see Beat 1). CAVEAT (comment audit
-# 2026-07-02): 0x949/0x94A/0x94B/0x94C are ALSO TEXTSHOWn by the tutorial-mode trade
-# demo compiled into src/bmtrade.c, which nothing patches -- if tutorial mode's trade
-# demo ever runs in our ROM, these ending-scene bodies would display there (same
-# false-negative class as the 0x993/0x994 lesson; needs an emulator repro to size).
+# per beat (A-F), on the dead slot-2 pool (see Beat 1). RESOLVED (#125, 2026-07-05):
+# 0x949/0x94A/0x94B/0x94C are ALSO TEXTSHOWn by the tutorial-mode trade demo compiled
+# into src/bmtrade.c (EventScr_TradeTut_SelectItem etc.), which nothing patches -- but
+# that demo is gated on CheckTradeTutorial() -> CheckFlag(0x87), and flag 0x87 has
+# exactly one setter in the whole decomp: ENUT(0x87) inside
+# EventScr_Ch1Tut_TradeSelectGalliamEnd (events/ch1-tutorials.h), part of vanilla's
+# REAL Ch1 slot (Ch1Events, data_8B363C.s) -- a separate ROM asset from PrologueEvents,
+# which is the only slot our chapter progression ever loads (New Game redirects to
+# PROLOGUE_HOST_INDEX; see _redirect_new_game). Vanilla Ch1 never loads in our build, so
+# flag 0x87 can never be set, CheckTradeTutorial() always returns false, and the trade
+# demo (and this msg-id collision) is provably unreachable -- no emulator repro needed.
 CH01_ENDING_CARD_MSG = 0x94C
 # AB,C,D,E1,E2(narration),E2b(Marty/Baxby),F. 0x93D is a dead vanilla Ch1-tutorial
 # slot-2 id (weapon-triangle blurb, stripped by the prologue host) reused for the


### PR DESCRIPTION
## Summary
- #125 flagged a risk: ch01 ending message ids (0x949-0x94C) are also `TEXTSHOW`n by vanilla's tutorial-mode trade demo (`bmtrade.c`), which nothing patches — previously thought to need an mGBA repro to size.
- Traced it statically instead: that demo only runs behind `CheckTradeTutorial()` → `CheckFlag(0x87)`, and flag `0x87` has exactly one setter in the whole decomp (`ENUT(0x87)` inside `events/ch1-tutorials.h`), which is part of vanilla's **real** Ch1 chapter slot (`Ch1Events`) — a separate ROM asset from `PrologueEvents`, the only slot our chapter progression ever loads.
- Since vanilla's real Ch1 never loads in our build, the flag can never be set, the trade demo can never run, and the collision is unreachable by construction.
- Updated the stale code comment in `build_campaign.py` and recorded the general lesson in `docs/decisions.md` (a live-looking msg reference can still be dead if its own trigger condition can't fire — extends the existing 0x993/0x994 msg-id-vetting gotcha).

No code/behavior change — comment + doc only.

## Test plan
- [x] `python3 tools/check.py` — drift clean
- [x] `python3 tools/test_build_campaign.py` — all 40 green

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pcYsFGfMj9WpbTxgHyDWX


---
_Generated by [Claude Code](https://claude.ai/code/session_015pcYsFGfMj9WpbTxgHyDWX)_