### PR TITLE
feat(#171): model recruit-flips + reinforcement timing in the parity engine

### DIFF
--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -709,6 +709,7 @@ def report(campaign, ch):
 
     _print_pressure(_chapter_pressure(chap))
     _print_economy(chap)
+    _print_dynamics(chap)
 
 
 def _chapter_pressure(chap, band=0.25):
@@ -768,8 +769,9 @@ def _print_pressure(p):
 # chests + village/house gifts + shops, valued from data_items.c. Drops are a documented v1
 # gap (the curated Ch4/Ch5 twins carry none) -- see #170.
 
-# parity_reference -> the decomp chapter file stem whose event data carries its economy.
-PARITY_REFERENCE_ECON = {
+# parity_reference -> the decomp chapter file stem (shared by the economy #170 and the
+# battlefield-dynamics #171 extractors -- both read that chapter's event data from HEAD).
+PARITY_REFERENCE_STEM = {
     'FE8 Prologue': 'prologue', 'FE8 Ch1': 'ch1', 'FE8 Ch2': 'ch2', 'FE8 Ch3': 'ch3',
     'FE8 Ch4': 'ch4', 'FE8 Ch5': 'ch5', 'FE8 Ch6': 'ch6', 'FE8 Ch13': 'ch13a',
 }
@@ -849,7 +851,7 @@ def vanilla_economy(parity_ref):
     """The vanilla twin's item economy, read from HEAD: chests, gifts (villages/houses/clear
     rewards), and shops, each valued in buy-gold. None if the reference has no mapped economy
     source (#170). Delivery context (# of villages/houses) is kept for the vehicle story."""
-    stem = PARITY_REFERENCE_ECON.get(parity_ref)
+    stem = PARITY_REFERENCE_STEM.get(parity_ref)
     if stem is None:
         return None
     info = bc.vanilla_decomp_text('src/events/%s-eventinfo.h' % stem)
@@ -915,6 +917,152 @@ def _print_economy(chap):
             parts.append('%s[%s]' % (label, ', '.join(map(str, ours[label]))))
     print('  ours:   %s' % ' · '.join(parts))
     print('  (advisory target: match the twin\'s magnitude + delivery vehicle; not a hard gate)')
+
+
+# ── Battlefield dynamics (#171): recruit-flips + reinforcement timing ────────────
+# The static bar counts every enemy as a turn-1 kill. Two vanilla set-pieces break that: a
+# CONVERTIBLE enemy (Joshua/Sahnar) you recruit rather than grind, and REINFORCEMENTS that
+# arrive over turns instead of alpha-striking. Both auto-detected from HEAD for the twin (CHAR
+# macro targets / TurnEventPlayer-loaded arrays) and read from `convertible`/`arrives_turn` in
+# our YAML. Additive view: the static ENEMY-PRESSURE verdict is unchanged (so already-locked
+# chapters don't shift) -- this shows, alongside it, what that static proxy can't see.
+
+CONVERT_CLEAR_DISCOUNT = 0.5   # a convertible is neutralized by recruiting, not ground down;
+                               # still part clear-load for the risk window before the flip.
+
+
+def _event_block(script_text, sym):
+    """The body of a CONST_DATA EventListScr <sym>[] = { ... }; block ('' if absent)."""
+    m = re.search(re.escape(sym) + r'\[\]\s*=\s*\{(.*?)\n\};', script_text, re.S)
+    return m.group(1) if m else ''
+
+
+def _vanilla_convertible_chars(stem):
+    """CHARACTER_ enums that are recruitable enemies (a CHAR macro's target) in the twin --
+    they flip to allies, so they aren't a kill the player must make."""
+    info = bc.vanilla_decomp_text('src/events/%s-eventinfo.h' % stem)
+    return {m.group(1) for m in re.finditer(
+        r'CHAR\([^,]+,\s*\w+,\s*CHARACTER_\w+,\s*(CHARACTER_\w+)\)', info)}
+
+
+def _vanilla_reinforcement_turns(stem):
+    """{UnitDef array -> arrival turn} for the enemy arrays a TurnEventPlayer script loads."""
+    info = bc.vanilla_decomp_text('src/events/%s-eventinfo.h' % stem)
+    script = bc.vanilla_decomp_text('src/events/%s-eventscript.h' % stem)
+    out = {}
+    for m in re.finditer(r'TurnEventPlayer\(\s*\d+,\s*(\w+),\s*(\d+)\)', info):
+        for arr in re.findall(r'UnitDef_\w+', _event_block(script, m.group(1))):
+            out[arr] = int(m.group(2))
+    return out
+
+
+def _entry_combatants(ed):
+    """The Combatants for one enemy_units entry (count/composition expanded, weapon-filtered)."""
+    if 'composition' in ed and 'class' not in ed:
+        level = ed.get('level', 1)
+        name = ed.get('id', ed.get('name', 'enemy'))
+        by_class = ed.get('inventory_by_class', {})
+        units = [_one_enemy('%s-%s' % (name, cls), cls, level,
+                            _weapon_for([{'id': w} for w in by_class.get(cls, [])]))
+                 for cls in ed.get('composition', [])]
+    else:
+        units = enemy_combatants(ed) * int(ed.get('count', 1))
+    return [u for u in units if u.weapon is not None]
+
+
+def chapter_enemy_groups(chap):
+    """Our force split by battlefield role (#171): line (turn-1 must-kill), reinforcements
+    (arrives_turn > 1), convertibles (recruitable). Each a Combatant list."""
+    g = {'line': [], 'reinforcements': [], 'convertibles': []}
+    for ed in chap.get('enemy_units', []):
+        units = _entry_combatants(ed)
+        if ed.get('convertible'):
+            g['convertibles'].extend(units)
+        elif int(ed.get('arrives_turn', 1) or 1) > 1:
+            g['reinforcements'].extend(units)
+        else:
+            g['line'].extend(units)
+    return g
+
+
+def vanilla_enemy_groups(parity_ref):
+    """Vanilla twin force split by role, with convertibles (CHAR targets) and reinforcement
+    turns (TurnEventPlayer-loaded arrays) auto-detected from HEAD. None if uncurated."""
+    spec = PARITY_REFERENCE_UDEFS.get(parity_ref)
+    if spec is None:
+        return None
+    relpath, arrays = spec
+    stem = PARITY_REFERENCE_STEM.get(parity_ref)
+    conv_chars = _vanilla_convertible_chars(stem) if stem else set()
+    reinf_turns = _vanilla_reinforcement_turns(stem) if stem else {}
+    text = bc.vanilla_decomp_text(relpath)
+    g = {'line': [], 'reinforcements': [], 'convertibles': []}
+    for arr in arrays:
+        turn = reinf_turns.get(arr, 1)
+        for i, d in enumerate(vanilla_unit_defs(text, arr)):
+            if d['allegiance'] != 'FACTION_ID_RED':
+                continue
+            weapon = _weapon_from_item_enums(d['items'])
+            if weapon is None:
+                continue
+            u = _enemy_from_enum('%s#%d' % (arr, i), d['classIndex'], d['level'], weapon)
+            if d['charIndex'] in conv_chars:
+                g['convertibles'].append(u)
+            elif turn > 1:
+                g['reinforcements'].append(u)
+            else:
+                g['line'].append(u)
+    return g
+
+
+def dynamic_pressure(groups, deploy_cap, yardstick=YARDSTICK):
+    """Pressure honoring battlefield dynamics (#171): turn-1 threat counts only units on the
+    field at the start (line + convertibles), NOT reinforcements; clear-load counts the full
+    line + all reinforcements + a discounted convertible (you mostly recruit it, not grind it).
+    Returns (threat/slot, clear-load/slot)."""
+    cap = max(1, deploy_cap)
+    present = groups['line'] + groups['convertibles']
+    threat = sum(fc.damage_per_round(e, yardstick) for e in present) / cap
+    clear = (sum(fc.rounds_to_kill(yardstick, e) for e in groups['line'])
+             + sum(fc.rounds_to_kill(yardstick, e) for e in groups['reinforcements'])
+             + CONVERT_CLEAR_DISCOUNT
+             * sum(fc.rounds_to_kill(yardstick, e) for e in groups['convertibles'])) / cap
+    return threat, clear
+
+
+def recruit_swing(groups):
+    """Post-flip ally throughput a chapter's convertibles add if recruited (kills/round, capped
+    1/unit vs the line+reinforcements) -- the 'advantage' half of risk-turned-advantage."""
+    line = groups['line'] + groups['reinforcements']
+    if not line:
+        return 0.0
+    return sum(min(1.0, max((fc.kills_per_round(c, e) for e in line), default=0.0))
+               for c in groups['convertibles'])
+
+
+def _print_dynamics(chap):
+    ref = chap.get('parity_reference')
+    ours = chapter_enemy_groups(chap)
+    van = vanilla_enemy_groups(ref)
+    cap = chapter_deploy_limit(chap, len(ROSTER))
+    dyn = (ours['reinforcements'] or ours['convertibles']
+           or (van and (van['reinforcements'] or van['convertibles'])))
+    if not dyn:
+        return   # nothing dynamic here -- keep the report quiet
+    print('\n-- BATTLEFIELD DYNAMICS (#171 -- what the static bar can\'t see) ' + '-' * 9)
+
+    def row(tag, g):
+        dt, dc = dynamic_pressure(g, cap)
+        print('  %-8s line %2d · reinf %2d · convertible %d  ->  threat/slot %.1f (turn-1) · '
+              'clear-load/slot %.1f' % (tag, len(g['line']), len(g['reinforcements']),
+                                        len(g['convertibles']), dt, dc))
+        if g['convertibles']:
+            print('           convertible x%.1f in clear-load · recruit swing +%.2f kills/round if flipped'
+                  % (CONVERT_CLEAR_DISCOUNT, recruit_swing(g)))
+    if van:
+        row('vanilla', van)
+    row('ours', ours)
+    print('  (additive -- the ENEMY-PRESSURE verdict above is still the static all-turn-1 bar)')
 
 
 def curve_gate_failures(rows):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -654,5 +654,69 @@ class ItemEconomy(unittest.TestCase):
         self.assertEqual(ours['shops'], ['termalaine'])
 
 
+class BattlefieldDynamics(unittest.TestCase):
+    """Recruit-flips + reinforcement timing (#171), auto-detected from HEAD for the twin and
+    read from our YAML. The static bar counts every enemy as a turn-1 kill; these model the two
+    vanilla set-pieces (convertible enemies, timed reinforcements) it can't see."""
+
+    # -- vanilla auto-detection --
+    def test_vanilla_convertible_from_char_macro(self):
+        self.assertEqual(df._vanilla_convertible_chars('ch5'), {'CHARACTER_JOSHUA'})
+        self.assertEqual(df._vanilla_convertible_chars('ch4'), set())
+
+    def test_vanilla_reinforcement_turns_from_turn_events(self):
+        turns = df._vanilla_reinforcement_turns('ch5')     # bandit waves on 2 / 6 / 8
+        self.assertEqual(sorted(turns.values()), [2, 6, 8])
+
+    def test_ch5_groups_split_joshua_and_the_waves(self):
+        g = df.vanilla_enemy_groups('FE8 Ch5')
+        self.assertEqual(len(g['convertibles']), 1)        # Joshua
+        self.assertEqual(len(g['reinforcements']), 6)      # the turn 2/6/8 arrays
+        self.assertEqual(sum(len(g[k]) for k in g), 23)    # still the full 23-unit force
+
+    def test_dynamic_threat_below_static_for_a_reinforced_chapter(self):
+        g = df.vanilla_enemy_groups('FE8 Ch5')
+        allf = g['line'] + g['reinforcements'] + g['convertibles']
+        self.assertLess(df.dynamic_pressure(g, 10)[0], df.enemy_pressure(allf, 10)[0])
+
+    # -- pure metric, hand oracle --
+    def test_reinforcements_excluded_from_turn1_threat_kept_in_clearload(self):
+        line = [combatant('l', pow_=5)]
+        reinf = [combatant('r', pow_=5)]
+        g = {'line': line, 'reinforcements': reinf, 'convertibles': []}
+        dt, dc = df.dynamic_pressure(g, 1)
+        self.assertAlmostEqual(dt, df.enemy_pressure(line, 1)[0])          # reinf not turn-1
+        self.assertAlmostEqual(dc, df.enemy_pressure(line + reinf, 1)[1])  # but still cleared
+
+    def test_convertible_is_present_threat_but_discounted_clearload(self):
+        line = [combatant('l', pow_=5)]
+        conv = [combatant('c', pow_=5)]
+        g = {'line': line, 'reinforcements': [], 'convertibles': conv}
+        dt, dc = df.dynamic_pressure(g, 1)
+        self.assertAlmostEqual(dt, df.enemy_pressure(line + conv, 1)[0])   # on the field turn 1
+        exp = (df.enemy_pressure(line, 1)[1]
+               + df.CONVERT_CLEAR_DISCOUNT * df.enemy_pressure(conv, 1)[1])
+        self.assertAlmostEqual(dc, exp)                                    # recruit, don't grind
+
+    def test_recruit_swing_positive_when_the_convertible_can_fight(self):
+        g = {'line': [combatant('l', hp=10, dfc=0)], 'reinforcements': [],
+             'convertibles': [combatant('c', pow_=20, spd=20, weapon='iron-sword')]}
+        self.assertGreater(df.recruit_swing(g), 0)
+
+    # -- our-side YAML flags --
+    def test_chapter_groups_read_convertible_and_arrives_turn(self):
+        chap = {'enemy_units': [
+            {'id': 'a', 'class': 'fighter', 'level': 1, 'count': 2,
+             'inventory': [{'id': 'iron-axe'}]},
+            {'id': 'r', 'class': 'soldier', 'level': 1, 'count': 3,
+             'inventory': [{'id': 'iron-lance'}], 'arrives_turn': 4},
+            {'id': 'c', 'class': 'myrmidon', 'level': 1, 'count': 1,
+             'inventory': [{'id': 'iron-sword'}], 'convertible': {'by': 'basil'}},
+        ]}
+        g = df.chapter_enemy_groups(chap)
+        self.assertEqual((len(g['line']), len(g['reinforcements']), len(g['convertibles'])),
+                         (2, 3, 1))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #171. The sibling to #170: gives the parity engine the two **battlefield dynamics** the static turn-1 bar can't see — a convertible enemy you recruit instead of kill, and reinforcements that arrive over turns.

> **Stacked on #172 (#170).** Merge #172 first; this branches off it. The clean #171-only diff is `difficulty.py` dynamics functions + `test_difficulty.py` `BattlefieldDynamics`.

### Why
The static bar counts all 23 of Ch5 as a turn-1 kill — but Joshua (the killing-edge Myrmidon) is a **recruit**, not a grind, and 6 of the 23 are **turn 2/6/8 bandit waves**. So the bar over-reads the alpha strike and the total kill-count. Our ch05 does the same beats (Sahnar flip, eruption waves), so both sides need to model it to compare fairly.

### What (all auto-detected from HEAD; symmetric with our YAML)
- **Convertibles** — `CHAR`-macro targets in the twin's eventinfo (Ch5 → `CHARACTER_JOSHUA`; Ch4 → none); `convertible:` on our `enemy_units`. Counted as **turn-1 threat** (dangerous until flipped) but **discounted ×0.5 in clear-load** (neutralize, don't grind), plus a reported **recruit swing** = post-flip ally throughput.
- **Reinforcements** — `TurnEventPlayer`-loaded arrays + their arrival turn (Ch5 → turn 2/6/8); `arrives_turn:` on our `enemy_units`. Kept in clear-load, **excluded from turn-1 threat**.
- New **`BATTLEFIELD DYNAMICS`** report section — **additive**. The static `ENEMY-PRESSURE` verdict and the curve gate are untouched, so already-locked chapters don't shift; this shows what the proxy misses beside it.

On **FE8 Ch5**: dynamic turn-1 threat **8.1 vs static 10.3** (6 of 23 arrive later; Joshua flips), clear-load ~unchanged (you still clear them, just later). Exactly the distortion #171 set out to expose.

### Verify
72 difficulty + 94 build_campaign tests green · `make check` drift clean · curve verdicts unchanged (additive) · `git diff --check` clean.

Also renames `PARITY_REFERENCE_ECON` → `PARITY_REFERENCE_STEM` (now shared by #170's economy and this — both read the twin's event data from HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
