### PR TITLE
fix: isolate Tourmaline icon palette

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/campaign.yaml
+++ b/campaigns/rime-of-the-frostmaiden/campaign.yaml
@@ -139,18 +139,15 @@ item_names:
 # FE8's shared item-icon palette via tools/item_icon_tool.py (blueberry_grid, design L2).
 item_icons:
   ITEM_VULNERARY: goodberry
-  ITEM_REDGEM: tourmaline        # the pink Tourmaline gem (#23) -- draws from pal 1 (item_icon_pal1 below)
+  ITEM_REDGEM: tourmaline        # the pink Tourmaline gem (#23) -- draws from custom pal 2 (below)
 
-# Item icons that draw from the SECOND item palette (pal 1, bank 0x5000) instead of the
-# shared pal 0. FE8's LoadIconPalettes loads TWO icon palettes adjacent, but no vanilla
-# icon uses the 2nd -- so it's free to repaint for a colour pal 0 lacks (pal 0 has no pink;
-# the Tourmaline needs one). build_campaign.inject_item_icon_pal1 repaints pal 1 with
-# `palette` and emits gMSPal1IconIds[] (the resolved iconIds); the generic DrawIcon hook
-# (engine_hooks._patch_draw_icon_pal1) bank-bumps those iconIds to pal 1 (OamPalBase |= 0x1000).
+# Custom-coloured item icons use an additive THIRD source palette. Vanilla banks 0 and 1 remain
+# unchanged; the build appends this 16-colour bank and the engine routes these standard item icons
+# from BG palette bank 4 to reserved bank 15. This avoids bank 5, which normal UI text can use.
 # palette: 16 BGR-quantised entries; index 0 = the vanilla transparent placeholder.
-# TO EXTEND (another custom-coloured item; or a 3rd/4th icon palette when pal 1's 16 colours run out):
-# see docs/decisions.md -> "A campaign item icon can use a colour pal 0 lacks" (the authoritative record).
-item_icon_pal1:
+# More custom colours can share this bank. Adding another bank requires a fresh BG-palette collision
+# audit; see docs/decisions.md -> "A campaign item icon can use a colour pal 0 lacks".
+item_icon_pal2:
   icons: [ITEM_REDGEM]
   palette: ["#c0f8c8", "#ffffff", "#f4d4e2", "#cf8ea8", "#6b2a4f", "#ffe0ef", "#e876ac",
             "#d85f9a", "#b0447e", "#f0a8c8", "#8a325e", "#c088c0", "#7a2450", "#f7b9d8",

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -725,36 +725,29 @@ door proof covers both. `gBmMapBaseTiles` is a ROM-`.data` pointer (objdump `g O
 EWRAM `sBmBaseTilesPool` row array, never reassigned — read the pointer from ROM, then index the rows.
 _Decided: 2026-07-11 (Nicolas — open-door tile rule; CLAUDE — shared-array wiring, #23 chests/doors)._
 
-**A campaign item icon can use a colour pal 0 lacks, via the 2nd (unused) item palette.**
-FE8 item icons all share ONE 16-colour palette (pal 0) — there's no per-item palette field, and pal 0
-has no pink + no globally-free index (every index is used by some co-displayed icon). So the pink
-Tourmaline (`ITEM_REDGEM` reskin, Nicolas) can't be done by recolouring pal 0. BUT `LoadIconPalettes`
-loads **two** icon palettes adjacent (`ApplyPalettes(item_icon_palette[0], Dest, 2)`), and **no vanilla
-icon uses the 2nd** — so pal 1 is a reserved, collision-free slot free to repaint. The mechanism:
-(a) `inject_item_icons` swaps the icon TILES (the gem shape, reused from the Red Gem) as usual;
-(b) `inject_item_icon_pal1` repaints pal 1 (bank 1 of `item_icon_palette.agbpal`) with a rose-pink
-gradient and emits `gMSPal1IconIds[]` (the iconIds that opt in); (c) the generic engine hook
-`_patch_draw_icon_pal1` makes `DrawIcon` bank-bump any iconId in that array (`OamPalBase |= 0x1000`
-→ the adjacent palette slot). Boundary-clean: the mechanism is campaign-agnostic (reads an injected
-array), the specific id (136) lives in campaign data (`campaign.yaml item_icon_pal1`). Verified
-in-engine (`run.sh ch03tourmaline`): the Tourmaline renders **pink** in the Item menu while Blue Gem
-+ Goodberry (pal 0) are untouched — no collateral. Reusable for any future item needing an off-pal-0
-colour. `gBmMapBaseTiles`-style note: item icons draw via BG tilemap entries, so the +0x1000 targets
-the BG palette nibble; the same bump works for OBJ draws (attr2 palette bits are also 12-15).
+**A campaign item icon can use a colour pal 0 lacks, via an additive third item palette.**
+FE8 item icons share a 16-colour pal 0, which has no pink and no globally-free colour index. The pink
+Tourmaline (`ITEM_REDGEM` reskin, Nicolas) therefore cannot recolour pal 0. The earlier assumption that
+the second source icon palette could be repainted was wrong: `LoadIconPalettes` places it in BG bank 5,
+which regular map/UI text can also use. Repainting it made that text pink.
 
-**Extending it — append, and add palettes freely (Nicolas 2026-07-11).** To give another item a
-custom colour: (1) paint its colours onto SPARE `item_icon_pal1.palette` indices (the Tourmaline uses
-~6 of pal 1's 16), (2) author `item_icons/<name>.png` on those indices + add it to `item_icons`,
-(3) add its `ITEM_*` to `item_icon_pal1.icons`. No code changes — `inject_item_icon_pal1` + the hook
-already read the list. **When pal 1's 16 shared colours aren't enough, DO NOT treat it as a ceiling —
-just load more icon palettes.** FE8 currently loads two (`LoadIconPalettes` → `ApplyPalettes(.., 2)`);
-bump that count, add a bank (or banks) to `item_icon_palette.agbpal`, and let the hook select the right
-one (each extra palette is another `+0x1000` step — pal 2 = `|= 0x2000`, pal 3 = `|= 0x3000`, …). Adding
-a 3rd/4th/Nth icon palette is a routine, sanctioned extension, not a barrier: scale to however many
-distinct-colour custom items the campaign needs. (Authoritative record; the `campaign.yaml item_icon_pal1`
-comment points here rather than restating it.)
-_Decided: 2026-07-11 (Nicolas — go pink, "you were right to push", + "bump to three or however many we
-need"; CLAUDE — pal-1 route + the scale-by-adding-palettes extension, #23)._
+The corrected mechanism keeps both vanilla source banks byte-for-byte intact: (a) `inject_item_icons`
+still swaps the Red Gem tiles; (b) `inject_item_icon_pal2` **appends** a third 16-colour source bank at
+bytes 64–95 of `item_icon_palette.agbpal` and emits `gMSPal2IconIds[]`; (c) the generic
+`_patch_draw_icon_pal2` hook leaves FE8's normal `ApplyPalettes(..., Dest, 2)` load alone. When an
+opted-in icon is drawn with normal item-UI base bank 4, it copies source bank 2 into reserved BG bank 15
+at draw time and replaces that icon's palette nibble with bank 15. The draw-time copy matters: earlier UI
+initialisation can overwrite a loader-time copy. Other icon callers retain their vanilla base.
+
+The palette-bank assertion in `run.sh ch03tourmaline` proves bank 5 remains vanilla (`0x7FDE` at index 1)
+while bank 15 carries the custom palette (`0x7FFF`), and audits the active BG tilemaps so bank 15 is used
+only by Tourmaline's four icon tiles. The accompanying screenshot proves the floor and text retain their
+normal colours while Tourmaline is pink. More custom colours can share `item_icon_pal2`. The GBA has only
+16 BG palette banks (0–15), so a further distinct palette is not an append-only live-memory change: it
+requires a new BG-bank reservation and runtime collision audit in every relevant UI context. The cast
+palette is an OBJ palette (bank 11), not a BG palette, so an item icon cannot point to it directly.
+_Revised: 2026-07-14 (Nicolas — observed pink text; Codex — additive source bank, draw-time BG bank-15
+route, and active-tilemap regression check; supersedes the 2026-07-11 pal-1 assumption)._
 
 **Two healers, differentiated by donor (same move as the shamans).** Sclorbo and Basil are both
 Priests, so they get *distinct* vanilla donor lines to avoid stat-twins: **Sclorbo → Moulder** (the

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -408,12 +408,12 @@ PATCHED_DECOMP_FILES = ['texts/texts.txt', 'src/data_characters.c', 'src/portrai
                         'src/banim-efxhit.c', 'data/data_banim.s',
                         # Goodberry (#21): vulnerary icon swapped by inject_item_icons
                         'graphics/item_icon/item_icon_vulnerary.png',
-                        # pink Tourmaline (#23): the pal-1 icon route -- inject_item_icons
-                        # reskins the Red Gem tiles, inject_item_icon_pal1 repaints icon
-                        # palette 1, and the _patch_draw_icon_pal1 engine hook bank-bumps
-                        # those iconIds in DrawIcon. icon.c's hook is NON-idempotent (its
+                        # pink Tourmaline (#23): the additive pal-2 icon route -- inject_item_icons
+                        # reskins the Red Gem tiles, inject_item_icon_pal2 appends its icon
+                        # palette, and the _patch_draw_icon_pal2 engine hook routes those iconIds
+                        # to reserved BG bank 15. The icon/header hooks are NON-idempotent (their
                         # guard hard-exits on a non-vanilla form), so it MUST restore each build.
-                        'src/icon.c', 'graphics/item_icon/item_icon_palette.agbpal',
+                        'src/icon.c', 'include/icon.h', 'graphics/item_icon/item_icon_palette.agbpal',
                         'graphics/item_icon/item_icon_red_gem.png',
                         'data/const_data_unit_icon_wait.s', 'data/const_data_unit_icon_move.s',
                         'include/unit_icon_pointer.h',
@@ -1073,59 +1073,66 @@ def _bgr555(hexstr):
     return (r >> 3) | ((g >> 3) << 5) | ((b >> 3) << 10)
 
 
-def _item_icon_pal1_bytes(colors):
+def _item_icon_pal2_bytes(colors):
     """16 '#rrggbb' colors -> a 32-byte BGR555 blob (one 16-colour item-icon palette bank)."""
     if len(colors) != 16:
-        sys.exit('ERROR: item_icon_pal1.palette must have exactly 16 colors (got %d)' % len(colors))
+        sys.exit('ERROR: item_icon_pal2.palette must have exactly 16 colors (got %d)' % len(colors))
     return b''.join(struct.pack('<H', _bgr555(c)) for c in colors)
 
 
-def _pal1_icon_ids(campaign):
-    """The iconIds (gItemData.iconId) of the campaign's item_icon_pal1.icons, sorted."""
+def _append_item_icon_pal2(raw, colors):
+    """Append the custom icon palette after FE8's two vanilla banks, without altering either."""
+    if len(raw) < 64:
+        sys.exit('ERROR: item_icon_palette.agbpal has %d bytes; expected two vanilla banks' % len(raw))
+    out = bytearray(raw)
+    if len(out) < 96:
+        out.extend(b'\x00' * (96 - len(out)))
+    out[64:96] = _item_icon_pal2_bytes(colors)
+    return out
+
+
+def _pal2_icon_ids(campaign):
+    """The iconIds (gItemData.iconId) of the campaign's item_icon_pal2.icons, sorted."""
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        pal1 = (yaml.safe_load(f) or {}).get('item_icon_pal1') or {}
-    return sorted(item_icon_id(e) for e in (pal1.get('icons') or []))
+        pal2 = (yaml.safe_load(f) or {}).get('item_icon_pal2') or {}
+    return sorted(item_icon_id(e) for e in (pal2.get('icons') or []))
 
 
-def _ms_pal1_iconids_asm(ids):
-    """gMSPal1IconIds[] -- the iconIds the DrawIcon hook bank-bumps to pal 1, 0xFFFF-terminated
-    (no valid iconId is 0xFFFF). The generic hook (engine_hooks._patch_draw_icon_pal1) externs it."""
-    lines = ['', '/* Manchego Stars item icons that draw from pal 1 (#23): the generic DrawIcon',
-             '   hook (engine_hooks._patch_draw_icon_pal1) bank-bumps these iconIds to pal 1. */',
-             '\t.align 2, 0', '\t.global gMSPal1IconIds', 'gMSPal1IconIds:']
+def _ms_pal2_iconids_asm(ids):
+    """gMSPal2IconIds[] -- iconIds the DrawIcon hook routes from BG bank 4 to reserved bank 15.
+    The 0xFFFF terminator is outside the valid icon-id range."""
+    lines = ['', '/* Manchego Stars item icons that draw from custom palette 2 (#23). */',
+             '\t.align 2, 0', '\t.global gMSPal2IconIds', 'gMSPal2IconIds:']
     lines += ['\t.hword %d' % i for i in ids]
     lines.append('\t.hword 0xFFFF')
     return '\n'.join(lines)
 
 
-def inject_item_icon_pal1(campaign, verbose=True):
-    """Wire the campaign's pal-1 item icons (#23): repaint FE8's 2nd, vanilla-unused item-icon
-    palette (bank 1, loaded adjacent by LoadIconPalettes) with item_icon_pal1.palette, and emit
-    gMSPal1IconIds[] -- the iconIds the generic DrawIcon hook bank-bumps to pal 1 so they draw
-    from a colour pal 0 lacks (e.g. the pink Tourmaline). inject_item_icons already swapped the
-    icon TILES; this adds the palette + the id list. No-op when no item_icon_pal1 is declared."""
+def inject_item_icon_pal2(campaign, verbose=True):
+    """Wire custom-coloured item icons (#23) through an additive third source palette.
+
+    The two vanilla banks stay byte-for-byte intact. This appends item_icon_pal2.palette and emits
+    gMSPal2IconIds[]; the generic DrawIcon hook routes those standard item icons from BG bank 4 to
+    the dedicated custom bank 15. No-op when no item_icon_pal2 is declared.
+    """
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        pal1 = (yaml.safe_load(f) or {}).get('item_icon_pal1') or {}
-    if not pal1:
+        pal2 = (yaml.safe_load(f) or {}).get('item_icon_pal2') or {}
+    if not pal2:
         if verbose:
-            print('  (no item_icon_pal1 declared)')
+            print('  (no item_icon_pal2 declared)')
         return
-    # Repaint bank 1 (bytes 32..63); bank 0 (the shared pal 0) is left byte-for-byte intact.
     palpath = os.path.join(DECOMP, 'graphics', 'item_icon', 'item_icon_palette.agbpal')
     with open(palpath, 'rb') as f:
         raw = bytearray(f.read())
-    if len(raw) < 64:
-        raw.extend(b'\x00' * (64 - len(raw)))
-    raw[32:64] = _item_icon_pal1_bytes(pal1['palette'])
     with open(palpath, 'wb') as f:
-        f.write(raw)
-    ids = _pal1_icon_ids(campaign)
+        f.write(_append_item_icon_pal2(raw, pal2['palette']))
+    ids = _pal2_icon_ids(campaign)
     with open(CONST_MAPS_S, 'a', encoding='utf-8') as f:
-        f.write(_ms_pal1_iconids_asm(ids) + '\n')
+        f.write(_ms_pal2_iconids_asm(ids) + '\n')
     if verbose:
-        print('  pal 1 repainted; gMSPal1IconIds = %s' % ids)
+        print('  custom palette appended; gMSPal2IconIds = %s' % ids)
 
 
 def inject_item_names(campaign, verbose=True):
@@ -6453,15 +6460,15 @@ def main():
         print('  banim (#65): combat anim lookup -> GetBattleAnimationId_WithUnique (per-character _u25)')
         engine_hooks._patch_banim_palette_custom_guard()
         print('  banim (#65): GetBanimPalette -> custom (appended) banims keep own palette (RBG cyan fix)')
-        engine_hooks._patch_draw_icon_pal1()
-        print('  item icons (#23): DrawIcon bank-bumps gMSPal1IconIds to item palette 1 (pink Tourmaline)')
+        engine_hooks._patch_draw_icon_pal2()
+        print('  item icons (#23): DrawIcon routes gMSPal2IconIds from BG bank 4 to custom bank 15')
         print('names:')
         inject_names(args.campaign)
         print('item names:')
         inject_item_names(args.campaign)
         print('item icons:')
         inject_item_icons(args.campaign)
-        inject_item_icon_pal1(args.campaign)
+        inject_item_icon_pal2(args.campaign)
         print('characters:')
         patch_character_data(args.campaign)
         print('portrait geometry:')

--- a/tools/check.py
+++ b/tools/check.py
@@ -402,9 +402,9 @@ def check_engine_guards_present(fail):
              'the #11 nat-20 crit flourish (a d20 pops on the SpellFx layer at the '
              'crit-flash teardown) -- the d20, the whole D&D thesis, would silently '
              'vanish from crits'),
-            ('_patch_draw_icon_pal1',
-             'the #23 item-icon pal-1 hook (DrawIcon bank-bumps gMSPal1IconIds to item '
-             'palette 1); without it the pink Tourmaline silently reverts to pal-0 colours')):
+            ('_patch_draw_icon_pal2',
+             'the #23 additive item-icon palette hook (DrawIcon routes gMSPal2IconIds to '
+             'reserved BG bank 15); without it the pink Tourmaline silently reverts to pal-0 colours')):
         if ('def %s(' % fn) not in eh:
             fail.append('engine hook %s() not DEFINED in tools/inject/engine_hooks.py '
                         '-- would silently drop %s (see docs/decisions.md)' % (fn, mechanic))

--- a/tools/inject/engine_hooks.py
+++ b/tools/inject/engine_hooks.py
@@ -27,6 +27,7 @@ EVENTINFO_C = os.path.join(DECOMP, 'src', 'eventinfo.c')
 PREP_SALLYCURSOR_C = os.path.join(DECOMP, 'src', 'prep_sallycursor.c')
 BANIM_EFXHIT_C = os.path.join(DECOMP, 'src', 'banim-efxhit.c')
 ICON_C = os.path.join(DECOMP, 'src', 'icon.c')
+ICON_H = os.path.join(DECOMP, 'include', 'icon.h')
 CHAPTER_TITLE_C = os.path.join(DECOMP, 'src', 'chapter_title.c')
 LORDFLOOR_APPLIED_FLAG = 0xFA
 
@@ -214,44 +215,70 @@ def _patch_terrain_name_guard():
         f.write(text.replace(orig, guarded, 1))
 
 
-def _patch_draw_icon_pal1():
-    """Let a campaign item icon draw from item palette 1 (a colour pal 0 lacks).
+def _patch_draw_icon_pal2_text(text):
+    """Pure icon.c transform for the additive custom item palette hook.
 
-    FE8's item icons all share ONE 16-colour palette (pal 0). LoadIconPalettes actually loads
-    TWO icon palettes adjacent, but no vanilla icon uses the 2nd -- so it's free for a colour
-    pal 0 can't provide (our pink Tourmaline). Campaign-agnostic mechanism: DrawIcon bank-bumps
-    any iconId listed in the injected gMSPal1IconIds[] (built by build_campaign.inject_item_icon_pal1,
-    which also repaints pal 1) -- adding 0x1000 to the tile's palette nibble selects the adjacent,
-    reserved palette slot, so it's collision-free. Boundary-clean: the specific ids live in campaign
-    data (gMSPal1IconIds), never here. Declarations precede statements (agbcc is C89)."""
-    with open(ICON_C, encoding='utf-8') as f:
-        text = f.read()
+    LoadIconPalettes preserves the vanilla two-bank load everywhere. DrawIcon loads source palette 2
+    into reserved BG bank 15 only while drawing an opted-in standard item icon, after the caller has
+    initialized its own UI palettes. Callers using other palette bases retain their vanilla selection.
+    """
     if '#include "hardware.h"' not in text:
-        sys.exit('ERROR: icon.c not in expected form (no hardware.h include) for the pal-1 hook')
+        sys.exit('ERROR: icon.c not in expected form (no hardware.h include) for the pal-2 hook')
     text = text.replace(
         '#include "hardware.h"',
         '#include "hardware.h"\n\n'
-        '/* MS (#23): iconIds that draw from item palette 1 (built by inject_item_icon_pal1). */\n'
-        'extern const u16 gMSPal1IconIds[];', 1)
+        '/* MS (#23): iconIds that draw from the additive custom item palette. */\n'
+        'extern const u16 gMSPal2IconIds[];', 1)
+    load_orig = ('void LoadIconPalettes(u32 Dest)\n'
+                 '{\n'
+                 '    ApplyPalettes(item_icon_palette[0], Dest, 2);\n'
+                 '}')
+    load_patched = load_orig
+    if load_orig not in text:
+        sys.exit('ERROR: LoadIconPalettes not in expected vanilla form in %s' % ICON_C)
+    text = text.replace(load_orig, load_patched, 1)
     orig = ('    } else {\n'
             '        u16 Tile = GetIconTileIndex(IconIndex) + OamPalBase;')
     if orig not in text:
         sys.exit('ERROR: DrawIcon not in expected vanilla form in %s' % ICON_C)
     patched = ('    } else {\n'
                '        u16 Tile;\n'
-               '        /* MS (#23): icons in gMSPal1IconIds draw from pal 1 (a colour pal 0 lacks,\n'
-               '           e.g. the pink Tourmaline). LoadIconPalettes loads pal 1 adjacent + unused,\n'
-               '           so bumping the palette nibble (+0x1000) is collision-free. */\n'
-               '        const u16* msPal1 = gMSPal1IconIds;\n'
-               '        while (*msPal1 != 0xFFFF) {\n'
-               '            if (*msPal1++ == IconIndex) {\n'
-               '                OamPalBase |= 0x1000;\n'
+               '        const u16* msPal2 = gMSPal2IconIds;\n'
+               '        /* MS (#23): only the normal item-UI base (BG bank 4) can move to the\n'
+               "           dedicated custom bank 15. Loading here follows the caller's UI setup. */\n"
+               '        while (*msPal2 != 0xFFFF) {\n'
+               '            if (*msPal2++ == IconIndex) {\n'
+               '                if ((OamPalBase & 0xF000) == 0x4000) {\n'
+               '                    ApplyPalette(item_icon_palette[2], 15);\n'
+               '                    OamPalBase = (OamPalBase & 0x0FFF) | 0xF000;\n'
+               '                }\n'
                '                break;\n'
                '            }\n'
                '        }\n'
                '        Tile = GetIconTileIndex(IconIndex) + OamPalBase;')
+    return text.replace(orig, patched, 1)
+
+
+def _patch_draw_icon_pal2():
+    """Append a custom item palette without repurposing the two vanilla icon palettes.
+
+    The palette asset grows from two to three source banks. An opted-in standard item icon loads the
+    custom source into reserved BG bank 15 after the UI's own palette setup; the stock banks remain at
+    4/5. Campaign-specific icon ids live in gMSPal2IconIds, not in this hook.
+    """
+    with open(ICON_C, encoding='utf-8') as f:
+        text = f.read()
     with open(ICON_C, 'w', encoding='utf-8') as f:
-        f.write(text.replace(orig, patched, 1))
+        f.write(_patch_draw_icon_pal2_text(text))
+
+    with open(ICON_H, encoding='utf-8') as f:
+        header = f.read()
+    orig = 'extern const u16 item_icon_palette[2][16]; // Item Icon Palette'
+    patched = 'extern const u16 item_icon_palette[3][16]; // Item Icon Palette + custom bank'
+    if orig not in header:
+        sys.exit('ERROR: icon.h not in expected vanilla form for the pal-2 hook')
+    with open(ICON_H, 'w', encoding='utf-8') as f:
+        f.write(header.replace(orig, patched, 1))
 
 
 def _patch_battle_map_kind_fallback():

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -454,6 +454,9 @@ local function bootToMap()
         press(i % 2 == 0 and K.A or K.START, 4)
         wait(26)
     end
+    log(string.format("boot stuck: chapter=%d host=%d faction=0x%02X turn=%d blue0=%s prep=%s",
+        chapter(), HOST_CHAPTER, faction(), turn(), tostring(unitAt(SYM.gUnitArrayBlue, 0) ~= nil),
+        tostring(procActive(SYM.gProcScr_SALLYCURSOR))))
     shot("boot-stuck")
     return false
 end
@@ -3481,7 +3484,7 @@ scenarios.ch03chest = function()
 end
 
 -- CH03TOURMALINE (#23 art): SHOW the pink Tourmaline icon in-engine. Give a deployed unit the
--- Tourmaline (ITEM_REDGEM, drawn from pal 1 via the DrawIcon hook) alongside pal-0 gems (Blue Gem,
+-- Tourmaline (ITEM_REDGEM, drawn from reserved BG bank 15 via the DrawIcon hook) alongside pal-0 gems (Blue Gem,
 -- Vulnerary/Goodberry) so the shot proves BOTH the pink renders AND the pal-0 items are unaffected.
 -- All three are non-weapons, so the command menu is [Item, Wait] -- Item at row 0. Run:
 -- PT_HOST_CHAPTER=4 tools/playtest/run.sh ch03tourmaline (needs a CH03BOOT=1 ROM).
@@ -3493,7 +3496,7 @@ scenarios.ch03tourmaline = function()
         if c and (c.state & 0x9) == 0 and c.x ~= 0xFF then u = c break end
     end
     if not u then return result("FAIL", "no deployed unit to hold the Tourmaline") end
-    -- items[0..2] = Tourmaline (0x76, pal 1), Blue Gem (0x75, pal 0), Goodberry/Vulnerary (0x6C, pal 0).
+    -- items[0..2] = Tourmaline (0x76, custom pal), Blue Gem (0x75, pal 0), Goodberry/Vulnerary (0x6C, pal 0).
     emu:write16(u.addr + 0x1E + 0, 0x76 | (0x01 << 8))
     emu:write16(u.addr + 0x1E + 2, 0x75 | (0x01 << 8))
     emu:write16(u.addr + 0x1E + 4, 0x6C | (0x01 << 8))
@@ -3530,6 +3533,40 @@ scenarios.ch03tourmaline = function()
     wait(20); shot("ch03tourmaline-cmdmenu")
     press(K.A, 4); wait(40)            -- Item (row 0, no weapon) -> inventory list with icons
     shot("ch03tourmaline-inventory")   -- the money shot: Tourmaline (pink) above two pal-0 items
+    -- Diagnostic for the custom-bank reservation: inventory remains over the battle map, so inspect
+    -- every enabled BG tilemap's palette nibbles before selecting a dedicated icon bank.
+    local dispcnt = ru16(0x04000000)
+    for bg = 0, 3 do
+        if (dispcnt & (1 << (8 + bg))) ~= 0 then
+            local cnt = ru16(0x04000008 + bg * 2)
+            local blocks = ({1, 2, 2, 4})[(cnt >> 14) + 1]
+            local base = 0x06000000 + (((cnt >> 8) & 0x1F) * 0x800)
+            local used = {}
+            for i = 0, blocks * 1024 - 1 do
+                local bank = ru16(base + i * 2) >> 12
+                used[bank] = (used[bank] or 0) + 1
+            end
+            local banks = {}
+            for bank = 0, 15 do if used[bank] then banks[#banks + 1] = bank end end
+            log(string.format("item-menu BG%d palette banks: %s", bg, table.concat(banks, ",")))
+            -- The custom 16x16 icon itself occupies four BG0 tilemap entries. Any additional
+            -- bank-15 entries mean another screen element shares the reservation.
+            if (used[15] or 0) > 4 then
+                return result("FAIL", string.format(
+                    "reserved custom palette bank 15 has %d entries on BG%d (want the Tourmaline's 4 only)",
+                    used[15], bg))
+            end
+        end
+    end
+    -- LoadIconPalettes(4) must preserve vanilla bank 5 (whose second colour is 0x7FDE) and load
+    -- the custom Tourmaline palette in reserved bank 15 (second colour = white, 0x7FFF). The old destructive
+    -- path repainted bank 5, which made regular map/UI text pink.
+    local pal5_second = ru16(0x05000000 + 5 * 32 + 2)
+    local pal15_second = ru16(0x05000000 + 15 * 32 + 2)
+    if pal5_second ~= 0x7FDE or pal15_second ~= 0x7FFF then
+        return result("FAIL", string.format(
+            "item palette banks wrong (bank5[1]=0x%04X, bank15[1]=0x%04X)", pal5_second, pal15_second))
+    end
     -- Data-side confirm: the item is really in slot 0 (the pixels are the deliverable; assert the item).
     local held = ru16(u.addr + 0x1E) & 0xFF
     if held ~= 0x76 then

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -12,6 +12,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import build_campaign as bc
+from inject import engine_hooks as eh
 
 # Read the COMMITTED decomp, not the working tree -- the build overwrites donor portrait
 # slots (Gilliam/Neimi/Moulder/Vanessa), so a working-tree read would be non-hermetic.
@@ -753,11 +754,11 @@ class Ch03TileChanges(unittest.TestCase):
         self.assertIn('.byte 0, 6, 10, 1, 1, 0, 0, 0', asm)   # id 0 at (x=6, y=10), 1x1 region
 
 
-class ItemIconPal1(unittest.TestCase):
-    """The pink-Tourmaline pal-1 route (#23): FE8's item icons all share pal 0 (no pink), but
-    LoadIconPalettes loads a 2nd, unused icon palette adjacent -- free to repaint. build_campaign
-    repaints it + emits gMSPal1IconIds[] (the iconIds that bank-bump to pal 1); the generic DrawIcon
-    hook consults that array."""
+class ItemIconPal2(unittest.TestCase):
+    """Custom-coloured icons append a third source palette and draw from reserved BG bank 15.
+
+    The two vanilla banks are shared UI state and must never be repainted; text can use bank 5.
+    """
     CAMPAIGN = 'rime-of-the-frostmaiden'
 
     def test_bgr555_packs_5bit_channels(self):
@@ -766,26 +767,53 @@ class ItemIconPal1(unittest.TestCase):
         self.assertEqual(bc._bgr555('#ff0000'), 0x001F)          # red in low 5 bits
         self.assertEqual(bc._bgr555('#0000ff'), 0x7C00)          # blue in high 5 bits
 
-    def test_pal1_palette_is_16_bgr555_entries(self):
+    def test_pal2_palette_is_16_bgr555_entries(self):
         colors = ['#000000'] * 16
-        b = bc._item_icon_pal1_bytes(colors)
+        b = bc._item_icon_pal2_bytes(colors)
         self.assertEqual(len(b), 32)                             # 16 colors x 2 bytes
         self.assertEqual(b, b'\x00' * 32)
 
-    def test_pal1_palette_rejects_wrong_length(self):
+    def test_pal2_palette_rejects_wrong_length(self):
         with self.assertRaises(SystemExit):
-            bc._item_icon_pal1_bytes(['#000000'] * 15)
+            bc._item_icon_pal2_bytes(['#000000'] * 15)
 
-    def test_redgem_resolves_to_pal1_icon_id_136(self):
-        # ITEM_REDGEM (the Tourmaline) is the campaign's one pal-1 icon; its iconId is 136.
-        self.assertEqual(bc._pal1_icon_ids(self.CAMPAIGN), [136])
+    def test_pal2_appends_third_bank_without_repainting_vanilla_banks(self):
+        vanilla = bytearray(range(64))
+        out = bc._append_item_icon_pal2(vanilla, ['#000000'] * 16)
+        self.assertEqual(out[:64], vanilla)
+        self.assertEqual(out[64:], b'\x00' * 32)
+
+    def test_redgem_resolves_to_pal2_icon_id_136(self):
+        # ITEM_REDGEM (the Tourmaline) is the campaign's one custom-palette icon; its iconId is 136.
+        self.assertEqual(bc._pal2_icon_ids(self.CAMPAIGN), [136])
 
     def test_iconids_asm_lists_ids_then_terminator(self):
-        asm = bc._ms_pal1_iconids_asm([136, 5])
-        self.assertIn('.global gMSPal1IconIds', asm)
+        asm = bc._ms_pal2_iconids_asm([136, 5])
+        self.assertIn('.global gMSPal2IconIds', asm)
         self.assertIn('.hword 136', asm)
         self.assertIn('.hword 5', asm)
         self.assertIn('.hword 0xFFFF', asm)                     # terminator (no valid iconId is 0xFFFF)
+
+    def test_hook_loads_custom_bank_fifteen_without_changing_vanilla_load(self):
+        source = ('#include "hardware.h"\n\n'
+                  'void LoadIconPalettes(u32 Dest)\n'
+                  '{\n'
+                  '    ApplyPalettes(item_icon_palette[0], Dest, 2);\n'
+                  '}\n\n'
+                  'void DrawIcon(int IconIndex, int TileX, int TileY, int TILEREF)\n'
+                  '{\n'
+                  '    if (TILEREF == 0xFFFF) {\n'
+                  '    } else {\n'
+                  '        u16 Tile = GetIconTileIndex(IconIndex) + OamPalBase;\n'
+                  '    }\n'
+                  '}\n')
+        out = eh._patch_draw_icon_pal2_text(source)
+        self.assertIn('ApplyPalettes(item_icon_palette[0], Dest, 2);', out)
+        self.assertNotIn('ApplyPalette(item_icon_palette[2], 15);\n}', out)
+        self.assertIn('gMSPal2IconIds', out)
+        self.assertIn('(OamPalBase & 0xF000) == 0x4000', out)
+        self.assertIn('ApplyPalette(item_icon_palette[2], 15);', out)
+        self.assertIn('OamPalBase = (OamPalBase & 0x0FFF) | 0xF000;', out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes the Tourmaline item-icon palette regression.

- Preserve both vanilla item-icon source palettes.
- Append the custom source palette instead of repainting a live vanilla bank.
- Route Tourmaline to a runtime-audited BG palette bank only while drawing the custom icon.
- Add unit and mGBA regression coverage: ch03tourmaline proves the pink icon does not recolour terrain or UI text.

Regression follow-up to #23.