### PR TITLE
refactor(#168): dedicated gMSSpellTint global replaces the gEfxSpellAnimExists overload

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1643,18 +1643,27 @@ Meesmickle exposed four rules that apply to every remaining custom battle animat
   per-preview step or start it before the user approves the packed-pixel preview.
 _Decided: 2026-07-14 (Meesmickle review + in-engine close-out, PR #163)_
 
-**Character-scoped spell colours are campaign data; transient tint state reuses the spell lifecycle (#165)**
+**Character-scoped spell colours are campaign data; the tint rides a dedicated overlay global (#165, #168)**
 Marty's `battle_anim.spell_palette_tint` declares a character + weapon-type match in YAML, so one
 row covers every Dark tome he can wield without naming Marty in engine code or changing the tome's
-mechanics. The generated table is immutable ROM data. At spell dispatch, its tint id is carried in
-the existing writable `gEfxSpellAnimExists` lifecycle value (`0` = absent, `1` = ordinary,
-`2` = green); every existing consumer treats that value as zero/nonzero. `SpellFx_Begin` preserves
-the green sentinel, palette registration recolours saturated BG/OBJ colours while retaining neutral
-greys, and `SpellFx_Finish` clears the state normally. Do not add a second mutable tint global in an
-unrelated compilation unit: this decomp's linker either placed that storage in ROM or discarded its
-new EWRAM section. The TESTCH `recordanim` capture is the visual gate; Marty rendered green Flux in
-mGBA while the table remains character- and `ITYPE_DARK`-scoped.
-_Decided: 2026-07-15 (Nicolas approved the in-engine Marty capture; #165)_
+mechanics. The generated table (`gBanimSpellPaletteTints`) is immutable ROM data. At spell dispatch,
+`StartSpellAnimation` records the matching tint id in `gMSSpellTint` — a dedicated
+`EWRAM_OVERLAY(banim) u8` declared beside `gEfxSpellAnimExists` in `banim-ekrbattle.c` (the enum is
+honest: `BANIM_SPELL_TINT_NONE = 0`, `BANIM_SPELL_TINT_GREEN = 1`). Palette registration reads
+`gMSSpellTint` and recolours saturated BG/OBJ colours while retaining neutral greys; teardown
+(`EkrEfxStatusClear`) clears it alongside the vanilla `gEfxSpellAnimExists` reset.
+
+The durable lesson: a caster-scoped tint gets its **own** overlay-banim global declared beside
+`gEfxSpellAnimExists` — do **not** overload the spell-lifecycle flag. A global's storage is decided
+by the compilation unit it lives in, not the abstract `EWRAM_*` macro: declared inside an unrelated
+TU the linker placed it in ROM (read-only, silently ignored writes), but declared beside the proven
+`EWRAM_OVERLAY(banim)` siblings in `banim-ekrbattle.c` it links writable. Overloading
+`gEfxSpellAnimExists` (the earlier shipped form) worked only because every vanilla reader compared
+`== 0`/`false`, an unenforced invariant that any future `= true`/`== 1` would silently break; the
+dedicated global removes that landmine. The TESTCH `recordanim` capture is the visual gate; Marty
+renders green Flux in mGBA while the table stays character- and `ITYPE_DARK`-scoped.
+_Decided: 2026-07-15 (#165 shipped the feature; #168 replaced the `gEfxSpellAnimExists` overload with
+the dedicated `gMSSpellTint` global, gated on the in-engine Marty capture)_
 
 **Event backgrounds (`BACG`): vendored winter CGs, injected as NEW `gConvoBackgroundData` slots**
 Cutscene backdrops are `gConvoBackgroundData[]` (eventscr2.c) `{tiles, map, palette}` triples, 240×160,

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -394,11 +394,14 @@ PATCHED_DECOMP_FILES = ['texts/texts.txt', 'src/data_characters.c', 'src/portrai
                         'src/banim_data.c', 'include/banim_pointer.h',
                         'src/data_banimconf.c', 'include/ekrbattle.h',
                         # #165 caster-scoped spell-palette tint (green Dark magic): the
-                        # _patch_banim_spell_palette_tint hook patches these two TUs (the
+                        # _patch_banim_spell_palette_tint hook patches these TUs -- the
                         # GetBanimSpellPaletteTint lookup + StartSpellAnimation seam in
-                        # efxmagic; the green recolour + palette-copy wrap in ekrutils);
-                        # ekrbattle.h (the enum/struct/table extern) is listed above.
+                        # efxmagic; the green recolour + palette-copy wrap in ekrutils; the
+                        # dedicated gMSSpellTint overlay global in ekrbattle (declared beside
+                        # gEfxSpellAnimExists); its teardown reset in ekrdispup. ekrbattle.h
+                        # (the enum/struct/table + gMSSpellTint extern) is listed above.
                         'src/banim-efxmagic.c', 'src/banim-ekrutils.c',
+                        'src/banim-ekrbattle.c', 'src/banim-ekrdispup.c',
                         'linker_script_banim.txt',
                         # #65 M-B (character-unique anims, no class slot): the per-character
                         # config table gets the AnimConf appended; the combat-lookup engine

--- a/tools/inject/engine_hooks.py
+++ b/tools/inject/engine_hooks.py
@@ -19,6 +19,8 @@ BANIM_EKRMAIN_C = os.path.join(DECOMP, 'src', 'banim-ekrmain.c')
 BANIM_DATA_C = os.path.join(DECOMP, 'src', 'banim_data.c')
 BANIM_EFXMAGIC_C = os.path.join(DECOMP, 'src', 'banim-efxmagic.c')
 BANIM_EKRUTILS_C = os.path.join(DECOMP, 'src', 'banim-ekrutils.c')
+BANIM_EKRBATTLE_C = os.path.join(DECOMP, 'src', 'banim-ekrbattle.c')
+BANIM_EKRDISPUP_C = os.path.join(DECOMP, 'src', 'banim-ekrdispup.c')
 BANIM_EKRBATTLE_H = os.path.join(DECOMP, 'include', 'ekrbattle.h')
 BMCAMADJUST_C = os.path.join(DECOMP, 'src', 'bmcamadjust.c')
 BMMAP_C = os.path.join(DECOMP, 'src', 'bmmap.c')
@@ -117,38 +119,24 @@ def _patch_banim_palette_custom_guard():
 
 
 def _spell_palette_tint_start(text):
-    """Encode the current caster's tint in the existing spell-effect state."""
+    """Record the current caster's tint in the dedicated spell-tint global."""
     line = '    s16 index = gEkrSpellAnimIndex[GetAnimPosition(anim)];\n'
     # This decomp targets C89: keep all local declarations before executable
     # statements in StartSpellAnimation.
-    injected = line + '    gEfxSpellAnimExists = GetBanimSpellPaletteTint(anim);\n'
-    if injected in text:
-        return text
-    text = text.replace('    gBanimSpellPaletteTint = GetBanimSpellPaletteTint(anim);\n', '', 1)
-    return text.replace(line, injected, 1)
-
-
-def _spell_palette_tint_begin(text):
-    """Do not overwrite the green-tint sentinel when the effect starts."""
-    line = '    gEfxSpellAnimExists = true;\n'
-    injected = ('    if (gEfxSpellAnimExists != BANIM_SPELL_TINT_GREEN)\n'
-                '        gEfxSpellAnimExists = true;\n')
+    injected = line + '    gMSSpellTint = GetBanimSpellPaletteTint(anim);\n'
     if injected in text:
         return text
     return text.replace(line, injected, 1)
-
-
-def _spell_palette_tint_finish(text):
-    """Migrate prior builds away from the discarded transient global."""
-    return text.replace('    gBanimSpellPaletteTint = BANIM_SPELL_TINT_NONE;\n', '', 1)
 
 
 def _patch_banim_spell_palette_tint():
     """Add a data-driven, caster-scoped spell-palette tint seam.
 
-    Campaign data appends character/weapon-type rows. The engine activates the matching
-    tint only for that spell dispatch, recolors spell BG/OBJ palette uploads, and clears it
-    with the existing SpellFx lifecycle. Normal effects and every unconfigured combatant
+    Campaign data appends character/weapon-type rows. The engine records the matching
+    tint for that spell dispatch in a dedicated EWRAM_OVERLAY(banim) global gMSSpellTint
+    (declared beside gEfxSpellAnimExists, the proven-writable overlay section), recolors
+    the spell's BG/OBJ palette uploads, and clears it with the existing SpellFx lifecycle.
+    gEfxSpellAnimExists stays byte-vanilla. Normal effects and every unconfigured combatant
     remain vanilla.
     """
     with open(BANIM_EKRBATTLE_H, encoding='utf-8') as f:
@@ -157,34 +145,34 @@ def _patch_banim_spell_palette_tint():
         anchor = 'enum ekr_hit_identifer {'
         decl = ('enum BanimSpellPaletteTintId {\n'
                 '    BANIM_SPELL_TINT_NONE = 0,\n'
-                '    BANIM_SPELL_TINT_GREEN = 2,\n'
+                '    BANIM_SPELL_TINT_GREEN = 1,\n'
                 '};\n\n'
                 'struct BanimSpellPaletteTint {\n'
                 '    u8 character;\n'
                 '    u8 weapon_type;\n'
                 '    u8 tint;\n'
                 '};\n\n'
-                'extern CONST_DATA struct BanimSpellPaletteTint gBanimSpellPaletteTints[];\n\n')
+                'extern CONST_DATA struct BanimSpellPaletteTint gBanimSpellPaletteTints[];\n'
+                'extern u8 gMSSpellTint;\n\n')
         if anchor not in header:
             sys.exit('ERROR: spell palette tint header anchor missing in %s' % BANIM_EKRBATTLE_H)
         with open(BANIM_EKRBATTLE_H, 'w', encoding='utf-8') as f:
             f.write(header.replace(anchor, decl + anchor, 1))
-    else:
-        header = header.replace('    BANIM_SPELL_TINT_NONE,\n'
-                                '    BANIM_SPELL_TINT_GREEN,\n',
-                                '    BANIM_SPELL_TINT_NONE = 0,\n'
-                                '    BANIM_SPELL_TINT_GREEN = 2,\n', 1)
-        header = header.replace('extern u8 gBanimSpellPaletteTint;\n', '', 1)
-        with open(BANIM_EKRBATTLE_H, 'w', encoding='utf-8') as f:
-            f.write(header)
+
+    with open(BANIM_EKRBATTLE_C, encoding='utf-8') as f:
+        battle = f.read()
+    if 'gMSSpellTint' not in battle:
+        anchor = 'EWRAM_OVERLAY(banim) u32 gEfxSpellAnimExists = 0;\n'
+        if anchor not in battle:
+            sys.exit('ERROR: spell-tint global anchor missing in %s' % BANIM_EKRBATTLE_C)
+        battle = battle.replace(
+            anchor,
+            anchor + 'EWRAM_OVERLAY(banim) u8 gMSSpellTint = BANIM_SPELL_TINT_NONE;\n', 1)
+        with open(BANIM_EKRBATTLE_C, 'w', encoding='utf-8') as f:
+            f.write(battle)
 
     with open(BANIM_EFXMAGIC_C, encoding='utf-8') as f:
         magic = f.read()
-    for old_decl in (
-        'EWRAM_OVERLAY(banim) u8 gBanimSpellPaletteTint = BANIM_SPELL_TINT_NONE;\n\n',
-        'EWRAM_DATA u8 gBanimSpellPaletteTint = BANIM_SPELL_TINT_NONE;\n\n',
-    ):
-        magic = magic.replace(old_decl, '', 1)
     if 'GetBanimSpellPaletteTint(struct Anim *anim)' not in magic:
         anchor = 'CONST_DATA SpellAnimFunc gEkrSpellAnimLut[] = {'
         support = ('static u8 GetBanimSpellPaletteTint(struct Anim *anim)\n'
@@ -207,24 +195,13 @@ def _patch_banim_spell_palette_tint():
         magic = magic.replace('#include "bmlib.h"', '#include "bmlib.h"\n#include "bmbattle.h"', 1)
         magic = magic.replace(anchor, support + anchor, 1)
     magic = _spell_palette_tint_start(magic)
-    if 'gEfxSpellAnimExists = GetBanimSpellPaletteTint(anim);' not in magic:
+    if 'gMSSpellTint = GetBanimSpellPaletteTint(anim);' not in magic:
         sys.exit('ERROR: StartSpellAnimation seam missing in %s' % BANIM_EFXMAGIC_C)
     with open(BANIM_EFXMAGIC_C, 'w', encoding='utf-8') as f:
         f.write(magic)
 
     with open(BANIM_EKRUTILS_C, encoding='utf-8') as f:
         utils = f.read()
-    for old_decl in (
-        'EWRAM_OVERLAY(banim) u8 gBanimSpellPaletteTint = BANIM_SPELL_TINT_NONE;\n',
-        'EWRAM_DATA u8 gBanimSpellPaletteTint = BANIM_SPELL_TINT_NONE;\n',
-        'u8 gBanimSpellPaletteTint = BANIM_SPELL_TINT_NONE;\n',
-        'u8 gBanimSpellPaletteTint;\n',
-    ):
-        utils = utils.replace(old_decl, '', 1)
-    utils = _spell_palette_tint_begin(utils)
-    utils = _spell_palette_tint_finish(utils)
-    utils = utils.replace('if (gBanimSpellPaletteTint == BANIM_SPELL_TINT_NONE)',
-                          'if (gEfxSpellAnimExists != BANIM_SPELL_TINT_GREEN)', 1)
     if 'BanimSpellPaletteCopy' not in utils:
         anchor = 'void SpellFx_RegisterObjGfx(const u16 * img, u32 size)\n'
         support = ('static u16 BanimSpellTintGreen(u16 color)\n'
@@ -247,7 +224,7 @@ def _patch_banim_spell_palette_tint():
                    'static void BanimSpellPaletteCopy(const u16 *src, u16 *dst, u32 size)\n'
                    '{\n'
                    '    u32 i;\n\n'
-                   '    if (gEfxSpellAnimExists != BANIM_SPELL_TINT_GREEN) {\n'
+                   '    if (gMSSpellTint != BANIM_SPELL_TINT_GREEN) {\n'
                    '        CpuFastCopy(src, dst, size);\n'
                    '        return;\n'
                    '    }\n\n'
@@ -263,6 +240,18 @@ def _patch_banim_spell_palette_tint():
                               '    BanimSpellPaletteCopy(pal, PAL_BG(OBJPAL_BANIM_SPELL_BG), size);\n', 1)
     with open(BANIM_EKRUTILS_C, 'w', encoding='utf-8') as f:
         f.write(utils)
+
+    # Clear the tint at spell teardown, alongside the vanilla gEfxSpellAnimExists reset.
+    with open(BANIM_EKRDISPUP_C, encoding='utf-8') as f:
+        dispup = f.read()
+    reset = '    gMSSpellTint = BANIM_SPELL_TINT_NONE;\n'
+    if reset not in dispup:
+        anchor = '    gEfxSpellAnimExists = 0;\n'
+        if anchor not in dispup:
+            sys.exit('ERROR: spell-tint reset anchor missing in %s' % BANIM_EKRDISPUP_C)
+        dispup = dispup.replace(anchor, anchor + reset, 1)
+        with open(BANIM_EKRDISPUP_C, 'w', encoding='utf-8') as f:
+            f.write(dispup)
 
 
 def _patch_player_start_cursor_guard():

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -582,53 +582,54 @@ class BattleSpellPaletteTint(unittest.TestCase):
         self.assertIn('{ CHARACTER_SETH, ITYPE_DARK, BANIM_SPELL_TINT_GREEN },', out)
         self.assertIn('{ 0, 0, BANIM_SPELL_TINT_NONE },', out)
 
-    def test_engine_hook_uses_the_existing_spell_lifecycle_state_for_tint(self):
+    def test_engine_hook_records_the_tint_in_the_dedicated_global(self):
         src = ('void StartSpellAnimation(struct Anim *anim)\n'
                '{\n'
                '    s16 index = gEkrSpellAnimIndex[GetAnimPosition(anim)];\n'
                '}\n')
         self.assertTrue(hasattr(eh, '_spell_palette_tint_start'))
         out = eh._spell_palette_tint_start(src)
-        self.assertIn('gEfxSpellAnimExists = GetBanimSpellPaletteTint(anim);', out)
-        self.assertLess(out.index('s16 index'), out.index('gEfxSpellAnimExists'))
+        self.assertIn('gMSSpellTint = GetBanimSpellPaletteTint(anim);', out)
+        self.assertLess(out.index('s16 index'), out.index('gMSSpellTint'))
 
-    def test_engine_hook_preserves_a_configured_tint_when_spell_begins(self):
-        src = ('void SpellFx_Begin(void)\n'
-               '{\n'
-               '    gEfxSpellAnimExists = true;\n'
-               '}\n')
-        self.assertTrue(hasattr(eh, '_spell_palette_tint_begin'))
-        out = eh._spell_palette_tint_begin(src)
-        self.assertIn('if (gEfxSpellAnimExists != BANIM_SPELL_TINT_GREEN)', out)
-        self.assertIn('gEfxSpellAnimExists = true;', out)
-
-    def test_engine_hook_reuses_writable_spell_state_without_a_new_global(self):
-        """The tint lives in the existing EWRAM lifecycle flag, never in ROM."""
-        with open(eh.BANIM_EKRBATTLE_H, encoding='utf-8') as f:
-            header_before = f.read()
-        with open(eh.BANIM_EFXMAGIC_C, encoding='utf-8') as f:
-            magic_before = f.read()
-        with open(eh.BANIM_EKRUTILS_C, encoding='utf-8') as f:
-            utils_before = f.read()
+    def test_tint_rides_a_dedicated_overlay_global_leaving_the_lifecycle_flag_vanilla(self):
+        """The tint rides its own EWRAM_OVERLAY(banim) global; gEfxSpellAnimExists stays vanilla."""
+        patched = ('BANIM_EKRBATTLE_H', 'BANIM_EFXMAGIC_C', 'BANIM_EKRUTILS_C',
+                   'BANIM_EKRBATTLE_C', 'BANIM_EKRDISPUP_C')
+        before = {name: open(getattr(eh, name), encoding='utf-8').read() for name in patched}
 
         try:
             eh._patch_banim_spell_palette_tint()
             with open(eh.BANIM_EKRBATTLE_H, encoding='utf-8') as f:
                 header = f.read()
+            with open(eh.BANIM_EKRBATTLE_C, encoding='utf-8') as f:
+                battle = f.read()
             with open(eh.BANIM_EKRUTILS_C, encoding='utf-8') as f:
                 utils = f.read()
-            self.assertNotIn('extern u8 gBanimSpellPaletteTint;', header)
-            self.assertNotIn('u8 gBanimSpellPaletteTint', utils)
+            with open(eh.BANIM_EKRDISPUP_C, encoding='utf-8') as f:
+                dispup = f.read()
+            # A dedicated global, declared beside the proven-writable lifecycle flag.
+            self.assertIn('extern u8 gMSSpellTint;', header)
+            self.assertIn('EWRAM_OVERLAY(banim) u8 gMSSpellTint = BANIM_SPELL_TINT_NONE;', battle)
+            # The abandoned transient global is gone everywhere (the plural
+            # gBanimSpellPaletteTints table is the legitimate data symbol).
+            self.assertIsNone(re.search(r'gBanimSpellPaletteTint\b', header))
+            self.assertIsNone(re.search(r'gBanimSpellPaletteTint\b', utils))
+            # SpellFx_Begin's lifecycle flag is untouched (no tint guard smuggled in).
+            begin = utils[utils.index('void SpellFx_Begin'):]
+            begin = begin[:begin.index('void SpellFx_Finish')]
+            self.assertIn('gEfxSpellAnimExists = true;', begin)
+            self.assertNotIn('BANIM_SPELL_TINT', begin)
+            # The palette copy reads the dedicated global, not the lifecycle flag.
             palette_copy = utils[utils.index('static void BanimSpellPaletteCopy'):]
-            self.assertIn('if (gEfxSpellAnimExists != BANIM_SPELL_TINT_GREEN)', palette_copy)
-            self.assertNotIn('gBanimSpellPaletteTint', palette_copy)
+            self.assertIn('if (gMSSpellTint != BANIM_SPELL_TINT_GREEN)', palette_copy)
+            self.assertNotIn('gEfxSpellAnimExists', palette_copy)
+            # Teardown clears the tint beside the vanilla lifecycle reset.
+            self.assertIn('gMSSpellTint = BANIM_SPELL_TINT_NONE;', dispup)
         finally:
-            with open(eh.BANIM_EKRBATTLE_H, 'w', encoding='utf-8') as f:
-                f.write(header_before)
-            with open(eh.BANIM_EFXMAGIC_C, 'w', encoding='utf-8') as f:
-                f.write(magic_before)
-            with open(eh.BANIM_EKRUTILS_C, 'w', encoding='utf-8') as f:
-                f.write(utils_before)
+            for name, text in before.items():
+                with open(getattr(eh, name), 'w', encoding='utf-8') as f:
+                    f.write(text)
 
 
 class BattlePlatformTerrain(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #165/#166 (green Dark magic), after the registration gaps were fixed in #167. This is the deeper cleanup #168 called for: remove a silent-failure landmine + dead code, and make the tint an honest abstraction. **No feature change** — Marty's green Flux renders identically; the mechanism underneath is now sound.

### What changed (Stages 1–4 from #168)
- **Stage 1 — dead migration shims deleted.** #167 restores the patched TUs from vanilla each build, so the hook only ever sees vanilla → the `gBanimSpellPaletteTint` strippers, `_spell_palette_tint_finish`, and the idempotent header else-branch were dead code. Gone.
- **Stage 2 — the substantive fix.** The tint no longer rides the spell-lifecycle boolean `gEfxSpellAnimExists` (safe *today* only because every vanilla reader compares `== 0`/`false` — an unenforced invariant any future `= true`/`== 1` would silently break). It now lives in a dedicated `EWRAM_OVERLAY(banim) u8 gMSSpellTint`, declared beside `gEfxSpellAnimExists` in `banim-ekrbattle.c` (the proven-writable overlay section). `StartSpellAnimation` sets it, `BanimSpellPaletteCopy` reads it, `EkrEfxStatusClear` resets it. **`gEfxSpellAnimExists` is byte-vanilla again** (`SpellFx_Begin` unguarded).
- **Stage 3 — honest enum.** `BANIM_SPELL_TINT_GREEN = 1` (value `1` freed by Stage 2). Recolor stays green-only (general hue-rotate is YAGNI until a 2nd tinted caster); table stays `character + weapon_type` extensible.
- **Stage 4 — tests + ADR.** Unit tests retargeted to the dedicated global/enum; `decisions.md` ADR rewritten natively (no revert banner).
- Registered `banim-ekrbattle.c` + `banim-ekrdispup.c` in `PATCHED_DECOMP_FILES`.

### Verification
- `make` (TESTCH + normal) green → **`gMSSpellTint` links writable, no fallback needed** (the one real Stage-2 risk).
- `verify_text` **3404/0** · **94** unit tests green · `check.py` **drift clean**.
- `PT_CHAR=marty recordanim` **PASS**, and the green Flux is confirmed by data — not eyeballed pixels: **3.51%** strongly green-dominant pixels in the two cast windows (frames 0039–0045, 0129–0135) vs **~0.6%** idle baseline (Marty's static sprite). A ~6× spike exactly during the casts.
- Boundary intact — no campaign id enters the engine hook.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
