### PR TITLE
feat(#176,#177): parity engine reads enemy drops + area-triggered reinforcements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ campaigns/*/map_sprites/.base/
 /references
 tools/emulator/
 tools/playtest/symbols.lua
+# local session scratch tool (HANDOFF references it; intentionally unversioned)
+tools/key_magenta.py
 # mGBA save-state checkpoints (per-ROM-build, regenerated) -- inline comments don't work
 # in .gitignore, so this must be on its own line
 tools/playtest/states/

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -659,6 +659,19 @@ Both stay `status: planned` seeds — this sets the targets; the map + events bu
 against the twin via `make difficulty` (economy #170 + recruit/reinforcement dynamics #171 now modeled).
 _Decided: 2026-07-15 (Nicolas + CLAUDE). Supersedes the earlier "split old Ch4 into two Ch4-parity halves"
 framing and the brainstormed Ch11-map-borrow (issues #24/#25) — both retired._
+
+**Parity-engine v1 gaps closed (#176 economy drops, #177 area-triggered reinforcements).** Two channels the
+first cut of the extractors punted on, both read from HEAD like the rest: (1) **enemy drops** — a red unit
+flagged `.itemDrop` drops its **last** inventory item on death (`US_DROP_ITEM`, the final slot per
+`statscreen.c:726`); `vanilla_economy` now values it as a `drops` channel folded into `total_gold` (the Ch4/Ch5
+lock twins carry none, so the lock is unchanged, but Ch2's Vulnerary / Ch3's keys / Ch13's crests now count).
+(2) **area/zone-triggered reinforcements** — `_vanilla_reinforcement_turns` matched only the `TurnEventPlayer`
+macro, so it missed Ch4 "Ancient Horrors"' waves: a turn-2 Bonewalker pack written as a raw
+`TURN(…, FACTION_BLUE)` and a Revenant pack behind a temp-flag-gated `TURN` that an `AREA(…)` trigger arms on
+zone-entry. It now also reads the raw-`TURN` expansion, treats any **flag-gated** turn event (and any `AREA`/
+`AFEV` script that LOADs a force) as a reinforcement, and models zone-entry arrivals as `_ZONE_ENTRY_TURN`
+(> 1, so they leave the turn-1 line) — Ch4 reads 16 line + 7 reinforcements, Ch5's 2/6/8 detection unchanged.
+_Decided: 2026-07-16 (CLAUDE; TDD). Closes the v1 scope noted on #170/#171._
 Worked example — **ch02 (parity FE8 Ch2):** gems + premium consumables only (vanilla Ch2's village
 gifts) + a regular armory + one enemy consumable drop; **no boosters, no promos.** The three chwinga
 "charms" are those gifts — **Elixir / Pure Water / Hand Axe** (the Hand Axe stands in for vanilla's

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -265,9 +265,11 @@ def _brace_entries(body):
 
 def vanilla_unit_defs(text, array_name):
     """Parse `CONST_DATA struct UnitDefinition <array_name>[] = { ... };` from decomp text
-    into a list of per-entry dicts (charIndex, classIndex, level, allegiance, items). The
-    trailing `{ 0 }` terminator (no .classIndex) is skipped. `charIndex` is the named
-    character enum for allies/bosses (a numeric token for generics, None if absent)."""
+    into a list of per-entry dicts (charIndex, classIndex, level, allegiance, itemDrop, items).
+    The trailing `{ 0 }` terminator (no .classIndex) is skipped. `charIndex` is the named
+    character enum for allies/bosses (a numeric token for generics, None if absent). `itemDrop`
+    is the `.itemDrop = 1` bit -- when set, the unit drops its LAST item on death (US_DROP_ITEM,
+    statscreen.c:726), the enemy-drop channel the economy reads (#176)."""
     s, e = bc._find_brace_block(text, array_name + '[]', '<udef:%s>' % array_name)
     body = text[s + 1:e - 1]
     out = []
@@ -284,6 +286,7 @@ def vanilla_unit_defs(text, array_name):
             'classIndex': cls.group(1),
             'level': int(lvl.group(1)) if lvl else 1,
             'allegiance': alg.group(1) if alg else None,
+            'itemDrop': bool(re.search(r'\.itemDrop\s*=\s*1', block)),
             'items': [t.strip() for t in items.group(1).split(',') if t.strip()]
                      if items else [],
         })
@@ -766,8 +769,9 @@ def _print_pressure(p):
 # The vanilla twin's payout, read from HEAD via bc.vanilla_decomp_text -- NEVER the working
 # tree, which the build injects our own chapters into (reading the tree by hand once had our
 # ch03 chests reported as vanilla Ch4's). Same ground-truth discipline as the enemy rosters:
-# chests + village/house gifts + shops, valued from data_items.c. Drops are a documented v1
-# gap (the curated Ch4/Ch5 twins carry none) -- see #170.
+# chests + village/house gifts + shops + enemy drops, valued from data_items.c. (#170 shipped
+# the first three; #176 added the drop channel -- a red unit flagged .itemDrop drops its last
+# item; the curated Ch4/Ch5 twins carry none, but Ch2/Ch3/Ch6/Ch13 do.)
 
 # parity_reference -> the decomp chapter file stem (shared by the economy #170 and the
 # battlefield-dynamics #171 extractors -- both read that chapter's event data from HEAD).
@@ -847,10 +851,31 @@ def _gift_items(eventscript_text):
     return out
 
 
+def vanilla_drops(parity_ref):
+    """The vanilla twin's enemy DROPS, read from HEAD: for each red unit flagged `.itemDrop`
+    in the chapter's curated UnitDefinition arrays, its LAST item (US_DROP_ITEM drops the final
+    inventory slot -- statscreen.c:726), valued in buy-gold. None if the reference isn't curated;
+    [] if it carries no drops (the Ch4/Ch5 lock twins). The channel #170 v1 skipped (#176)."""
+    spec = PARITY_REFERENCE_UDEFS.get(parity_ref)
+    if spec is None:
+        return None
+    relpath, arrays = spec
+    text = bc.vanilla_decomp_text(relpath)
+    out = []
+    for array_name in arrays:
+        for d in vanilla_unit_defs(text, array_name):
+            if d['allegiance'] != 'FACTION_ID_RED' or not d['itemDrop'] or not d['items']:
+                continue
+            item = d['items'][-1]
+            out.append((item, item_gold_value(item)))
+    return out
+
+
 def vanilla_economy(parity_ref):
     """The vanilla twin's item economy, read from HEAD: chests, gifts (villages/houses/clear
-    rewards), and shops, each valued in buy-gold. None if the reference has no mapped economy
-    source (#170). Delivery context (# of villages/houses) is kept for the vehicle story."""
+    rewards), shops, and enemy drops, each valued in buy-gold. None if the reference has no
+    mapped economy source (#170/#176). Delivery context (# of villages/houses) is kept for the
+    vehicle story."""
     stem = PARITY_REFERENCE_STEM.get(parity_ref)
     if stem is None:
         return None
@@ -859,11 +884,12 @@ def vanilla_economy(parity_ref):
     shoptext = bc.vanilla_decomp_text('src/events_shoplist.c')
     chests = [(it, item_gold_value(it)) for it in re.findall(r'Chest\((ITEM_\w+)', info)]
     gifts = [(it, item_gold_value(it)) for it in _gift_items(script)]
+    drops = vanilla_drops(parity_ref) or []
     shops = [(sym, _shoplist_items(shoptext, sym))
              for sym in re.findall(r'(?:Armory|Vendor)\(\s*(\w+)', info)]
-    total = sum(v for _, v in chests) + sum(v for _, v in gifts)
-    return {'reference': parity_ref, 'chests': chests, 'gifts': gifts, 'shops': shops,
-            'n_villages': len(re.findall(r'Village\(', info)),
+    total = sum(v for _, v in chests) + sum(v for _, v in gifts) + sum(v for _, v in drops)
+    return {'reference': parity_ref, 'chests': chests, 'gifts': gifts, 'drops': drops,
+            'shops': shops, 'n_villages': len(re.findall(r'Village\(', info)),
             'n_houses': len(re.findall(r'House\(', info)), 'total_gold': total}
 
 
@@ -903,10 +929,11 @@ def _print_economy(chap):
         def fmt(pairs):
             return ', '.join('%s %dg' % (it.replace('ITEM_', ''), v)
                              for it, v in pairs) or 'none'
-        print('  vanilla %-11s ~%dg total in gifts+chests' % (ref, van['total_gold']))
+        print('  vanilla %-11s ~%dg total in gifts+chests+drops' % (ref, van['total_gold']))
         print('    chests: %s' % fmt(van['chests']))
         print('    gifts:  %s  (via %d village/%d house + clear rewards)'
               % (fmt(van['gifts']), van['n_villages'], van['n_houses']))
+        print('    drops:  %s  (enemy .itemDrop -- last item)' % fmt(van['drops']))
         print('    shops:  %s' % (', '.join('%s (%d items)'
               % (s.replace('ShopList_Event_', ''), len(items))
               for s, items in van['shops']) or 'none'))
@@ -945,14 +972,61 @@ def _vanilla_convertible_chars(stem):
         r'CHAR\([^,]+,\s*\w+,\s*CHARACTER_\w+,\s*(CHARACTER_\w+)\)', info)}
 
 
+# A reinforcement that arrives on ZONE-ENTRY (a monster-hunt / room-breach trigger) rather than
+# on a fixed turn -- Ch4 "Ancient Horrors"' Revenant wave. Modeled as an arrival > turn 1 so it
+# lands in the reinforcement split, not the turn-1 line; the exact value is immaterial to the
+# metric (dynamic_pressure only splits on turn == 1 vs > 1). #177.
+_ZONE_ENTRY_TURN = 2
+
+
+def _is_flag_gated(eid):
+    """A turn/area event with a temp-flag condition (EVFLAG_TMP(n) etc.) only fires once that
+    flag is set mid-map -- so a flag-gated turn event is a triggered reinforcement, not a fixed
+    turn-1 spawn. `0` / EVFLAG_NONE mean unconditional."""
+    return eid.strip() not in ('0', 'EVFLAG_NONE')
+
+
+def _player_turn_events(info):
+    """Yield (eid, script_sym, turn) for each PLAYER-phase turn event -- both the TurnEventPlayer
+    macro (Ch5's waves) and its raw `TURN(eid, scr, turn, end, FACTION_BLUE)` expansion (Ch4's
+    wave). Enemy/green-phase TURN(...) entries (allies, NPC spawns) are excluded."""
+    for m in re.finditer(r'TurnEventPlayer\(\s*([^,]+?)\s*,\s*(\w+)\s*,\s*(\d+)\s*\)', info):
+        yield m.group(1), m.group(2), int(m.group(3))
+    for m in re.finditer(r'(?<![A-Za-z_])TURN\(\s*([^,]+?)\s*,\s*(\w+)\s*,\s*(\d+)\s*,'
+                         r'\s*\d+\s*,\s*(FACTION_\w+)\s*\)', info):
+        if 'BLUE' in m.group(4):
+            yield m.group(1), m.group(2), int(m.group(3))
+
+
+def _area_event_scripts(info):
+    """The event scripts a zone/area trigger runs -- AREA (zone-entry) and AFEV (flag) entries.
+    A unit array these LOAD is a zone-triggered reinforcement (#177). (Ch4's AREA sets the flag
+    its gated TURN reads, so the load is caught there too -- this also covers chapters whose AREA
+    script loads the array directly.)"""
+    return [m.group(1) for m in re.finditer(r'(?:AREA|AFEV)\(\s*[^,]+?\s*,\s*(\w+)', info)]
+
+
 def _vanilla_reinforcement_turns(stem):
-    """{UnitDef array -> arrival turn} for the enemy arrays a TurnEventPlayer script loads."""
+    """{UnitDef array -> arrival turn} for enemy arrays that are NOT on the field at turn 1:
+    player-phase turn events past turn 1 (Ch5's 2/6/8 waves), plus area/zone-triggered spawns --
+    a temp-flag-gated turn event or an AREA load (Ch4 "Ancient Horrors"' Revenant wave), which
+    arrive on zone-entry and are modeled as _ZONE_ENTRY_TURN (#177). Turn-1 unconditional events
+    (the initial line force) contribute nothing."""
     info = bc.vanilla_decomp_text('src/events/%s-eventinfo.h' % stem)
     script = bc.vanilla_decomp_text('src/events/%s-eventscript.h' % stem)
     out = {}
-    for m in re.finditer(r'TurnEventPlayer\(\s*\d+,\s*(\w+),\s*(\d+)\)', info):
-        for arr in re.findall(r'UnitDef_\w+', _event_block(script, m.group(1))):
-            out[arr] = int(m.group(2))
+    for eid, scr, turn in _player_turn_events(info):
+        if _is_flag_gated(eid):
+            arrival = _ZONE_ENTRY_TURN     # only fires once an area trigger sets its flag
+        elif turn > 1:
+            arrival = turn
+        else:
+            continue                       # unconditional turn-1 event = the initial line
+        for arr in re.findall(r'UnitDef_\w+', _event_block(script, scr)):
+            out[arr] = arrival
+    for scr in _area_event_scripts(info):  # an AREA/AFEV script that loads a force directly
+        for arr in re.findall(r'UnitDef_\w+', _event_block(script, scr)):
+            out.setdefault(arr, _ZONE_ENTRY_TURN)
     return out
 
 

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -269,13 +269,40 @@ CONST_DATA struct UnitDefinition UnitDef_Test[] = {
 """
 
 
+_UDEF_DROP_SNIPPET = """
+CONST_DATA struct UnitDefinition UnitDef_Drop[] = {
+    {
+        .charIndex = 0x8e,
+        .classIndex = CLASS_BRIGAND,
+        .allegiance = FACTION_ID_RED,
+        .level = 3,
+        .itemDrop = 1,
+        .items = {
+            ITEM_AXE_IRON,
+            ITEM_VULNERARY,
+        },
+    },
+    {
+        .charIndex = 0x8f,
+        .classIndex = CLASS_FIGHTER,
+        .allegiance = FACTION_ID_RED,
+        .level = 2,
+        .items = {
+            ITEM_AXE_IRON,
+        },
+    },
+    { 0 },
+};
+"""
+
+
 class VanillaUnitDefParser(unittest.TestCase):
     def test_parses_each_entry_class_level_allegiance_items(self):
         defs = df.vanilla_unit_defs(_UDEF_SNIPPET, 'UnitDef_Test')
         self.assertEqual(len(defs), 3)           # the { 0 } terminator is skipped
         self.assertEqual(defs[0], {'charIndex': 'CHARACTER_BREGUET',
                                    'classIndex': 'CLASS_ARMOR_KNIGHT', 'level': 4,
-                                   'allegiance': 'FACTION_ID_RED',
+                                   'allegiance': 'FACTION_ID_RED', 'itemDrop': False,
                                    'items': ['ITEM_LANCE_IRON']})
         self.assertEqual(defs[1]['classIndex'], 'CLASS_SOLDIER')
         self.assertEqual(defs[1]['items'], ['ITEM_LANCE_IRON', 'ITEM_VULNERARY'])
@@ -286,6 +313,13 @@ class VanillaUnitDefParser(unittest.TestCase):
         defs = df.vanilla_unit_defs(_UDEF_SNIPPET, 'UnitDef_Test')
         self.assertEqual(defs[0]['charIndex'], 'CHARACTER_BREGUET')
         self.assertEqual(defs[2]['charIndex'], 'CHARACTER_EIRIKA')
+
+    def test_captures_item_drop_bit(self):
+        # #176: a unit flagged .itemDrop = 1 drops its LAST item (US_DROP_ITEM, the final
+        # inventory slot -- statscreen.c:726). Units without the flag read itemDrop False.
+        defs = df.vanilla_unit_defs(_UDEF_DROP_SNIPPET, 'UnitDef_Drop')
+        self.assertTrue(defs[0]['itemDrop'])
+        self.assertFalse(defs[1]['itemDrop'])
 
 
 class VanillaEnemies(unittest.TestCase):
@@ -638,6 +672,33 @@ class ItemEconomy(unittest.TestCase):
     def test_unmapped_reference_returns_none(self):
         self.assertIsNone(df.vanilla_economy('FE8 Ch99'))
 
+    def test_vanilla_drops_reads_the_last_item_of_each_flagged_red_unit(self):
+        # #176: vanilla Ch2's brigand carries { Iron Axe, Vulnerary } with .itemDrop set,
+        # so it drops the Vulnerary (the last slot), valued in buy-gold (300g).
+        drops = df.vanilla_drops('FE8 Ch2')
+        self.assertEqual(drops, [('ITEM_VULNERARY', 300)])
+
+    def test_vanilla_drops_uncurated_reference_is_none(self):
+        self.assertIsNone(df.vanilla_drops('FE8 Ch99'))
+
+    def test_ch2_economy_counts_the_vulnerary_drop_in_total(self):
+        # The drop channel #170 v1 skipped: it must show under `drops` AND lift total_gold.
+        e = df.vanilla_economy('FE8 Ch2')
+        self.assertEqual(e['drops'], [('ITEM_VULNERARY', 300)])
+        self.assertIn(300, [v for _, v in e['drops']])
+        self.assertGreaterEqual(e['total_gold'], 300)   # drops fold into the payout magnitude
+
+    def test_ch3_economy_reports_its_key_drops(self):
+        # Vanilla Ch3's two brigands drop a Door Key (50g) and a Chest Key (300g).
+        drops = dict(df.vanilla_economy('FE8 Ch3')['drops'])
+        self.assertEqual(drops.get('ITEM_DOORKEY'), 50)
+        self.assertEqual(drops.get('ITEM_CHESTKEY'), 300)
+
+    def test_ch4_ch5_twins_have_no_drops(self):
+        # The lock twins carry zero enemy drops -- the v1 gap didn't affect the ch04/ch05 lock.
+        self.assertEqual(df.vanilla_economy('FE8 Ch4')['drops'], [])
+        self.assertEqual(df.vanilla_economy('FE8 Ch5')['drops'], [])
+
     def test_chapter_economy_reads_our_declared_yaml(self):
         chap = {
             'villages': [{'visit_reward': [{'id': 'gold', 'amount': 150},
@@ -673,6 +734,23 @@ class BattlefieldDynamics(unittest.TestCase):
         self.assertEqual(len(g['convertibles']), 1)        # Joshua
         self.assertEqual(len(g['reinforcements']), 6)      # the turn 2/6/8 arrays
         self.assertEqual(sum(len(g[k]) for k in g), 23)    # still the full 23-unit force
+
+    def test_ch4_detects_area_and_timed_reinforcements(self):
+        # #177: Ch4 "Ancient Horrors" spawns via non-TurnEventPlayer triggers the v1 missed --
+        # a turn-2 Bonewalker wave (raw TURN(..., FACTION_BLUE)) and a zone-entry Revenant wave
+        # (a temp-flag-gated TURN set by an AREA trigger). Both must read as arriving after turn 1.
+        turns = df._vanilla_reinforcement_turns('ch4')
+        self.assertEqual(set(turns), {'UnitDef_088B4C88', 'UnitDef_088B4C24'})
+        self.assertEqual(turns['UnitDef_088B4C88'], 2)     # the timed Bonewalker wave
+        self.assertTrue(all(t > 1 for t in turns.values()))
+
+    def test_ch4_groups_split_the_seven_reinforcements(self):
+        # 16 turn-1 line + (3 Bonewalkers + 4 Revenants) reinforcements = the full 23-monster force.
+        g = df.vanilla_enemy_groups('FE8 Ch4')
+        self.assertEqual(len(g['line']), 16)
+        self.assertEqual(len(g['reinforcements']), 7)
+        self.assertEqual(len(g['convertibles']), 0)
+        self.assertEqual(sum(len(g[k]) for k in g), 23)
 
     def test_dynamic_threat_below_static_for_a_reinforced_chapter(self):
         g = df.vanilla_enemy_groups('FE8 Ch5')


### PR DESCRIPTION
Closes #176 and #177 — the two v1 gaps the parity extractors punted on, both read from HEAD (never the injected worktree).

## #176 — economy: enemy drops (`.itemDrop`)
`vanilla_unit_defs` now captures the `.itemDrop` bit. A red unit so flagged drops its **last** inventory item on death (`US_DROP_ITEM`, the final slot per `statscreen.c:726`). New `vanilla_drops()` values each via `item_gold_value`; `vanilla_economy` folds a `drops` channel into `total_gold` and the `ITEM-ECONOMY` print.

- Ch4/Ch5 lock twins carry **zero** drops → the ch04/ch05 lock is unchanged.
- Ch2 Vulnerary (300g), Ch3 Door/Chest keys (50/300g), Ch13 crests now counted.

## #177 — dynamics: area/zone-triggered reinforcements
`_vanilla_reinforcement_turns` matched only the `TurnEventPlayer` macro, so Ch4 "Ancient Horrors" reported `reinf 0` (dynamic == static, wrongly). It now also:
- reads the raw `TURN(…, FACTION_BLUE)` expansion (Ch4's turn-2 Bonewalker wave),
- treats any **temp-flag-gated** turn event, and any `AREA`/`AFEV` script that `LOAD`s a force, as a **zone-entry** reinforcement (`_ZONE_ENTRY_TURN`, modeled > turn 1) — Ch4's Revenant wave armed by an `AREA(…)` trigger.

Result: `vanilla_enemy_groups` for FE8 Ch4 → **16 line + 7 reinforcements** (3 Bonewalkers + 4 Revenants). Ch5's 2/6/8 turn-based detection unchanged.

## Verification
- TDD — added parser/drops/economy tests (#176) and Ch4 reinforcement tests (#177); Ch5 regressions kept green.
- `python3 -m unittest tools.test_difficulty tools.test_build_campaign` → **174/0**.
- `make check` → drift clean; `git diff --check` clean.
- Rendered end-to-end: ch03 economy prints `drops: DOORKEY 50g, CHESTKEY 300g`; ch04 dynamics prints `line 16 · reinf 7`.
- ADR in `docs/decisions.md` (dated 2026-07-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
