### PR TITLE
ch03 chests + doors — tile-changes wired & in-engine verified (#23)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,54 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 `git log --oneline -20` + closed issues, not here. **Backlog** → GitHub issues. **Decisions** →
 `docs/decisions.md`. **Operating instructions** → `CLAUDE.md`. Run `/handoff` to refresh this file in place.
 
-> **Last session (2026-07-11 #2, VSCode/remote — ⭐ CH02→CH03 CHAIN wired; PR #154 OPEN (awaiting Nicolas's merge), `feat/23-chain-ch02-ch03`.):**
+> **Last session (2026-07-11 #3, VSCode/remote — ⭐ CH03 CHESTS + ch02 RED-GEM FIX on `feat/23-ch03-chests` (WIP, pushed, NOT yet a PR). main @ recordchain #155 merged. CURRENT BRANCH = `feat/23-ch03-chests`; check it out to continue.):**
+> **ch02 RED-GEM BUG FIXED (Nicolas caught it in the chain GIF — the Red Gem was still gifted in ch02).** Root cause =
+> the gift was declared in THREE places that drifted: the ch02 YAML `green_allies[].gift: hand-axe` (CORRECT, per the
+> ch02↔ch03 swap ADR) but a hardcoded `CH02_CHWINGA` Python tuple **and** a duplicate `charm_gifts.gifts` YAML block both
+> still said `red-gem` — and the build emitted the stale tuple. **FIX (single source of truth):** `inject_ch02` now reads
+> the gift from `green_allies[].gift` (with a build-time guard that every gift resolves + ids match); dropped the tuple's
+> gift field + the duplicate `charm_gifts` block; harness `CH02_CHARMS` 0x76→**0x28** (Hand Axe). **VERIFIED IN-ENGINE:**
+> `clear_ch02` PASS — Mote now gifts **Hand Axe / Elixir / Pure Water**; Red Gem freed for ch03. Committed `5f54a34`.
+> **⭐ CH03 CHESTS WIRED (#23 — BUILDS + LINKS CLEAN; IN-ENGINE VERIFY PENDING).** 4 chests at the **vanilla Ch3 Borgo
+> coords 1:1** (pulled from `git -C fireemblem8u show HEAD:src/events/ch3-eventinfo.h`): `Chest(ITEM_LANCE_IRON,6,3)`,
+> `Chest(ITEM_SWORD_IRON,10,3)`, `Chest(ITEM_LANCE_JAVELIN,6,12)`, **`Chest(ITEM_REDGEM,8,3)`** — (8,3) is vanilla's
+> Hand-Axe tile = our **Tourmaline** (the swap is coordinate-perfect). Positions authored in the ch03 YAML `chests:`;
+> emitted into `EventListScr_Ch4_Location[]`. **The 17→29 open flip** (Nicolas's vendored FF5 navy chest: closed metatile
+> 17 / open 29, painted at G3/I3/K3/G12): new helper `_inject_ch03_chest_map_changes` writes **`MS_Ch03ChestMapChanges`**
+> asm to `const_data_chapter_maps.s` (one 1×1 `MapChange` per chest, tile = **29<<2 = 116**), registers it as a fresh
+> `gChapterDataAssetTable` word, and sets slot-4 `changeLayerId=246`. Committed `598f0ce`.
+> **⭐⭐ THE DECODED FE8 CHEST/DOOR MECHANISM (reference — don't re-derive):** `Chest(item,x,y)`/`Door_(x,y)` (Main_Code_Helpers.h)
+> are Location tile-commands; `IsThereClosedChestAt` reads the Location list. Open flow: `ActionPick` (bmusemind.c) →
+> `StartAvailableChestTileEvent` → `StartAvailableTileEvent` → `TILE_COMMAND_CHEST` → **`CallChestOpeningEvent(GetMapChangeIdAt(x,y), item)`**
+> (gives item + applies the tilechange); doors → `CallTileChangeEvent(GetMapChangeIdAt(x,y))` + `SetFlag`. `struct MapChange`
+> (types.h) = `{s8 id; u8 xOrigin,yOrigin,xSize,ySize; u8 pad[3]; const void* data(→u16 tiles);}` (12 B, list terminated
+> by id<0). **`GetMapChangeIdAt(x,y)` auto-finds the change whose region covers the tile — position-matched, no id wiring.**
+> `GetChapterMapChangesPointer(ch) = gChapterDataAssetTable[chapterStruct.map.changeLayerId]`. **TILE ENCODING:**
+> `gBmMapBaseTiles` holds `metatile<<2` (.mar = metatile<<5, `mar_to_map` >>3 → <<2; confirmed vs vanilla `Ch3MapChanges`
+> 2616=654<<2). So an open metatile N → tile `N<<2`.
+> **TOURMALINE ITEM (ITEM_REDGEM reskin, Nicolas asked).** NAME **done** (`campaign.yaml item_names: ITEM_REDGEM: "Tourmaline"`
+> via `inject_item_names`, the Goodberry=Vulnerary precedent). **PINK ICON = IN PROGRESS via the palette-1 route (Nicolas
+> was RIGHT to push):** FE8 item icons share ONE palette (pal 0, bank `0x4000`) — **no per-item palette field** in `ItemData`;
+> all draws hardcode `0x4000` (bmitem.c:416+). Pal 0 has **no pink** + every index is used by 75-224 icons (no free slot).
+> **BUT a 2nd item palette (pal 1) is loaded at bank `0x5000`** (`bm.c:592 LoadIconPalettes(4)`) and is **UNUSED by item
+> icons → free to repaint.** **PLAN:** (a) repaint pal 1 (2nd 16-color pal in `graphics/item_icon/item_icon_palette.agbpal`)
+> with a pink gem gradient; (b) author `campaigns/.../item_icons/tourmaline.png` (16×16 mode-P) on pal-1's pink indices +
+> `campaign.yaml item_icons: ITEM_REDGEM: tourmaline`; (c) ONE generic hook in `tools/inject/engine_hooks.py` patching
+> `DrawIcon` (icon.c:94 `u16 Tile = GetIconTileIndex(IconIndex) + OamPalBase;`) to `OamPalBase |= 0x1000` (→ bank 5 = pal 1)
+> for icon-ids in a small campaign-injected list; **tourmaline icon-id = 136** (`item_icon_id('ITEM_REDGEM')`) goes in it.
+> Boundary-clean (generic mechanism + campaign-data id list); register the hook in `check.py` guards. Zero collateral on
+> other items. (Earlier dead-ends: recolour within pal 0 → reads brown/taupe, no real pink; no globally-free pal-0 index.)
+> **DOORS — OPEN QUESTION (blocker):** doors need an **open-door metatile** for their tilechange — `ch03-retile.py:39`
+> maps the CLOSED door → tile 812 and notes "813+814 = double" but designates no single OPEN-door tile. **ASK Nicolas /
+> find the open-door tile in the cave-interior tileset, or make an opened door become a passable floor tile.** Then
+> `Door_(x,y)` at vanilla coords (6,10)/(10,5)/(2,3) + a MapChange to the open tile (reuse the chest map-change mechanism).
+> Doors gate the chest rooms in Borgo → needed for real-play reachability (chests are verifiable via teleport regardless).
+> **NEXT (priority):** (1) **verify chests in-engine** — a new scenario (or extend `ch03talk`): teleport Trex onto a chest
+> → open → assert the item lands in inventory/convoy AND `gBmMapBaseTiles` flips 17→29. (2) **pink Tourmaline icon** via the
+> palette-1 hook above. (3) **doors** (needs the open-door tile). Then PR `feat/23-ch03-chests`. `make`/`verify_text`/tests
+> green through all commits so far.
+>
+> **Prior session (2026-07-11 #2, VSCode/remote — ⭐ CH02→CH03 CHAIN wired; PR #154 SQUASH-MERGED; `recordchain` PR #155 SQUASH-MERGED; `feat/23-chain-ch02-ch03` deleted. main advanced.):**
 > **THE CAMPAIGN NOW FLOWS ch02 → ch03.** ch02's ending `MNC2(0x4)`s straight into ch03 (slot 4), retiring the
 > dev-placeholder→title landing it parked on while ch03 was unbuilt. Two coupled moves in `build_campaign.main()`:
 > (a) **`inject_ch03` now runs in EVERY non-boot build** (hosted alongside `inject_ch02`, and in the `--test-chapter`
@@ -353,13 +400,16 @@ how-to for the host machinery = `docs/adding-a-chapter.md`.**
   `0xb6` + a silent flagged `gDefeatTalkList` entry → `EVFLAG_TMP(10)` → a Misc `AFEV(EVFLAG_TMP(11), midmap, EVFLAG_TMP(10))`
   fires the on-map cutscene once, chapter continues). 7-beat restage + the Brute's custom mug (Caellach guest slot, zoom 0.70).
   See the top block for the full detail + the on-map-cutscene-rendering ADR.
-- **✅ DONE — Chain ch02→ch03 (PR #154, OPEN — awaiting Nicolas's merge):** ch02's ending `MNC2(0x4)`s into ch03;
-  `inject_ch03(boot=False)` hosted in every non-boot build (persistent ch02 party feeds PREP, seed dropped). Verified
-  in-engine (`clear_ch02` lands on ch03, chapter=4). ch03's OWN ending still parks on the dev-placeholder until ch04
-  hosts (replace with the real ending cutscene then). See the top block + `decisions.md` Ch3-chains ADR.
+- **✅ DONE (PR #154, MERGED) — Chain ch02→ch03:** ch02's ending `MNC2(0x4)`s into ch03; `inject_ch03(boot=False)`
+  hosted in every non-boot build (persistent ch02 party feeds PREP, seed dropped). Verified in-engine (`clear_ch02`
+  lands on ch03, chapter=4). ch03's OWN ending still parks on the dev-placeholder until ch04 hosts. `decisions.md` Ch3-chains ADR.
+- **🔨 IN PROGRESS — Chests + Tourmaline (`feat/23-ch03-chests`, WIP branch, pushed, not PR'd):** 4 chests wired at
+  vanilla Borgo coords with the FF5-navy `17→29` open flip (builds+links clean, **in-engine verify PENDING**); the ch02
+  Red-Gem→Hand-Axe swap FIXED + verified; Tourmaline NAME done; pink icon + doors remain. **Full detail in the top block.**
 - **⭐ REMAINING (unchecked on #23):**
-  1. **Chests/doors** — per-chest **`17→29` TILECHANGE**; Trex opens, key-droppers back up.
-  2. **Title-card** (replace the vanilla slot-4 **"Za'ha Woods"** placeholder that shows at chapter start) — **couple this
+  1. **Chests/doors** — chest wiring done (verify in-engine next); **DOORS need an open-door metatile** (top block); Trex opens, key-droppers back up.
+  2. **Tourmaline pink icon** — palette-1 repaint + `DrawIcon` bank-bump hook (top block).
+  3. **Title-card** (replace the vanilla slot-4 **"Za'ha Woods"** placeholder that shows at chapter start) — **couple this
      with the opening map-flash fix** (both are the same `gProcScr_ChapterIntro` sequence). + full load-test scenarios
      `ch03`/`smoke_ch03`/`clear_ch03` (the `ch03prep`/`ch03win`/`ch03talk`/`koboldview`/`enemycheck` scenarios seed these;
      a fair-play `clear_ch03` needs a `CA_BOSS` grell or a pid-targeted bot).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,7 +4,27 @@ The **single** live-state doc (one trunk, feature-flow — no per-lane handoffs)
 `git log --oneline -20` + closed issues, not here. **Backlog** → GitHub issues. **Decisions** →
 `docs/decisions.md`. **Operating instructions** → `CLAUDE.md`. Run `/handoff` to refresh this file in place.
 
-> **Last session (2026-07-11 #3, VSCode/remote — ⭐ CH03 CHESTS + ch02 RED-GEM FIX on `feat/23-ch03-chests` (WIP, pushed, NOT yet a PR). main @ recordchain #155 merged. CURRENT BRANCH = `feat/23-ch03-chests`; check it out to continue.):**
+> **Last session (2026-07-11 #4, VSCode/remote — ⭐ CH03 DOORS wired + BOTH chests & doors IN-ENGINE VERIFIED on `feat/23-ch03-chests` (WIP, pushed @ `66b6d5b`, NOT yet a PR — pink Tourmaline icon is the last in-scope item before the PR). CURRENT BRANCH = `feat/23-ch03-chests`.):**
+> **⭐ CH03 DOORS DONE + VERIFIED IN-ENGINE.** The 3 vanilla Ch3 doors (`Door_(6,10)/(10,5)/(2,3)`) are wired as
+> thief/key doors that **open to the passable floor tile DIRECTLY BELOW the door cell** (Nicolas's answer: "the tile
+> directly adjacent and below it") — read off the painted `.mar` at build time (`_read_map_metatile`, drift-proof,
+> no hand-copied tile numbers). On the committed map that's 572/626/492 (road / stairs-down / road, all passable).
+> **Doors ride the SAME per-chapter MapChange array as the chests** — `GetMapChangeIdAt` matches by POSITION, so
+> `Chest()`/`Door_()` coexist in one `MS_Ch03MapChanges` (ids 0-3 chests → shared 17→29; ids 4-6 doors → per-door
+> below-tile). Generalized `_inject_ch03_chest_map_changes` → **`_inject_ch03_tile_changes`** with a pure
+> `_ch03_tile_changes_asm` builder + `_read_map_metatile` reader (6 new unit tests, 81 total green). Authored as a
+> `doors:` position list in the ch03 YAML. Committed `9907324`.
+> **⭐⭐ BOTH CHESTS & DOORS NOW VERIFIED IN-ENGINE (closes the handoff's #1 pending item).** Two new PASS/FAIL
+> scenarios read `gBmMapBaseTiles` ground truth (`gBmMapBaseTiles` is a ROM-`.data` pointer @ **0x085AF5DC** →
+> the EWRAM `sBmBaseTilesPool` row array, never reassigned — read the ROM pointer, index the rows; the layout-guess
+> at gBmMapUnit+0x20 was WRONG, cost one probe): **`ch03door`** (hand a unit a Door Key, drive Door → tile flips
+> 3248→1968 = 812→492<<2) and **`ch03chest`** (Chest Key, teleport onto the (6,3) chest, drive Chest → tile flips
+> 68→116 = 17→29 **AND the Iron Lance lands in inventory**). Both PASS. The menu is `[Door/Chest, Item, Wait]` with
+> the weapon stripped, so the special command is row 0 (deterministic). Committed `66b6d5b`. ADR in `decisions.md`.
+> **REMAINING in-scope on this branch before PR: the pink Tourmaline icon** (palette-1 repaint + `DrawIcon` bank-bump
+> hook — full plan in the prior block below). Then title-card + load-test scenarios can be a follow-up branch.
+>
+> **Prior session (2026-07-11 #3, VSCode/remote — ⭐ CH03 CHESTS + ch02 RED-GEM FIX on `feat/23-ch03-chests`):**
 > **ch02 RED-GEM BUG FIXED (Nicolas caught it in the chain GIF — the Red Gem was still gifted in ch02).** Root cause =
 > the gift was declared in THREE places that drifted: the ch02 YAML `green_allies[].gift: hand-axe` (CORRECT, per the
 > ch02↔ch03 swap ADR) but a hardcoded `CH02_CHWINGA` Python tuple **and** a duplicate `charm_gifts.gifts` YAML block both
@@ -302,7 +322,9 @@ ADR: `decisions.md` §Distribution.
   - logic/stability: `win|gameover|ch01win|clear|clear_ch01|smoke|smoke_ch01|fuzz`
   - **ch3 (#23):** `PT_HOST_CHAPTER=4 run.sh mapshot` (map+units) · **`ch03prep`** (Preparations opens → Fight!
     fields 9 at the deploy_slots, Trex green) · **`ch03win`** (kill grell → assert `EVFLAG_DEFEAT_BOSS` → ending) ·
-    **`ch03talk`** (Trex green→blue via Talk) · **`koboldview`** (pull off-camera enemies next to the party) — all on
+    **`ch03talk`** (Trex green→blue via Talk) · **`ch03door`** (Door Key → open → tile flips to the below-cell) ·
+    **`ch03chest`** (Chest Key → open the (6,3) chest → tile flips 17→29 + Iron Lance granted) ·
+    **`koboldview`** (pull off-camera enemies next to the party) — all on
     a `make CH03BOOT=1` ROM (macOS: apply the `build.sh` shebang-fix loop first). `bootToMap` drives through PREP.
   - **LLM commander (#63):** `llm` — needs the sidecar running (`llm_player.py serve`; see run.sh header).
   - **ch2 (#22):** `ch02` · `smoke_ch02` · `clear_ch02` (all load a `ch02start` checkpoint).
@@ -403,12 +425,14 @@ how-to for the host machinery = `docs/adding-a-chapter.md`.**
 - **✅ DONE (PR #154, MERGED) — Chain ch02→ch03:** ch02's ending `MNC2(0x4)`s into ch03; `inject_ch03(boot=False)`
   hosted in every non-boot build (persistent ch02 party feeds PREP, seed dropped). Verified in-engine (`clear_ch02`
   lands on ch03, chapter=4). ch03's OWN ending still parks on the dev-placeholder until ch04 hosts. `decisions.md` Ch3-chains ADR.
-- **🔨 IN PROGRESS — Chests + Tourmaline (`feat/23-ch03-chests`, WIP branch, pushed, not PR'd):** 4 chests wired at
-  vanilla Borgo coords with the FF5-navy `17→29` open flip (builds+links clean, **in-engine verify PENDING**); the ch02
-  Red-Gem→Hand-Axe swap FIXED + verified; Tourmaline NAME done; pink icon + doors remain. **Full detail in the top block.**
+- **✅ DONE — Chests + Doors (`feat/23-ch03-chests`, WIP branch, pushed @ `66b6d5b`, not PR'd):** 4 chests + 3 doors
+  wired in ONE `MS_Ch03MapChanges` array (chests share the FF5-navy `17→29` flip; each door opens to the passable
+  floor tile directly below it, Nicolas's rule). **BOTH VERIFIED IN-ENGINE** (`ch03door` + `ch03chest` PASS — tile
+  flips + Iron Lance grant read from `gBmMapBaseTiles`). ch02 Red-Gem→Hand-Axe swap FIXED + verified; Tourmaline NAME
+  done. **Full detail in the top block + `decisions.md` Ch3 chests/doors ADR.** Only the pink icon remains on this branch.
 - **⭐ REMAINING (unchecked on #23):**
-  1. **Chests/doors** — chest wiring done (verify in-engine next); **DOORS need an open-door metatile** (top block); Trex opens, key-droppers back up.
-  2. **Tourmaline pink icon** — palette-1 repaint + `DrawIcon` bank-bump hook (top block).
+  1. ✅ **Chests/doors — DONE + in-engine verified** (top block). Trex (thief) opens without keys; the key-dropper kobolds back up.
+  2. **Tourmaline pink icon** — palette-1 repaint + `DrawIcon` bank-bump hook (top block). **← the last in-scope item before the PR.**
   3. **Title-card** (replace the vanilla slot-4 **"Za'ha Woods"** placeholder that shows at chapter start) — **couple this
      with the opening map-flash fix** (both are the same `gProcScr_ChapterIntro` sequence). + full load-test scenarios
      `ch03`/`smoke_ch03`/`clear_ch03` (the `ch03prep`/`ch03win`/`ch03talk`/`koboldview`/`enemycheck` scenarios seed these;

--- a/campaigns/rime-of-the-frostmaiden/campaign.yaml
+++ b/campaigns/rime-of-the-frostmaiden/campaign.yaml
@@ -130,6 +130,7 @@ enemy_class_reskins:
 # (Marty's druidic ration; everyone shares one consumable name).
 item_names:
   ITEM_VULNERARY: "Goodberry"
+  ITEM_REDGEM: "Tourmaline"     # Termalaine's signature gem (ch03 chest); mechanics = Red Gem (2,500g sell), #23
 
 # Item icon overrides: swap a vanilla item's 16x16 icon for a campaign asset under
 # item_icons/<name>.4bpp (build wiring = build_campaign.inject_item_icons, which resolves

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
@@ -251,16 +251,14 @@ reinforcements:
 # ── Rewards (no chest — vanilla Ch2 has none) ─────────────────────────────────────
 # Vanilla Ch2's loot = three VILLAGE GIFTS (Red Gem / Elixir / Pure Water) + one enemy
 # vulnerary drop. Reward ADR (decisions.md §"Reward/item budget"): ch02 parity = FE8 Ch2
-# = gems + premium consumables, NO boosters/promos. We deliver the three gifts 1:1 as the
-# chwinga charm-gifts (per-survivor, see green_allies above), and the enemy drop is the
-# chardalyn-scavenger's vulnerary. No on-map chest (vanilla Ch2 has none).
+# = gems + premium consumables, NO boosters/promos. We deliver the gifts as the chwinga
+# charm-gifts (per-survivor) — but with the ch02↔ch03 reward swap: Mote's slot gives a Hand
+# Axe (vanilla Ch2's Red Gem moved to ch03's gem-mine chest), Rime = Elixir, Glimmer = Pure
+# Water. The enemy drop is the chardalyn-scavenger's vulnerary. No on-map chest (vanilla has none).
+# The gift item lives in ONE place — green_allies[].gift above — which the build reads directly.
 chests: []
 charm_gifts:
-  note: "Each SURVIVING chwinga gifts its charm at chapter end (gated on the per-unit survival flag)."
-  gifts:                             # 1:1 with vanilla Ch2's three village gifts
-    - { from: chwinga-mote,    item: red-gem,    hex: "0x76" }
-    - { from: chwinga-rime,    item: elixir,     hex: "0x6D" }
-    - { from: chwinga-glimmer, item: pure-water, hex: "0x6E" }
+  note: "Each SURVIVING chwinga gifts its charm at chapter end (gated on the per-unit survival flag); the item is authored per-unit in green_allies[].gift."
 
 # ── Events (pacing / cutscene placement) ─────────────────────────────────────────
 events:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -247,17 +247,20 @@ enemy_units:
 # gift, and ch02's Red Gem moves here. Net wealth + item set across ch02+ch03 = vanilla; only
 # the location of the two items swaps. Thematic: it's a famous gem mine, and Trex opens the seam.
 # Trex (recruited mid-map) is the intended opener; the two key-dropper kobolds are the backup.
+# Positions = vanilla FE8 Ch3 (Borgo) chest tiles 1:1 (our map is a Borgo retile); the FF5 navy
+# chest tile (closed 17) is painted at each. (8,3) held vanilla's Hand Axe — now the Tourmaline
+# (Red Gem), the ch02↔ch03 swap; the other three keep vanilla's item at vanilla's tile.
 chests:
-  - position: tbd               # the mine tools — reflavored basic gear (book M1 Tool Room: "racks of picks and hammers")
+  - position: [6, 3]            # the mine tools — reflavored basic gear (book M1 Tool Room: "racks of picks and hammers")
     contents:
-      - id: iron-lance          # a miner's drill-spear
-  - position: tbd
+      - id: iron-lance          # a miner's drill-spear (vanilla Chest(ITEM_LANCE_IRON, 6, 3))
+  - position: [10, 3]
     contents:
-      - id: iron-sword          # a cutting tool
-  - position: tbd
+      - id: iron-sword          # a cutting tool (vanilla Chest(ITEM_SWORD_IRON, 10, 3))
+  - position: [6, 12]
     contents:
-      - id: javelin             # a throwing pick (vanilla Ch3's off-on-its-own chest)
-  - position: tbd               # the deep seam, near the lair — Trex's signature pop
+      - id: javelin             # a throwing pick (vanilla Ch3's off-on-its-own chest @ (6,12))
+  - position: [8, 3]            # vanilla's Hand Axe tile — the deep-seam Tourmaline (ch02↔ch03 swap)
     contents:
       - id: red-gem             # a pink Tourmaline — Termalaine's signature gem (2,500g sell). DEVIATION: see ADR.
         flavor: "a fist-sized rose-pink tourmaline, the best seam in the mine"

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -265,6 +265,17 @@ chests:
       - id: red-gem             # a pink Tourmaline — Termalaine's signature gem (2,500g sell). DEVIATION: see ADR.
         flavor: "a fist-sized rose-pink tourmaline, the best seam in the mine"
 
+# ── Doors (thief lesson): gate the mine's inner galleries ────────────────────
+# Positions = vanilla FE8 Ch3 (Borgo) door tiles 1:1 (our map is a Borgo retile); the closed
+# single-door metatile (812) is painted at each. A thief (Trex) or a Door Key opens one; on open
+# the tile flips to the passable floor tile DIRECTLY BELOW the door (Nicolas 2026-07-11 — "the
+# tile directly adjacent and below it"), read off the painted map so it tracks any re-retile.
+# (10,5) opens onto the stairs down; (6,10)/(2,3) onto gallery road. Doors make the thief matter.
+doors:
+  - position: [6, 10]           # vanilla Ch3 Door_(6, 10) — the lower gallery
+  - position: [10, 5]           # vanilla Ch3 Door_(10, 5) — gates the stairs down
+  - position: [2, 3]            # vanilla Ch3 Door_(2, 3)  — the upper-left room
+
 # ── Events (pacing / cutscene placement) ─────────────────────────────────────────
 # Beat PLACEMENT only — final dialogue is written via the dialogue-pass skill (voice bibles +
 # the #58 opaque-box narration convention), gated by tools/verify_text.py. Grounded in the DM

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -707,6 +707,24 @@ until `chapter() == 4` (ch03) and FAILs if the chain doesn't land — the ch02�
 the `reachCh02Map` `MNC2(0x3)` proof.
 _Decided: 2026-07-11 (CLAUDE, #23 item 1 — chaining pass)._
 
+**Ch3 chests + doors ride ONE per-chapter MapChange array; a door opens to the tile below it.**
+FE8 flips a tile on loot/open via a per-chapter `struct MapChange` array (`gChapterDataAssetTable[map.changeLayerId]`):
+opening a chest runs `CallChestOpeningEvent(GetMapChangeIdAt(x,y), item)` and opening a door runs
+`CallTileChangeEvent(GetMapChangeIdAt(x,y))` — **both look up the change by POSITION** (`GetMapChangeIdAt`
+auto-finds the 1×1 region covering the tile), so chests and doors coexist in one array (`MS_Ch03MapChanges`);
+ids only need to stay unique. `ApplyMapChangesById` writes `gBmMapBaseTiles[y][x] = tile` for each non-zero
+`metatile<<2` word. **The chests** all open to the shared FF5-navy open tile (17→29). **The doors** each open to
+the metatile **directly below the door cell** (Nicolas 2026-07-11 — "use the tile directly adjacent and below
+it"), read off the painted `.mar` at build time (`_read_map_metatile`) so it tracks any re-retile — no hand-copied
+tile numbers. On the committed map that's road/stairs (572/626/492, all passable): vanilla Ch3's `Door_(6,10)`
+opens the lower gallery, `Door_(10,5)` the stairs down, `Door_(2,3)` the upper room. Authored as `chests:`/`doors:`
+position lists in the ch03 YAML → `Chest()`/`Door_()` in `EventListScr_Ch4_Location[]` + the paired MapChange.
+Verified in-engine (`PT_HOST_CHAPTER=4 run.sh ch03door`): hand a unit a Door Key, drive Door, and
+`gBmMapBaseTiles[3][2]` flips 3248→1968 (812→492<<2). The chest path shares this array + code path, so the
+door proof covers both. `gBmMapBaseTiles` is a ROM-`.data` pointer (objdump `g O ROM` @ 0x085AF5DC) → the
+EWRAM `sBmBaseTilesPool` row array, never reassigned — read the pointer from ROM, then index the rows.
+_Decided: 2026-07-11 (Nicolas — open-door tile rule; CLAUDE — shared-array wiring, #23 chests/doors)._
+
 **Two healers, differentiated by donor (same move as the shamans).** Sclorbo and Basil are both
 Priests, so they get *distinct* vanilla donor lines to avoid stat-twins: **Sclorbo → Moulder** (the
 durable "war-priest": HP70/Def25, balanced, accurate) and **Basil → Natasha** (the frail "mage-healer":

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5486,9 +5486,16 @@ CH03_CLASS_IDS = {'mogall': 'CLASS_MOGALL', 'brigand': 'CLASS_BLST_KILLER_EMPTY'
                   'brigand-brute': 'CLASS_MNC_LIZARDZERKER_BRUTE'}
 CH03_ITEM_IDS = {'iron-axe': 'ITEM_AXE_IRON', 'hand-axe': 'ITEM_AXE_HANDAXE',
                  'steel-axe': 'ITEM_AXE_STEEL', 'iron-sword': 'ITEM_SWORD_IRON',
+                 'iron-lance': 'ITEM_LANCE_IRON', 'javelin': 'ITEM_LANCE_JAVELIN',
                  'iron-bow': 'ITEM_BOW_IRON', 'evil-eye': 'ITEM_MONSTER_EVILEYE',
+                 'red-gem': 'ITEM_REDGEM',
                  'pure-water': 'ITEM_PUREWATER', 'antitoxin': 'ITEM_ANTITOXIN',
                  'door-key': 'ITEM_DOORKEY', 'chest-key': 'ITEM_CHESTKEY'}
+# The FF5 navy chest metatile in the cave-interior tileset (retile.py): closed 17 / open 29.
+# gBmMapBaseTiles stores metatile<<2 (compile_layout: .mar = metatile<<5, mar_to_map >>3, so
+# the loaded tile = metatile<<2), so the open-chest tile a MapChange writes is 29<<2 (#23).
+CH03_CHEST_CLOSED_TILE = 17
+CH03_CHEST_OPEN_TILE = 29
 # Left-entrance floor tiles (verified walkable on the painted .mar, clear of enemy tiles) --
 # the party deploys here statically (fast-boot; the real PREP flow lands with deploy_slots + cutscenes).
 # 9 tiles = the ch03 field roster (cast_available_at(3) = the 8 founding party + Baxby, the
@@ -5556,6 +5563,44 @@ CH03_MIDMAP_MSGS = (0x9AF, 0x9B0, 0x9B1, 0x9B4, 0x9B5, 0x9B6, 0x9B7)
 CH03_CRIER_FID = '[FID_VillagerYoungBoy]'   # the boy crying the bounty on his crate (book p.95; generic mug)
 CH4_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventinfo.h')
 CH4_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventscript.h')
+
+
+def _inject_ch03_chest_map_changes(chap, host_index):
+    """Author the ch03 chest tile-changes + point slot `host_index` at them (#23).
+
+    FE8 flips a chest's tile on loot via a per-chapter MapChange array: opening a chest runs
+    CallChestOpeningEvent(GetMapChangeIdAt(x, y), item) (eventinfo.c), which finds the change
+    whose 1x1 region covers the chest tile and writes its tiles into gBmMapBaseTiles. So one
+    MapChange per chest, at the chest's (x, y), holding the OPEN FF5 navy chest metatile.
+
+    struct MapChange { s8 id; u8 xOrigin, yOrigin, xSize, ySize; u8 pad[3]; const void* data; }
+    (12 B; data at 0x08). Tile data is metatile<<2 (the gBmMapBaseTiles encoding; see
+    CH03_CHEST_OPEN_TILE). The array terminates on id < 0. Registered as a fresh
+    gChapterDataAssetTable word; slot `host_index`'s map.changeLayerId indexes it
+    (GetChapterMapChangesPointer -> gChapterDataAssetTable[changeLayerId], chapterdata.c)."""
+    open_tile = CH03_CHEST_OPEN_TILE << 2
+    entries = ''.join(
+        '\t.byte %d, %d, %d, 1, 1, 0, 0, 0\n\t.word MS_Ch03ChestOpenTile\n'
+        % (i, c['position'][0], c['position'][1])
+        for i, c in enumerate(chap['chests']))
+    block = '\n'.join([
+        '', '/* Manchego Stars ch03 chest tile-changes (#23): flip FF5 navy chest %d->%d on loot */'
+        % (CH03_CHEST_CLOSED_TILE, CH03_CHEST_OPEN_TILE),
+        '\t.align 2, 0', '\t.global MS_Ch03ChestMapChanges', 'MS_Ch03ChestMapChanges:',
+        entries.rstrip('\n'),
+        '\t.byte -1, 0, 0, 0, 0, 0, 0, 0 /* terminator (id < 0) */', '\t.word 0',
+        'MS_Ch03ChestOpenTile:',
+        '\t.hword %d /* %d << 2 (open metatile) */' % (open_tile, CH03_CHEST_OPEN_TILE)])
+    with open(CONST_MAPS_S, 'a', encoding='utf-8') as f:
+        f.write(block + '\n')
+    idx = _append_asm_table_words(ASSET_TABLE_S, 'gChapterDataAssetTable',
+                                  ['MS_Ch03ChestMapChanges'])
+    with open(CHAPTER_SETTINGS_JSON, encoding='utf-8') as f:
+        settings = json.load(f)
+    settings['chapters'][host_index]['map']['changeLayerId'] = idx
+    with open(CHAPTER_SETTINGS_JSON, 'w', encoding='utf-8') as f:
+        json.dump(settings, f, indent=2)
+    return idx
 
 
 def inject_ch03(campaign, boot=False, verbose=True):
@@ -5704,7 +5749,16 @@ def inject_ch03(campaign, boot=False, verbose=True):
         '{\n    TURN(0x0, %s, 1, 0, FACTION_ID_BLUE)'
         ' /* turn-1: Trex\'s light entrance (Colm pattern) */\n    END_MAIN\n}'
         % CH03_TREX_ENTRANCE_SCRIPT, CH4_EVENTINFO_H)
-    info = _replace_brace_block(info, 'EventListScr_Ch4_Location[] =', '{\n    END_MAIN\n}', CH4_EVENTINFO_H)
+    # Location = the 4 mine chests (#23): each Chest(item, x, y) makes its tile openable
+    # (IsThereClosedChestAt reads this list) and gives the item; the paired MS_Ch03ChestMapChanges
+    # entry (step 6b) flips the FF5 navy chest 17->29 when looted. Coords + items from the YAML
+    # (vanilla Ch3 Borgo 1:1; (8,3) = the Tourmaline, the ch02<->ch03 swap). Doors: follow-up.
+    chest_events = '{\n' + ''.join(
+        '    Chest(%s, %d, %d) /* %s */\n'
+        % (CH03_ITEM_IDS[c['contents'][0]['id']], c['position'][0], c['position'][1],
+           c['contents'][0]['id'])
+        for c in chap['chests']) + '    END_MAIN\n}'
+    info = _replace_brace_block(info, 'EventListScr_Ch4_Location[] =', chest_events, CH4_EVENTINFO_H)
     # Character events = the Trex talk-recruit (#23 item 2): the CHAR-per-candidate list.
     info = _replace_brace_block(info, 'EventListScr_Ch4_Character[] =', char_events, CH4_EVENTINFO_H)
     # Misc = the win/lose machinery + the mid-map RBG-execution AFEV. DefeatBoss(ending) fires on
@@ -5723,6 +5777,11 @@ def inject_ch03(campaign, boot=False, verbose=True):
     info = _replace_brace_block(info, 'EventListScr_Ch4_Tutorial[] =', '{\n    END_MAIN\n}', CH4_EVENTINFO_H)
     with open(CH4_EVENTINFO_H, 'w', encoding='utf-8') as f:
         f.write(info)
+
+    # 3b. Chest tile-changes: pair each Chest() location event above with a MapChange that flips
+    #     the FF5 navy chest 17->29 on loot (must run AFTER _retarget_host_chapter zeroed the
+    #     slot's changeLayerId in step 1).
+    _inject_ch03_chest_map_changes(chap, CH03_HOST_INDEX)
 
     with open(CH4_EVENTSCRIPT_H, encoding='utf-8') as f:
         script = f.read()

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -326,18 +326,20 @@ CH02_CLASS_IDS = {'brigand': 'CLASS_BRIGAND', 'archer': 'CLASS_ARCHER',
                   'pegasus_knight': 'CLASS_PEGASUS_KNIGHT'}   # chwinga chassis (balance match to Ross+Garcia)
 CH02_ITEM_IDS = {'iron-axe': 'ITEM_AXE_IRON', 'steel-axe': 'ITEM_AXE_STEEL',
                  'iron-bow': 'ITEM_BOW_IRON', 'vulnerary': 'ITEM_VULNERARY',
-                 'slim-lance': 'ITEM_LANCE_SLIM',
+                 'slim-lance': 'ITEM_LANCE_SLIM', 'hand-axe': 'ITEM_AXE_HANDAXE',
                  'red-gem': 'ITEM_REDGEM', 'elixir': 'ITEM_ELIXIR', 'pure-water': 'ITEM_PUREWATER'}
 CH02_GENERIC_PID = '0x8e'    # vanilla slot-3 generic-minion charIndex (autolevelled trash)
 # The three GREEN chwinga (protect layer): each rides a distinct minor vanilla NPC slot so
 # its survival is individually trackable via CHECK_ALIVE at the ending scene. Slots are
 # collision-free (absent from our ch00-08); their map sprite + portrait + name-text
 # (Mote/Rime/Glimmer) are the art checkpoint (#38/#39) -- placeholder vanilla faces meanwhile.
-# (yaml_id, vanilla character slot, charm-gift item the survivor delivers)
+# (yaml_id, vanilla character slot). The charm-gift each survivor delivers is NOT stored here --
+# it is read from the chapter YAML's green_allies[].gift (single source of truth; the ch02<->ch03
+# reward swap lives in the YAML, so a hardcoded copy here silently drifted once -- #23).
 CH02_CHWINGA = (
-    ('chwinga-mote',    'DARA',   'red-gem'),
-    ('chwinga-rime',    'KLIMT',  'elixir'),
-    ('chwinga-glimmer', 'MANSEL', 'pure-water'),
+    ('chwinga-mote',    'DARA'),
+    ('chwinga-rime',    'KLIMT'),
+    ('chwinga-glimmer', 'MANSEL'),
 )
 # The chwinga wear Sclorbo's chwinga map sprite (he is one), recoloured by the green NPC
 # faction palette -- identical green triplets (Nicolas 2026-06-24). Build-time derived from
@@ -2404,7 +2406,7 @@ def _inject_ch02_chwinga_sprites(campaign, verbose=True):
 
     # The three NPC slots all override onto the one shared chwinga slot/sheet. Insert at
     # the front of each table (linear scan; chwinga charIds are distinct from cast slots).
-    slots = [slot for _, slot, _ in CH02_CHWINGA]
+    slots = [slot for _, slot in CH02_CHWINGA]
     _insert_table_head(UNIT_ICON_WAIT_C, 'gMapSpriteOverride[]',
                        ''.join('\tCHARACTER_%s, %d,\n' % (s.upper(), sms) for s in slots))
     _insert_table_head(UNIT_ICON_MOVE_C, 'gMuImgOverride[]',
@@ -2450,13 +2452,13 @@ def inject_ch02_chwinga_faces(campaign, verbose=True):
     by_id = {g['id']: g for g in chap['deployment']['green_allies']}
     with open(TEXTS_TXT, encoding='utf-8') as f:
         lines = f.read().split('\n')
-    for uid, slot, _gift in CH02_CHWINGA:
+    for uid, slot in CH02_CHWINGA:
         set_message_body(lines, vanilla_name_text_id(slot),
                          name_message_body(display_name(by_id[uid])))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     if verbose:
-        names = ', '.join(display_name(by_id[uid]) for uid, _, _ in CH02_CHWINGA)
+        names = ', '.join(display_name(by_id[uid]) for uid, _ in CH02_CHWINGA)
         print('  chwinga faces -> %s (shared green bust + names: %s)'
               % (', '.join(CH02_CHWINGA_PORTRAIT_SLOT.values()), names))
 
@@ -5234,15 +5236,24 @@ def inject_ch02(campaign, verbose=True):
     #     matches CH02_CHWINGA). autolevel leans on the class curve (bases = tuning
     #     checkpoint).
     chwinga_by_id = {g['id']: g for g in chap['deployment']['green_allies']}
+    # The charm-gift is authored in the YAML (green_allies[].gift) -- the single source of truth
+    # for the ch02<->ch03 reward swap. Validate every gift resolves + the id sets agree, so a YAML
+    # edit that adds/renames a gift fails loudly here instead of silently shipping the wrong item.
+    for uid, _slot in CH02_CHWINGA:
+        g = chwinga_by_id.get(uid)
+        if not g or 'gift' not in g:
+            sys.exit('ERROR: ch02 chwinga %s missing from deployment.green_allies or has no gift' % uid)
+        if g['gift'] not in CH02_ITEM_IDS:
+            sys.exit('ERROR: ch02 chwinga %s gift %r not in CH02_ITEM_IDS' % (uid, g['gift']))
     chwinga = [_ally_unit_entry(None, slot,
                                 CH02_CLASS_IDS[chwinga_by_id[uid]['class']],
                                 chwinga_by_id[uid]['level'],
                                 chwinga_by_id[uid]['position'][0],
                                 chwinga_by_id[uid]['position'][1],
-                                lance, ' /* chwinga %s (%s) */' % (uid, gift),
+                                lance, ' /* chwinga %s (gift: %s) */' % (uid, chwinga_by_id[uid]['gift']),
                                 allegiance='GREEN', autolevel=True,
                                 ai=CH02_AI['cautious'])
-               for uid, slot, gift in CH02_CHWINGA]
+               for uid, slot in CH02_CHWINGA]
 
     # 2c. RED reinforcements (088B4758) -- vanilla 088B4470 mix: one L2 + one L3, turn 3.
     reinforce = [_enemy_unit_entry(CH02_GENERIC_PID, brig, lv, True, x, y, axe,
@@ -5361,8 +5372,8 @@ def inject_ch02(campaign, verbose=True):
         '    BEQ(0x%X, EVT_SLOT_C, EVT_SLOT_0) /* fell -> forfeit its own charm */\n'
         '    GIVEITEMTO(CHAR_EVT_PLAYER_LEADER)\n'
         'LABEL(0x%X)\n'
-        % (CH02_ITEM_IDS[gift], uid, slot.upper(), 0x30 + i, 0x30 + i)
-        for i, (uid, slot, gift) in enumerate(CH02_CHWINGA))
+        % (CH02_ITEM_IDS[chwinga_by_id[uid]['gift']], uid, slot.upper(), 0x30 + i, 0x30 + i)
+        for i, (uid, slot) in enumerate(CH02_CHWINGA))
     script = _replace_brace_block(
         script, 'EventScr_Ch3_EndingScene[] =',
         '{\n    MUSC(SONG_VICTORY)\n'

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5565,36 +5565,73 @@ CH4_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventinfo.h')
 CH4_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventscript.h')
 
 
-def _inject_ch03_chest_map_changes(chap, host_index):
-    """Author the ch03 chest tile-changes + point slot `host_index` at them (#23).
+def _read_map_metatile(maps_dir, stem, x, y):
+    """Return the metatile index painted at (x, y) on a compiled .mar layout. compile_layout
+    stores each cell as metatile<<5 with no header (map_tileset_tool), row-major over the
+    width from the paired .json -- so reading the door's OPEN tile off the map itself tracks
+    any re-retile (no hand-copied tile numbers to drift)."""
+    with open(os.path.join(maps_dir, stem + '.json'), encoding='utf-8') as f:
+        w = json.load(f)['width']
+    with open(os.path.join(maps_dir, stem + '.mar'), 'rb') as f:
+        mar = f.read()
+    return struct.unpack_from('<H', mar, (y * w + x) * 2)[0] >> 5
 
-    FE8 flips a chest's tile on loot via a per-chapter MapChange array: opening a chest runs
-    CallChestOpeningEvent(GetMapChangeIdAt(x, y), item) (eventinfo.c), which finds the change
-    whose 1x1 region covers the chest tile and writes its tiles into gBmMapBaseTiles. So one
-    MapChange per chest, at the chest's (x, y), holding the OPEN FF5 navy chest metatile.
+
+def _ch03_tile_changes_asm(chests, doors):
+    """Pure: the MS_Ch03MapChanges ASM block for the ch03 chest + door tile-changes (#23).
+
+    FE8 flips a tile on loot/open via a per-chapter MapChange array: opening a chest runs
+    CallChestOpeningEvent(GetMapChangeIdAt(x, y), item) and opening a door runs
+    CallTileChangeEvent(GetMapChangeIdAt(x, y)) (eventinfo.c) -- both find the change whose
+    1x1 region covers the tile and write its tiles into gBmMapBaseTiles. GetMapChangeIdAt
+    matches by POSITION, so chests and doors share ONE array; ids only need to stay unique.
+
+    chests = [(x, y), ...]        -- all open to the shared FF5 navy chest tile (17->29).
+    doors  = [(x, y, open_metatile), ...] -- each opens to its OWN below-cell floor tile
+             (Nicolas 2026-07-11: an opened door becomes the passable tile directly below it).
 
     struct MapChange { s8 id; u8 xOrigin, yOrigin, xSize, ySize; u8 pad[3]; const void* data; }
-    (12 B; data at 0x08). Tile data is metatile<<2 (the gBmMapBaseTiles encoding; see
-    CH03_CHEST_OPEN_TILE). The array terminates on id < 0. Registered as a fresh
-    gChapterDataAssetTable word; slot `host_index`'s map.changeLayerId indexes it
-    (GetChapterMapChangesPointer -> gChapterDataAssetTable[changeLayerId], chapterdata.c)."""
-    open_tile = CH03_CHEST_OPEN_TILE << 2
-    entries = ''.join(
-        '\t.byte %d, %d, %d, 1, 1, 0, 0, 0\n\t.word MS_Ch03ChestOpenTile\n'
-        % (i, c['position'][0], c['position'][1])
-        for i, c in enumerate(chap['chests']))
-    block = '\n'.join([
-        '', '/* Manchego Stars ch03 chest tile-changes (#23): flip FF5 navy chest %d->%d on loot */'
-        % (CH03_CHEST_CLOSED_TILE, CH03_CHEST_OPEN_TILE),
-        '\t.align 2, 0', '\t.global MS_Ch03ChestMapChanges', 'MS_Ch03ChestMapChanges:',
-        entries.rstrip('\n'),
-        '\t.byte -1, 0, 0, 0, 0, 0, 0, 0 /* terminator (id < 0) */', '\t.word 0',
-        'MS_Ch03ChestOpenTile:',
-        '\t.hword %d /* %d << 2 (open metatile) */' % (open_tile, CH03_CHEST_OPEN_TILE)])
+    (12 B; data at 0x08). Tile data is metatile<<2 (the gBmMapBaseTiles encoding). The array
+    terminates on id < 0. The caller registers MS_Ch03MapChanges as a fresh gChapterDataAssetTable
+    word and points the host slot's map.changeLayerId at it."""
+    lines = ['', '/* Manchego Stars ch03 tile-changes (#23): flip FF5 navy chest %d->%d on loot;'
+             ' open each door to the floor tile directly below it */'
+             % (CH03_CHEST_CLOSED_TILE, CH03_CHEST_OPEN_TILE),
+             '\t.align 2, 0', '\t.global MS_Ch03MapChanges', 'MS_Ch03MapChanges:']
+    tiles = ['MS_Ch03ChestOpenTile:',
+             '\t.hword %d /* %d << 2 (open chest metatile) */'
+             % (CH03_CHEST_OPEN_TILE << 2, CH03_CHEST_OPEN_TILE)]
+    mid = 0
+    for x, y in chests:
+        lines.append('\t.byte %d, %d, %d, 1, 1, 0, 0, 0\n\t.word MS_Ch03ChestOpenTile'
+                     % (mid, x, y))
+        mid += 1
+    for di, (x, y, open_metatile) in enumerate(doors):
+        sym = 'MS_Ch03DoorOpenTile_%d' % di
+        lines.append('\t.byte %d, %d, %d, 1, 1, 0, 0, 0\n\t.word %s' % (mid, x, y, sym))
+        tiles.append('%s:\n\t.hword %d /* %d << 2 (open door -> floor below) */'
+                     % (sym, open_metatile << 2, open_metatile))
+        mid += 1
+    lines.append('\t.byte -1, 0, 0, 0, 0, 0, 0, 0 /* terminator (id < 0) */\n\t.word 0')
+    return '\n'.join(lines + tiles)
+
+
+def _inject_ch03_tile_changes(chap, maps_dir, host_index):
+    """Author the ch03 chest + door tile-changes + point slot `host_index` at them (#23).
+
+    Emits MS_Ch03MapChanges (chests then doors -- see _ch03_tile_changes_asm), registers it as
+    a fresh gChapterDataAssetTable word, and sets the host slot's map.changeLayerId to that index
+    (GetChapterMapChangesPointer -> gChapterDataAssetTable[changeLayerId], chapterdata.c). Each
+    door's open tile is read off the painted map (the metatile directly below the door cell)."""
+    chests = [(c['position'][0], c['position'][1]) for c in chap.get('chests', [])]
+    doors = [(d['position'][0], d['position'][1],
+              _read_map_metatile(maps_dir, CH03_LAYOUT[1], d['position'][0], d['position'][1] + 1))
+             for d in chap.get('doors', [])]
+    block = _ch03_tile_changes_asm(chests, doors)
     with open(CONST_MAPS_S, 'a', encoding='utf-8') as f:
         f.write(block + '\n')
     idx = _append_asm_table_words(ASSET_TABLE_S, 'gChapterDataAssetTable',
-                                  ['MS_Ch03ChestMapChanges'])
+                                  ['MS_Ch03MapChanges'])
     with open(CHAPTER_SETTINGS_JSON, encoding='utf-8') as f:
         settings = json.load(f)
     settings['chapters'][host_index]['map']['changeLayerId'] = idx
@@ -5749,16 +5786,20 @@ def inject_ch03(campaign, boot=False, verbose=True):
         '{\n    TURN(0x0, %s, 1, 0, FACTION_ID_BLUE)'
         ' /* turn-1: Trex\'s light entrance (Colm pattern) */\n    END_MAIN\n}'
         % CH03_TREX_ENTRANCE_SCRIPT, CH4_EVENTINFO_H)
-    # Location = the 4 mine chests (#23): each Chest(item, x, y) makes its tile openable
-    # (IsThereClosedChestAt reads this list) and gives the item; the paired MS_Ch03ChestMapChanges
-    # entry (step 6b) flips the FF5 navy chest 17->29 when looted. Coords + items from the YAML
-    # (vanilla Ch3 Borgo 1:1; (8,3) = the Tourmaline, the ch02<->ch03 swap). Doors: follow-up.
-    chest_events = '{\n' + ''.join(
+    # Location = the mine chests + doors (#23). Each Chest(item, x, y) makes its tile openable
+    # (IsThereClosedChestAt reads this list) and gives the item; each Door_(x, y) makes its tile a
+    # thief/key door (TILE_COMMAND_DOOR, script=1 -> CallTileChangeEvent). The paired
+    # MS_Ch03MapChanges entry (step 6b) flips the chest 17->29 on loot / the door to the floor tile
+    # below it on open. Coords + items from the YAML (vanilla Ch3 Borgo 1:1; (8,3) = the Tourmaline,
+    # the ch02<->ch03 swap).
+    loc_events = '{\n' + ''.join(
         '    Chest(%s, %d, %d) /* %s */\n'
         % (CH03_ITEM_IDS[c['contents'][0]['id']], c['position'][0], c['position'][1],
            c['contents'][0]['id'])
-        for c in chap['chests']) + '    END_MAIN\n}'
-    info = _replace_brace_block(info, 'EventListScr_Ch4_Location[] =', chest_events, CH4_EVENTINFO_H)
+        for c in chap['chests']) + ''.join(
+        '    Door_(%d, %d)\n' % (d['position'][0], d['position'][1])
+        for d in chap.get('doors', [])) + '    END_MAIN\n}'
+    info = _replace_brace_block(info, 'EventListScr_Ch4_Location[] =', loc_events, CH4_EVENTINFO_H)
     # Character events = the Trex talk-recruit (#23 item 2): the CHAR-per-candidate list.
     info = _replace_brace_block(info, 'EventListScr_Ch4_Character[] =', char_events, CH4_EVENTINFO_H)
     # Misc = the win/lose machinery + the mid-map RBG-execution AFEV. DefeatBoss(ending) fires on
@@ -5778,10 +5819,10 @@ def inject_ch03(campaign, boot=False, verbose=True):
     with open(CH4_EVENTINFO_H, 'w', encoding='utf-8') as f:
         f.write(info)
 
-    # 3b. Chest tile-changes: pair each Chest() location event above with a MapChange that flips
-    #     the FF5 navy chest 17->29 on loot (must run AFTER _retarget_host_chapter zeroed the
-    #     slot's changeLayerId in step 1).
-    _inject_ch03_chest_map_changes(chap, CH03_HOST_INDEX)
+    # 3b. Tile-changes: pair each Chest()/Door_() location event above with a MapChange -- flips the
+    #     FF5 navy chest 17->29 on loot, and each door to the floor tile below it on open (must run
+    #     AFTER _retarget_host_chapter zeroed the slot's changeLayerId in step 1).
+    _inject_ch03_tile_changes(chap, maps_dir, CH03_HOST_INDEX)
 
     with open(CH4_EVENTSCRIPT_H, encoding='utf-8') as f:
         script = f.read()

--- a/tools/playtest/ch02check.lua
+++ b/tools/playtest/ch02check.lua
@@ -5,8 +5,9 @@ local M = {}
 
 -- Given a flat list of collected item ids and the set of charm item ids to look for, return
 -- the charm ids that are present -- de-duplicated and in charmIds order (deterministic), with
--- empty 0x00 slots ignored. Used to verify the per-chwinga charm-gifts (Red Gem / Elixir /
+-- empty 0x00 slots ignored. Used to verify the per-chwinga charm-gifts (Hand Axe / Elixir /
 -- Pure Water) actually landed in the leader's inventory or the convoy after the ending scene.
+-- (Mote's gift was vanilla Ch2's Red Gem; the ch02<->ch03 reward swap moved it to a ch03 chest, #23.)
 function M.deliveredCharms(items, charmIds)
     local present = {}
     for _, id in ipairs(items) do

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -3343,6 +3343,84 @@ scenarios.ch03prep = function()
         "ch03 Preparations opened -> Fight! fielded %d units (cap 9), Trex held green", deployed))
 end
 
+-- gBmMapBaseTiles (u16**): the metatile grid a chest/door tile-change writes (ApplyMapChangesById,
+-- bmtrick.c). Unlike the gBmMap* grids, this variable lives in FE8's ROM .data (objdump: `g O ROM`
+-- at 0x085AF5DC) -- it's never reassigned, holding a constant pointer to the sBmBaseTilesPool row-
+-- pointer array in EWRAM. So: read the pointer from ROM, index the row array, read the tile. The
+-- scenario asserts the closed door reads 812<<2 first, validating this chain before the flip check.
+local GBMMAPBASETILES_ADDR = 0x085AF5DC
+local function baseTile(x, y)
+    local grid = ru32(GBMMAPBASETILES_ADDR)   -- u16** value = &sBmBaseTilesPool
+    return ru16(ru32(grid + y * 4) + x * 2)
+end
+
+-- CH03DOOR (#23 chests/doors): prove the door tile-change wiring end-to-end in-engine. Boot to the
+-- ch03 map, hand a deployed unit a Door Key (and strip its weapon so the command menu is [Door,
+-- Item, Wait] -- Door at row 0, deterministic), park it beside the (2,3) door, drive Door, and
+-- assert gBmMapBaseTiles[3][2] flips from the closed door (812<<2) to the floor tile below it
+-- (492<<2, per Nicolas's "the tile directly below"). Run: PT_HOST_CHAPTER=4 run.sh ch03door
+-- (needs a CH03BOOT=1 ROM). The chest path shares this MapChange array -- verifying the door proves
+-- both mechanisms (GetMapChangeIdAt -> CallTileChangeEvent -> ApplyMapChangesById).
+scenarios.ch03door = function()
+    if not bootToMap() then return result("FAIL", "never reached the ch03 map") end
+    local DX, DY = 2, 3
+    local CLOSED, OPEN_T = 812 * 4, 492 * 4   -- gBmMapBaseTiles holds metatile<<2
+    local pre = baseTile(DX, DY)
+    log(string.format("door (%d,%d) tile before = %d (want closed %d)", DX, DY, pre, CLOSED))
+    if pre ~= CLOSED then
+        return result("FAIL", string.format(
+            "door (%d,%d) reads %d, not the closed-door tile %d -- placement or gBmMapBaseTiles addr wrong",
+            DX, DY, pre, CLOSED))
+    end
+    -- Grab the first deployed blue unit (on the field: not US_HIDDEN|US_NOT_DEPLOYED, real tile).
+    local u
+    for i = 0, 23 do
+        local c = unitAt(SYM.gUnitArrayBlue, i)
+        if c and (c.state & 0x9) == 0 and c.x ~= 0xFF then u = c break end
+    end
+    if not u then return result("FAIL", "no deployed blue unit to open the door") end
+    -- Door Key in slot 0 (0x6A, 1 use), zero the rest -> no weapon -> no Attack row.
+    emu:write16(u.addr + 0x1E, 0x6A | (0x01 << 8))
+    for s = 1, 4 do emu:write16(u.addr + 0x1E + s * 2, 0) end
+    -- Park orthogonally adjacent to the door on a known-passable floor cell ((2,2) floor / (2,4) road;
+    -- the door's left/right are wall frame). Vacate the old tile, occupy the new -- cursor-select
+    -- reads gBmMapUnit, not xPos (cf. the ch03talk park trick).
+    local grid = mapUnitAt(u.x, u.y)
+    local parked
+    for _, t in ipairs({ { DX, DY - 1 }, { DX, DY + 1 } }) do
+        if mapUnitAt(t[1], t[2]) == 0 then
+            setMapUnit(u.x, u.y, 0)
+            emu:write8(u.addr + 0x10, t[1]); emu:write8(u.addr + 0x11, t[2])
+            setMapUnit(t[1], t[2], grid)
+            parked = t
+            break
+        end
+    end
+    if not parked then return result("FAIL", "no free tile adjacent to the (2,3) door to park a unit") end
+    log(string.format("parked opener at (%d,%d), adjacent to the door", parked[1], parked[2]))
+    shot("ch03door-before")
+    -- Select (no move) -> command menu; Door is row 0. A picks Door, A confirms the sole target.
+    waitFor(function() return faction() == 0 and not menuOpen() end, 300, true)
+    if not moveUnit(parked[1], parked[2], parked[1], parked[2]) then
+        shot("ch03door-no-menu")
+        return result("FAIL", "could not open the opener's command menu")
+    end
+    wait(20); shot("ch03door-menu")
+    press(K.A, 4); wait(30)   -- Door (row 0)
+    press(K.A, 4)             -- confirm the door target
+    local flipped = waitFor(function() return baseTile(DX, DY) == OPEN_T end, 400, true)
+    wait(20); shot("ch03door-after")
+    local post = baseTile(DX, DY)
+    log(string.format("door (%d,%d) tile after = %d (want open %d)", DX, DY, post, OPEN_T))
+    if not flipped then
+        return result("FAIL", string.format(
+            "door did not open: tile stayed %d (want %d = 492<<2, the floor below)", post, OPEN_T))
+    end
+    return result("PASS", string.format(
+        "Door opened: gBmMapBaseTiles[%d][%d] flipped %d -> %d (812->492, the tile below) (#23)",
+        DY, DX, pre, post))
+end
+
 -- KOBOLDVIEW (#23 art): pull the enemy kobolds ON-SCREEN next to the party so their reskinned
 -- map sprites are visible (the roster deploys off-camera at the enemy tiles). Teleports the first
 -- few red brigand generics (pid 0xaa) to tiles around braulo's spawn and screenshots. No combat.

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -2928,7 +2928,7 @@ end
 -- top speed); ch02 / smoke_ch02 / clear_ch02 LOAD it so each is fast. Char/class/item ids from
 -- the decomp + the ch02 build (CH02_CHWINGA / CH02_ITEM_IDS in tools/build_campaign.py).
 local CH02_CHWINGA_PIDS = { 0xCA, 0xC9, 0xC8 }   -- DARA/KLIMT/MANSEL = Mote/Rime/Glimmer (green)
-local CH02_CHARMS = { 0x76, 0x6D, 0x6E }         -- Red Gem / Elixir / Pure Water (the gifts)
+local CH02_CHARMS = { 0x28, 0x6D, 0x6E }         -- Hand Axe / Elixir / Pure Water (Mote's Red Gem moved to ch03's chest, #23)
 local CLASS_ARCHER = 0x19                          -- the fliers-vs-bows debut enemy (CH02_CLASS_IDS)
 local CH02_CHAPTER = 3                             -- ch02 hosts on chapter slot 3 (ch01 -> MNC2(0x3))
 local CH03_CHAPTER = 4                             -- ch03 hosts on chapter slot 4 (ch02 ending -> MNC2(0x4))

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -3421,6 +3421,65 @@ scenarios.ch03door = function()
         DY, DX, pre, post))
 end
 
+-- CH03CHEST (#23 chests/doors): prove the chest tile-change + item grant in-engine. Boot to the ch03
+-- map, hand a deployed unit a Chest Key (strip its weapon -> menu is [Chest, Item, Wait], Chest at row
+-- 0), teleport it ONTO the (6,3) chest tile (chests open from the tile, not adjacent -- TERRAIN_CHEST_FULL),
+-- drive Chest, and assert (a) gBmMapBaseTiles[3][6] flips 17<<2 -> 29<<2 (closed FF5 chest -> open) AND
+-- (b) the chest's Iron Lance lands in the opener's inventory. Run: PT_HOST_CHAPTER=4 run.sh ch03chest
+-- (needs a CH03BOOT=1 ROM). Shares the MS_Ch03MapChanges array + code path with ch03door.
+scenarios.ch03chest = function()
+    if not bootToMap() then return result("FAIL", "never reached the ch03 map") end
+    local CX, CY = 6, 3
+    local CLOSED, OPEN_T = 17 * 4, 29 * 4     -- FF5 navy chest: closed 17 / open 29, metatile<<2
+    local IRON_LANCE = 0x14                    -- the (6,3) chest's Iron Lance (ch03 YAML)
+    local pre = baseTile(CX, CY)
+    log(string.format("chest (%d,%d) tile before = %d (want closed %d)", CX, CY, pre, CLOSED))
+    if pre ~= CLOSED then
+        return result("FAIL", string.format(
+            "chest (%d,%d) reads %d, not the closed-chest tile %d -- placement/addr wrong", CX, CY, pre, CLOSED))
+    end
+    local u
+    for i = 0, 23 do
+        local c = unitAt(SYM.gUnitArrayBlue, i)
+        if c and (c.state & 0x9) == 0 and c.x ~= 0xFF then u = c break end
+    end
+    if not u then return result("FAIL", "no deployed blue unit to open the chest") end
+    -- Chest Key in slot 0 (0x69, 1 use), zero the rest -> no weapon (no Attack) + free slots for the loot.
+    emu:write16(u.addr + 0x1E, 0x69 | (0x01 << 8))
+    for s = 1, 4 do emu:write16(u.addr + 0x1E + s * 2, 0) end
+    -- Chests open from ON the tile: teleport the opener onto (6,3) (vacate old tile, occupy the chest).
+    if mapUnitAt(CX, CY) ~= 0 then return result("FAIL", "the (6,3) chest tile is already occupied") end
+    setMapUnit(u.x, u.y, 0)
+    local grid = 1  -- blue army slot-1 grid marker isn't needed; any non-zero registers occupancy
+    emu:write8(u.addr + 0x10, CX); emu:write8(u.addr + 0x11, CY)
+    setMapUnit(CX, CY, grid)
+    shot("ch03chest-before")
+    waitFor(function() return faction() == 0 and not menuOpen() end, 300, true)
+    if not moveUnit(CX, CY, CX, CY) then
+        shot("ch03chest-no-menu")
+        return result("FAIL", "could not open the opener's command menu on the chest tile")
+    end
+    wait(20); shot("ch03chest-menu")
+    press(K.A, 4); wait(40)   -- Chest (row 0); the open animation + item pop-up plays
+    for _ = 1, 8 do press(K.A, 3); wait(20) end   -- clear the "got Iron Lance" fanfare/textbox
+    local flipped = waitFor(function() return baseTile(CX, CY) == OPEN_T end, 400, true)
+    wait(20); shot("ch03chest-after")
+    local post = baseTile(CX, CY)
+    -- Re-find the opener (its array index is stable; read items[0..4] for the loot).
+    local got = false
+    for s = 0, 4 do if (ru16(u.addr + 0x1E + s * 2) & 0xFF) == IRON_LANCE then got = true break end end
+    log(string.format("chest (%d,%d) tile after = %d (want %d); iron-lance in inventory = %s",
+        CX, CY, post, OPEN_T, tostring(got)))
+    if not flipped then
+        return result("FAIL", string.format("chest tile did not flip: stayed %d (want %d)", post, OPEN_T))
+    end
+    if not got then
+        return result("FAIL", "chest opened (tile flipped) but the Iron Lance did not land in the opener's inventory")
+    end
+    return result("PASS", string.format(
+        "Chest opened: tile flipped %d -> %d (17->29) AND the Iron Lance was granted (#23)", pre, post))
+end
+
 -- KOBOLDVIEW (#23 art): pull the enemy kobolds ON-SCREEN next to the party so their reskinned
 -- map sprites are visible (the roster deploys off-camera at the enemy tiles). Teleports the first
 -- few red brigand generics (pid 0xaa) to tiles around braulo's spawn and screenshots. No combat.

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -707,5 +707,51 @@ class Ch03MidmapExecution(unittest.TestCase):
                          [False, True, True, False, True, False, False])   # A3 (Brute) faceless w/o a mug
 
 
+class Ch03TileChanges(unittest.TestCase):
+    """The ch03 chest + door tile-changes (#23): one MapChange array flips each chest's
+    FF5 navy tile 17->29 on loot and opens each door to the floor tile DIRECTLY BELOW it
+    (Nicolas 2026-07-11 -- 'use the tile directly adjacent and below it'). GetMapChangeIdAt
+    matches by POSITION, so chests + doors coexist in one array; ids just stay unique."""
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+    STEM = bc.CH03_LAYOUT[1]
+    MAPS = os.path.join(bc.REPO, 'campaigns', 'rime-of-the-frostmaiden', 'maps')
+
+    def test_reads_the_painted_metatile_at_a_cell(self):
+        # The retile paints the FF5 navy chest (metatile 17) at (6,3); the .mar stores
+        # metatile<<5, so the reader must decode 17 back out.
+        self.assertEqual(bc._read_map_metatile(self.MAPS, self.STEM, 6, 3), 17)
+
+    def test_door_open_tile_is_the_metatile_directly_below(self):
+        # Vanilla Ch3 doors sit at (6,10)/(10,5)/(2,3); the open tile = the cell one row down
+        # on the COMMITTED (hand-painted) map -- road tiles (572/492) + the stairs down (626),
+        # all passable, so the opened door lets the party through.
+        below = [bc._read_map_metatile(self.MAPS, self.STEM, x, y + 1)
+                 for (x, y) in [(6, 10), (10, 5), (2, 3)]]
+        self.assertEqual(below, [572, 626, 492])
+
+    def test_asm_emits_one_change_per_chest_then_per_door_with_unique_ids(self):
+        asm = bc._ch03_tile_changes_asm([(6, 3), (8, 3)], [(6, 10, 98), (2, 3, 66)])
+        ids = [int(l.split(',')[0].split()[1]) for l in asm.splitlines()
+               if l.strip().startswith('.byte') and 'terminator' not in l]
+        self.assertEqual(ids, [0, 1, 2, 3])   # 2 chests then 2 doors, contiguous + unique
+        self.assertIn('.byte -1', asm)        # id<0 terminator closes the array
+
+    def test_asm_chests_share_the_open_chest_tile_word(self):
+        asm = bc._ch03_tile_changes_asm([(6, 3), (8, 3)], [])
+        self.assertEqual(asm.count('.word MS_Ch03ChestOpenTile'), 2)
+        self.assertIn('.hword %d' % (bc.CH03_CHEST_OPEN_TILE << 2), asm)
+
+    def test_asm_each_door_gets_its_own_below_tile_word(self):
+        asm = bc._ch03_tile_changes_asm([], [(6, 10, 98), (10, 5, 302)])
+        self.assertIn('.word MS_Ch03DoorOpenTile_0', asm)
+        self.assertIn('.word MS_Ch03DoorOpenTile_1', asm)
+        self.assertIn('.hword %d' % (98 << 2), asm)     # open metatile stored as metatile<<2
+        self.assertIn('.hword %d' % (302 << 2), asm)
+
+    def test_asm_carries_the_door_cell_coords(self):
+        asm = bc._ch03_tile_changes_asm([], [(6, 10, 98)])
+        self.assertIn('.byte 0, 6, 10, 1, 1, 0, 0, 0', asm)   # id 0 at (x=6, y=10), 1x1 region
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Chests + doors for Ch3 "The Termalaine Mine" (#23), plus the ch02<->ch03 Red-Gem/Hand-Axe swap fix and the Tourmaline item name.

## What's here
- **4 chests + 3 doors** in ONE per-chapter MapChange array (`MS_Ch03MapChanges`). `GetMapChangeIdAt` matches by position, so `Chest()`/`Door_()` coexist: ids 0-3 chests -> shared `17->29` FF5-navy flip; ids 4-6 doors -> each opens to the passable floor tile **directly below the door cell** (Nicolas's rule), read off the painted `.mar` at build time so it tracks any re-retile.
- **ch02 Red-Gem -> Hand-Axe swap fixed** - the chwinga-mote gift now reads from the YAML (single source of truth); Red Gem freed for ch03's Tourmaline chest.
- **Tourmaline item name** (`ITEM_REDGEM` -> "Tourmaline").

## Verified in-engine (not just built)
Two new PASS/FAIL scenarios read `gBmMapBaseTiles` ground truth on a `CH03BOOT=1` ROM:
- `PT_HOST_CHAPTER=4 run.sh ch03door` -> drive Door -> tile flips **812->492** (pass)
- `PT_HOST_CHAPTER=4 run.sh ch03chest` -> drive Chest on the (6,3) chest -> tile flips **17->29 AND the Iron Lance lands in inventory** (pass)

## Tests / gates
- 6 new unit tests (pure ASM builder + drift-proof map reader), **81 total green**
- `make` green, `verify_text` 3404/0, drift clean, 6 Lua harness tests green

## Not in this PR (own branch)
- Pink Tourmaline **icon** (palette-1 repaint + `DrawIcon` bank-bump hook) - split to its own branch.
- Title-card + `smoke_ch03`/`clear_ch03` load-test scenarios - follow-up.

ADR: `docs/decisions.md` -> "Ch3 chests + doors ride ONE per-chapter MapChange array".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
