### PR TITLE
feat(#23): Trex talk-recruit (item 2) — Colm-style green→blue, decoupled from the execution beat

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,26 +4,46 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 `git log --oneline -20` + closed issues, not here. **Backlog** → GitHub issues. **Decisions** →
 `docs/decisions.md`. **Operating instructions** → `CLAUDE.md`. Run `/handoff` to refresh this file in place.
 
-> **Last session (2026-07-09, desktop — ch3 dialogue re-pass MERGED #147; generic cutscene recorder + branch cleanup #148 OPEN/green):**
-> **Ch3 dialogue re-pass (PR #147, SQUASH-MERGED):** re-passed the opening + RBG-execution/Trex-recruit beats on
-> the 2026-07-06 reframe. Pinky's shaft-scout **FOLDED INTO the opening** (he's the flier → a flyover recon; the
-> grell is visible at `(14,1)` from turn 1, Bazba-style; the standalone `shaft_mouth_reached` beat + its scripted
-> spawn/map-change are **retired**). Trex's entrance = feral-splinter disavowal + clear-our-name motive; **wings
-> DROPPED** (not in his portrait/map sprite → cut from the fiction incl. `lore/trex.md` + Meesmickle's ending
-> button; his hook is the self-taught eloquence). **Pinky = our "Neimi"** (the talk-recruit telegraph — the open
-> creative fork, RESOLVED). Canon fix **Maxol→Masthew** (book pp.93–94). `decisions.md` Ch3 ADR records all three.
-> This **LOCKS the cutscene text** that #23 items 2/4/5 wire; beats validated by YAML parse + drift (not host-wired yet).
+> **Last session (2026-07-09 #2, desktop — Ch3 Trex TALK-RECRUIT wired + verified; PR #150 OPEN/green, awaits Nicolas's `gh pr merge`):**
+> **#23 item 2 DONE — Trex talk-recruit (the vanilla Colm/Neimi pattern).** Trex stands GREEN; **ANY core party
+> member** who **Talks** to him flips him blue via `CUSA`. Talker-agnostic + non-missable: one
+> `CHAR(flag, script, <candidate>, CHARACTER_RENNAC)` per ch03 field candidate (`talk_recruiters` =
+> `cast_available_at(3)`), all → ONE shared recruit script (FE8's ch14a-Rennac multi-recruiter idiom). Wiring
+> repurposes dead ch4 symbols the host frees: **`EventScr_089F199C`** (was the Ch4 Turn-2 green script) + msg
+> **`0x9A5`** + **`EVFLAG_TMP(9)`**. New `build_campaign` helpers (all TDD, 6 tests): `char_symbol`,
+> `on_map_talk_recruits`, `talk_recruiters`, `talk_recruit_char_entries`, `talk_recruit_script`.
+> **VERIFIED IN-ENGINE:** `PT_HOST_CHAPTER=4 run.sh ch03talk` **PASS** — park a candidate adjacent to green Trex →
+> Talk (menu row 0) → Trex leaves the green array and lands in **`blue[09]=0x1C`**; the migrated dialogue (bounty
+> framing) renders. **Gotcha:** the `blue()` harness helper scans only 8 slots (ch00 party) — ch03 deploys 9+, so
+> a recruit lands at a higher index; scan the full array (`findUnit(gUnitArrayBlue, 20, …)`).
 >
-> **Generic cutscene recorder + branch cleanup (PR #148, SQUASH-MERGED):**
-> repackaged the per-scene `record*` recorders into ONE `recordCutscene(opts)` + an env-driven **`recordscene`** —
-> record ANY dialogue cutscene with no new Lua (`PT_STATE=<ckpt> PT_TAG=<tag> PT_UNTIL=prep|title|chapter`);
-> `recordch02intro` + `recordending` are one-line presets over it. **VERIFIED IN-ENGINE (3 PASS).** **mGBA IS
-> runnable here** (`tools/emulator/mGBA-dev.app` — run.sh auto-provisions it + builds checkpoints; `/opt/homebrew/bin/lua`
-> present) — running it caught 2 bugs `luac -p` can't: `os.getenv` is dead in mGBA's sandbox (config comes via
-> `PLAYTEST_*` wrapper globals injected by run.sh), and a Lua `local function` used **above** its definition
-> resolves to a nil global. Also salvaged the reusable `recordch02*` tooling from the stale `demo/ch2-gifs` branch
-> (its stale GIFs **dropped** — pre-date the ch2 name-leak fixes) and closed stale PR #130 (its
-> `fe8.triangleattack.com` vanilla-map-screenshot note → `docs/adding-a-chapter.md`).
+> **DECOUPLE (Nicolas):** Trex's entrance + recruit are split **OUT of** the RBG-execution cutscene. Colm's on-map
+> appearance is a LIGHT green-NPC beat and ALL his substance rides the Talk — no second cutscene re-introduces him.
+> So the ch03 **RBG-execution beat is now RBG's alone (+ Wolfram)**, and Trex's disavowal/boast/deal MOVED to the
+> talk. **Why (the bug it fixes):** a freely-timed talk recruit + a fixed Brute-defeat cutscene fire in either
+> order, so bolting Trex's intro onto the execution let a player who talked first recruit him *before* the cutscene
+> "introduced" him. Talk line reframed to *"the wild ones — the ones your bounty names"* (accurate from turn 1,
+> zero kills). ch03 YAML split into `trex_entrance` (light, Pinky telegraph + RBG "little dragon" — rides the
+> Cutscenes item) + `talk_recruit` (the wired substance). ADR in `decisions.md` → Recruit wiring.
+>
+> **Trex iron-sword fix:** he had no YAML `inventory:`, so `difficulty.py` read "no weapon" and modeled him as a
+> **staff healer (0 throughput)** — `make difficulty CH=ch03` showed `(staff)`. Added iron-sword to his YAML
+> inventory (**difficulty-only**: the `inventory` field is read solely by difficulty.py; in-game deploy kit still
+> comes from `CLASS_LOADOUT['CLASS_THIEF']`, unchanged). Now models as iron-sword w/ real throughput. **Confirmed
+> Trex gets Colm's PERSONAL bases + growths via the donor** (BASE/GROWTH/STAT_DONOR=COLM — NOT base-thief): bases
+> HP18/Pow4/Skl4/Spd10/Def3/Res1/Lck8, growths HP75/Pow40/Skl40/Spd65/Def25/Res20/Lck45. ch03 enemy parity
+> unchanged (threat ×1.12, clear-load ×0.99 vs vanilla FE8 Ch3). **Open note:** arming Trex bumped him into the
+> difficulty "best 9 fielded" for ch03 (over sclorbo) — the field-picker draws the full roster, so a recruit shows
+> in its join chapter; the binding **enemy** parity is unaffected. Optional follow-up: filter the party metric to
+> prep-availability (Trex as +1 bonus, not a deploy-slot swap).
+>
+> **Prior session (PRs #147 + #148, both SQUASH-MERGED):** #147 re-passed the ch03 opening + RBG-execution beats on
+> the 2026-07-06 reframe (Pinky's shaft-scout folded into the opening; grell visible turn 1; **wings dropped**;
+> Pinky = our "Neimi") — **LOCKED the cutscene text** the item-2/cutscene passes wire. #148 built the generic
+> **`recordscene`** recorder (`PT_STATE=<ckpt> PT_TAG=<tag> PT_UNTIL=prep|title|chapter` — record ANY cutscene, no
+> new Lua) — **the tool for the deferred ch03 cutscenes**. mGBA runnable here (`tools/emulator/mGBA-dev.app`;
+> `/opt/homebrew/bin/lua`); its sandbox has no `os.getenv` (config via `PLAYTEST_*` wrapper globals) and a Lua
+> `local function` used above its definition resolves to a nil global.
 
 > **Prior session (2026-07-08 #3, MERGED PR #146 — recruit-persist join-LOAD):** cutscene recruits now PERSIST —
 > `build_campaign.offmap_join_recruits(N)` LOADs off-map recruits (Baxby) on a free UnitDef (`088B476C`), blue,
@@ -164,7 +184,7 @@ ch03 recruit, added to #65**.
 + 3 descaled frames, one feature-flow branch per unit (or small batch), `custom_unit` issue template.
 - **Deferred polish (tracked):** braulo's white swing-arc weapon-trail → **#91**; goblin enemy class-level anim → **#90**.
 
-### Content — Ch3 "The Termalaine Mine" (#23) — HOSTED + WIN + ENEMY SPRITES + DIALOGUE DONE; recruit/prep/chain/cutscene-wiring/chests remain
+### Content — Ch3 "The Termalaine Mine" (#23) — HOSTED + WIN + ENEMY SPRITES + DIALOGUE + RECRUIT DONE; ⭐ prep-deploy + cutscene-wiring next; chain/chests/title/art remain
 Vanilla-FE8-Ch3 reskin as Termalaine's kobold-overrun tourmaline mine. Teaching goal = the **thief**
 (Trex = our Colm). Decisions: `decisions.md` → Ch3 ADR (four deviations + **item 4 = Defeat Boss**) + the
 ch03 YAML `design_notes` (2026-07-06 narrative reframe). **Live build checklist = #23 (the source of truth);
@@ -172,7 +192,7 @@ how-to for the host machinery = `docs/adding-a-chapter.md`.**
 - **DONE:** map painted + hosted on slot 4; **DefeatBoss WIN + `ch03win`** (PR #143); **Trex bust** (PR #142);
   **ALL enemy map sprites in-engine** — Wildling grunts (PR #144) + **Lizardzerker blade skirmisher + steel
   brute** on appended classes 0x80/0x81 (PR #145, audited via `enemycheck`). archer + thief + grell VANILLA.
-  **Recruit UNITS wired on `feat/23-trex-recruit-unit` (PR #146, OPEN — not merged):** reusable data-driven
+  **Recruit UNITS wired (PR #146, MERGED):** reusable data-driven
   recruit model (`decisions.md` → **Recruit wiring** ADR) — a recruit = a classed cast member + a
   `recruit.chapter`; `cast_available_at(N)` = founding + recruits recruited before N. **Trex** = real unit
   (Rennac slot, Colm donor) placed **GREEN** on the ch03 map (Colm-style talk recruit; joins via `CUSA` →
@@ -189,26 +209,36 @@ how-to for the host machinery = `docs/adding-a-chapter.md`.**
   `tools/playtest/run.sh ch02baxby` PASS — Baxby at `blue[8]=0x10` in the prep roster AND deployable +
   fighting on the ch02 map (killed a raider in melee). Existing `ch02` scenario still PASS (deploy cap 5).
   3 new unit tests (58 total green). Talk recruits (Trex) still self-join via `CUSA`.
-- **REMAINING (unchecked on #23, priority order):**
-  1. ✅ **DONE (this session, PR #147) — Ch3 DIALOGUE LOCKED.** Opening + RBG-execution/Trex-recruit beats
-     re-passed on the reframe (feral-splinter kobolds, clear-our-name motive, RBG executes a feral one); Pinky's
-     scout **folded into the opening** (grell visible turn 1); **wings dropped**; **Pinky = our "Neimi"** (the
-     talk-recruit hint line). The locked cutscene text lives in the ch03 YAML `script:` blocks — items 2/4/5 WIRE it.
-  2. **⭐ NEXT — Trex talk-recruit event** — `CHAR(flag, script, <every core-party candidate>, CHARACTER_RENNAC)`
-     + `CUSA(RENNAC)`. The hint line is LOCKED (Pinky's "He waved at me! Can we go say hello?" in the mid-map
-     beat); talker = ANY core party member. Trex's map sprite + bust are done — **NO wings anymore** (dropped #147).
-  3. **Real PREP deploy** — author `deployment.deploy_slots` (9 tiles) + a PREP CALL; today it's the static
-     fast-boot spawn (`CH03_SPAWN_POSITIONS` = `cast_available_at(3)` = 8 founding + Baxby), party WEAPONLESS
-     (`items='0'`). (The ch02 off-map join-LOAD pattern is the reference for how recruits ride the prep roster.)
-  4. **Chain ch02→ch03** — point ch02's ending `MNC2(0x4)` at ch03 (drop the ch02 dev-placeholder landing).
-  5. **Cutscenes wiring** — the dialogue text is **LOCKED (#147)**; wire the 3 beats (#58 opaque-box). Opening on
-     chapter_start (incl. Pinky's flyover scout); mid-map on the BRUTE (`kobold-steel`) defeat; replace the minimal
-     DefeatBoss ending with the real ending cutscene. New reusable tool: **`recordscene`** (record any cutscene,
-     #148) captures each beat as a GIF for motion review.
-  6. **Chests/doors** — per-chest **`17→29` TILECHANGE**; Trex opens, key-droppers back up.
-  7. **Title-card image** + full load-test scenarios `ch03`/`smoke_ch03`/`clear_ch03` (the `ch03win`/
+- **DONE (this session, PR #150 OPEN/green):** ✅ **item 2 — Trex TALK-RECRUIT** (green→blue via `CUSA`; talker =
+  any core party member; verified in-engine `ch03talk`) + the **decouple** (entrance/execution split; Trex's
+  substance moved to the Talk) + the **Trex iron-sword** difficulty fix. See the session block up top for detail.
+  Also DONE (PR #147): **Ch3 DIALOGUE LOCKED** — the 3 cutscene beats' text lives in the ch03 YAML `script:` blocks.
+- **REMAINING (unchecked on #23) — ⭐ the next two are the requested handoff targets:**
+  1. **⭐ NEXT-A — Real PREP deploy** (item 3). Author `deployment.deploy_slots` (9 tiles) in the ch03 YAML + wire a
+     **PREP CALL** in `inject_ch03`'s beginning scene (today it's the static `CH03_SPAWN_POSITIONS` fast-boot spawn,
+     party WEAPONLESS `items='0'`). **Reference impls in the SAME file:** `inject_ch01`/`inject_ch02` already emit a
+     PREP flow (`_deploy_cap_entries` + the deploy-cap template + the PREP CALL); the ch02 off-map join-LOAD
+     (`offmap_join_recruits` → Baxby before the PREP CALL) shows how a recruit rides the prep roster. **Cap is
+     already recruit-correct:** `deploy_limit: 9` over `cast_available_at(3)` (9 units, Trex EXCLUDED — he joins
+     mid-map on top, like vanilla Colm; included from ch04). Real equipping (`CLASS_LOADOUT`) lands with the prep
+     flow. Verify with a new/updated scenario that the prep screen opens + Pick Units fields the roster (cf.
+     `recordsupply`/`ch02` menu-driving).
+  2. **⭐ NEXT-B — Cutscene wiring** (the "Cutscenes" item). Text is **LOCKED** in the ch03 YAML `events:` blocks
+     (4 beats: `chapter_start` opening w/ Pinky's flyover scout; `midmap` RBG-execution-on-Brute-defeat — now
+     RBG+Wolfram ONLY, Trex removed; `trex_entrance` LIGHT beat — Pinky telegraph + RBG "little dragon"; `chapter_end`
+     ending). Wire each via the #58 opaque-box narration + the scene helpers (`_emit_scene_beats`/`_scenic_beat_calls`/
+     `_script_to_message` — the ch01/ch02 injectors are the pattern). **Use `dialogue-pass` skill** for any text
+     touch-ups and **`recordscene`** (PR #148: `PT_STATE=<ckpt> PT_TAG=<tag> PT_UNTIL=…`) to capture each beat as a
+     GIF for Nicolas's motion review (deliver via `docs/demo/`). BGs: **reference `bg_TargosWinter`, don't import**
+     (mid-map beats play on-map, no BG). The `talk_recruit` event is already wired (item 2) — don't re-wire it.
+  3. **Chain ch02→ch03** — point ch02's ending `MNC2(0x4)` at ch03 (drop the ch02 dev-placeholder landing); replace
+     the ch03 minimal DefeatBoss ending with the real ending cutscene once ch04 hosts (or park like ch02 until then).
+  4. **Chests/doors** — per-chest **`17→29` TILECHANGE**; Trex opens, key-droppers back up.
+  5. **Title-card image** + full load-test scenarios `ch03`/`smoke_ch03`/`clear_ch03` (the `ch03win`/`ch03talk`/
      `koboldview`/`enemycheck` scenarios seed these; a fair-play `clear_ch03` needs a `CA_BOSS` grell or a
      pid-targeted bot).
+  - **Optional polish:** the recruit talk renders in the **map speech bubble** (no portrait box), canonical for
+    on-map CHAR talks — switch to the full portrait box if Nicolas wants Trex's bust to show on recruit.
 - **Cutscene BGs DECIDED (Nicolas): reference, don't import** — reuse `bg_TargosWinter`; mid-map beats on-map.
 - Then chapters #24–#28 follow the same slice via `docs/adding-a-chapter.md`.
 

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -316,18 +316,14 @@ events:
       one warmth is his son, executes it at gunpoint (rbg_kobold_execution) — pleasant
       pun, cold act. Pinky reads it innocently as rescue (he doesn't see the rest);
       RBG's warmth seeds beat 3 + the finale Wish. Wolfram's ore-snacking gag deflates
-      it (wolfram_ore_snacking — he obliviously missed the whole thing). Then Trex —
-      the self-taught kobold leader — drops in, DISAVOWS the Brute as a feral splinter
-      (2026-07-06 reframe: the enemy kobolds are a wild breakaway, not his warren), and
-      DEFECTS, offering to help kill the grell and win his people a place in Termalaine
-      in exchange for his thieving (the chapter's thief/chests/doors lesson). Pinky
-      (our "Neimi", Nicolas 2026-07-09) telegraphs the talk-recruit with an innocent
-      "can we go say hello?". WINGS DROPPED (Nicolas 2026-07-09: not in Trex's portrait
-      or map sprite, so cut from the fiction; his hook is the self-taught eloquence, not
-      the cosmetic gag — see lore/trex.md). Voice: lore/{prof-rbg,marty,wolfram,pinky,
-      trex}.md. LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue-pass, co-written
-      with Nicolas). PENDING: eventscript + Brute-defeat trigger + Darmo/kobold mugs +
-      Trex recruit wiring + motion review.
+      it (wolfram_ore_snacking — he obliviously missed the whole thing). This beat is now
+      RBG's ALONE: Trex's entrance + recruit are DECOUPLED into their own events below
+      (2026-07-09, Nicolas — Colm-style light entrance + everything in the Talk; it fixes an
+      ordering bug and de-crams this cutscene). WINGS DROPPED (Nicolas 2026-07-09: not in
+      Trex's portrait or map sprite, so cut from the fiction — see lore/trex.md). Voice:
+      lore/{prof-rbg,marty,wolfram,pinky}.md. LOCKED 2026-06-26, RE-PASSED 2026-07-09
+      (dialogue-pass, co-written with Nicolas). PENDING: eventscript + Brute-defeat trigger
+      + Darmo/kobold mugs + motion review.
     script:                     # LOCKED 2026-06-26, RE-PASSED 2026-07-09 (dialogue pass, co-written with Nicolas)
       # ── A: the routine fails (the Brute, beaten, makes his last move) ──
       # (The Brute is beaten — down at the back of the gallery, his packmates dead around
@@ -353,36 +349,63 @@ events:
       #  The senses come first; he names the metal before he notices the room — lore/wolfram.md.)
       - wolfram: "Copper, tin... a touch of silver. Good ore."
       - wolfram: "...Did something happen?"
-      - beat_break: D
-      # ── D: Trex defects (self-taught eloquence vs the broken-Common kobold above) ──
-      # (A scrape of claw above; a kobold drops down lightly, holding himself like he's
-      #  addressing a court. He takes in the Brute's body without a flicker and disavows it:
-      #  the wild ones are a feral splinter, not his warren — 2026-07-06 reframe; lore/trex.md.
-      #  The eloquence-vs-broken-Common gap with the just-killed Brute does the work for free.)
+      # (Trex is NOT in this beat anymore — his entrance + recruit are DECOUPLED below.)
+
+  # ── Trex: a Colm-style on-map TALK recruit — DECOUPLED from the RBG-execution beat
+  #    (2026-07-09, Nicolas). Vanilla Colm's entrance is a LIGHT turn-1 green-NPC beat (one
+  #    line, he walks in) and ALL his substance rides the TALK (EventScr_Ch3_Talk_NeimiColm).
+  #    We mirror that: the execution beat above is now RBG's alone; Trex's disavowal + boast +
+  #    deal MOVE to the talk. This fixes an ORDERING bug — a freely-timed talk recruit can't
+  #    put its intro in a fixed Brute-defeat cutscene (a player who talks to green Trex first
+  #    would recruit him BEFORE the cutscene "introduces" him, and his line would thank RBG for
+  #    an execution that hadn't happened). See decisions.md → Ch3 recruit-wiring ADR.
+  - trigger: trex_entrance     # light green-NPC beat (Colm's turn-1 pattern); rides the #23 Cutscenes item
+    type: cutscene
+    description: >
+      Trex's LIGHT entrance (Colm-style). He is the green, non-hostile kobold in the
+      galleries from turn 1; a brief beat delivers Pinky's telegraph — Trex waves, Pinky
+      wants to go say hello — cueing the player to walk a unit over and Talk. No history, no
+      deal here; that all rides the talk-recruit below. Pinky = our "Neimi" (the talk-recruit
+      telegraph). RBG's warm "little dragon" answer indulges his son and pre-welcomes the
+      friendly kobold on sight (kobolds revere dragons — lore/trex.md). Voice:
+      lore/{pinky,prof-rbg,trex}.md. PENDING: eventscript (rides the #23 Cutscenes item with
+      the opening/execution/ending beats).
+    script:                    # LOCKED 2026-07-09 (co-written with Nicolas)
+      # (Trex, green in the galleries, lifts a clawed hand in a careful little wave. Pinky,
+      #  delighted, tugs at the nearest grown-up — the telegraph teaching "talk to the green unit".)
+      - pinky: "He waved at me! Can we go say hello? Father, can we?"
+      - prof-rbg: "Welcome aboard, little dragon."
+  - trigger: talk_recruit      # ANY core party member Talks to green Trex → CUSA join (#23 item 2)
+    type: talk
+    recruits: trex             # inject_ch03 wires CHAR(flag, script, <each core member>, RENNAC) + CUSA(RENNAC)
+    description: >
+      The Trex recruit — his HEAVY dialogue, migrated here from the old RBG-execution beat
+      (2026-07-09, Nicolas). A unit Talks to green Trex → he introduces himself, disavows the
+      wild ones (framed as "the ones your bounty names" — accurate from turn 1 with zero kills,
+      and it ties to his people's trouble with the town), pitches the deal (kill the grell + a
+      place for his warren + every lock opens = the chapter's chests/doors lesson), and joins
+      (CUSA → blue). Recruiter = ANY core party member (non-missable — he's the army's only
+      thief; one CHAR entry per candidate, all → this one script). Trex rides the Rennac slot.
+      Voice: lore/trex.md §Voice. LOCKED 2026-07-09 (co-written with Nicolas).
+    script:                    # LOCKED 2026-07-09 (co-written with Nicolas)
+      # (Trex holds himself like he's addressing a court — the eloquence IS his pitch. He
+      #  disavows the wild ones as a feral splinter; the BOUNTY framing (Nicolas 2026-07-09)
+      #  is true whether or not the party has killed a single one yet.)
       - trex: >-
-          Ah — you've met the wild ones. They broke from my warren when the hunger came
-          up the deep. They drove your miners out; they've earned you every gold of that
-          bounty. Killing them, you do my people a service.
-      # (He introduces himself with a flourish — his one boast is the tongue he taught
-      #  himself from miners' ledgers, "a beat too proudly"; lore/trex.md §Voice.)
+          The wild ones — the ones your bounty names — broke from my warren when the hunger
+          came up the deep. They drove your miners out and fouled our name with the town.
+          Put them down, and you do my people a service.
+      # (His one boast: the tongue he taught himself, worn "a beat too proudly"; lore/trex.md §Voice.)
       - trex: >-
           I am Trex. Forgive the manner of speech — I taught myself your tongue from a
           miner's ledgers, a thousand nights by candle. It has its uses.
-      # (Then the deal: kill the grell AND win his warren a place in Termalaine — his real
-      #  subject is always his people's survival; the thief's offer = the chests/doors lesson.)
+      # (The deal: kill the grell AND win his warren a place in Termalaine — his real subject is
+      #  always his people's survival; the thief's offer carries the chests/doors lesson.)
       - trex: >-
           But the wild ones are the least of it. There is a thing in the deep, eating my
           people and yours — and I cannot fight it. Help me kill it, and win my warren a
           place in this town, and every lock in this mine opens for you. Its doors, its
           gems — yours.
-      # (Pinky = our "Neimi": the innocent telegraph teaching "talk to the green unit to
-      #  recruit". Mechanically the recruiter is ANY core party member; Pinky just cues it.
-      #  RBG answering his son with the welcome is peak paternal-warmth on-brand — lore/{pinky,prof-rbg}.md.
-      #  Braulo's old "he opens the locks, we take the mine — fair deal" settling line was CUT
-      #  2026-07-09 (Nicolas): Trex's own pitch already carries the thief-utility bark, and
-      #  Meesmickle's ending button now echoes it — answering Trex's "if you'll have a thief?".)
-      - pinky: "He waved at me! Can we go say hello? Father, can we?"
-      - prof-rbg: "Welcome aboard, little dragon."
   # (The standalone shaft_mouth_reached "pinky-scout" beat was RETIRED 2026-07-09: its
   #  RBG/Pinky two-hander + grell reveal folded into the chapter_start opening as Pinky's
   #  flyover recon. The grell is now visible at (14,1) from turn 1 (Bazba-style), so there

--- a/campaigns/rime-of-the-frostmaiden/npcs/trex.yaml
+++ b/campaigns/rime-of-the-frostmaiden/npcs/trex.yaml
@@ -59,6 +59,18 @@ promotion:
   branch: [Rogue, Assassin]  # vanilla FE8 Thief branch (classchg-data.c [CLASS_THIEF])
   default: Rogue
 
+# ── Inventory — the FIGHTING kit (an iron sword: a Thief fights, weakly, like vanilla Colm).
+#    This is what difficulty.py reads (_weapon_for) to model him as a combatant; without it he
+#    resolved to the staff/support path (0 throughput) as if a healer. The steal/unlock utility
+#    (door + chest keys + vulnerary) rides the DEPLOY loadout CLASS_LOADOUT['CLASS_THIEF'], not
+#    the combat model. fe_base = vanilla FE8 stats (Mt/Hit/Crit/Wt), no custom tuning.
+inventory:
+  - id: iron-sword
+    name: "Iron Sword"
+    fe_base: iron-sword
+    fe_weapon_type: Sword
+    damage_type: slashing           # cosmetic flavor label only
+
 recruited_via: "story — joins after the Termalaine mine (Ch3)"
 recruit:
   chapter: ch03-the-termalaine-mine

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -583,20 +583,36 @@ stat patching) still covers every recruit.
 - **Trex (ch03)** — a **Colm-style on-map TALK recruit**: placed GREEN, joins via `CUSA` when talked to
   (the vanilla `EventScr_Ch3_Talk_NeimiColm → CUSA(COLM)` pattern; `CHAR(flag, script, talker, target)`).
   Rides **Rennac** (donor Colm/Thief). He is the army's ONLY thief, so recruitment must be **non-missable**
-  and telegraphed **Joshua-style** (a hint line + FE8's auto Talk prompt). Talker: see the open decision
-  below. The `CHAR`+`CUSA`+hint-line wiring rides the ch03 event/cutscene pass (#23 item 4); until then
-  he stands green on the map and the availability filter gives him ch04+ prep.
+  and telegraphed **Joshua-style** (a hint line + FE8's auto Talk prompt). Talker = any core party member
+  (below). WIRED (#23 item 2, 2026-07-09): `inject_ch03` emits the `CHAR`-per-candidate list + the shared
+  `CUSA(CHARACTER_RENNAC)` script; the hint line rides the Cutscenes item. The availability filter gives
+  him ch04+ prep, and the `CUSA` join makes him persist naturally (no off-map join-LOAD).
 - **Lupin/Sahnar/Basil (ch04/ch05)** — wired per their YAML method when those slices land (not now).
 **A generic "recruit engine" that auto-registers a unit from its YAML was explicitly rejected** (Nicolas,
 2026-07-08): unit identity (slot/donor/portrait) is genuinely per-unit — vanilla has per-character tables
 too — and each recruit's join method differs, so a one-size engine is over-engineering. The reusable
 pieces are the availability filter + the vanilla `CUSA`/`CHAR` primitives, nothing more.
-**OPEN (talker for Trex):** recruit-able by **any core party member** (guarantees the always-force-deployed
-lord can, since a fixed recruiter is missable and a static `CHAR` entry can't name the *chosen* lord) —
-implemented as one talk entry per lord candidate → `CUSA(Trex)`. Alternative: restrict to the chosen lord.
-Pending Nicolas; lands with #23 item 4.
-_Decided: 2026-07-08 (Nicolas + CLAUDE; the #23 recruit pass — wired Baxby + Trex as the first two
-consumers; audit found Lupin/Sahnar/Basil in the same "authored-YAML, no unit" state, wired per-slice)._
+**Talker for Trex = ANY core party member** (RESOLVED — the only thief must be non-missable, and a static
+`CHAR` can't name the *chosen* lord). Implemented (`build_campaign.talk_recruiters`) as one
+`CHAR(flag, script, <candidate>, CHARACTER_RENNAC)` per field candidate — the ch03 blue roster
+(`cast_available_at(3)`) — all pointing at ONE shared recruit script (`talk_recruit_char_entries` +
+`talk_recruit_script`): completing any one talk runs `CUSA(CHARACTER_RENNAC)` (green→blue) and the shared
+flag disables the rest. FE8's own multi-recruiter idiom (cf. vanilla ch14a Rennac's two `CHAR` entries).
+Verified in-engine: `PT_HOST_CHAPTER=4 run.sh ch03talk` — park a candidate adjacent to green Trex, drive
+Talk → Trex leaves the green array and lands in blue (`blue[09]=0x1C`).
+
+**Entrance + recruit are DECOUPLED from the RBG-execution beat** (the vanilla Colm shape). Colm's on-map
+appearance is a LIGHT turn-1 green-NPC beat (one line); ALL his substance rides the Talk
+(`EventScr_Ch3_Talk_NeimiColm`) — there is no second cutscene that re-introduces him. We now match that:
+the ch03 RBG-execution beat is RBG's alone (+ Wolfram), and Trex's disavowal/boast/deal MOVED to the talk.
+**Why (the bug this fixes):** a freely-timed talk recruit and a fixed Brute-defeat cutscene fire in either
+order, so bolting Trex's introduction onto the execution beat let a player who talked to green Trex first
+recruit him *before* the cutscene "introduced" him — his line even thanked RBG for an execution that hadn't
+happened. The talk line is reframed to "the wild ones — the ones your bounty names" so it is accurate from
+turn 1 with zero kills (the bounty, not a kill count, is the town-trust thread). The light entrance beat
+(Pinky's telegraph + RBG's "little dragon") rides the #23 Cutscenes item with the other scripted beats.
+_Decided: 2026-07-08 (recruit model; Baxby + Trex the first two consumers) + 2026-07-09 (Nicolas + CLAUDE;
+#23 item 2 — talker=any-core-member RESOLVED, Colm-style decouple, talk-recruit wired + verified in-engine)._
 
 **Reward/item budget: a chapter's loot mirrors its `parity_reference` vanilla chapter — same as its enemies.**
 Just as `deploy_limit` and the enemy roster track the parity-reference chapter (§Field parity), so does

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -4010,6 +4010,68 @@ def offmap_join_recruits(campaign, chapter_number):
     return out
 
 
+def char_symbol(slot):
+    """The CHARACTER_ enum for a vanilla character slot name (the unit's on-map pid/FID
+    symbol). A cast PC rides its PORTRAIT_MAP slot, so its map identity is CHARACTER_<slot>."""
+    return 'CHARACTER_%s' % slot.upper()
+
+
+def on_map_talk_recruits(campaign, chapter_number):
+    """Cast members recruited MID-MAP via Talk IN `chapter_number` (the mirror of
+    offmap_join_recruits): recruits whose recruit chapter IS this chapter and whose join
+    method is an on-map talk (recruit.via in ON_MAP_RECRUIT_VIA). Returns
+    [(unit_id, slot, class_enum, deploy_class_enum, level)] in PORTRAIT_MAP order. Each is
+    placed GREEN and joined by a CHAR talk -> CUSA (the vanilla Colm/Neimi pattern, #23 item 2)."""
+    out = []
+    for unit_id, slot in PORTRAIT_MAP.items():
+        unit = load_unit(campaign, unit_id)
+        unit.setdefault('id', unit_id)
+        class_enum = class_enum_for(unit)
+        if class_enum is None:
+            continue
+        if recruit_chapter_number(campaign, unit) != chapter_number:
+            continue   # not recruited in THIS chapter
+        if (unit.get('recruit') or {}).get('via') not in ON_MAP_RECRUIT_VIA:
+            continue   # off-map recruit -- joins via offmap_join_recruits, not an on-map talk
+        out.append((unit_id, slot, class_enum, deploy_class_for(unit),
+                    int(unit.get('fe_stats', {}).get('level', 1))))
+    return out
+
+
+def talk_recruiters(campaign, chapter_number):
+    """The candidate RECRUITERS for an on-map talk recruit in chapter N = every core party
+    member on the blue field roster (cast_available_at(N) = _classed_cast(available_at=N)),
+    as CHARACTER_ symbols. "Talker = ANY core party member" (Nicolas, 2026-07-08: the only
+    thief must be non-missable, and a static CHAR can't name the CHOSEN lord) -> one CHAR
+    entry per candidate, all -> the shared recruit script."""
+    cast, _ = _classed_cast(campaign, available_at=chapter_number)
+    return [char_symbol(slot) for _, slot, *_ in cast]
+
+
+def talk_recruit_char_entries(recruiters, target, flag, script):
+    """One CHAR(flag, script, recruiter, target) per recruiter -- FE8's multi-recruiter talk
+    idiom (cf. vanilla ch14a Rennac: two CHAR entries sharing a flag). All share flag + script
+    + target, so ANY recruiter's talk recruits `target` and completing it sets the shared flag,
+    disabling every entry (no re-trigger)."""
+    return ''.join('    CHAR(%s, %s, %s, %s)\n' % (flag, script, r, target)
+                   for r in recruiters)
+
+
+def talk_recruit_script(msg_id, target):
+    """The shared Colm-style talk-recruit script (cf. vanilla EventScr_Ch3_Talk_NeimiColm):
+    show the migrated talk line, CUSA the green `target` to BLUE (EvtChangeFaction), set the
+    map-event visibility evbit, end. MUSS/STAL are trimmed -- the line rides the map talk
+    window, not a fanfare."""
+    return ('{\n'
+            '    TEXTSTART\n'
+            '    TEXTSHOW(0x%X)\n'
+            '    TEXTEND\n'
+            '    REMA\n'
+            '    CUSA(%s) /* green -> blue: the talk recruits the target */\n'
+            '    EVBIT_T(7)\n'
+            '    ENDA\n}' % (msg_id, target))
+
+
 def _ally_unit_entry(leader, slot, class_enum, level, x, y, items, comment,
                      allegiance='BLUE', autolevel=False, ai=None):
     """One non-RED UnitDefinition row (events_udefs.c) for a chapter join/deploy/
@@ -5277,6 +5339,15 @@ CH03_ITEM_IDS = {'iron-axe': 'ITEM_AXE_IRON', 'hand-axe': 'ITEM_AXE_HANDAXE',
 CH03_SPAWN_POSITIONS = [(1, 10), (1, 11), (1, 12), (1, 9), (1, 8), (2, 8), (0, 10), (0, 12),
                         (2, 11)]
 CH03_TREX_GREEN_POS = (10, 6)   # mid-galleries: Trex sits green (unrecruited) until talked to
+# Trex talk-recruit wiring (#23 item 2) -- the vanilla Colm/Neimi pattern. Repurpose dead
+# vanilla Ch4 symbols the host frees: EventScr_089F199C is the Ch4 Turn-2 green script (its
+# only referrer was EventListScr_Ch4_Turn, emptied by the host) -> the shared recruit script;
+# 0x9A5 is a dead Ch4 opening-cutscene line (referenced only by the replaced BeginningScene,
+# like the boss-death 0x9A3) -> the talk body; EVFLAG_TMP(9) is vanilla ch3 Colm's own CHAR
+# talk flag, unused in our minimal host.
+CH03_TREX_TALK_SCRIPT = 'EventScr_089F199C'
+CH03_TREX_TALK_MSG = 0x9A5
+CH03_TREX_TALK_FLAG = 'EVFLAG_TMP(9)'
 CH4_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventinfo.h')
 CH4_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventscript.h')
 
@@ -5289,10 +5360,12 @@ def inject_ch03(campaign, verbose=True):
 
     The DefeatBoss(grell) WIN is wired: Misc DefeatBoss AFEV + the grell's flagged (EVFLAG_DEFEAT_BOSS)
     defeat quote + a minimal ending script (victory -> dev-placeholder landing until ch04 hosts).
-    DEFERRED (next passes, flagged not done): the real PREP deploy (needs deployment.deploy_slots
-    authored in the YAML); the opening/recruit/ending CUTSCENES (dialogue-pass on the #97 beats + the
-    2026-07-06 reframe) + chaining ch02->ch03; Trex recruit; chests/doors; title-card art; enemy/boss
-    art. Boot: --ch03-boot points New Game straight here (mirrors the TESTCH sandbox, on slot 4 + cave)."""
+    Trex's TALK RECRUIT (#23 item 2) is wired: he stands GREEN (step 2); ANY core party member Talks
+    to him -> the shared recruit script CUSA-flips him BLUE (the Colm/Neimi pattern -- one CHAR entry
+    per field candidate). DEFERRED (next passes, flagged not done): the real PREP deploy (needs
+    deployment.deploy_slots authored in the YAML); the opening/execution/entrance/ending CUTSCENES
+    (dialogue-pass, decoupled from the recruit) + chaining ch02->ch03; chests/doors; title-card art;
+    enemy/boss art. Boot: --ch03-boot points New Game straight here (like the TESTCH sandbox, slot 4)."""
     maps_dir = os.path.join(REPO, 'campaigns', campaign, 'maps')
     chap = _load_chapter_yaml(campaign, CH03_CHAPTER_YAML)
 
@@ -5321,14 +5394,20 @@ def inject_ch03(campaign, verbose=True):
         for (uid, slot, ce, dce, lv), (x, y) in zip(cast, CH03_SPAWN_POSITIONS)]
     # Trex: the chapter's on-map recruit, placed GREEN (Colm-style) at the galleries. He is a
     # classed cast member (full cast, not available_at(3)); pull his slot/class from the roster.
-    trex_full = next(c for c in _classed_cast(campaign)[0] if c[0] == 'trex')
-    _, tslot, _, tdce, tlv = trex_full
+    (trex_uid, tslot, _, tdce, tlv), = on_map_talk_recruits(campaign, chap['chapter_number'])
     tx, ty = CH03_TREX_GREEN_POS
     ally_rows.append(_ally_unit_entry(
         leader, tslot, tdce, tlv, tx, ty, '0',
-        ' /* trex -- green talk-recruit (Colm-style; CUSA on talk, #23 item 4) */',
+        ' /* trex -- green talk-recruit (Colm-style; CUSA on talk, #23 item 2) */',
         allegiance='GREEN'))
     ally = '{\n' + '\n'.join(ally_rows) + '\n    { 0 },\n}'
+    # Trex talk-recruit (#23 item 2): ONE CHAR entry per core-party candidate (talker = ANY
+    # core party member -> the ch03 field roster), all -> the shared recruit script (CUSA flips
+    # green Trex blue). FE8's multi-recruiter idiom (cf. vanilla ch14a Rennac). Trex rides Rennac.
+    trex_char = char_symbol(tslot)
+    char_events = ('{\n' + talk_recruit_char_entries(
+        talk_recruiters(campaign, chap['chapter_number']),
+        trex_char, CH03_TREX_TALK_FLAG, CH03_TREX_TALK_SCRIPT) + '    END_MAIN\n}')
 
     enemies = []
     for e in chap['enemy_units']:
@@ -5359,8 +5438,10 @@ def inject_ch03(campaign, verbose=True):
     #    CauseGameOverIfLordDies = AFEV on EVFLAG_GAMEOVER (the lord's flagged quote / lord-select hook).
     with open(CH4_EVENTINFO_H, encoding='utf-8') as f:
         info = f.read()
-    for name in ('EventListScr_Ch4_Turn', 'EventListScr_Ch4_Character', 'EventListScr_Ch4_Location'):
+    for name in ('EventListScr_Ch4_Turn', 'EventListScr_Ch4_Location'):
         info = _replace_brace_block(info, name + '[] =', '{\n    END_MAIN\n}', CH4_EVENTINFO_H)
+    # Character events = the Trex talk-recruit (#23 item 2): the CHAR-per-candidate list.
+    info = _replace_brace_block(info, 'EventListScr_Ch4_Character[] =', char_events, CH4_EVENTINFO_H)
     info = _replace_brace_block(
         info, 'EventListScr_Ch4_Misc[] =',
         '{\n    DefeatBoss(%s)\n    CauseGameOverIfLordDies\n    END_MAIN\n}' % CH03_ENDING_SCRIPT,
@@ -5386,6 +5467,11 @@ def inject_ch03(campaign, verbose=True):
               + dev_placeholder_scene() +
               '    ENDA\n}')
     script = _replace_brace_block(script, CH03_ENDING_SCRIPT + '[] =', ending, CH4_EVENTSCRIPT_H)
+    # Trex talk-recruit script (#23 item 2): repurpose the dead Ch4 Turn-2 green script symbol
+    # -> show Trex's migrated talk line then CUSA green Trex to blue. Every CHAR entry (step 3)
+    # points here, so ANY core party member's talk runs it (the vanilla Colm/Neimi shape).
+    script = _replace_brace_block(script, CH03_TREX_TALK_SCRIPT + '[] =',
+                                  talk_recruit_script(CH03_TREX_TALK_MSG, trex_char), CH4_EVENTSCRIPT_H)
     with open(CH4_EVENTSCRIPT_H, 'w', encoding='utf-8') as f:
         f.write(script)
 
@@ -5401,6 +5487,12 @@ def inject_ch03(campaign, verbose=True):
     set_message_body(lines, host['chapTitleTextId'], name_message_body(chap['title']))
     set_message_body(lines, CH03_BOSS_DEATH_MSG, _script_to_message(
         [{'grell': shriek}], {'grell': ('[OpenMidRight]', None)}))
+    # Trex talk-recruit body (#23 item 2): his migrated pitch (chapter YAML talk_recruit event,
+    # single source of truth), faced on the Rennac slot. One speaker -> one [OpenX] block with
+    # page breaks; the recruit script (EventScr_089F199C) TEXTSHOWs it before the CUSA.
+    talk = next(e for e in chap['events'] if e.get('trigger') == 'talk_recruit')['script']
+    set_message_body(lines, CH03_TREX_TALK_MSG, _script_to_message(
+        talk, {trex_uid: ('[OpenMidRight]', _fid_tag(tslot))}))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
 

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -3082,6 +3082,69 @@ scenarios.ch03win = function()
     result("PASS", "grell killed -> EVFLAG_DEFEAT_BOSS set -> DefeatBoss ending ran to title (ch03 win wired)")
 end
 
+-- CH03TALK (#23 item 2): prove Trex's TALK-RECRUIT flips him GREEN -> BLUE (the CUSA fires). Boot
+-- the ch03 map, PARK the leader on a free tile adjacent to green Trex (the setMapUnit dance keeps
+-- the occupancy grid in sync, so cursor-select + Talk-adjacency both work with no phase cycle --
+-- same trick ch03win uses to park the grell), then drive the Talk command and assert Trex leaves
+-- the green array and joins the blue one. Run: PT_HOST_CHAPTER=4 run.sh ch03talk (needs CH03BOOT=1).
+scenarios.ch03talk = function()
+    if not bootToMap() then return result("FAIL", "never reached the ch03 map") end
+    local CHAR_TREX = 0x1C -- CHARACTER_RENNAC (Trex rides the Rennac slot)
+    -- ch03 deploys 9+ blue units, so scan the full blue array (blue() only checks the ch00
+    -- 8-slot party -> a recruit at a higher index would be missed).
+    local function blueTrex() return findUnit(SYM.gUnitArrayBlue, 20, CHAR_TREX) end
+    local trex = findUnit(SYM.gUnitArrayGreen, 12, CHAR_TREX)
+    if not trex then return result("FAIL", "green Trex (0x1C) not found in the green array") end
+    if blueTrex() then return result("FAIL", "Trex is already blue before any talk") end
+    local rec = blue(0x01) -- the leader is always deployed and is a recruit candidate
+    if not rec then return result("FAIL", "leader (0x01) not deployed") end
+    log(string.format("green Trex at (%d,%d); recruiter at (%d,%d)", trex.x, trex.y, rec.x, rec.y))
+    shot("ch03talk-green")
+    -- Park the recruiter on a free tile orthogonally adjacent to Trex.
+    local rgrid = mapUnitAt(rec.x, rec.y)
+    local parked = false
+    for _, d in ipairs({ { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }) do
+        local tx, ty = trex.x + d[1], trex.y + d[2]
+        if tx >= 0 and tx <= 24 and ty >= 0 and ty <= 15 and mapUnitAt(tx, ty) == 0 then
+            setMapUnit(rec.x, rec.y, 0)
+            emu:write8(rec.addr + 0x10, tx); emu:write8(rec.addr + 0x11, ty)
+            setMapUnit(tx, ty, rgrid)
+            log(string.format("recruiter parked at (%d,%d), adjacent to Trex (%d,%d)", tx, ty, trex.x, trex.y))
+            parked = true
+            break
+        end
+    end
+    if not parked then return result("FAIL", "no free tile adjacent to Trex to park the recruiter") end
+    -- Select the recruiter (no move) -> command menu. Adjacent to a talkable green with a matching
+    -- CHAR entry, Talk is the first special row (fast-boot is weaponless, so no Attack precedes it).
+    rec = blue(0x01)
+    waitFor(function() return faction() == 0 and not menuOpen() end, 300, true)
+    if not moveUnit(rec.x, rec.y, rec.x, rec.y) then
+        shot("ch03talk-no-menu")
+        return result("FAIL", "could not open the recruiter's command menu")
+    end
+    wait(30); shot("ch03talk-menu")
+    press(K.A, 4); wait(50) -- top row = Talk (when adjacent to the recruitable green)
+    shot("ch03talk-dialogue-1") -- Trex's migrated talk lines rendering in-engine
+    for i = 1, 60 do        -- advance the talk line through to the CUSA, grabbing each page
+        if blueTrex() then break end
+        if i <= 4 then wait(30); shot(string.format("ch03talk-dialogue-p%d", i + 1)) end
+        press(K.A, 3); wait(20)
+    end
+    wait(30); shot("ch03talk-after")
+    for i = 0, 19 do -- dump the full blue roster so the flip is unambiguous
+        local u = unitAt(SYM.gUnitArrayBlue, i)
+        if u then log(string.format("  blue[%02d] char=0x%02X pos=(%d,%d)", i, u.charId, u.x, u.y)) end
+    end
+    local nowBlue = blueTrex() ~= nil
+    local stillGreen = findUnit(SYM.gUnitArrayGreen, 12, CHAR_TREX) ~= nil
+    log(string.format("post-talk: Trex blue=%s stillGreen=%s", tostring(nowBlue), tostring(stillGreen)))
+    if not nowBlue then
+        return result("FAIL", "Trex did not join the blue army after Talk -- CUSA did not fire")
+    end
+    return result("PASS", "Talk -> CUSA: Trex flipped GREEN -> BLUE (talk-recruit wired, #23 item 2)")
+end
+
 -- KOBOLDVIEW (#23 art): pull the enemy kobolds ON-SCREEN next to the party so their reskinned
 -- map sprites are visible (the roster deploys off-camera at the enemy tiles). Teleports the first
 -- few red brigand generics (pid 0xaa) to tiles around braulo's spawn and screenshots. No combat.

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -198,6 +198,56 @@ class RecruitAvailability(unittest.TestCase):
         self.assertIn(class_enum, bc.CLASS_LOADOUT)   # the join-LOAD arms him from CLASS_LOADOUT
 
 
+class TalkRecruitWiring(unittest.TestCase):
+    """Trex's Colm-style talk recruit (#23 item 2): placed GREEN, recruited when ANY core
+    party member Talks to him (one CHAR entry per candidate -> one shared script -> CUSA).
+    These pin the pure data + string builders inject_ch03 consumes."""
+
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def test_char_symbol_from_slot(self):
+        self.assertEqual(bc.char_symbol('Rennac'), 'CHARACTER_RENNAC')
+        self.assertEqual(bc.char_symbol('Eirika'), 'CHARACTER_EIRIKA')
+
+    def test_trex_is_ch03_on_map_talk_recruit_on_the_rennac_slot(self):
+        """on_map_talk_recruits(N) = the recruits who join mid-map via Talk in chapter N."""
+        rows = bc.on_map_talk_recruits(self.CAMPAIGN, 3)
+        self.assertEqual([r[0] for r in rows], ['trex'])
+        uid, slot, class_enum, deploy_class, level = rows[0]
+        self.assertEqual(slot, 'Rennac')                 # Trex's on-map CHARACTER symbol slot
+        self.assertEqual(class_enum, 'CLASS_THIEF')
+
+    def test_no_talk_recruit_in_a_chapter_without_one(self):
+        """ch02 has no on-map talk recruit (Baxby is an off-map cutscene recruit)."""
+        self.assertEqual(bc.on_map_talk_recruits(self.CAMPAIGN, 2), [])
+
+    def test_recruiters_are_the_ch03_field_roster_minus_trex(self):
+        """Talker = ANY core party member -> the ch03 blue field roster (cast_available_at(3)).
+        Trex himself is never a recruiter (he is the green target, not on the prep roster)."""
+        recruiters = bc.talk_recruiters(self.CAMPAIGN, 3)
+        field = {bc.char_symbol(slot) for _, slot, *_ in bc._classed_cast(self.CAMPAIGN, available_at=3)[0]}
+        self.assertEqual(set(recruiters), field)
+        self.assertNotIn('CHARACTER_RENNAC', recruiters)   # the target isn't a recruiter
+        self.assertGreaterEqual(len(recruiters), 8)        # the founding party at least
+
+    def test_char_entries_one_per_recruiter_sharing_flag_and_script(self):
+        """The talker-agnostic wiring: one CHAR(flag, script, recruiter, target) per candidate,
+        all pointing at the SAME flag + script + target (so any one talk recruits + disables all)."""
+        recruiters = ['CHARACTER_EIRIKA', 'CHARACTER_FRANZ', 'CHARACTER_GILLIAM']
+        c = bc.talk_recruit_char_entries(recruiters, 'CHARACTER_RENNAC',
+                                         'EVFLAG_TMP(9)', 'EventScr_TrexTalk')
+        self.assertEqual(c.count('CHAR('), 3)
+        for r in recruiters:
+            self.assertIn('CHAR(EVFLAG_TMP(9), EventScr_TrexTalk, %s, CHARACTER_RENNAC)' % r, c)
+
+    def test_recruit_script_flips_the_target_blue_with_cusa(self):
+        """The shared script shows the talk line then CUSA(target) = EvtChangeFaction to BLUE."""
+        s = bc.talk_recruit_script(0x9A5, 'CHARACTER_RENNAC')
+        self.assertIn('TEXTSHOW(0x9A5)', s)
+        self.assertIn('CUSA(CHARACTER_RENNAC)', s)
+        self.assertTrue(s.rstrip().endswith('ENDA\n}') or s.rstrip().endswith('ENDA'))
+
+
 class LordFloorRows(unittest.TestCase):
     """The per-lord survivability-floor table (#45 3b) the build emits as gLordFloorDeltas[]
     and the engine applies once at chapter start (#45 3c). One (hp, def, res) row per lord


### PR DESCRIPTION
## What
Wires Trex's mid-map recruit (#23 **item 2**) as the vanilla **Colm/Neimi** pattern: he stands **GREEN**, and **any core party member** who **Talks** to him flips him blue via `CUSA`. Non-missable (he's the army's only thief) — one `CHAR` entry per ch03 field candidate (`talk_recruiters` = `cast_available_at(3)`), all sharing one recruit script + flag (FE8's own multi-recruiter idiom, cf. vanilla ch14a Rennac). Trex rides the Rennac slot; the wiring repurposes dead ch4 symbols the host frees (`EventScr_089F199C` + msg `0x9A5` + `EVFLAG_TMP(9)`).

## Decouple (Nicolas)
The entrance + recruit are split **out of** the RBG-execution cutscene. Colm's on-map appearance is a light green-NPC beat and **all** his substance rides the Talk — no second cutscene re-introduces him. Ours now matches: the execution beat is RBG's alone (+ Wolfram), and Trex's disavowal/boast/deal **move to the talk**.

**Bug this fixes:** a freely-timed talk recruit and a fixed Brute-defeat cutscene fire in *either* order, so bolting Trex's intro onto the execution beat let a player who talked to green Trex first recruit him *before* the cutscene "introduced" him (and his line thanked RBG for an execution that hadn't happened). The talk line is reframed to *"the wild ones — the ones your bounty names"* so it reads true from turn 1 with zero kills.

## How
- `build_campaign`: `char_symbol`, `on_map_talk_recruits`, `talk_recruiters`, `talk_recruit_char_entries`, `talk_recruit_script` — all TDD'd (6 new tests).
- `inject_ch03`: populate `EventListScr_Ch4_Character` (CHAR-per-candidate) + the shared recruit script + the talk-body text (migrated lines; the chapter YAML is the single source of truth).
- ch03 YAML: split the bundled beat into a light `trex_entrance` + a `talk_recruit` event.
- `decisions.md`: talker = any-core-member **RESOLVED**; the Colm-style decouple ADR.

## Verification
- **In-engine (the real proof):** `PT_HOST_CHAPTER=4 tools/playtest/run.sh ch03talk` **PASS** — park a candidate adjacent to green Trex, drive Talk → Trex leaves the green array and lands in blue (`blue[09]=0x1C`). The command menu shows **Talk** at row 0; the migrated dialogue (with the bounty framing) renders in-engine.
- `make CH03BOOT=1` green; `mapshot` still boots the map with the populated Character list.
- `make difficulty CH=ch03` → **PARITY** (threat ×1.12, clear-load ×0.99, within band); the calc fields the 9-unit party and excludes Trex (mid-map recruit, like vanilla Colm).
- 64 `test_build_campaign` tests pass; `check.py` drift clean; `verify_text.py` clean (0 runaway).

## Notes / follow-ups (not this PR)
- The **real PREP screen** (enforcing `deploy_limit`, `deploy_slots`) is still **item 3** — today ch03 fast-boots the 9-unit roster statically. Trex is correctly **excluded** from `cast_available_at(3)` (joins mid-map, on top) and **included** from ch04 — so the cap already accounts for the recruit (vanilla "cap + Colm" == ours "cap + Trex").
- The recruit talk renders in the **map speech bubble** (no portrait box), canonical for on-map CHAR talks — can switch to the full portrait box (so Trex's bust shows) if wanted.
- The light `trex_entrance` (Pinky telegraph + RBG "little dragon") + the RBG-execution/opening/ending cutscenes ride the **#23 Cutscenes** item.

Advances #23 (item 2). Slice stays open for prep / cutscenes / chests / art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
