### PR TITLE
docs: handoff refresh + agent-discipline learnings (feature-flow, git-hook GIT_* gotcha)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,120 +1,81 @@
 # Handoff - Manchego Stars live state
 
 `HANDOFF.md` is live state only. Settled decisions live in `docs/decisions.md`; operating rules
-live in `CLAUDE.md`; issue scope and backlog live in GitHub. Before a context rollover, warn
-Nicolas, refresh this file, and begin a fresh instance — don't rely on auto-compaction.
+live in `CLAUDE.md`/`AGENTS.md`; issue scope and backlog live in GitHub. Before a context rollover,
+warn Nicolas, refresh this file, and begin a fresh instance — don't rely on auto-compaction.
 
 ## Current state
 
-- **Parity/difficulty engine is three-dimensional** (`tools/difficulty.py`, all read from HEAD):
-  enemy pressure + **item economy** (#170/#172; drops #176/#178) + **battlefield dynamics**
-  (convertibles + reinforcement timing; #171/#174; area/zone #177/#178). `make difficulty CH=chNN`
-  shows all three, via `vanilla_decomp_text` (`git show HEAD:`) — immune to the working-tree injection.
-- **ch04/ch05 design LOCKED** (#175; ADR "ch04 and ch05 each map 1:1…"). Each chapter maps 1:1 to its
-  numeric FE8 twin (map + parity); theme layered on top. Both `status: planned` seeds; build at M3.
-- **Spell-palette tint** shipped: dedicated `gMSSpellTint` overlay global (#168/#169). Green Flux etc.
-- **ch03** (#23) complete (enemy battle-anim art was the last gap, via #90).
-- **Enemy battle-anim import pipeline** (#90): reskinned enemy CLASSES animate as real FE-native
-  community anims. `tools/feditor_to_banim.py` imports FEditor `.txt` + PNGs → decomp banim;
-  `inject_enemy_class_battle_anims` binds per-class via `pBattleAnimDef`. ADR "Imported enemy battle anims".
-- **Per-caster charge flash** (#183): each caster's sprite pulses its signature colour on the wind-up beat
-  (Rootis blue · Marty green · Meesmickle purple). One YAML line per caster; reusable engine kernel in
-  ADR "Per-caster charge flash".
-- **PC battle anims — 8 of 8 DONE** (braulo, marty, meesmickle, prof-rbg, wolfram, rootis, pinky,
-  **sclorbo**). ALL PC cast anims shipped. Faked 3-pose casters ride `inject_battle_anims` (per-character
-  `_u25`); the flier (Pinky) rides the N-frame IMPORT path (below). Sclorbo (the healer, #191) added the
-  reusable **BISHOP dual-slot donor** (staff heal + light attack from one anim) that **Basil (#25) reuses**.
-- **Recruit art (ch04/ch05)** shipped as portraits + map sprites: **Basil** (Oddish, #179), **Lupin**
-  (direwolf/Lycanroc + glasses) + **Sahnar** (spectral-skeleton) (#181). Their build *wiring* (slot,
-  STAT_DONOR, injection, live `battle_anim:`) is ch04/ch05-slice work (#24/#25). Basil's battle anim is
-  blocked on the SAME priest/staff donor Sclorbo needs (below). Deferred battle anims ride the #90 path.
+- **Winter forest fidelity is an invariant (#193, merged `6a538bc`).** Snowy Bern retiles preserve the
+  vanilla artists' forest sequences: the learned per-metatile map in `reskin-learned.json` is the sole
+  authority, `gen_map_editor.py` refuses to generate on an unmapped forest variant, and
+  `import_map_layout.py` re-checks every protected cell. Ch00–Ch02 backfilled. ADR: "Winter retiles
+  preserve the vanilla artists' forest sequences…".
+- **ch04 "The White Moose" combat slice is hosted (#24, branch `feat/24-ch04-map`, pushed, NOT merged).**
+  `inject_ch04` hosts Ch4 1:1 on the vanilla Ch5 slot: 15×15 snowy retile (vanilla geometry + forest
+  sequences preserved), roster grounded to real FE8 monster classes (Mauthe Doog / Bonewalker-bow /
+  Mogall / Entombed), fog 3, PREP (9 of 10), DefeatAll/Rout, 16 line + 4(t2) + 3(t3) reinforcements,
+  `--ch04-boot` fast-boot, `chain_ch03_to_ch04`. Borrows Super Fields' Snag family into Snowy Bern's
+  empty slots (ADR). **Full ROM build green; 230 tests + `check.py` clean.** This is a WIP checkpoint —
+  see NEXT.
+- **Parity/difficulty engine is three-dimensional** (`tools/difficulty.py`, all from HEAD): enemy
+  pressure + item economy (#170/#172; drops #176/#178) + battlefield dynamics (convertibles + reinforcement
+  timing #171/#174; area/zone #177/#178). `make difficulty CH=chNN` shows all three.
+- **PC battle anims — 8 of 8 DONE** (braulo, marty, meesmickle, prof-rbg, wolfram, rootis, pinky, sclorbo).
+  Sclorbo (#191) added the reusable **BISHOP dual-slot donor** (staff heal + light attack) that
+  **Basil (ch05, #25) plugs into** (`battle_anim: {clone_from: bishop}` — no new donor work).
+- **Enemy battle-anim import pipeline** (#90) + **per-caster charge flash** (#183) shipped; spell-palette
+  tint (#168/#169) shipped. ch03 (#23) complete.
+- **Recruit art shipped** (portraits + map sprites): Basil/Oddish (#179), Lupin + Sahnar (#181). Their
+  build *wiring* (slot, STAT_DONOR, live `battle_anim:`) is ch04/ch05-slice work (#24/#25).
 
-## This session (2026-07-18, Opus — Pinky flier battle anim SHIPPED, #190)
+## This session (2026-07-21, Opus — landed #193, reconciled + hosted the ch04 combat slice)
 
-- **#190 shipped** (squash `a51faf7`, merged; ADR in decisions.md "A PC flier rides the IMPORT pipeline").
-  Pinky (the army's flier — **he/him**, RBG's homunculus son) gets a real **6-frame swoop**: launch →
-  apex (ears out) → dive-bomb onto the foe (lanceless body-slam + pink impact swirl) → fly home.
-- **New seam — merged the two banim pipelines:** a PC can now ride the #90 N-frame IMPORT path
-  (`feditor_to_banim.build_import`) but bind **per-CHARACTER via `_u25`** (the enemy path binds
-  per-class). `build_unit_battle_anim` dispatches on a `battle_anim.import: {txt, frames_dir}` block;
-  both sources return the identical `{sheets,pal,motion_s}` shape so the binding is unchanged. New
-  `pegasus` `BANIM_DONORS` row (`CLASS_PEGASUS_KNIGHT`, ITYPE_LANCE). This is the model for any PC whose
-  motion can't be faked from 3 static poses.
-- **New tool `tools/poses_to_feditor.py`:** hi-res poses → FEditor 248×160 frames. INVERSE of
-  `descale_battleframe` — descale PINS the feet (kills inter-frame motion); this places each pose on a
-  shared canvas so the per-frame shift BECOMES the on-screen motion. Arc lives in a `poses.yaml` manifest.
-- **Reusable learnings (full list in the ADR):**
-  - **Facing:** flip source to screen-left (cast convention) AND negate the dx signs (a left-facing unit
-    strikes toward a foe on its left).
-  - **Ear-clip:** his tail dragged the `w/2,h*5/8` anchor down → the ear-tip hit the arena's top clip line;
-    shrinking him (idle ~27×31, the roster's smallest) cleared it. Future tailed/tall unit → body-based anchor.
-  - **Arc = the DONOR's real on-screen path** (rise → dive → strike at melee range ~56px), NOT the concept
-    layout (which overshot past the foe).
-  - **Dodge timing is script-synced, not on-screen:** `wait_hp_deplete` (`C01`, `0x85000001`) is NOT a NOP —
-    it PAUSES until the hit resolves. Put the hop AFTER it to fire at the miss (vanilla hops before → early);
-    then HOLD the back-frame across the enemy's lance-extension (hop at full extension, land at retract).
-  - **Process cost (recorded in memory + ADR):** a `recordanim` capture interleaves attack 1 · counter/dodge ·
-    attack 2 (double) — I burned ~10 rebuilds analyzing the WRONG frames (2nd-attack swoop read as "the dodge").
-    ALWAYS identify which beat a window is first (attacker → foe; defender → away); render UNCROPPED full-combat
-    GIFs for review. And GitHub caches raw GIFs by URL — cache-bust with fresh filenames.
-- Showcase GIF: `docs/demo/pinky-full-combat.gif`. 245 tests green, `check.py`/`verify_text`/`git diff --check` clean.
+- **#193 landed** (PR #194 squash-merged, CI green) after audit: strong regression coverage (forest
+  counts + exact mapping + sha256-pinned non-forest cells), correct `.bin`→`.mar` format migration.
+- **ch04 committed + rebased onto #193** as one clean commit (`df3183b`). #193 and ch04 were sibling
+  branches that had both edited the map tooling / `reskin-learned.json` / `decisions.md`; reconciliation
+  took #193's forest machinery + reskin-learned (superset), kept both ADRs and both test suites, and
+  ported ch04's `review_output` (preview-beside-editor) onto #193's map editor.
+- **Two agent-discipline learnings recorded in `decisions.md`** (so Codex finds them too):
+  (1) *feature-flow only works if each feature LANDS before the next starts* — the parallel-unmerged-branch
+  post-mortem that explains the recurring rebase; (2) an Operational Gotcha: **a `git` subprocess inside a
+  git hook resolves against the outer repo unless you strip `GIT_*`** (this bit us — flipped `core.bare`
+  and wrote a corrupt commit; fixed in `_vanilla_decomp_text` + the map-tileset test fixture).
 
-## Prior sessions (condensed — full detail in decisions.md ADRs + the PRs)
+## NEXT SESSION — start here: finish the ch04 slice (`feat/24-ch04-map`)
 
-- **2026-07-18 (#183):** per-caster charge flash shipped (Marty green · Rootis blue · Meesmickle purple).
-  Reusable kernel: arm from an EXISTING banim command, raised-cosine LUT, pulse the actor OBJ palette from a
-  `PROC_REPEAT` proc. Gotchas: new hook-target file MUST be in `PATCHED_DECOMP_FILES`; no `.bss` statics in banim TUs.
-- **2026-07-17 (#184):** Rootis frost-mage anim. `clone_from` = the unit's OWN class (new `mage` donor);
-  element = colour-only spell tint, not a proc swap; `--reserve` threaded through the adaptive palette path.
-- **2026-07-17 (#90):** enemy battle-anim import pipeline (kobolds/goblins) + landed the stranded Braulo refresh.
-- **2026-07-17 (#181):** Lupin + Sahnar recruit art. **2026-07-16 (#179):** Basil/Oddish art kit.
-- **2026-07-17 (#186, CLOSED):** ch04 roster grounded (23-unit force mirroring the vanilla Ch4 twin) +
-  the tiered-difficulty ADR (roster ballpark → map+placement → spatial check → play → lock; spatial check =
-  facts fed to an LLM analyst, not an LLM playing FE). `placement_directives` written into the ch04 map notes.
-- **2026-07-16 (#178):** closed both parity-engine v1 gaps (economy drops #176 + area/zone reinforcements #177).
+The combat slice is hosted and builds; it is **not** a complete chapter. To finish and PR-merge #24:
 
-## NEXT SESSION — start here: ch04 / ch05 slices (all PC anims now done)
+1. **Wolf parley + Marty-Talk teaching** — the two open events decisions in `ch04-the-white-moose.yaml`:
+   parley behavior (green-and-fight vs green-and-leave) and teaching the player Marty can Talk to parley
+   the Mauthe Doog pack (Lupin recruits as a non-combat NPC). `inject_ch04` currently wires combat only.
+2. **Authored ending scene** — currently a `dev_placeholder_scene()`; write the real ch04→ch05 hand-off.
+3. **Tiered-difficulty spatial check + playtest** — run the analyst pass on the placed map, then play the
+   `--ch04-boot` build, then lock. Then open the PR (`Closes #24`).
+4. Wire Basil/Lupin/Sahnar STAT_DONORs when their ch04/ch05 slices need them.
 
-**Sclorbo shipped (#191, merged) — the last PC battle anim.** ADR in `decisions.md`
-("A HEALER (staff caster) rides ONE anim…"). The reusable **BISHOP dual-slot donor** (staff heal + light
-attack from one clone) is now what **Basil (ch05, #25) plugs into** — give Basil a `battle_anim:` block with
-`clone_from: bishop` (+ his frames) when his ch05 slice is built; no new donor work needed. Note the healer
-capture path added to `recordanim` (`captureHealerAnim`) for any future staff unit.
-
-**Main line (ch04/ch05):** ch04 MAP (step 2) then ch05 slice (M3).
-ch04 roster grounded; next = the Tiled retile of vanilla Ch4 per the `placement_directives`, then the spatial
-check + build/play (tiered-difficulty flow). Two open ch04 events decisions: parley behavior (green-and-fight
-vs green-and-leave) + teaching the player Marty can Talk to parley the wolves. ch05 not started (`status:
-planned`, 8-enemy seed unmodeled — needs the same grounding pass ch04 got, + wire Lupin/Sahnar/Basil STAT_DONORs).
-
-## Next steps (priority order)
-
-1. **Build the ch04 / ch05 slices** (M3). Per-chapter vertical slice on #24/#25, through the
-   tiered-difficulty flow. ch04 = the map step next; ch05 = the grounding pass (+ wire Basil's
-   `battle_anim: {clone_from: bishop}` — donor now exists, #191).
-2. **#138** config-driven `inject_chapter(descriptor)` (YAML `host:` block — approved, paused for ch04/ch05).
-3. Then **#29** world map.
+Then: **#138** config-driven `inject_chapter(descriptor)` (approved, paused for ch04/ch05); **ch05** (#25)
+grounding pass; **#29** world map.
 
 ## Working tree - do not lose or revert
 
 - `fireemblem8u` is dirty from injected/generated build artifacts. **Never commit its submodule pointer.**
+  To run the map/forest tests cleanly after a build, restore the injected decomp files:
+  `git -C fireemblem8u restore src/data/chapter_settings.json data/data_8B363C.s`.
 - Untracked local/session files (`.agents/`, `AGENTS.md`, `skills-lock.json`) are intentionally not
   versioned; leave them alone. `tools/key_magenta.py` is **gitignored** (#178).
-- **Nicolas's parallel ch04 work is live: branch `feat/24-ch04-roster-grounding` + worktree
-  `.claude/worktrees/ch04-map` (locked, the ch04 MAP step). Leave both alone** — in-progress, not stale.
-  (PR #186 is closed; the roster grounding merged/superseded — verify with Nicolas before touching.)
-- The Pinky session's branch (`feat/pinky-battle-anim`, #190) is squash-merged and deleted. Everything is
-  on `main` (pushed); CI green.
+- `feat/24-ch04-map` (pushed) carries the ch04 combat slice — in progress, not stale. The old
+  `feat/24-ch04-roster-grounding` branch is superseded (retire it).
 
 ## Quick commands
 
 ```sh
 # Parity/difficulty read (all from HEAD)
-make difficulty CH=ch05            # or ch04, etc.
+make difficulty CH=ch04
 
-# Battle-animation capture (requires a `make TESTCH=1` ROM)
-PT_CHAR=marty tools/playtest/run.sh recordanim          # PC anim; PT_CHAR=<id>
-tools/playtest/make_gif.py recordanim marty --name X    # frames -> review GIF (fresh name = cache-bust)
+# ch04 fast-boot playtest build (New Game -> White Moose forest, party + foes deployed)
+make CAMPAIGN=rime-of-the-frostmaiden CH04BOOT=1 fireemblem8.gba -j$(nproc)
 
 # Required before claiming a change is finished
 python3 -m unittest tools.test_build_campaign tools.test_difficulty

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -327,6 +327,30 @@ file seam — **stand**: worktrees are now ephemeral-per-feature, and the file s
 feature-flow keeps.
 _Decided: 2026-06-24 (Nicolas — chose feature-flow + PRs; codified from the "not my job" design review)_
 
+**Feature-flow only works if each feature LANDS before the next starts — parallel unmerged lines on
+shared files are what force a rebase every time you come back.** Symptom (2026-07-21): two sibling
+branches off `main` — #193 (winter forest fidelity) and the ch04 map slice — were open at once, one a
+committed-but-PR-less branch, the other **uncommitted WIP left in its worktree**. Both edited the same
+cross-cutting "hot" files (`tools/gen_map_editor.py`, `tools/map_tileset_tool.py`,
+`campaigns/.../maps/reskin-learned.json`, and `docs/decisions.md` — every ADR appends near the same
+line), and both **independently re-derived** the same vanilla-layout `.bin`→`.mar` reader under
+different function names. `main` then moved underneath the stale WIP, and integrating them cost a full
+conflict-resolving rebase. The rebase is the *symptom*; the discipline that prevents it:
+
+- **Land each feature end-to-end before starting or resuming the next** (commit → PR → CI → squash-merge
+  → delete branch), especially anything touching shared tooling / JSON / `decisions.md`.
+- **Never leave a worktree dirty across a session boundary** — at minimum commit a checkpoint on the
+  feature branch so `main` can't strand it. Long `HANDOFF.md` "do not lose or revert" lists are the smell
+  that this rule is being broken.
+- **Reuse, don't re-derive** — grep for an existing helper before writing a new one; two branches solving
+  one problem two ways guarantees both wasted work and a merge conflict.
+- **Append new ADRs at the END of their section**, not mid-file, so two branches don't insert at the same
+  line and collide.
+
+This is the operational half of the feature-flow ADR above (which settled the *structure*); this settles
+how it must be *practiced* by any agent (Claude or Codex) picking work up across sessions.
+_Decided: 2026-07-21 (post-mortem of the #193 / ch04 parallel-branch rebase)._
+
 **Boot decision localized; bows need a min-range in playtest targeting (the first feature-flow feature).**
 The boot cut + New-Game redirect were decided in BOTH `inject_prologue` and `inject_test_chapter` (the
 duplication the Coordination ADR cites). Localized to one `_configure_boot(target, montage)` owner called
@@ -2581,6 +2605,15 @@ _Decided: 2026-07-05 (CLAUDE; pipeline track. #125, closed not-planned — no co
 _Moved here from `HANDOFF.md` 2026-07-02 (audit): these are durable engineering constraints, not
 session state. `HANDOFF.md` points here._
 
+- **A `git` subprocess run inside a git hook resolves against the OUTER repo unless you strip `GIT_*`.**
+  Git exports `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` while a hook runs (pre-commit drift → `check.py`
+  → the `test_*.py` suite). Any tool or **test fixture** that then shells out to `git` — `git -C <dir> …`,
+  a throwaway `git init`/`commit` in a tempdir, `_vanilla_decomp_text`'s `git show HEAD:` — has its
+  `-C`/cwd **overridden** by the ambient `GIT_DIR` and silently operates on the real repo. On 2026-07-21
+  this flipped `core.bare=true` on the live repo and wrote a corrupt commit before it was caught. **Always
+  pass a sanitized env** — `{k: v for k, v in os.environ.items() if not k.startswith('GIT_')}` — to any
+  `git` subprocess that must target a specific repo, and add `-c core.hooksPath=/dev/null` to fixture
+  commits so they can't re-enter the outer hook. Fixed in `_vanilla_decomp_text` + `test_map_tileset.py`.
 - **Per-unit descale recipe is recorded in the unit YAML comment** (data-is-the-doc) — read it before
   regenerating; don't guess flags. Swapping ONE pose still requires re-descaling the **whole 3-frame set
   together** (shared palette recompute shifts the other two — that's correct, not a bug).


### PR DESCRIPTION
Clean handoff refresh now that #193 is merged and the ch04 combat slice is hosted on `feat/24-ch04-map`, plus two durable learnings recorded in `decisions.md` so any agent (Claude or Codex) picking up work later finds them.

## HANDOFF.md
Rewritten to live state: #193 winter-forest fidelity merged; ch04 "White Moose" combat slice hosted (builds green, WIP); next = wolf parley + Marty-Talk + ending scene, then PR.

## decisions.md
- **Coordination model:** feature-flow only works if each feature *lands* before the next starts — the post-mortem of the #193/ch04 parallel-branch rebase (don't leave uncommitted WIP across sessions; reuse don't re-derive; append ADRs at section end).
- **Operational Gotcha:** a `git` subprocess inside a git hook resolves against the outer repo unless `GIT_*` is stripped — this flipped `core.bare` and wrote a corrupt commit this session; fixed in `_vanilla_decomp_text` + the map-tileset test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)