### PR TITLE
feat(#23): wire the ch03 DefeatBoss(grell) WIN + in-engine load-test

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2019,6 +2019,14 @@ session state. `HANDOFF.md` points here._
   `set_message_body(vanilla_name_text_id(slot), name_message_body(display_name(unit)))`. Give units a short `fe_name` (≤12).
 - **Clear-bot can't fully clear a chapter yet (#60).** Helpers that must REACH a later chapter use directed
   seizes / frail+teleport (`reachCh02Map`, `clear_ch02`), not fair-play clears.
+- **DefeatBoss fires from the FLAGGED defeat quote, not `CA_BOSS`** (`eventinfo.c`: `SetPidDefeatedFlag`
+  runs for ANY unit whose pid matches a `gDefeatTalkList` entry on death — no boss-attribute gate). So a
+  boss on a **raw pid with no `gCharacterData` entry** (ch03's grell = `0xb7`, chosen to avoid leaking a
+  vanilla boss's name/face/quote) still wins the map via a head-of-list quote keyed to `(pid, CHAPTER_L_N,
+  EVFLAG_DEFEAT_BOSS)`. **Trade-off:** with no `CA_BOSS` it shows **no boss HP gauge** and the generic
+  clear-bot/`findBoss()` (reads `CA_BOSS`) can't target it — so a per-boss load-test must reach it by
+  pid+tile (`ch03win`: teleport the grell to the lord and strike), and a future `clear_chNN` needs either a
+  `CA_BOSS` character entry for the boss or a pid-targeted bot. Verified in-engine (`ch03win`, 2026-07-07).
 - **Don't reuse a playtest checkpoint across an injection/build change** — only across pure graphics-byte
   swaps. Checkpoints are ROM-hash-stamped in `tools/playtest/states/` (gitignored); delete `.ss`/`.romhash`
   to force a rebuild. (A battle-anim frame change IS a build change → re-record from a fresh ROM.)

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5019,8 +5019,17 @@ CH03_LAYOUT = ('Ch03TermalaineMineMap', 'ch03-the-termalaine-mine')  # (asset la
 CH03_CHAPTER_YAML = 'ch03-the-termalaine-mine.yaml'
 CH03_TILESET = 'cave-interior'   # stem 'Cave' (TILESET_STEMS); first chapter to use it -> self-registers
 CH03_GOAL_DONOR = 6              # vanilla slot 6 = defeat_boss goal template (untouched by our injectors)
-CH03_BOSS_PID = '0xb7'          # grell rides the vanilla ch4 boss charIndex
+CH03_BOSS_PID = '0xb7'          # grell rides a raw charIndex (NOT the vanilla ch4 boss ENTOUMBED_CH4=0x49):
+                                # a clean slate -- no vanilla boss name/face/defeat-quote leaks, and our
+                                # flagged gDefeatTalkList entry (CHAPTER_L_4) uniquely keys the DefeatBoss win to it.
 CH03_GENERIC_PID = '0xaa'       # vanilla slot-4 generic-minion charIndex (autolevelled trash)
+# The grell's flagged death quote (gDefeatTalkList) sets EVFLAG_DEFEAT_BOSS -> the Misc DefeatBoss AFEV.
+# Body rides a dead vanilla Ch4 message id: 0x9A3 is the Ch4 opening cutscene's first line (Seth/Eirika at
+# Serafew), referenced ONLY inside EventScr_Ch4_BeginningScene -- which inject_ch03 replaces -> dead in our build.
+CH03_BOSS_DEATH_MSG = 0x9A3
+# DefeatBoss ending script: repurpose the vanilla Ch4 ending EventScr_089F19F8 (defined in ch4-eventscript.h,
+# already extern-referenced by the vanilla Ch4 Misc's DefeatAll -> visible to ch4-eventinfo.h's Misc list).
+CH03_ENDING_SCRIPT = 'EventScr_089F19F8'
 CH03_AI = {'aggressive': '{0x0, 0x0, 0x1, 0x0}',   # pursue/charge
            'defensive':  '{0x3, 0x3, 0x9, 0x20}'}  # attack in place, never move (hold the galleries)
 CH03_CLASS_IDS = {'mogall': 'CLASS_MOGALL', 'brigand': 'CLASS_BRIGAND',
@@ -5043,11 +5052,12 @@ def inject_ch03(campaign, verbose=True):
     entrance + the 10 vanilla-Ch3-parity enemies (reflavored kobolds / grell / svirfneblin)
     at their vanilla tiles, strip cutscenes, and leave a walkable load-test map.
 
-    DEFERRED (next passes, flagged not done): the DefeatBoss(grell) WIN + its flagged
-    defeat quote; the real PREP deploy (needs deployment.deploy_slots authored in the YAML);
-    the opening/recruit CUTSCENES (dialogue-pass on the #97 beats + the 2026-07-06 reframe);
-    Trex recruit; chests/doors; title-card art; enemy/boss art. Boot: --ch03-boot points New
-    Game straight here (mirrors the TESTCH sandbox, but on slot 4 + the cave map)."""
+    The DefeatBoss(grell) WIN is wired: Misc DefeatBoss AFEV + the grell's flagged (EVFLAG_DEFEAT_BOSS)
+    defeat quote + a minimal ending script (victory -> dev-placeholder landing until ch04 hosts).
+    DEFERRED (next passes, flagged not done): the real PREP deploy (needs deployment.deploy_slots
+    authored in the YAML); the opening/recruit/ending CUTSCENES (dialogue-pass on the #97 beats + the
+    2026-07-06 reframe) + chaining ch02->ch03; Trex recruit; chests/doors; title-card art; enemy/boss
+    art. Boot: --ch03-boot points New Game straight here (mirrors the TESTCH sandbox, on slot 4 + cave)."""
     maps_dir = os.path.join(REPO, 'campaigns', campaign, 'maps')
     chap = _load_chapter_yaml(campaign, CH03_CHAPTER_YAML)
 
@@ -5096,16 +5106,19 @@ def inject_ch03(campaign, verbose=True):
     with open(EVENTS_UDEFS_C, 'w', encoding='utf-8') as f:
         f.write(udefs)
 
-    # 3. Strip cutscenes (cf. inject_test_chapter): empty the Ch4 event lists, keep only
-    #    lord-death game-over in Misc (NO win trigger yet -- DefeatBoss lands with the
-    #    cutscene pass), and make the beginning scene a bare deploy of both rosters.
+    # 3. Strip cutscenes (cf. inject_test_chapter): empty the Ch4 event lists, wire the win/lose
+    #    machinery into Misc (DefeatBoss on the grell's death + lord-death game-over), and make the
+    #    beginning scene a bare deploy of both rosters. DefeatBoss = AFEV on EVFLAG_DEFEAT_BOSS,
+    #    which the grell's FLAGGED defeat quote sets on its death (step 5) -> runs the ending script;
+    #    CauseGameOverIfLordDies = AFEV on EVFLAG_GAMEOVER (the lord's flagged quote / lord-select hook).
     with open(CH4_EVENTINFO_H, encoding='utf-8') as f:
         info = f.read()
     for name in ('EventListScr_Ch4_Turn', 'EventListScr_Ch4_Character', 'EventListScr_Ch4_Location'):
         info = _replace_brace_block(info, name + '[] =', '{\n    END_MAIN\n}', CH4_EVENTINFO_H)
     info = _replace_brace_block(
         info, 'EventListScr_Ch4_Misc[] =',
-        '{\n    CauseGameOverIfLordDies\n    END_MAIN\n}', CH4_EVENTINFO_H)
+        '{\n    DefeatBoss(%s)\n    CauseGameOverIfLordDies\n    END_MAIN\n}' % CH03_ENDING_SCRIPT,
+        CH4_EVENTINFO_H)
     # Ch4's tutorial list is an EventListScr[] (struct array), NOT the prologue's pointer
     # array -- so it terminates with END_MAIN, not NULL (NULL -> int-from-pointer error).
     info = _replace_brace_block(info, 'EventListScr_Ch4_Tutorial[] =', '{\n    END_MAIN\n}', CH4_EVENTINFO_H)
@@ -5117,19 +5130,50 @@ def inject_ch03(campaign, verbose=True):
     begin = ('{\n    LOAD1(0x1, UnitDef_088B4A80)\n    ENUN\n'
              '    LOAD1(0x1, UnitDef_Event_Ch4Ally)\n    ENUN\n    ENDA\n}')
     script = _replace_brace_block(script, 'EventScr_Ch4_BeginningScene[] =', begin, CH4_EVENTSCRIPT_H)
+    # DefeatBoss ending (the script the Misc AFEV runs on the grell's death). MINIMAL for now:
+    # victory sting -> fade -> the dev-placeholder landing (RBG-by-the-campfire, then back to title),
+    # exactly as ch02's ending parks until its next chapter is hosted. ch04 isn't hosted yet, so the
+    # rich ending cutscene (the reframed beats) rides the dialogue-pass (#23 Cutscenes) + the chaining
+    # pass (#23 item 3) that swaps this dev landing for MNC2 -> ch04.
+    ending = ('{\n    MUSC(SONG_VICTORY)\n'
+              '    FADI(16) /* fade the mine out */\n'
+              + dev_placeholder_scene() +
+              '    ENDA\n}')
+    script = _replace_brace_block(script, CH03_ENDING_SCRIPT + '[] =', ending, CH4_EVENTSCRIPT_H)
     with open(CH4_EVENTSCRIPT_H, 'w', encoding='utf-8') as f:
         f.write(script)
 
-    # 4. Chapter title text (the status/prep banner).
+    # 4. Texts: chapter title (status/prep banner) + the grell's death quote. The grell has no
+    #    portrait yet (#23 Art), so its line renders FACELESS (stage business, (open, None)) -- a
+    #    reframe-neutral shriek, so it's safe to wire ahead of the cutscene dialogue-pass. Body from
+    #    the chapter YAML (single source of truth); asterisks are the YAML's stage-direction marks.
+    grell = next(e for e in chap['enemy_units'] if e.get('is_boss'))
+    shriek = grell['death_quote'].strip().strip('*').strip()
+    shriek = shriek[0].upper() + shriek[1:] if shriek else shriek
     with open(TEXTS_TXT, encoding='utf-8') as f:
         lines = f.read().split('\n')
     set_message_body(lines, host['chapTitleTextId'], name_message_body(chap['title']))
+    set_message_body(lines, CH03_BOSS_DEATH_MSG, _script_to_message(
+        [{'grell': shriek}], {'grell': ('[OpenMidRight]', None)}))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
 
+    # 5. The grell's flagged defeat quote -> head of gDefeatTalkList (first-match scan wins, so this
+    #    head entry keys the DefeatBoss win to the grell's raw pid; no vanilla 0xb7 entry to shadow).
+    #    .flag = EVFLAG_DEFEAT_BOSS is what fires the win (CA_BOSS alone sets nothing -- eventinfo.c
+    #    SetPidDefeatedFlag runs for ANY unit with a matching gDefeatTalkList entry on death).
+    quote = ('    {\n'
+             '        .pid     = %s, /* grell (ch03 boss) death quote sets the DefeatBoss flag */\n'
+             '        .route   = CHAPTER_MODE_ANY,\n'
+             '        .chapter = CHAPTER_L_4, /* ch03 is hosted on chapter slot 4 */\n'
+             '        .flag    = EVFLAG_DEFEAT_BOSS,\n'
+             '        .msg     = 0x%X, /* faceless shriek body (grell death_quote, step 4) */\n'
+             '    },' % (CH03_BOSS_PID, CH03_BOSS_DEATH_MSG))
+    _prepend_defeat_quote(quote)
+
     if verbose:
-        print('  ch03 map (obj1=%d pal=%d cfg=%d layout=%d) hosted on chapter %d; defeat_boss '
-              'goal, %d-unit deploy + %d enemies (grell@14,1); cutscenes + DefeatBoss win deferred'
+        print('  ch03 map (obj1=%d pal=%d cfg=%d layout=%d) hosted on chapter %d; defeat_boss goal + '
+              'DefeatBoss(grell) WIN wired, %d-unit deploy + %d enemies (grell@14,1); rich cutscenes deferred'
               % (obj_idx, pal_idx, cfg_idx, layout_idx, CH03_HOST_INDEX, len(ally_rows), len(enemies)))
 
 

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -2955,6 +2955,79 @@ local function protectChwinga()
     end
 end
 
+-- CH03WIN (#23 item 1): kill the grell -> its FLAGGED defeat quote sets EVFLAG_DEFEAT_BOSS
+-- -> the Ch4 Misc DefeatBoss AFEV runs the ending. Proves the ch03 win wiring fires. The grell
+-- rides a RAW pid (0xb7, no CA_BOSS -- so the generic clear-bot can't target it) and sits far
+-- from the left-entrance spawn, so we teleport the leader (braulo, pid 0x01) onto a grell-adjacent
+-- tile and strike. Poke the grell frail first (1 HP, no avoid) so one clean melee hit kills; a
+-- Mogall's Evil Eye is range 2+, so a range-1 strike draws no lethal counter. EVFLAG_DEFEAT_BOSS
+-- (flag 2) is the definitive assertion: the engine binds the DefeatBoss AFEV directly to it, and
+-- SetPidDefeatedFlag (eventinfo.c) sets it on the grell's death REGARDLESS of CA_BOSS.
+-- Run: PT_HOST_CHAPTER=4 tools/playtest/run.sh ch03win  (needs a CH03BOOT=1 ROM). Seeds #23 item 7.
+scenarios.ch03win = function()
+    if not bootToMap() then return result("FAIL", "never reached the ch03 map") end
+    if not red(0xb7) then return result("FAIL", "grell (pid 0xb7) not found in the red array") end
+    if not blue(0x01) then return result("FAIL", "leader (braulo, pid 0x01) not deployed") end
+    -- The fast-boot deploys the party weaponless (items='0'; real equipping rides the PREP pass,
+    -- #23 item 2), so give the leader an Iron Axe (id 0x1F | 45 uses) in items[0] so Attack appears.
+    emu:write16(blue(0x01).addr + 0x1E, 0x2D1F)
+    log("leader given an Iron Axe (fast-boot deploys weaponless)")
+    -- Bring the grell TO braulo's isolated left-entrance spawn (no other enemy is near it) so the
+    -- grell is the ONLY unit in braulo's range -- chooseAttack's default target can't pick a kobold
+    -- by mistake (the (14,1) lair sits amid other foes). Up to 3 player turns, enemy-phase between,
+    -- re-frailing + re-parking the grell each turn in case a whiff or its AI move disturbs it.
+    for turn = 1, 3 do
+        local g = red(0xb7)
+        if isDead(g) or eventFlag(2) then break end
+        local leader = blue(0x01)
+        pokeFrail(g)
+        g = red(0xb7)
+        local ggrid = mapUnitAt(g.x, g.y)
+        local parked = false
+        for _, d in ipairs({ { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }) do
+            local tx, ty = leader.x + d[1], leader.y + d[2]
+            if tx >= 0 and tx <= 24 and ty >= 0 and ty <= 15 and mapUnitAt(tx, ty) == 0 then
+                setMapUnit(g.x, g.y, 0)
+                emu:write8(g.addr + 0x10, tx); emu:write8(g.addr + 0x11, ty)
+                setMapUnit(tx, ty, ggrid)
+                log(string.format("turn %d: grell parked at (%d,%d) next to braulo (%d,%d)",
+                    turn, tx, ty, leader.x, leader.y))
+                parked = true
+                break
+            end
+        end
+        if not parked then return result("FAIL", "no free tile adjacent to braulo to park the grell") end
+        if moveUnit(leader.x, leader.y, leader.x, leader.y) then
+            shot("attacking-grell")
+            chooseAttack(leader.addr)
+        end
+        if isDead(red(0xb7)) or eventFlag(2) then break end
+        log("grell survived turn " .. turn .. " (miss?); running enemy phase to retry")
+        if runEnemyPhase() == "gameover" then return result("FAIL", "unexpected game over in ch03win") end
+    end
+    if not (isDead(red(0xb7)) or eventFlag(2)) then
+        shot("grell-alive")
+        return result("FAIL", "could not kill the grell in 3 turns")
+    end
+    log("grell dead; waiting out the defeat quote for EVFLAG_DEFEAT_BOSS")
+    -- The flag is set AFTER the death quote renders (DisplayDefeatTalkForPid: show msg, THEN
+    -- SetPidDefeatedFlag), so tap A through the shriek line while polling the flag.
+    local won = waitFor(function() return eventFlag(2) end, 3600, true)
+    log(string.format("debug: EVFLAG_DEFEAT_BOSS(2)=%s chapter=%d (host=%d)",
+        tostring(eventFlag(2)), chapter(), HOST_CHAPTER))
+    if not won then
+        shot("grell-dead-no-flag")
+        return result("FAIL", "grell died but EVFLAG_DEFEAT_BOSS never set (win did not fire)")
+    end
+    -- Flag set -> the Misc DefeatBoss AFEV runs the ending script (victory sting -> dev-placeholder
+    -- campfire -> MNTS back to title, since ch04 isn't hosted). Let it play out to the title screen
+    -- WITHOUT mashing A (mashing would hit "Press START" and boot a spurious New Game). Screenshot
+    -- the endpoint as a no-crash confirmation that the ending script itself is valid.
+    wait(240)
+    shot("ch03-ending-ran")
+    result("PASS", "grell killed -> EVFLAG_DEFEAT_BOSS set -> DefeatBoss ending ran to title (ch03 win wired)")
+end
+
 -- ch02: entry assertions on the ch02 map (mirrors scenarios.ch01). The 3 green chwinga are on
 -- the field, the party deploys to the cap, and the archer + boss are present.
 scenarios.ch02 = function()


### PR DESCRIPTION
The Termalaine Mine now **ends when the grell dies**. Before, the goal banner read "Defeat boss" but nothing won the map — the Ch4 Misc list held only `CauseGameOverIfLordDies`.

### What this wires (`inject_ch03`)
- **Misc win trigger:** `DefeatBoss(EventScr_089F19F8)` + `CauseGameOverIfLordDies`. The ending script repurposes the vanilla Ch4 ending symbol `EventScr_089F19F8` (defined in `ch4-eventscript.h`, already extern-referenced by the vanilla Misc's `DefeatAll` → visible to `ch4-eventinfo.h`).
- **Flagged defeat quote:** head of `gDefeatTalkList`, keyed to `(pid 0xb7, CHAPTER_L_4, EVFLAG_DEFEAT_BOSS)` — the flag is what fires the win. Body = the grell's faceless shriek (no portrait yet; #23 Art), read from the chapter YAML `death_quote`, on a dead vanilla Ch4 message id (`0x9A3`).
- **Minimal ending:** victory sting → dev-placeholder landing (RBG campfire → title), as ch02 parks until its next chapter is hosted. The rich ending cutscene rides the reframed dialogue-pass (#23 Cutscenes) + chaining (#23 item 3).

### Verified in-engine
New `ch03win` harness scenario (`PT_HOST_CHAPTER=4 tools/playtest/run.sh ch03win`, needs a `CH03BOOT=1` ROM): teleports the grell to the lord, kills it, and asserts `EVFLAG_DEFEAT_BOSS` flips → the DefeatBoss ending runs to the title screen. **PASS.** Seeds the deferred #23 item-7 scenarios.

### Gotcha recorded (`decisions.md`)
DefeatBoss fires from the flagged quote, **not** `CA_BOSS`. So the raw-pid grell wins the map but shows **no boss HP gauge**, and the generic clear-bot can't target it — a future `clear_ch03` needs a `CA_BOSS` entry or a pid-targeted bot.

Advances the ch03 vertical slice (#23, objective-wiring checklist item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
