### PR TITLE
cleanup: the two nits from the #198 review

### DIFF
--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -2625,20 +2625,23 @@ PRE_RECRUIT_STRUCT = ('struct PreRecruitVariant { unsigned short charId; '
                       'unsigned short smsId; const void * muImg; };\n')
 
 
-def _pre_recruit_lookup(unit_expr, indent='    '):
+def _pre_recruit_lookup(unit_expr, indent='    ', char_var='charId'):
     """C (agbcc/C89: declarations first) resolving `unit_expr` to its pre-recruit variant
-    row, or NULL when the unit has joined / has no variant."""
+    row, or NULL when the unit has joined / has no variant.
+
+    `char_var` names an int the CALLER has already set to the unit's charId -- all three
+    override hooks compute one for their own table scan, so the lookup reuses it rather
+    than recomputing UNIT_CHAR_ID into a second local."""
     i = indent
     return (i + 'struct PreRecruitVariant * prv = 0;\n'
             + i + 'if (UNIT_FACTION(%s) != FACTION_BLUE) {\n' % unit_expr
-            + i + '    struct PreRecruitVariant * it = gPreRecruitVariant;\n'
-            + i + '    int prvChar = UNIT_CHAR_ID(%s);\n' % unit_expr
-            + i + '    while (it->charId != 0) {\n'
-            + i + '        if (it->charId == prvChar) {\n'
-            + i + '            prv = it;\n'
+            + i + '    struct PreRecruitVariant * prvIt = gPreRecruitVariant;\n'
+            + i + '    while (prvIt->charId != 0) {\n'
+            + i + '        if (prvIt->charId == %s) {\n' % char_var
+            + i + '            prv = prvIt;\n'
             + i + '            break;\n'
             + i + '        }\n'
-            + i + '        it++;\n'
+            + i + '        prvIt++;\n'
             + i + '    }\n'
             + i + '}\n')
 
@@ -2721,7 +2724,7 @@ def _remap_indices(src_path, roles, palette_png, out_path):
         sys.exit('ERROR: %s uses cast index/indices %s with no pre_recruit_roles entry'
                  % (os.path.basename(src_path), ', '.join(str(m) for m in missing)))
     out = Image.new('P', im.size)
-    out.putpalette(map_sprite_tool._read_palette(palette_png))
+    out.putpalette(map_sprite_tool.read_palette(palette_png))
     out.putdata([0 if v == 0 else roles[v] for v in im.getdata()])
     out.save(out_path)
 

--- a/tools/map_sprite_editor.py
+++ b/tools/map_sprite_editor.py
@@ -41,7 +41,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import map_sprite_tool  # noqa: E402  (sheet_info + _read_palette)
+import map_sprite_tool  # noqa: E402  (sheet_info + read_palette)
 from PIL import Image  # noqa: E402
 
 # FE8 standing idle, straight from src/bmudisp.c: GetGameClock() % 72 picks frames
@@ -81,7 +81,7 @@ class Doc:
             sys.exit('ERROR: %s is %dx%d but donor %s is %dx%d'
                      % (sheet_path, w, h, src, self.fw, self.fh))
         self.n = h // self.fh
-        flat = map_sprite_tool._read_palette(palette_path)
+        flat = map_sprite_tool.read_palette(palette_path)
         self.palette = [flat[i * 3:i * 3 + 3] for i in range(16)]
         data = list(im.getdata())
         self.frames = [data[f * self.fw * self.fh:(f + 1) * self.fw * self.fh]

--- a/tools/map_sprite_tool.py
+++ b/tools/map_sprite_tool.py
@@ -121,8 +121,11 @@ def sheet_info(path, expect=None):
     return SMS_SIZES[(fw, fh)], fw, fh, h // fh
 
 
-def _read_palette(path):
-    """Load cast_palette.png -> a flat 16*3 RGB palette list (index 0 = transparent)."""
+def read_palette(path):
+    """Load an indexed PNG's palette -> a flat 16*3 RGB list (index 0 = transparent).
+
+    Public: build_campaign and map_sprite_editor both read palettes this way, so the
+    leading underscore was misdescribing it as module-private."""
     im = Image.open(path)
     if im.mode != 'P':
         sys.exit('ERROR: %s must be indexed (mode P) to define the cast palette' % path)
@@ -169,7 +172,7 @@ def recolour(base_path, palette_path, out_path, overrides=None):
                  % (base_path, im.mode))
     src_pal = im.getpalette() or []
 
-    cast = _read_palette(palette_path)
+    cast = read_palette(palette_path)
     cast_rgb = [tuple(cast[3 * i:3 * i + 3]) for i in range(16)]
 
     # Build donor-index -> cast-index map. Index 0 is the engine's transparent slot in
@@ -224,7 +227,7 @@ def remap_sms_palette(src_path, donor_palette_png, out_path, overrides=None):
     if im.mode != 'P':
         sys.exit('ERROR: %s is mode %s; expected an indexed (mode P) sheet' % (src_path, im.mode))
     src_pal = im.getpalette() or []
-    tgt = _read_palette(donor_palette_png)
+    tgt = read_palette(donor_palette_png)
     tgt_rgb = [tuple(tgt[3 * i:3 * i + 3]) for i in range(16)]
 
     remap = {0: 0}
@@ -465,7 +468,7 @@ def grid(sheet_path, out_path, frame=0, scale=28):
 def palette_chart(palette_path, out_path):
     """Swatch chart of the 16 cast indices (number + RGB + colour block) so a called-out
     index is unambiguous. Index 0 is the transparent slot."""
-    pal = _read_palette(palette_path)
+    pal = read_palette(palette_path)
     rowh, w = 36, 320
     canvas = Image.new('RGB', (w, rowh * 16), (30, 30, 30))
     d = ImageDraw.Draw(canvas)

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1446,3 +1446,27 @@ class PreRecruitVariant(unittest.TestCase):
         body = [ln.strip() for ln in bc._pre_recruit_lookup('unit').splitlines() if ln.strip()]
         self.assertTrue(body[0].startswith('struct PreRecruitVariant * prv'))
         self.assertNotIn('//', bc._pre_recruit_lookup('unit'))
+
+    def test_the_lookup_reuses_the_caller_s_charId_and_shadows_nothing(self):
+        """Every hook already computes the charId for its own table scan, and GetMuImg
+        walks its override table with a cursor called `it` -- so the lookup must not
+        recompute UNIT_CHAR_ID into a second local, nor name its cursor `it`."""
+        c = bc._pre_recruit_lookup('proc->unit')
+        self.assertIn('prvIt->charId == charId', c)
+        self.assertEqual(c.count('UNIT_CHAR_ID'), 0, 'charId is the caller\'s to compute')
+        self.assertNotIn(' it ', c)
+        self.assertNotIn('it++', c.replace('prvIt++', ''))
+        # Callers with a differently-named charId can say so.
+        self.assertIn('prvIt->charId == cid', bc._pre_recruit_lookup('unit', char_var='cid'))
+
+    def test_every_hook_defines_charId_before_the_lookup_uses_it(self):
+        """C89 + the reuse above: `int charId = ...` must precede the emitted lookup in
+        each of the three hooks, or the generated source will not compile."""
+        src = open(os.path.join(bc.REPO, 'tools', 'build_campaign.py'), encoding='utf-8').read()
+        for fn in ('_inject_sms_override_hook', '_inject_mu_override_hook',
+                   '_inject_palette_bank_hook'):
+            body = src[src.index('def %s(' % fn):]
+            body = body[:body.index('\ndef ')]
+            self.assertLess(body.index('int charId = UNIT_CHAR_ID'),
+                            body.index('_pre_recruit_lookup('),
+                            '%s must set charId before the pre-recruit lookup' % fn)


### PR DESCRIPTION
Clearing the two nits the #198 review left rather than carrying them as known debt.

**1. `map_sprite_tool._read_palette` was private in name only.** `build_campaign` and `map_sprite_editor` both already reached into it, and `_remap_indices` made a third caller. It is the module’s way to read an indexed PNG’s palette, so it is now `read_palette` and all four call sites say so. No alias left behind.

**2. The pre-recruit lookup computed a second charId.** All three per-character override hooks already derive one for their own table scan; the lookup now takes the caller’s variable (`char_var`, defaulting to `charId`).

Renamed the lookup cursor `it` -> `prvIt` while in there: in `GetMuImg` it shadowed the `gMuImgOverride` cursor of the same name. Legal C, and it compiled — but two different `it`s in nested scopes of one function is a trap for the next reader.

Two tests lock both in: the lookup must contain no `UNIT_CHAR_ID` at all and must not name anything `it`; and each hook must set `charId` **before** the emitted lookup, which C89 requires.

## Verification

The ROM is **not** byte-identical to main, and should not be — dropping a local changes agbcc’s register/stack allocation. Verified behaviourally instead: **528 tests** · `make CH04BOOT=1` green · `verify_text` 3404 messages / 0 runaway · `make difficulty CH=ch04` **PARITY** · `make check` clean · `git diff --check` clean. Rebuild is reproducible (sha `5c6db1e6…` twice).

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)