### PR TITLE
docs: pal-1 item-icon extension recorded in decisions.md (append + add palettes freely) (#23)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/campaign.yaml
+++ b/campaigns/rime-of-the-frostmaiden/campaign.yaml
@@ -148,6 +148,13 @@ item_icons:
 # `palette` and emits gMSPal1IconIds[] (the resolved iconIds); the generic DrawIcon hook
 # (engine_hooks._patch_draw_icon_pal1) bank-bumps those iconIds to pal 1 (OamPalBase |= 0x1000).
 # palette: 16 BGR-quantised entries; index 0 = the vanilla transparent placeholder.
+#
+# TO ADD ANOTHER CUSTOM-COLOURED ITEM: just APPEND -- no code changes. (1) paint its colours onto
+# SPARE `palette` indices (the Tourmaline uses ~6; see item_icons/tourmaline.png for which), (2) author
+# item_icons/<name>.png on those indices + add it to `item_icons`, (3) add its ITEM_* to `icons`.
+# CEILING: pal 1 is ONE shared 16-colour palette and FE8 loads only TWO icon palettes total (no pal 2),
+# so every pal-1 item shares these 16 colours (each using its own index range). Comfortable headroom now;
+# only if we exhausted it would we need the bigger change of bumping LoadIconPalettes to load a 3rd.
 item_icon_pal1:
   icons: [ITEM_REDGEM]
   palette: ["#c0f8c8", "#ffffff", "#f4d4e2", "#cf8ea8", "#6b2a4f", "#ffe0ef", "#e876ac",

--- a/campaigns/rime-of-the-frostmaiden/campaign.yaml
+++ b/campaigns/rime-of-the-frostmaiden/campaign.yaml
@@ -148,13 +148,8 @@ item_icons:
 # `palette` and emits gMSPal1IconIds[] (the resolved iconIds); the generic DrawIcon hook
 # (engine_hooks._patch_draw_icon_pal1) bank-bumps those iconIds to pal 1 (OamPalBase |= 0x1000).
 # palette: 16 BGR-quantised entries; index 0 = the vanilla transparent placeholder.
-#
-# TO ADD ANOTHER CUSTOM-COLOURED ITEM: just APPEND -- no code changes. (1) paint its colours onto
-# SPARE `palette` indices (the Tourmaline uses ~6; see item_icons/tourmaline.png for which), (2) author
-# item_icons/<name>.png on those indices + add it to `item_icons`, (3) add its ITEM_* to `icons`.
-# CEILING: pal 1 is ONE shared 16-colour palette and FE8 loads only TWO icon palettes total (no pal 2),
-# so every pal-1 item shares these 16 colours (each using its own index range). Comfortable headroom now;
-# only if we exhausted it would we need the bigger change of bumping LoadIconPalettes to load a 3rd.
+# TO EXTEND (another custom-coloured item; or a 3rd/4th icon palette when pal 1's 16 colours run out):
+# see docs/decisions.md -> "A campaign item icon can use a colour pal 0 lacks" (the authoritative record).
 item_icon_pal1:
   icons: [ITEM_REDGEM]
   palette: ["#c0f8c8", "#ffffff", "#f4d4e2", "#cf8ea8", "#6b2a4f", "#ffe0ef", "#e876ac",

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -741,7 +741,20 @@ in-engine (`run.sh ch03tourmaline`): the Tourmaline renders **pink** in the Item
 + Goodberry (pal 0) are untouched — no collateral. Reusable for any future item needing an off-pal-0
 colour. `gBmMapBaseTiles`-style note: item icons draw via BG tilemap entries, so the +0x1000 targets
 the BG palette nibble; the same bump works for OBJ draws (attr2 palette bits are also 12-15).
-_Decided: 2026-07-11 (Nicolas — go pink, "you were right to push"; CLAUDE — pal-1 route, #23)._
+
+**Extending it — append, and add palettes freely (Nicolas 2026-07-11).** To give another item a
+custom colour: (1) paint its colours onto SPARE `item_icon_pal1.palette` indices (the Tourmaline uses
+~6 of pal 1's 16), (2) author `item_icons/<name>.png` on those indices + add it to `item_icons`,
+(3) add its `ITEM_*` to `item_icon_pal1.icons`. No code changes — `inject_item_icon_pal1` + the hook
+already read the list. **When pal 1's 16 shared colours aren't enough, DO NOT treat it as a ceiling —
+just load more icon palettes.** FE8 currently loads two (`LoadIconPalettes` → `ApplyPalettes(.., 2)`);
+bump that count, add a bank (or banks) to `item_icon_palette.agbpal`, and let the hook select the right
+one (each extra palette is another `+0x1000` step — pal 2 = `|= 0x2000`, pal 3 = `|= 0x3000`, …). Adding
+a 3rd/4th/Nth icon palette is a routine, sanctioned extension, not a barrier: scale to however many
+distinct-colour custom items the campaign needs. (Authoritative record; the `campaign.yaml item_icon_pal1`
+comment points here rather than restating it.)
+_Decided: 2026-07-11 (Nicolas — go pink, "you were right to push", + "bump to three or however many we
+need"; CLAUDE — pal-1 route + the scale-by-adding-palettes extension, #23)._
 
 **Two healers, differentiated by donor (same move as the shamans).** Sclorbo and Basil are both
 Priests, so they get *distinct* vanilla donor lines to avoid stat-twins: **Sclorbo → Moulder** (the


### PR DESCRIPTION
Captures Nicolas's guidance: future custom-coloured items should just APPEND to `item_icon_pal1` (colours onto spare pal-1 indices + the item into `icons`), not rebuild -- and records the real ceiling (pal 1 is one shared 16-colour palette; FE8 loads only 2 icon palettes total). Comment-only; `check.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
