### PR TITLE
content(#23): re-pass ch03 dialogue on the 2026-07-06 reframe

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -34,17 +34,17 @@ introduces:
 # vanished; the town posts a bounty to clear it. The truth (the book's "something else
 # wrong"): a Grell — an Underdark aberration — came up the mine's central shaft "in search
 # of food" and is preying on miners AND kobolds, which is why the kobolds are agitated. Their
-# leader, Trex (a clever winged kobold — canon), defects to the party.
+# leader, Trex (a clever, self-taught kobold — canon), defects to the party.
 narrative: >
   Termalaine's tourmaline mine has been overrun by kobolds and its miners have
   gone missing, so the town posts a bounty to clear it. Inside, the kobolds are
   territorial but rattled — something deeper is hunting them too. Wolfram digs
   tourmalines from the walls and snacks on raw ore; the party corners a kobold and
   RBG executes it at gunpoint during a "good cop, bad cop" interrogation; then they
-  meet Trex, the clever winged kobold leading the warren, who throws in with them.
-  At the central shaft they send Pinky into the dark to scout — and a Grell, the
-  aberration that crawled up from the Underdark, is revealed. They take the deep
-  workings and head back to Termalaine to collect the bounty.
+  meet Trex, the clever self-taught kobold leading the warren, who throws in with them.
+  At the mine mouth Pinky flies a scout over the workings and glimpses the Grell — the
+  aberration that crawled up from the Underdark — waiting in the deep. They fight down
+  to the deep workings, kill it, and head back to Termalaine to collect the bounty.
 
 # ── Map ────────────────────────────────────────────────────────────────────────
 # Structure: rooms-on-ONE-flat-map (FE8 has no z-levels; "multi-level" is impossible —
@@ -261,17 +261,24 @@ events:
       a monster bounty. RBG keeps the public mask UP (no open villainy in a town
       street — his banned list); the naked greed already aired in the ch02 seed. The
       "KOBOLDS ONLY" sign (book p.95, elegant calligraphy) is the first whisper of
-      Trex. LOCKED 2026-06-26 (dialogue-pass, co-written with Nicolas). BG DECIDED
+      Trex. Pinky's shaft-scout FOLDS IN HERE (2026-07-09 re-pass on the reframe): he
+      is the army's flier, so his recon reads as a flyover from the mine mouth — the
+      grell's eye finds him across the dark and he bolts back, which is the reframe's
+      "player sees the mogall up top" reveal. The RBG/Pinky Wish-seed two-hander
+      (over-long pause, "Straight back. You hear me?", "Form up.") is preserved intact;
+      the old standalone shaft_mouth_reached beat is retired. LOCKED 2026-06-26,
+      RE-PASSED 2026-07-09 (dialogue-pass, co-written with Nicolas). BG DECIDED
       2026-07-04 (Nicolas): REUSE the ch02 bg_TargosWinter slot for the Termalaine
       street (vanilla-style BG reuse; no new slot, dodges the BG_RANDOM relocation).
       PENDING: the eventscript that consumes this + Darmo's generic villager mug +
       motion review.
-    script:                     # LOCKED 2026-06-26 (dialogue pass, co-written with Nicolas)
+    script:                     # LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue pass, co-written with Nicolas)
       - location_card: "Termalaine"
       # (The gem town. Empty ore-carts line a tunnel-mouth in the hillside. A boy stands
       #  on a crate, bellowing the news to a street that walks straight past him. Minor NPC
       #  → generic FE8 villager face at wiring; book p.95 = Darmo Mazle; npc-bench texture: loud.)
-      - boy-crier: "Mine's closed! Monsters in the dark! Speaker Maxol pays fifty gold to whoever clears it out!"
+      # (Speaker = Oarus MASTHEW, book p.93–94; the boxed crier text reads "Speaker Masthew".)
+      - boy-crier: "Mine's closed! Monsters in the dark! Speaker Masthew pays fifty gold to whoever clears it out!"
       - prof-rbg: >-
           Monsters menacing honest miners? We'd be remiss to walk past. ...And the mine
           does sit full of unminded tourmaline. A public service, Pinky. Mostly.
@@ -280,6 +287,20 @@ events:
       - wolfram: "...Pink tourmaline. A whole seam of it. We're going in."
       # (A crude charcoal sign is propped against the empty carts — book p.95.)
       - narration: "The sign read KOBOLDS ONLY — in a hand far too elegant for any kobold."
+      - beat_break: C           # Pinky wings ahead over the workings — the flier's recon (folded in from the old shaft-scout beat)
+      # (Pinky is the army's flier; his scout reads as a quick flyover from the mine mouth.
+      #  RBG's reluctance is the over-long pause, never a stated line — lore/{pinky,prof-rbg}.md.)
+      - pinky: "I'll look ahead! Quick and quiet, I promise!"
+      - prof-rbg: "...Straight back. You hear me?"
+      - pinky: "Straight back!"
+      # (He lifts over the dark of the mine. Far below at the deep workings, something vast
+      #  turns a single wet eye up to follow him. He drops back to the party white-faced.
+      #  The grell is VISIBLE at (14,1) from turn 1, Bazba-style — no fog, no scripted spawn.
+      #  "looked at me" seeds its Evil Eye gaze.)
+      - pinky: "It looked at me. It— ...Father, it looked at me."
+      # (RBG steps between the boy and the dark — the finale-Wish seed carried by the move,
+      #  not a line; the on-the-nose "nothing is taking you from me" stays CUT.)
+      - prof-rbg: "Form up."
   - trigger: midmap   # fires on the BRUTE's DEFEAT (the mid-gallery miniboss) — a defeat-triggered
                       # death cutscene. The "good cop / bad cop" routine collapses into the boss's
                       # death beat: Marty's mercy fails, the beaten Brute makes one last lunge at
@@ -296,13 +317,18 @@ events:
       pun, cold act. Pinky reads it innocently as rescue (he doesn't see the rest);
       RBG's warmth seeds beat 3 + the finale Wish. Wolfram's ore-snacking gag deflates
       it (wolfram_ore_snacking — he obliviously missed the whole thing). Then Trex —
-      the self-taught winged kobold leader — drops in, plays the Brute off as one of
-      his own troublemakers, and DEFECTS, revealing the grell in the deep and offering
-      his thieving (the chapter's thief/chests/doors lesson). Voice: lore/{prof-rbg,
-      marty,wolfram,pinky,braulo,trex}.md. LOCKED 2026-06-26 (dialogue-pass, co-written
+      the self-taught kobold leader — drops in, DISAVOWS the Brute as a feral splinter
+      (2026-07-06 reframe: the enemy kobolds are a wild breakaway, not his warren), and
+      DEFECTS, offering to help kill the grell and win his people a place in Termalaine
+      in exchange for his thieving (the chapter's thief/chests/doors lesson). Pinky
+      (our "Neimi", Nicolas 2026-07-09) telegraphs the talk-recruit with an innocent
+      "can we go say hello?". WINGS DROPPED (Nicolas 2026-07-09: not in Trex's portrait
+      or map sprite, so cut from the fiction; his hook is the self-taught eloquence, not
+      the cosmetic gag — see lore/trex.md). Voice: lore/{prof-rbg,marty,wolfram,pinky,
+      braulo,trex}.md. LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue-pass, co-written
       with Nicolas). PENDING: eventscript + Brute-defeat trigger + Darmo/kobold mugs +
       Trex recruit wiring + motion review.
-    script:                     # LOCKED 2026-06-26 (dialogue pass, co-written with Nicolas)
+    script:                     # LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue pass, co-written with Nicolas)
       # ── A: the routine fails (the Brute, beaten, makes his last move) ──
       # (The Brute is beaten — down at the back of the gallery, his packmates dead around
       #  him, the party closing in. Marty crouches to its level; Pinky drifts in, kind.
@@ -329,59 +355,38 @@ events:
       - wolfram: "...Did something happen?"
       - beat_break: D
       # ── D: Trex defects (self-taught eloquence vs the broken-Common kobold above) ──
-      # (A scrape of claw above; a winged kobold drops down lightly, holding himself like he's
-      #  addressing a court — fashioned, strapped-on wings. He takes in the Brute's body without
-      #  a flicker, and plays it off: the aggressive ones were trouble for him too — lore/trex.md.)
+      # (A scrape of claw above; a kobold drops down lightly, holding himself like he's
+      #  addressing a court. He takes in the Brute's body without a flicker and disavows it:
+      #  the wild ones are a feral splinter, not his warren — 2026-07-06 reframe; lore/trex.md.
+      #  The eloquence-vs-broken-Common gap with the just-killed Brute does the work for free.)
       - trex: >-
-          Ah — the Brute. Aggressive to a fault, that one; trouble for my own warren as
-          much as for you. Between us? You've done me a kindness.
-      - trex: "I am Trex. You'll forgive the wings — a leader must look the part."
+          Ah — you've met the wild ones. They broke from my warren when the hunger came
+          up the deep. They drove your miners out; they've earned you every gold of that
+          bounty. Killing them, you do my people a service.
+      # (He introduces himself with a flourish — his one boast is the tongue he taught
+      #  himself from miners' ledgers, "a beat too proudly"; lore/trex.md §Voice.)
       - trex: >-
-          There is a thing in the deep, eating my people and yours. I cannot fight it —
-          but I know every lock in this mine, and I will open what you cannot. Help me
-          kill it, and the mine — its doors, its gems — is yours.
-      # (The thief's offer = the chapter's chests/doors lesson; Braulo's one blunt line
-      #  settles it, in his fair-dealing register — lore/braulo.md.)
+          I am Trex. Forgive the manner of speech — I taught myself your tongue from a
+          miner's ledgers, a thousand nights by candle. It has its uses.
+      # (Then the deal: kill the grell AND win his warren a place in Termalaine — his real
+      #  subject is always his people's survival; the thief's offer = the chests/doors lesson.)
+      - trex: >-
+          But the wild ones are the least of it. There is a thing in the deep, eating my
+          people and yours — and I cannot fight it. Help me kill it, and win my warren a
+          place in this town, and every lock in this mine opens for you. Its doors, its
+          gems — yours.
+      # (Braulo's one blunt line settles it, in his fair-dealing register — lore/braulo.md.)
       - braulo: "He opens the locks, we take the mine. Fair deal."
+      # (Pinky = our "Neimi": the innocent telegraph teaching "talk to the green unit to
+      #  recruit". Mechanically the recruiter is ANY core party member; Pinky just cues it.
+      #  RBG answering his son with the welcome is peak paternal-warmth on-brand — lore/{pinky,prof-rbg}.md.)
+      - pinky: "He waved at me! Can we go say hello? Father, can we?"
       - prof-rbg: "Welcome aboard, little dragon."
-  - trigger: shaft_mouth_reached
-    type: cutscene
-    ea_file: events/ch03-pinky-scout.ea
-    description: >
-      Scripted scout beat (pinky_scout), fires when the first unit reaches the central
-      shaft. Pure RBG/Pinky two-hander, played OBLIQUE — the emotion lives in staging,
-      not stated lines: Pinky volunteers eagerly; RBG's reluctance is an over-long pause
-      + a clipped "you hear me?"; the grell is revealed only through Pinky's terror on
-      the way back up ("it looked at me" — quietly seeds its Evil Eye gaze), NOT shown.
-      The Grell spawns here (scripted, NOT fog; Ch3 has no fog) — the army's first true
-      monster. RBG's protectiveness (the finale-Wish seed) is carried by ACTION — he
-      steps between his son and the shaft — with the on-the-nose "nothing is taking you
-      from me" line deliberately CUT (Nicolas), ending cold on "Form up." A map-change
-      grinds the sealed way down open onto the deep workings (the seize tile). Voice:
-      lore/{prof-rbg,pinky}.md. LOCKED 2026-06-26 (dialogue-pass, co-written with
-      Nicolas). PENDING: eventscript + grell scripted-spawn + map-change wiring + motion review.
-    script:                     # LOCKED 2026-06-26 (dialogue pass, co-written with Nicolas)
-      # ── A: Pinky volunteers ──
-      # (The central shaft — a black drop, water hissing far below. Pinky is already at the
-      #  lip, wings half-open, bright; his bible's calibration beat for this exact scene.)
-      - pinky: "I'll look. Quick and quiet, I promise!"
-      - beat_break: B
-      # ── B: RBG assents (reluctance shown, never stated) ──
-      # (RBG looks at the dark, then at him. The pause goes a beat too long.)
-      - prof-rbg: "...Straight back. You hear me?"
-      - pinky: "Straight back!"
-      # (He drops into the black. Gone.)
-      - beat_break: C
-      # ── C: the grell, through Pinky's terror (not shown) ──
-      # (Silence; the waterfall. Then, far below, a wet clicking shriek that is no animal.
-      #  A beat of nothing. Pinky rockets back up white-faced and doesn't stop until he's
-      #  behind his father. The Grell spawns here — scripted, not fog. "looked at me" seeds Evil Eye.)
-      - pinky: "It looked at me. It— ...Father, it looked at me."
-      - beat_break: D
-      # ── D: the order (protectiveness = action, the Wish-seed line CUT) ──
-      # (RBG steps between the boy and the shaft — the finale-Wish seed, carried by the move,
-      #  not a line. A map-change grinds the sealed way down open onto the deep workings = seize tile.)
-      - prof-rbg: "Form up."
+  # (The standalone shaft_mouth_reached "pinky-scout" beat was RETIRED 2026-07-09: its
+  #  RBG/Pinky two-hander + grell reveal folded into the chapter_start opening as Pinky's
+  #  flyover recon. The grell is now visible at (14,1) from turn 1 (Bazba-style), so there
+  #  is no scripted mid-map spawn and no "open the way down" map-change — the deep workings
+  #  are pathable from the start.)
   - trigger: chapter_end
     type: cutscene
     ea_file: events/ch03-ending.ea
@@ -398,12 +403,12 @@ events:
       lore/{prof-rbg,trex,meesmickle}.md. LOCKED 2026-06-26 (dialogue-pass, co-written
       with Nicolas). BG DECIDED 2026-07-04 (Nicolas): REUSE bg_TargosWinter (same slot
       as the opening; the two mid-map beats play ON-MAP, no BG). PENDING: eventscript +
-      Maxol generic mug + motion review.
+      Masthew generic mug + motion review.
     script:                     # LOCKED 2026-06-26 (dialogue pass, co-written with Nicolas)
       - location_card: "Termalaine"
       # ── A: bounty + gems (RBG's avarice payoff from the ch02 seed) ──
-      # (Termalaine square, the mine cleared. Speaker Maxol counts the bounty into RBG's glove;
-      #  Wolfram's pack clinks with raw tourmaline. Maxol = book p.93 town speaker, minor NPC → generic mug.)
+      # (Termalaine square, the mine cleared. Speaker Masthew counts the bounty into RBG's glove;
+      #  Wolfram's pack clinks with raw tourmaline. Masthew = Oarus Masthew, book p.93 town speaker → generic mug.)
       - prof-rbg: "Always a pleasure to serve. ...The gems, we'll call a gratuity."
       - beat_break: B
       # ── B: the grell's death opens the town to the kobolds → frees Trex to leave ──
@@ -421,7 +426,7 @@ events:
       # ── C: Meesmickle's deadpan button — his only line of the chapter (lore/meesmickle.md).
       #  Road north resumes the druid thread (ch04) by staging, not a line. ──
       # (The company back on the lakeshore road north, Trex falling in at the back.)
-      - meesmickle: "He glued on wings and taught himself to talk. Most qualified hire so far."
+      - meesmickle: "Taught himself to read, then talked his way onto the payroll. Most qualified hire so far."
 
 # ── Post-Chapter ─────────────────────────────────────────────────────────────────
 post_chapter:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -425,11 +425,11 @@ events:
           read about. If you'll have a thief?
       - beat_break: C
       # ── C: Meesmickle's deadpan button — his only line of the chapter (lore/meesmickle.md).
-      #  Answers Trex's "if you'll have a thief?" AND doubles as the thief-utility telegraph
-      #  (he opens locks) now that Braulo's mid-map line is cut. Road north resumes the druid
-      #  thread (ch04) by staging, not a line. ──
+      #  Folds the self-taught callback + the thief-utility telegraph (he opens locks) into one
+      #  flat line now that Braulo's mid-map line is cut. Road north resumes the druid thread
+      #  (ch04) by staging, not a line. ──
       # (The company back on the lakeshore road north, Trex falling in at the back.)
-      - meesmickle: "A thief who opens any lock we point him at. Most qualified hire so far."
+      - meesmickle: "He taught himself to talk and can open any lock. Most qualified hire so far."
 
 # ── Post-Chapter ─────────────────────────────────────────────────────────────────
 post_chapter:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -325,7 +325,7 @@ events:
       "can we go say hello?". WINGS DROPPED (Nicolas 2026-07-09: not in Trex's portrait
       or map sprite, so cut from the fiction; his hook is the self-taught eloquence, not
       the cosmetic gag — see lore/trex.md). Voice: lore/{prof-rbg,marty,wolfram,pinky,
-      braulo,trex}.md. LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue-pass, co-written
+      trex}.md. LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue-pass, co-written
       with Nicolas). PENDING: eventscript + Brute-defeat trigger + Darmo/kobold mugs +
       Trex recruit wiring + motion review.
     script:                     # LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue pass, co-written with Nicolas)
@@ -375,11 +375,12 @@ events:
           people and yours — and I cannot fight it. Help me kill it, and win my warren a
           place in this town, and every lock in this mine opens for you. Its doors, its
           gems — yours.
-      # (Braulo's one blunt line settles it, in his fair-dealing register — lore/braulo.md.)
-      - braulo: "He opens the locks, we take the mine. Fair deal."
       # (Pinky = our "Neimi": the innocent telegraph teaching "talk to the green unit to
       #  recruit". Mechanically the recruiter is ANY core party member; Pinky just cues it.
-      #  RBG answering his son with the welcome is peak paternal-warmth on-brand — lore/{pinky,prof-rbg}.md.)
+      #  RBG answering his son with the welcome is peak paternal-warmth on-brand — lore/{pinky,prof-rbg}.md.
+      #  Braulo's old "he opens the locks, we take the mine — fair deal" settling line was CUT
+      #  2026-07-09 (Nicolas): Trex's own pitch already carries the thief-utility bark, and
+      #  Meesmickle's ending button now echoes it — answering Trex's "if you'll have a thief?".)
       - pinky: "He waved at me! Can we go say hello? Father, can we?"
       - prof-rbg: "Welcome aboard, little dragon."
   # (The standalone shaft_mouth_reached "pinky-scout" beat was RETIRED 2026-07-09: its
@@ -424,9 +425,11 @@ events:
           read about. If you'll have a thief?
       - beat_break: C
       # ── C: Meesmickle's deadpan button — his only line of the chapter (lore/meesmickle.md).
-      #  Road north resumes the druid thread (ch04) by staging, not a line. ──
+      #  Answers Trex's "if you'll have a thief?" AND doubles as the thief-utility telegraph
+      #  (he opens locks) now that Braulo's mid-map line is cut. Road north resumes the druid
+      #  thread (ch04) by staging, not a line. ──
       # (The company back on the lakeshore road north, Trex falling in at the back.)
-      - meesmickle: "Taught himself to read, then talked his way onto the payroll. Most qualified hire so far."
+      - meesmickle: "A thief who opens any lock we point him at. Most qualified hire so far."
 
 # ── Post-Chapter ─────────────────────────────────────────────────────────────────
 post_chapter:

--- a/campaigns/rime-of-the-frostmaiden/lore/trex.md
+++ b/campaigns/rime-of-the-frostmaiden/lore/trex.md
@@ -9,12 +9,12 @@
 
 ## Concept
 
-- **Race:** Kobold — with **self-fashioned cosmetic wings** (DM notes: "fashioned cosmetic
-  wings for himself"). Kobolds revere dragons; a winged kobold reads, to his warren, as
-  something closer to one.
+- **Race:** Kobold — a clever one, and his warren's leader. Kobolds are dragonkin who revere
+  dragons; that reverence is why a kobold this sharp becomes the one his people follow (and why
+  RBG's fond "little dragon" lands).
 - **Canon:** the named leader of the kobolds in the Termalaine gem mine ("A Beautiful Mine").
-- **Role:** the army's **thief** — steal / chests / doors; the campaign's only one. The wings
-  are cosmetic art, **not** a flier (Thief is a foot unit). See [`npcs/trex.yaml`](../npcs/trex.yaml).
+- **Role:** the army's **thief** — steal / chests / doors; the campaign's only one. A foot unit
+  (Thief), no flier. See [`npcs/trex.yaml`](../npcs/trex.yaml).
 - **Joins:** mid-map in Ch3 ([`chapters/ch03-the-termalaine-mine.yaml`](../chapters/ch03-the-termalaine-mine.yaml)),
   defecting to the party during the RBG-execution cutscene.
 
@@ -26,11 +26,14 @@ before any of that could be explained, the town posted a bounty, and now somethi
 has come up the central shaft from the Underdark: a grell, preying on miners and kobolds
 alike. Trex needs the intruders he should fear.
 
-**Canon deviation (recorded for voice):** in the published module Trex's startling eloquence
-is *borrowed* — he is possessed by the ghost of a sage (Janth Alowar / Pagophil, varies by
-table), played "eerily articulate." **Our table dropped the possession.** His eloquence is
-**self-taught**, which is the whole of his character: he *earned* the big folk's tongue. No
-ghost, no uncanny — just a kobold who out-worked his birth.
+**Canon deviations (recorded for voice):** two, both toward the same idea — a kobold who
+earned his place, no gimmicks. (1) In the published module Trex's startling eloquence is
+*borrowed* — he is possessed by the ghost of a sage (Janth Alowar / Pagophil, varies by
+table), played "eerily articulate." **Our table dropped the possession**; his eloquence is
+**self-taught**. (2) The table also gave him self-fashioned cosmetic wings (DM notes:
+"fashioned cosmetic wings for himself"); the **FE version drops the wings** — they're not in
+his portrait or map sprite (Nicolas, 2026-07-09), and his hook was never the costume but the
+tongue he taught himself. No ghost, no wings — just a kobold who out-worked his birth.
 
 ## Voice
 
@@ -45,12 +48,13 @@ with a survivor's cunning underneath. (Interview with Nicolas, 2026-06-26.)
   language from text, not a mother tongue. He occasionally over-reaches a fancy word and
   lands it a beat too proudly.
 - **Never** the broken "me Trex" kobold pidgin — that is the **other** kobolds, his
-  deliberate foil. Stage him beside a broken-Common kobold ("He has wings like a dragon!")
-  and let the gap do the characterization for free.
+  deliberate foil. Stage him beside a broken-Common kobold (book register: "Trex smart! He
+  speaks like human who knows a lot.") and let the gap do the characterization for free.
 - **Negotiator's reflexes:** opens with terms, not threats; reframes a fight as a deal;
   surrenders instantly and turns it to advantage — always from **dignity**, never groveling.
-- The **wings are sincere** to him (a leader of kobolds should look like the dragons they
-  revere). The comedy is in *others'* reactions, never in his own treatment of them.
+- The **eloquence is sincere** — he is genuinely proud of the tongue he earned, and wears it
+  a beat too proudly. The comedy is in *others'* reactions to a kobold who out-talks them,
+  never in any cringing on his part.
 - Under the airs, his real subject is always the **warren's survival** — food, warmth, a
   place in the town, the thing in the deep eating them. Let the mask of eloquence slip into
   genuine weight when it counts.
@@ -58,11 +62,16 @@ with a survivor's cunning underneath. (Interview with Nicolas, 2026-06-26.)
   angles, and may lean on his own kobolds to do it. Seasoning, not the whole dish:
   pragmatic, not villainous.
 
-**Calibration moment (first meeting — dropping between RBG and the cornered kobold)**
-- Voice target: *"Please — lower the weapon. He is only frightened. …You'll forgive the
-  wings; a leader must look the part. I taught myself your tongue from a miner's ledgers — a
-  thousand nights by candle. There is a thing in the deep eating my people and yours. Help
-  me, and this mine — its locks, its gems — is yours."*
+**Calibration moment (first meeting — dropping in on the executed *feral* kobold)**
+The 2026-07-06 reframe makes the enemy kobolds a **feral splinter**, not his warren, so his
+entrance is *distinguish-myself-and-pitch-the-deal*, not protect-my-kin (the old "he is only
+frightened" read is retired). The ch03 locked lines are the target:
+- Disavowal: *"Ah — you've met the wild ones. They broke from my warren when the hunger came
+  up the deep. …Killing them, you do my people a service."*
+- Self-made boast: *"I am Trex. Forgive the manner of speech — I taught myself your tongue
+  from a miner's ledgers, a thousand nights by candle. It has its uses."*
+- The deal: *"Help me kill it, and win my warren a place in this town, and every lock in this
+  mine opens for you. Its doors, its gems — yours."*
 
 **Banned:** broken-Common kobold pidgin ("me want," "Trex smart!"); cartoon vanity with no
 substance under it; cowardice played straight or mustache-twirling villainy; Draconic (he has

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -650,6 +650,19 @@ notes, and the Frostmaiden book "A Beautiful Mine" pp.93–96) — item 4 added 
 multi-level maps, so the book's 3-level mine is authored as one flat walled interior (rooms via
 TERRAIN_DOOR + one TILECHANGE), not a verticality gimmick — the doors make the thief (Trex) matter._
 
+**Ch3 dialogue re-pass on the 2026-07-06 reframe (2026-07-09, Nicolas + CLAUDE).** Three fiction
+changes settled while re-passing the opening + RBG-execution/Trex-recruit beats (roster/positions
+unchanged; still plays like Bandits of Borgo): (a) **Trex's cosmetic wings are dropped** — the
+table gave him self-fashioned wings, but they're not in his FE portrait or map sprite, so they're
+cut from the fiction (his hook was always the self-taught eloquence, not the costume). This retires
+`lore/trex.md`'s wings content and Meesmickle's wings-based ending button; it also moots the "wings
+pixel edit" art task on #23. (b) **Pinky's shaft-scout folds into the opening cutscene** — as the
+army's flier he does a flyover recon from the mine mouth; the grell is now **visible at (14,1) from
+turn 1** (Bazba-style), so the old standalone `shaft_mouth_reached` beat, its scripted grell spawn,
+and its "open the way down" map-change are all retired (the deep workings are pathable from the
+start). The RBG/Pinky Wish-seed two-hander is preserved intact. (c) **Canon name fix:** the town
+speaker is **Oarus Masthew** (book pp.93–94), not "Maxol" — corrected in the crier + ending lines.
+
 **Ch3 layout = vanilla Borgo geometry repainted, NOT a custom Gem-Mine blockout.**
 The 2026-06-29 session *proposed* pivoting the ch03 layout to a custom flattened trace of the
 book's Gem Mine map (Map 1.19) and posted a blockout on #23 pending Nicolas's OK. That OK never


### PR DESCRIPTION
Re-passes the two beats the 2026-07-06 narrative reframe superseded — the **opening** and the **RBG-execution / Trex-recruit** — with Nicolas via the `dialogue-pass` skill. Grounded in the Frostmaiden book "A Beautiful Mine" (pp.93–96) and the DM notes, read directly. Roster/positions unchanged; still plays like Bandits of Borgo.

## What changed
- **Pinky's shaft-scout folds into the opening.** He's the army's flier, so his recon is a flyover from the mine mouth — the grell's eye finds him across the dark and he bolts back. The grell is now **visible at (14,1) from turn 1** (Bazba-style). The standalone `shaft_mouth_reached` beat, its scripted grell spawn, and its "open the way down" map-change are retired (deep workings pathable from the start). The RBG/Pinky Wish-seed two-hander is preserved intact.
- **Trex's entrance + pitch** reworked for the feral-splinter / clear-our-name motive (he disavows the wild ones as a breakaway, not his warren; pitch folds in "win my warren a place in Termalaine").
- **Wings dropped.** Not in Trex's portrait or map sprite → cut from the fiction (his hook is the self-taught eloquence). Retires `lore/trex.md` wings content + the stale "he is only frightened" calibration, and rewrites Meesmickle's wings-based ending button. **Moots the "wings pixel edit" art task on #23.**
- **Pinky = our "Neimi":** restored "He waved at me! Can we go say hello?" as the Colm-style talk-recruit telegraph.
- **Canon fix:** the town speaker is **Oarus Masthew** (book pp.93–94), not "Maxol" (crier + ending lines).

## Not in scope
Cutscene **wiring** (#23 items 2/4/5 — eventscript, Brute-defeat trigger, talk-recruit CUSA, chain ch02→ch03), art, title card. In-game motion review happens at wiring.

## Checks
`make check` (drift) clean; ch03 YAML parses (3 events). Scripts aren't host-wired yet, so `verify_text` (built-ROM decode) isn't applicable — validated by parse + drift, per #97. Decision recorded in `docs/decisions.md` (Ch3 ADR).

Refs #23 (dialogue re-pass item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
