### PR TITLE
docs: handoff + ADR for Lupin/Sahnar art (#181)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -42,8 +42,30 @@ Nicolas, refresh this file, and begin a fresh instance — don't rely on auto-co
   ADR in decisions.md "Adopting non-FE sprite sources"). His build **wiring** (slot, Natasha
   STAT_DONOR, injection, a `priest` staff/heal BANIM_DONORS row — NOT shaman) is a checklist on the
   ch05 slice **#25**; a live `battle_anim:` block in basil.yaml waits on that donor row.
+- **Lupin + Sahnar art SHIPPED** (#181, merged 2026-07-17):
+  - **Lupin** (ch04) — direwolf **map sprite** (stand + walk) from the Midday **Lycanroc** overworld
+    sheet (princess-phoenix, CC-BY 3.0), recolored to the cast grey ramp to match his portrait, with
+    **hand-drawn hipster glasses** tracked to the eye across every walk frame. `base: Gwyllgi` geometry.
+    Battle anim NOT done — deferred, source = **PMD SpriteCollab Lycanroc #0745** (pointer on #24).
+  - **Sahnar** (ch05) — hooded **spectral-skeleton** blademaster (the "mummy" was dropped: no elegant
+    mummy art exists anywhere, only skeletal undead — skeleton reads cleaner + the trio matches).
+    **Portrait** = Glaceo "Skeleton (Assassin)" bust (hood recolored to the map cloak slate); **map
+    sprite** = Alexsplode "Specter" (cast-palette slate, spectral glow dropped). Battle anim decided
+    (Alexsplode's matching Specter sword anim, **native palette — do not recolor**) but deferred (#25).
+  - Both recruits' build **wiring** (slot, STAT_DONOR, injection, live `battle_anim:`) is ch04/ch05-slice
+    work (#24/#25), same scoping as Basil. Pipeline learnings: decisions.md "Adopting sprites, part 2".
 
-## This session (2026-07-17, Opus — #90 enemy battle anims SHIPPED, ch03 complete)
+## This session (2026-07-17, Fable→Opus — Lupin + Sahnar recruit art)
+
+- **#181 shipped** (squash `9792bb6`, merged): Lupin direwolf map sprite (Lycanroc + hand-drawn glasses)
+  + Sahnar spectral-skeleton portrait + map sprite. Detail above + on #24/#25. Reusable learnings in
+  decisions.md "Adopting sprites, part 2": DeviantArt oEmbed for signed image URLs; hand-drawn details
+  anchored to a detected eye pixel so they track the walk-bob; the community has NO mummy (only skeletal
+  undead) so spectral-skeleton is the cohesive route; palette-lock the portrait robe to the map sprite's
+  *dominant* cloak shade; keep adopted battle anims in their native palette. Both deferred battle anims
+  now ride the #90 import pipeline.
+
+## Prior session (2026-07-17, Opus — #90 enemy battle anims SHIPPED, ch03 complete)
 
 - **#90 shipped** (squash `35666c3`, pushed; ADR "Imported enemy battle anims"). New
   `tools/feditor_to_banim.py` imports FEditor community anims → decomp banim; class-bound via

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2017,6 +2017,40 @@ when a source fits. What the next adoption should know:
   frames + recipe live in `battle_anims/basil/` + `npcs/basil.yaml` meanwhile.
 _Decided: 2026-07-16_
 
+**Adopting sprites, part 2 — Lupin (Lycanroc) + Sahnar (spectral skeleton)**
+Two more recruits' art adopted from community/non-FE sprites (#181). What generalizes:
+- **Sources beyond PMD/Pokémon:** a plain DeviantArt overworld sheet works too. Lupin's map sprite is
+  the **Midday Lycanroc** form from *"Rockruff & Lycanroc Overworlds"* by **princess-phoenix** (CC-BY 3.0
+  — cleaner licensing than most FE-Repo assets). Get the signed image URL via the DeviantArt **oEmbed**
+  endpoint (`backend.deviantart.com/oembed?url=…`) — the raw wixmp URL 401s without the token.
+- **Hand-drawing identity details onto an adopted sprite:** Lupin's glasses were drawn per-frame,
+  **anchored to the source's eye pixel** (detected by color) so they track the walk-cycle head-bob
+  automatically — the eye moves, the glasses follow. Iterate the design on the un-recolored base first
+  (bold vs thin, opaque vs clear lens, height, pupil), THEN recolor. Draw glasses only on face-visible
+  directions (down + both sides); the back/up run has no face.
+- **`base:` for a quadruped map sprite = geometry token only.** Lupin uses `base: Gwyllgi` (FE8's own
+  dire-wolf: `{3 frames, UNIT_ICON_SIZE_32x32}` wait-table row) — apt AND correct geometry; the class
+  stays Cavalier. Committed both the 32×96 wait + 32×480 MU (real directional walk from the sheet;
+  right = engine H-flip of the side run), unlike Baxby's synth-MU.
+- **The community has NO mummy — only skeletal undead.** Swept FE-Repo (40k-file listing) + FEUniverse +
+  broader web (FFTA/Castlevania exist but can't port a battle **anim** into FE's frame format). Undead
+  busts are green-zombie recolors or bare skeletons; undead sword **anims** are all skeletal monsters
+  (Bonewalker/Wight/Specter). So a literal "mummy" = custom/generation for everything; a **skeletal
+  revenant** is the cohesive, fully-sourced alternative. Sahnar took the skeleton route (Nicolas's call).
+- **Trio cohesion via one artist + palette-lock:** Sahnar's map sprite + battle anim are a matched
+  **Alexsplode** pair (the "Specter"); the portrait is **Glaceo**'s "Skeleton (Assassin)" bust. No single
+  artist made all three, so the **portrait is the free variable** — recolor its robe to the map sprite's
+  *exact* cast cloak shade (don't grab a mismatched premade undead bust). Match the map's dominant tone,
+  not its lightest: the cloak read dark because idx1 dominated, so the portrait's hood bulk must be dark
+  too (a big-canvas hood over-reads any light highlight). **Do NOT recolor the battle anim** — keep its
+  native palette (Nicolas: it's polished/consistent; the skull + spectral glow are the throughline).
+- **Recoloring an anim GIF:** remap by matching the source cloak RGBs on the composited RGBA frames
+  (robust), or swap the GIF's palette entries directly (cloak lives in a contiguous index band).
+- **Deferred anims now have a home:** Sahnar's Specter sword anim + Lupin's Lycanroc #0745 anim both ride
+  the **#90 enemy-anim import pipeline** (`tools/feditor_to_banim.py`) once picked up — source pointers in
+  the YAMLs + on #24 (Lupin) / #25 (Sahnar). Not vendored yet (re-fetch on pickup).
+_Decided: 2026-07-17_
+
 ---
 
 ## Class Mapping & Promotions


### PR DESCRIPTION
Handoff refresh + decisions ADR capturing the Lupin/Sahnar art session (#181, merged).

- **HANDOFF.md**: Lupin + Sahnar art added to Current state; this-session note; #90 session relabeled prior.
- **decisions.md**: "Adopting sprites, part 2" ADR — DeviantArt oEmbed for signed URLs, eye-anchored hand-drawn glasses, the community-has-no-mummy finding (skeletal-only), palette-lock the portrait to the map sprite dominant shade, keep adopted battle anims native. Deferred anims ride the #90 pipeline.

Docs only. make check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)