### PR TITLE
docs(#65): record Meesmickle animation lessons

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,10 +6,10 @@ live in `CLAUDE.md`; issue scope and backlog live in GitHub.
 ## Current state
 
 - Battle-animation review for RBG and Wolfram is complete in PR #161. Meesmickle's Shaman-based
-  animation is complete on `feat/65-meesmickle-battle-animation`, pending its close-out PR.
+  animation is merged in PR #163 (`1cd65bd`).
 - The Tourmaline palette correction is separately merged as PR #162 (`f9ed1cc`); #161 is based on
   that work and does not reintroduce the palette change.
-- Current focus: merge Meesmickle, then choose the next character for battle-animation review.
+- Current focus: choose the next character for battle-animation review.
 - Before a context rollover, warn Nicolas, refresh this file, and begin a fresh instance. Do not rely
   on automatic context compaction as the handoff mechanism.
 
@@ -34,6 +34,9 @@ live in `CLAUDE.md`; issue scope and backlog live in GitHub.
   preserve the source poses' relative alignment, and use the Shaman magic cadence. The vanilla
   Shaman's visual charge is baked into its many actor frames; Meesmickle instead holds the supplied
   wind-up pose with the charge sound before Flux. Nicolas accepted that limitation for this pass.
+- The reusable review-loop lessons are recorded in `docs/decisions.md`: distinguish donor actor art
+  from engine effects, preview the final GBA palette before packing, preserve opaque black outside
+  OBJ index 0, and defer the 1,507-entry archive rebuild until a candidate is selected.
 
 ### Demo cleanup
 
@@ -69,8 +72,8 @@ live in `CLAUDE.md`; issue scope and backlog live in GitHub.
 
 ## Working tree - do not lose or revert
 
-All Meesmickle source, pipeline, and animation changes are committed and pushed on
-`feat/65-meesmickle-battle-animation`. The temporary review GIF is pruned before merge.
+All Meesmickle source, pipeline, and animation changes are merged in PR #163. Its remote feature
+branch and temporary review GIF are pruned.
 
 Other working-tree state:
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1618,6 +1618,31 @@ campaign-agnostically.
   only quote-less frames, and key the verdict on capturing real anim frames (`sawAnim`).
 _Decided: 2026-06-26_
 
+**Faked battle-animation review loop: donor visuals, game-valid previews, and archive cost (#65)**
+Meesmickle exposed four rules that apply to every remaining custom battle animation.
+- **Study the donor's pictures as well as its commands.** A `motion.s` command can start an engine
+  effect, play audio, or merely advance actor frames. The vanilla Shaman's visible charge is not a
+  reusable Flux effect: it is drawn across roughly 35 Shaman actor frames between
+  `banim_code_sound_elec_charge` and `banim_code_call_spell_anim`. A three-pose replacement can copy
+  that timing and sound but cannot reproduce the visual charge unless the supplied art includes a
+  charge loop. Meesmickle deliberately ships with a held wind-up pose plus the vanilla charge sound
+  and Flux release; that limitation was accepted after an in-engine comparison. Future magic donors
+  must classify every visible beat as actor art versus engine effect before wiring begins.
+- **"Least processed" still means game-valid.** The first review image comes from cleaned alpha art,
+  one shared geometry transform, hard alpha, and the final shared OBJ palette (at most 15 visible
+  colours). Sharpening, outline growth, and pixel touch-up are later A/B passes. Never ask for visual
+  approval on a full-colour intermediate that cannot be packed into the GBA.
+- **OBJ palette index 0 is transparency, even when its RGB is black.** Opaque black therefore needs
+  a duplicate nonzero palette entry; mapping it to index 0 creates holes that a desktop PNG preview
+  will not reveal. Palette tests pin this, and the accepted candidate still requires a real mGBA
+  capture before merge.
+- **Batch art decisions before the archive rebuild.** `data_banim.o` is produced by a serial linker
+  that walks all 1,507 battle-animation inputs, so a full repack takes minutes. Direct palette-valid
+  previews are the fast iteration loop; pay the archive rebuild only after a candidate is selected,
+  then use `recordanim` as the final visual gate. Do not describe the full repack as a normal
+  per-preview step or start it before the user approves the packed-pixel preview.
+_Decided: 2026-07-14 (Meesmickle review + in-engine close-out, PR #163)_
+
 **Event backgrounds (`BACG`): vendored winter CGs, injected as NEW `gConvoBackgroundData` slots**
 Cutscene backdrops are `gConvoBackgroundData[]` (eventscr2.c) `{tiles, map, palette}` triples, 240×160,
 4bpp with up to **8 sixteen-colour sub-palettes** (one per 8×8 tile = 128 colours). We vendor winter


### PR DESCRIPTION
## Summary

- refresh `HANDOFF.md` to the merged Meesmickle state
- record donor-visual versus engine-effect lessons from the Shaman comparison
- codify game-valid palette previews and delayed archive rebuilds for future animation reviews

## Verification

- `python3 tools/test_descale_battleframe.py`
- `python3 -m unittest tools/test_ref_to_battleframe.py tools/test_build_campaign.py` (132 tests)
- `python3 tools/verify_text.py` (3,404 messages, no runaway text)
- `make check`
- `git diff --check`

Refs #65
