### PR TITLE
feat(#170): extract vanilla twin item economy from HEAD in the parity engine

### DIFF
--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -708,6 +708,7 @@ def report(campaign, ch):
               % (num, ref))
 
     _print_pressure(_chapter_pressure(chap))
+    _print_economy(chap)
 
 
 def _chapter_pressure(chap, band=0.25):
@@ -758,6 +759,162 @@ def _print_pressure(p):
              ol, v['load_ratio'], v['load']))
     print('  verdict: %s' % ('PARITY (within band)' if v['verdict'] == 'OK'
                              else 'OFF-PARITY -- threat %s, clear-load %s' % (v['threat'], v['load'])))
+
+
+# ── Item-economy parity (#170) ──────────────────────────────────────────────────
+# The vanilla twin's payout, read from HEAD via bc.vanilla_decomp_text -- NEVER the working
+# tree, which the build injects our own chapters into (reading the tree by hand once had our
+# ch03 chests reported as vanilla Ch4's). Same ground-truth discipline as the enemy rosters:
+# chests + village/house gifts + shops, valued from data_items.c. Drops are a documented v1
+# gap (the curated Ch4/Ch5 twins carry none) -- see #170.
+
+# parity_reference -> the decomp chapter file stem whose event data carries its economy.
+PARITY_REFERENCE_ECON = {
+    'FE8 Prologue': 'prologue', 'FE8 Ch1': 'ch1', 'FE8 Ch2': 'ch2', 'FE8 Ch3': 'ch3',
+    'FE8 Ch4': 'ch4', 'FE8 Ch5': 'ch5', 'FE8 Ch6': 'ch6', 'FE8 Ch13': 'ch13a',
+}
+
+_ITEM_VALUES = None
+_ITEM_IDS = None
+
+
+def _item_gold_values():
+    """ITEM_x enum -> buy gold (costPerUse * maxUses) from vanilla data_items.c (HEAD). A
+    gem/booster's value is that product; sell is ~half. Cached (one decomp read)."""
+    global _ITEM_VALUES
+    if _ITEM_VALUES is None:
+        text = bc.vanilla_decomp_text('src/data_items.c')
+        _ITEM_VALUES = {}
+        for m in re.finditer(r'\[(ITEM_\w+)\]\s*=\s*\{(.*?)\n\s*\},', text, re.S):
+            body = m.group(2)
+            cpu = re.search(r'\.costPerUse\s*=\s*(\d+)', body)
+            uses = re.search(r'\.maxUses\s*=\s*(\d+)', body)
+            _ITEM_VALUES[m.group(1)] = ((int(cpu.group(1)) if cpu else 0)
+                                        * (int(uses.group(1)) if uses else 1))
+    return _ITEM_VALUES
+
+
+def item_gold_value(item_enum):
+    """Buy-gold of a vanilla ITEM_x enum (0 if unknown or valueless)."""
+    return _item_gold_values().get(item_enum, 0)
+
+
+def _item_id_to_enum():
+    """Numeric item id -> ITEM_x enum, from vanilla constants/items.h (HEAD). Village/house
+    GIVEITEMTO gifts name their item by numeric id (SVAL), so we resolve id -> enum -> value."""
+    global _ITEM_IDS
+    if _ITEM_IDS is None:
+        text = bc.vanilla_decomp_text('include/constants/items.h')
+        _ITEM_IDS = {}
+        val = -1
+        for line in text.splitlines():
+            s = line.strip()
+            if not s.startswith('ITEM_'):
+                continue
+            m = re.match(r'(ITEM_\w+)\s*(?:=\s*(0x[0-9a-fA-F]+|\d+))?', s)
+            if not m:
+                continue
+            val = int(m.group(2), 0) if m.group(2) else val + 1
+            _ITEM_IDS[val] = m.group(1)
+    return _ITEM_IDS
+
+
+def _shoplist_items(shoplist_text, list_sym):
+    """The ITEM_x enums a ShopList_ array stocks (ITEM_NONE terminator dropped)."""
+    m = re.search(re.escape(list_sym) + r'\[\]\s*=\s*\{(.*?)\}', shoplist_text, re.S)
+    if not m:
+        return []
+    return [it for it in re.findall(r'ITEM_\w+', m.group(1)) if it != 'ITEM_NONE']
+
+
+def _gift_items(eventscript_text):
+    """Every item handed out in the chapter script: for each GIVEITEMTO, the nearest preceding
+    SVAL(EVT_SLOT_3, <id>) sets its item. Catches village/house gifts AND conditional/clear
+    rewards given outside a Village macro (e.g. Ch5's all-villages-saved Guiding Ring, handed to
+    the leader). Returns the ITEM_x enums. An event village that only spawns a unit (SVAL to a
+    different slot, no GIVEITEMTO) contributes nothing, as it should."""
+    id2e = _item_id_to_enum()
+    out = []
+    for g in re.finditer(r'GIVEITEMTO', eventscript_text):
+        pre = re.findall(r'SVAL\(EVT_SLOT_3,\s*(0x[0-9a-fA-F]+|\d+)\)',
+                         eventscript_text[:g.start()])
+        if pre:
+            enum = id2e.get(int(pre[-1], 0))
+            if enum:
+                out.append(enum)
+    return out
+
+
+def vanilla_economy(parity_ref):
+    """The vanilla twin's item economy, read from HEAD: chests, gifts (villages/houses/clear
+    rewards), and shops, each valued in buy-gold. None if the reference has no mapped economy
+    source (#170). Delivery context (# of villages/houses) is kept for the vehicle story."""
+    stem = PARITY_REFERENCE_ECON.get(parity_ref)
+    if stem is None:
+        return None
+    info = bc.vanilla_decomp_text('src/events/%s-eventinfo.h' % stem)
+    script = bc.vanilla_decomp_text('src/events/%s-eventscript.h' % stem)
+    shoptext = bc.vanilla_decomp_text('src/events_shoplist.c')
+    chests = [(it, item_gold_value(it)) for it in re.findall(r'Chest\((ITEM_\w+)', info)]
+    gifts = [(it, item_gold_value(it)) for it in _gift_items(script)]
+    shops = [(sym, _shoplist_items(shoptext, sym))
+             for sym in re.findall(r'(?:Armory|Vendor)\(\s*(\w+)', info)]
+    total = sum(v for _, v in chests) + sum(v for _, v in gifts)
+    return {'reference': parity_ref, 'chests': chests, 'gifts': gifts, 'shops': shops,
+            'n_villages': len(re.findall(r'Village\(', info)),
+            'n_houses': len(re.findall(r'House\(', info)), 'total_gold': total}
+
+
+def chapter_economy(chap):
+    """Our chapter's declared economy from its YAML: explicit gold + item ids by vehicle.
+    Campaign item ids aren't valued here (they aren't vanilla enums) -- the vanilla bar is the
+    gold target; ours is listed alongside for a same-glance compare."""
+    gold = 0
+    gifts, chests, drops = [], [], []
+    for v in chap.get('villages') or []:
+        for r in v.get('visit_reward') or []:
+            if r.get('id') == 'gold':
+                gold += int(r.get('amount') or 0)
+            elif r.get('id'):
+                gifts.append(r['id'])
+    for c in chap.get('chests') or []:
+        for it in c.get('contents') or []:
+            if it.get('id'):
+                chests.append(it['id'])
+    for ed in chap.get('enemy_units') or []:
+        if ed.get('item_drop'):
+            drops.append(ed['item_drop'])
+    pc = chap.get('post_chapter') or {}
+    gold += int(pc.get('gold_reward') or 0)
+    shops = list(pc.get('available_shops') or chap.get('available_shops') or [])
+    return {'gold': gold, 'gifts': gifts, 'chests': chests, 'drops': drops, 'shops': shops}
+
+
+def _print_economy(chap):
+    ref = chap.get('parity_reference')
+    van = vanilla_economy(ref)
+    print('\n-- ITEM-ECONOMY PARITY (vs %s) [from HEAD, not the injected worktree] '
+          % (ref or '?') + '-' * 6)
+    if van is None:
+        print('  (no mapped vanilla economy for %r -- skipped)' % ref)
+    else:
+        def fmt(pairs):
+            return ', '.join('%s %dg' % (it.replace('ITEM_', ''), v)
+                             for it, v in pairs) or 'none'
+        print('  vanilla %-11s ~%dg total in gifts+chests' % (ref, van['total_gold']))
+        print('    chests: %s' % fmt(van['chests']))
+        print('    gifts:  %s  (via %d village/%d house + clear rewards)'
+              % (fmt(van['gifts']), van['n_villages'], van['n_houses']))
+        print('    shops:  %s' % (', '.join('%s (%d items)'
+              % (s.replace('ShopList_Event_', ''), len(items))
+              for s, items in van['shops']) or 'none'))
+    ours = chapter_economy(chap)
+    parts = ['%dg declared' % ours['gold']]
+    for label in ('chests', 'gifts', 'drops', 'shops'):
+        if ours[label]:
+            parts.append('%s[%s]' % (label, ', '.join(map(str, ours[label]))))
+    print('  ours:   %s' % ' · '.join(parts))
+    print('  (advisory target: match the twin\'s magnitude + delivery vehicle; not a hard gate)')
 
 
 def curve_gate_failures(rows):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -589,5 +589,70 @@ class LordFloorSolver(unittest.TestCase):
         self.assertFalse(f.reached)
 
 
+class ItemEconomy(unittest.TestCase):
+    """Vanilla twin economy is extracted from HEAD (#170) -- never the working tree, which the
+    build injects our own chapters into. These lock the HEAD-verified numbers so the class of
+    bug that had our ch03 chests reported as vanilla Ch4's can't recur silently."""
+
+    def test_item_gold_value_from_head(self):
+        self.assertEqual(df.item_gold_value('ITEM_AXE_IRON'), 270)
+        self.assertEqual(df.item_gold_value('ITEM_GUIDINGRING'), 10000)
+        self.assertEqual(df.item_gold_value('ITEM_BOOSTER_DEF'), 8000)
+        self.assertEqual(df.item_gold_value('ITEM_TORCH'), 500)
+        self.assertEqual(df.item_gold_value('ITEM_REDGEM'), 5000)
+        self.assertEqual(df.item_gold_value('ITEM_NOT_A_REAL_ITEM'), 0)
+
+    def test_ch4_is_lean_two_villages_no_chests(self):
+        # The bug fixture: vanilla Ch4 is 2 villages / one Iron Axe (~270g) / ZERO chests.
+        # (The worktree's ch4 slot may hold our injected ch03 chests -- reading HEAD ignores them.)
+        e = df.vanilla_economy('FE8 Ch4')
+        self.assertEqual(e['total_gold'], 270)
+        self.assertEqual(e['chests'], [])
+        self.assertEqual(e['gifts'], [('ITEM_AXE_IRON', 270)])
+        self.assertEqual(e['shops'], [])
+        self.assertEqual(e['n_villages'], 2)
+
+    def test_ch5_gifts_include_the_clear_reward_and_two_shops(self):
+        # ~27,760g: the Guiding Ring is a clear reward handed to the leader OUTSIDE any Village
+        # macro -- the gift scan must still catch it (else we under-count by the biggest item).
+        e = df.vanilla_economy('FE8 Ch5')
+        self.assertEqual(e['total_gold'], 27760)
+        self.assertEqual(e['chests'], [])
+        gift_items = dict(e['gifts'])
+        self.assertEqual(gift_items['ITEM_GUIDINGRING'], 10000)
+        self.assertEqual(gift_items['ITEM_BOOSTER_DEF'], 8000)
+        self.assertEqual(gift_items['ITEM_BOOSTER_SKL'], 8000)
+        self.assertEqual(gift_items['ITEM_SWORD_ARMORSLAYER'], 1260)
+        self.assertEqual(len(e['shops']), 2)          # Armory + Vendor
+        self.assertEqual(e['n_villages'], 4)
+
+    def test_ch3_chests_are_read_from_head(self):
+        # Vanilla Ch3 (Borgo) is a 4-chest chapter -- proves chest extraction, distinct from the
+        # gift/village path, and that the reader isn't confusing vehicles.
+        e = df.vanilla_economy('FE8 Ch3')
+        chest_items = [i for i, _ in e['chests']]
+        self.assertEqual(len(e['chests']), 4)
+        self.assertIn('ITEM_LANCE_JAVELIN', chest_items)
+        self.assertEqual(e['gifts'], [])
+
+    def test_unmapped_reference_returns_none(self):
+        self.assertIsNone(df.vanilla_economy('FE8 Ch99'))
+
+    def test_chapter_economy_reads_our_declared_yaml(self):
+        chap = {
+            'villages': [{'visit_reward': [{'id': 'gold', 'amount': 150},
+                                           {'id': 'vulnerary'}]}],
+            'chests': [{'contents': [{'id': 'red-gem'}]}],
+            'enemy_units': [{'id': 'k', 'item_drop': 'chest-key'}],
+            'post_chapter': {'gold_reward': 200, 'available_shops': ['termalaine']},
+        }
+        ours = df.chapter_economy(chap)
+        self.assertEqual(ours['gold'], 350)               # 150 village + 200 post
+        self.assertEqual(ours['gifts'], ['vulnerary'])
+        self.assertEqual(ours['chests'], ['red-gem'])
+        self.assertEqual(ours['drops'], ['chest-key'])
+        self.assertEqual(ours['shops'], ['termalaine'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #170. Gives the parity engine an **item-economy dimension**, read from **HEAD** — the gap that let the ch04/ch05 twins' payouts be hand-transcribed (and wrong).

### Why
`difficulty.py` modeled enemy pressure but nothing about gold/items, so the economy got typed into the brainstorm from memory. Worse, reading the **working tree** by hand mislabels data: our ch03 is injected into the Ch4 host slot, so a naive grep reports *our* chests as vanilla Ch4's. (That exact mistake happened this session — retracted on #24.) `vanilla_decomp_text` reads `git show HEAD:`, immune to the injection — so the engine now does too.

### What
- **`item_gold_value(ITEM_x)`** — buy gold (`costPerUse × maxUses`) from `data_items.c`.
- **`vanilla_economy(ref)`** — chests (`Chest` macros), gifts (**every** `SVAL(EVT_SLOT_3)`+`GIVEITEMTO` — including conditional/clear rewards handed out *outside* a `Village` macro, so Ch5's all-villages-saved Guiding Ring isn't missed), shops (`ShopList_` arrays), each valued and totaled.
- **`chapter_economy(chap)`** — our chapter's declared economy from YAML (gold + item ids by vehicle).
- **`report()`** prints an `ITEM-ECONOMY PARITY` section beside the enemy bar.

### Locked by tests (HEAD-verified)
| Twin | Economy |
|---|---|
| FE8 Ch4 | **270g** — one Iron Axe, **2 villages, 0 chests** (the brainstorm was right; "4 chests" was the injected worktree) |
| FE8 Ch5 | **27,760g** — incl. the **10,000g Guiding Ring** clear reward + Armorslayer + 2 stat boosters + Torch, + Armory & Vendor |
| FE8 Ch3 | **4 Borgo chests** (proves chest extraction, distinct from the gift path) |

Drops are a documented v1 gap (both curated twins carry none) — noted in code + the issue.

### Verify
64 difficulty tests + 94 build_campaign tests green · `make check` drift clean · `git diff --check` clean.

Sibling #171 (recruit-flip + reinforcement-timing) is the other half of "the proxy misses a dynamic."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
