### PR TITLE
perf: idempotent injection — warm rebuild 188s → 28s, ROM byte-identical (#24)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -41,6 +41,21 @@ _Decided: 2026-06-04 (supersedes the PRD's TS toolchain plan); 2026-06-09 (Ruby 
 `build_campaign.py` writes our content directly into the `fireemblem8u` working tree at build time — `graphics/portrait/` (busts), `texts/texts.txt` (names/dialogue), `src/data_characters.c` (class/stats), and `src/events/<ch>-event*.h` (chapters) — then `make` compiles it. No Event Assembler / ColorzCore / `.ea` buildfiles. This is the "make a hack directly from the fireemblem8u decomp" path (FEU thread 17428). Generated files are reproducible artifacts: restore vanilla with `git -C fireemblem8u checkout <path>`.
 _Decided: 2026-06-04 (supersedes the PRD's Event Assembler plan; retires the `tools/build-events.ts` idea)_
 
+**Injection is idempotent: a byte-identical re-emit rewinds the file's mtime, so `make` skips it.**
+Because injection rewrites the decomp's own sources every build (above), and `restore_vanilla_sources`
+re-`git checkout`s them, every touched file's mtime moved on every build — and `make` keys off mtime, not
+content. A no-change rebuild therefore paid the full ~354-TU cascade from restored widely-included headers
+plus the serial `data_banim.o` link over 1752 assets. `build_campaign` now snapshots the previous build's
+injection footprint (content sha1 + `mtime_ns`) before injecting and rewinds the mtime of every file whose
+bytes come out **identical**. Only mtime is written, and only on unchanged content, so the ROM cannot move.
+**Measured on the ch04 branch (CH04BOOT, `-j`):** warm rebuild **188s → 28s** (6.7×); clean build 232s
+without vs 236s with, and all of {clean-without, warm-without, warm-with ×2, clean-with} produced the same
+ROM `sha256 dc1c56bf…`. The risk this design carries is that a wrong content-check would be invisible to
+`make` (stale objects, silently), so it is also proved from the other side: changing one line of real
+content (a `death_quote`) moved the ROM sha and left that file un-rewound (482 → 481), and reverting it
+returned the ROM to `dc1c56bf…` exactly. Re-run those two gates if the footprint logic is ever touched.
+_Decided: 2026-07-30 (#24; written 2026-07-21, merged only once the ROM gates could run on the Mac)_
+
 **No SRD/Open5e pull.** PC data is authored from the players' D&D Beyond JSON (`data/pc-sheets/`); D&D is flavor-only over vanilla FE combat (see FE-strictness below). No SRD downloader, no `srd-snapshot.json`, no homebrew engine classes — the cast use stock FE8 classes (see Class Mapping).
 _Decided: 2026-06-04_
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -23,6 +23,7 @@ Milestones B+ (characters, chapter, dialogue codegen) hang off the same CLI.
 """
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -481,6 +482,72 @@ PATCHED_DECOMP_FILES = ['texts/texts.txt', 'src/data_characters.c', 'src/portrai
                         'src/prep_sallycursor.c'] + [
                         'graphics/op_subtitle/OpSubtitle_%02d.png' % i
                         for i in range(gen_subtitle_cards.CARD_COUNT)]
+
+
+# --- warm-rebuild acceleration: idempotent injection ---------------------------
+# The injection re-emits (very nearly) byte-identical decomp sources every build,
+# but the plain writes -- and restore_vanilla_sources' `git checkout` -- bump each
+# touched file's mtime. `make` keys off mtime, so it recompiles the translation
+# unit AND re-runs the expensive graphics compression / serial banim link even when
+# the CONTENT is unchanged from the last build. The dominant costs are the ~354-TU
+# recompile cascade from restored widely-included headers (variables.h, ekrbattle.h,
+# classes.h) and the serial `arm_compressing_linker.py` rebuild of data_banim.o
+# (1752 assets) whenever any banim sheet/motion/agbpal mtime moves.
+#
+# Fix: snapshot the previous build's injection footprint (content hash + mtime) up
+# front, and once injection finishes, rewind the mtime of every file whose bytes are
+# byte-for-byte identical. `make` then treats those targets as up to date. This is
+# purely an mtime optimisation -- a file is rewound ONLY when its content is
+# unchanged, so the compiled ROM is bit-identical. See docs/decisions.md (Build).
+
+def _decomp_footprint():
+    """Absolute paths git reports as modified/untracked under the decomp -- i.e. the
+    previous build's injection footprint (source files; the .o/.lz/.4bpp build
+    outputs are .gitignored, so they are excluded). Never raises: a git hiccup just
+    yields an empty snapshot, which preserves correctness and only skips the speed-up."""
+    try:
+        out = subprocess.run(
+            ['git', '-C', DECOMP, 'status', '--porcelain', '-z', '-uall'],
+            check=True, capture_output=True).stdout
+    except (subprocess.SubprocessError, OSError):
+        return []
+    paths = []
+    for rec in out.split(b'\0'):
+        # porcelain -z record: 'XY <path>' (rename records carry a trailing NUL-
+        # separated old path, which harmlessly resolves to a real file too).
+        if len(rec) > 3:
+            paths.append(os.path.join(
+                DECOMP, rec[3:].decode('utf-8', 'surrogateescape')))
+    return paths
+
+
+def _snapshot_mtimes(paths):
+    """{abs_path: (mtime_ns, sha1_digest)} for each existing regular file in `paths`."""
+    snap = {}
+    for p in paths:
+        try:
+            st = os.stat(p)
+            with open(p, 'rb') as f:
+                snap[p] = (st.st_mtime_ns, hashlib.sha1(f.read()).digest())
+        except OSError:
+            pass  # missing / directory / unreadable -> just don't track it
+    return snap
+
+
+def _rewind_unchanged_mtimes(snap):
+    """Rewind the mtime of every snapshotted file whose bytes are unchanged, so make
+    skips its (redundant) recompile/recompression. Returns the count rewound. Only
+    ever touches mtime, and only for byte-identical content -- never file bytes."""
+    n = 0
+    for p, (mtime_ns, digest) in snap.items():
+        try:
+            with open(p, 'rb') as f:
+                if hashlib.sha1(f.read()).digest() == digest:
+                    os.utime(p, ns=(mtime_ns, mtime_ns))
+                    n += 1
+        except OSError:
+            pass
+    return n
 
 
 def restore_vanilla_sources():
@@ -6839,6 +6906,9 @@ def main():
         args.test_chapter = True  # the fast-boot rides the sandbox
 
     print('build_campaign: injecting "%s" into %s' % (args.campaign, DECOMP))
+    # Snapshot the previous build's injection footprint BEFORE we touch anything, so
+    # we can rewind mtimes for whatever comes out byte-identical (fast warm rebuilds).
+    _mtime_snapshot = _snapshot_mtimes(_decomp_footprint())
     print('portraits:')
     inject_portraits(args.campaign)
     if not args.portraits_only:
@@ -6924,6 +6994,10 @@ def main():
                 _configure_boot(PROLOGUE_HOST_INDEX, montage=args.montage)
         print('death quotes (#6):')
         inject_pc_death_quotes(args.campaign)
+    rewound = _rewind_unchanged_mtimes(_mtime_snapshot)
+    if rewound:
+        print('idempotent injection: rewound %d unchanged file(s) -> make skips them'
+              % rewound)
     print('done. Run `make` to compile the ROM.')
 
 

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -5,6 +5,7 @@ These pin the donor-inheritance primitives the difficulty engine and the charact
 patcher share, against real vanilla values read from fireemblem8u/src/data_characters.c.
 Run:  python3 tools/test_build_campaign.py
 """
+import hashlib
 import os
 import re
 import sys
@@ -1101,6 +1102,62 @@ class ItemIconPal2(unittest.TestCase):
         self.assertIn('(OamPalBase & 0xF000) == 0x4000', out)
         self.assertIn('ApplyPalette(item_icon_palette[2], 15);', out)
         self.assertIn('OamPalBase = (OamPalBase & 0x0FFF) | 0xF000;', out)
+
+
+class IdempotentInjectionMtimes(unittest.TestCase):
+    """The warm-rebuild speed-up: rewind mtimes only for byte-identical files, so
+    `make` skips unchanged targets while the ROM stays bit-identical (#build-speed)."""
+
+    def _tmpfile(self, data=b'hello'):
+        import tempfile
+        fd, path = tempfile.mkstemp()
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        with os.fdopen(fd, 'wb') as f:
+            f.write(data)
+        return path
+
+    def test_snapshot_records_mtime_and_hash(self):
+        p = self._tmpfile(b'abc')
+        snap = bc._snapshot_mtimes([p])
+        self.assertIn(p, snap)
+        mtime_ns, digest = snap[p]
+        self.assertEqual(mtime_ns, os.stat(p).st_mtime_ns)
+        self.assertEqual(digest, hashlib.sha1(b'abc').digest())
+
+    def test_snapshot_skips_missing_files(self):
+        # A path that does not exist is simply not tracked (no raise).
+        self.assertEqual(bc._snapshot_mtimes(['/no/such/file/xyz']), {})
+
+    def test_rewinds_mtime_when_content_unchanged(self):
+        # Rewriting a file with IDENTICAL bytes normally bumps mtime; the rewind
+        # must restore the snapshot mtime so make treats the target as up to date.
+        p = self._tmpfile(b'same-bytes')
+        snap = bc._snapshot_mtimes([p])
+        os.utime(p, ns=(snap[p][0] + 5_000_000_000, snap[p][0] + 5_000_000_000))
+        with open(p, 'wb') as f:          # rewrite identical content (new mtime)
+            f.write(b'same-bytes')
+        self.assertNotEqual(os.stat(p).st_mtime_ns, snap[p][0])
+        n = bc._rewind_unchanged_mtimes(snap)
+        self.assertEqual(n, 1)
+        self.assertEqual(os.stat(p).st_mtime_ns, snap[p][0])
+
+    def test_does_not_rewind_when_content_changed(self):
+        # A genuinely changed file KEEPS its fresh mtime, so make rebuilds it.
+        p = self._tmpfile(b'original')
+        snap = bc._snapshot_mtimes([p])
+        with open(p, 'wb') as f:
+            f.write(b'CHANGED')
+        changed_mtime = os.stat(p).st_mtime_ns
+        n = bc._rewind_unchanged_mtimes(snap)
+        self.assertEqual(n, 0)
+        self.assertEqual(os.stat(p).st_mtime_ns, changed_mtime)  # not rewound
+
+    def test_footprint_lists_modified_and_untracked_sources(self):
+        # The footprint comes from `git status` on the decomp: an mtime rewind is only
+        # meaningful for files git already sees as part of the injection (source, not
+        # the .gitignored build outputs). Just assert it returns decomp-rooted paths.
+        for p in bc._decomp_footprint():
+            self.assertTrue(p.startswith(bc.DECOMP), p)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Unblocks ch04 Stages 3–5 (issue #24's ⚡ section). The code was written in the web container on 2026-07-21 and committed unverified on 2026-07-30 because it had sat uncommitted in a worktree for 9 days; **both gates it demanded have now been run on the Mac**, where a ROM build is possible again.

## What it does

Injection re-emits (very nearly) byte-identical decomp sources every build, but the writes — and `restore_vanilla_sources`' `git checkout` — bump every touched file's mtime. `make` keys off mtime, so a no-change rebuild still paid the ~354-TU cascade from restored widely-included headers plus the serial `data_banim.o` link over 1752 assets.

`build_campaign` now snapshots the previous build's injection footprint (content sha1 + `mtime_ns`) **before** injecting, then rewinds the mtime of every file whose bytes come out identical. Only mtime is written, and only on unchanged content.

## Gate 1 — byte-identical ROM

Full clean build with and without the change, plus the warm rebuilds in between (`CH04BOOT=1`, `-j`):

| build | perf | wall | ROM sha256 |
|---|---|---|---|
| clean | without | 232s | `dc1c56bf…` |
| warm | without | 188s | `dc1c56bf…` |
| warm | **with** | **28s** | `dc1c56bf…` |
| warm | **with** | **29s** | `dc1c56bf…` |
| clean | **with** | 236s | `dc1c56bf…` |

Same ROM in every combination. 482 files rewound per warm build.

## Gate 2 — measured speedup

Warm rebuild **188s → 28s (6.7×)**. Cold is unchanged (232s vs 236s, noise) — as expected, since nothing is skippable on a clean tree.

## The risk, proved from the other side

The design's real hazard is that mtime rewinding is invisible to `make`: a wrong content-check would silently reuse stale objects. So it was also run in reverse — change one line of real content (Braulo's `death_quote`), rebuild:

- ROM sha moved to `52afe132…`, and the rewind count dropped 482 → **481** (the changed file was correctly *not* rewound);
- reverting the line returned the ROM to `dc1c56bf…` **exactly**.

Stale objects are never reused. ADR in `docs/decisions.md` (Engine & Tech Stack) records the numbers and names the two gates to re-run if the footprint logic is ever touched.

## Verification

- 487 unit tests OK (5 cover snapshot / rewind / no-rewind-on-change / footprint)
- `make check` clean · `git diff --check` clean

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
