### PR TITLE
fix(ch04): host slot 5 was running Ch5X's events, not ours (#24)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -26,8 +26,8 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
 
 ## Recipe (mirror `inject_ch03`)
 
-1. **Module constants** — add a `CHNN_*` block next to the others (host index, layout
-   `(asset_label, maps_stem)` tuple, chapter YAML name, tileset, goal donor, boss/generic PIDs,
+1. **Module constants** — add a `CHNN_*` block next to the others (host index, **event group
+   symbol** (step 4), layout `(asset_label, maps_stem)` tuple, chapter YAML name, tileset, goal donor, boss/generic PIDs,
    `CHNN_AI` byte-vectors, `CHNN_CLASS_IDS` / `CHNN_ITEM_IDS` dicts mapping our YAML ids → decomp
    enums, spawn positions, and the `ChM_EVENTINFO_H` / `ChM_EVENTSCRIPT_H` path constants for the
    host slot's vanilla `M = N` symbols).
@@ -41,10 +41,24 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
    `(obj_idx, pal_idx, cfg_idx, layout_idx)`. Reads the layout `.json`'s `tileset` stamp.
 
 4. **Retarget the host slot + pick a goal donor** —
-   `host = _retarget_host_chapter(CHNN_HOST_INDEX, GOAL_DONOR, '<goal_type>', err, indices, chapter_number)`.
-   It points the slot's map at `indices`, **copies vanilla slot `GOAL_DONOR`'s goal banner** (asserting
-   its `windowDataType == goal_type`), and sets `prepScreenNumber = chapter_number * 2`. Pick a donor
-   slot whose goal type matches and that our injectors don't overwrite:
+   `host = _retarget_host_chapter(CHNN_HOST_INDEX, GOAL_DONOR, '<goal_type>', err, indices, chapter_number, CHNN_EVENT_GROUP)`.
+   It points the slot's map at `indices`, **repoints the slot's `mapEventDataId` at `CHNN_EVENT_GROUP`**,
+   **copies vanilla slot `GOAL_DONOR`'s goal banner** (asserting its `windowDataType == goal_type`),
+   and sets `prepScreenNumber = chapter_number * 2`.
+
+   **`CHNN_EVENT_GROUP` is the `ChapterEventGroup` symbol your injector fills, and you must name it
+   — never assume the slot already points there.** Vanilla's slot index tracks the chapter number
+   only up to 4: FE8 inserts chapter 5X at **slot 5**, so from there the two diverge (slot 5 ships
+   pointing at `Ch5XEvents`, while a chapter hosted there writes its events into `Ch5EventData`).
+   This fails *silently and totally*: retargeting the map ids alone is enough to make the chapter
+   look right, so the slot presents YOUR map while running the host slot's roster and scripts —
+   foreign units on coordinates off your footprint, no party deployed, no PREP. Cost when it bit
+   ch04: a whole session chasing a "harness soft-lock" that was only the cursor initialising onto
+   an undeployed unit's off-map sentinel. Resolve the symbol → index with
+   `_asm_table_word_index(ASSET_TABLE_S, 'gChapterDataAssetTable', ...)`; `HostChapterEventGroup`
+   in `tools/test_build_campaign.py` pins it.
+
+   Pick a donor slot whose goal type matches and that our injectors don't overwrite:
 
    | Goal | `windowDataType` | Clean donor slots (vanilla, post-inject) |
    |---|---|---|

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2871,6 +2871,22 @@ _Decided: 2026-07-30 (CLAUDE; ch05 `0x9C9` Sahnar block)._
 _Moved here from `HANDOFF.md` 2026-07-02 (audit): these are durable engineering constraints, not
 session state. `HANDOFF.md` points here._
 
+- **A host slot's index stops tracking the chapter number at 5, and a hosted chapter must name the
+  `ChapterEventGroup` it fills** (2026-07-31, ch04 #24). FE8 inserts chapter 5X at **slot 5**, so
+  `chapter_settings.json` slot 5 ships with `mapEventDataId` → `Ch5XEvents` while a chapter hosted
+  there writes its events into the `Ch5*` symbols (`Ch5EventData`). Slots 1–4 are correct only by
+  the coincidence that index == chapter number there. `_retarget_host_chapter` therefore takes a
+  mandatory `event_group` and repoints `mapEventDataId` itself, so map and events stay ONE decision;
+  `HostChapterEventGroup` in `tools/test_build_campaign.py` pins both the trap and the repoint.
+  **Why this one is worth a durable entry: it fails silently and totally.** Retargeting the map ids
+  alone makes the chapter *look* injected — correct `gBmMapSize`, correct tileset, correct goal
+  banner — while the slot runs the host's roster and scripts underneath. The observable symptoms all
+  point away from the cause: foreign units on coordinates off your footprint, a party that never
+  deploys, no PREP, and a cursor initialised onto an undeployed unit's `x=255` sentinel, which
+  presents as the *playtest harness* wedging. Diagnose it by reading `gBmMapSize` and the live unit
+  arrays in-engine (data, not screenshots — the map is genuinely yours, so pixels mislead) and by
+  resolving the slot's `mapEventDataId` through `gChapterDataAssetTable`.
+
 - **A chapter's message text lives in TWO decomp files, in TWO channels — a partial scan reads as
   proof that vanilla lacks a beat.** `src/events/<ch>-eventscript.h` holds the scenes, mixing
   `TEXTSHOW` (on-map, units staged by `LOAD1`, bubbles wrap at 29 chars) with

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -171,6 +171,7 @@ CH3_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'ch3-eventinfo.h')
 CH3_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch3-eventscript.h')
 EVENTS_UDEFS_C = os.path.join(DECOMP, 'src', 'events_udefs.c')
 CH01_HOST_INDEX = 2          # CHAPTER_L_2 -- the prologue ending's MNC2(0x2) target
+CH01_EVENT_GROUP = 'Ch2Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
 CH01_LAYOUT = ('Ch01IronTrailMap', 'ch01-the-iron-trail')  # (asset label, maps/ stem)
 CH01_CHAPTER_YAML = 'ch01-the-iron-trail.yaml'
 CH01_BOSS_SLOT = 'BREGUET'   # vanilla Ch1's boss slot: CA_BOSS + hand-authored
@@ -301,6 +302,7 @@ CH01_LORDSEL_BG = 'BG_DARKLING_WOODS'
 # Seize(14,1) is dropped, so CountRedUnits() drives the rout win; CauseGameOverIfLordDies
 # already sits in EventListScr_Ch3_Misc.
 CH02_HOST_INDEX = 3          # CHAPTER_L_3 -- ch01's ending MNC2(0x3) target
+CH02_EVENT_GROUP = 'Ch3Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
 CH02_LAYOUT = ('Ch02ColdWelcomeMap', 'ch02-cold-welcome')  # (asset label, maps/ stem)
 CH02_CHAPTER_YAML = 'ch02-cold-welcome.yaml'
 CH02_BOSS_SLOT = 'BAZBA'      # vanilla Ch3's boss slot -- Halvar mirror (custom bust #19 later)
@@ -4698,13 +4700,21 @@ def _register_chapter_map(maps_dir, layout, comment):
 
 
 def _retarget_host_chapter(host_index, goal_slot, goal_type, goal_err, indices,
-                           chapter_number):
+                           chapter_number, event_group):
     """Point host chapter slot `host_index` (chapter_settings.json) at a registered
     map (`indices` from _register_chapter_map) and copy vanilla slot `goal_slot`'s
     goal template (checked against windowDataType `goal_type`, else sys.exit(goal_err)).
     The prep-screen header reads "Chapter NN" from prepScreenNumber, not the slot
     index. It is a double-wide glyph index: vanilla slots carry exactly 2 * chapter
-    number (slot1=2, slot2=4, ... both ch5 and ch5x = 10). Returns the host dict."""
+    number (slot1=2, slot2=4, ... both ch5 and ch5x = 10). Returns the host dict.
+
+    `event_group` is the ChapterEventGroup SYMBOL the caller's injector fills, and it is
+    mandatory because the slot's own mapEventDataId cannot be trusted to name it: FE8
+    inserts chapter 5X at slot 5, so from there on the slot index stops tracking the
+    chapter number (slot 5 -> Ch5XEvents, while ch04's events live in Ch5EventData).
+    Retargeting only the map ids is enough to make the chapter LOOK right, so a wrong
+    event group fails silently and totally -- the slot presents our map while running the
+    host slot's roster and scripts. Repointing it here keeps map and events one decision."""
     obj_idx, pal_idx, cfg_idx, layout_idx = indices
     with open(CHAPTER_SETTINGS_JSON, encoding='utf-8') as f:
         settings = json.load(f)
@@ -4715,6 +4725,8 @@ def _retarget_host_chapter(host_index, goal_slot, goal_type, goal_err, indices,
     host['map'].update({'obj1Id': obj_idx, 'obj2Id': 0, 'paletteId': pal_idx,
                         'tileConfigId': cfg_idx, 'mainLayerId': layout_idx,
                         'objAnimId': 0, 'paletteAnimId': 0, 'changeLayerId': 0})
+    host['mapEventDataId'] = _asm_table_word_index(
+        ASSET_TABLE_S, 'gChapterDataAssetTable', event_group)
     host['goal'] = dict(goal)
     host['prepScreenNumber'] = chapter_number * 2
     # fadeToBlack=1: the chapter INTRO ends on BLACK instead of fading the battle map in
@@ -5182,7 +5194,7 @@ def inject_ch01(campaign, verbose=True):
         CH01_HOST_INDEX, 1, 'seize',
         'ERROR: slot 1 goal is not the vanilla Seize template -- '
         'inject_ch01 must run BEFORE inject_prologue',
-        indices, chap['chapter_number'])
+        indices, chap['chapter_number'], CH01_EVENT_GROUP)
 
     # 2. Rosters (events_udefs.c). Four tables, all reusing vanilla Ch2 symbols so no
     #    extern surgery is needed (scripts/eventinfo already declare them):
@@ -5923,7 +5935,7 @@ def inject_ch02(campaign, verbose=True):
         CH02_HOST_INDEX, 4, 'defeat_all',
         'ERROR: slot 4 goal is not the vanilla defeat_all template '
         '(needed as the ch02 DefeatAll donor)',
-        indices, chap['chapter_number'])
+        indices, chap['chapter_number'], CH02_EVENT_GROUP)
 
     # 2. Rosters (events_udefs.c). Four tables, reusing vanilla Ch3 symbols (already
     #    declared in eventcall.h, so no extern surgery):
@@ -6232,6 +6244,7 @@ def inject_ch02(campaign, verbose=True):
 #    "Bandits of Borgo", so the roster/positions mirror vanilla Ch3 1:1). Uses the vanilla
 #    "Ch4" decomp symbol set (host index N -> ChN symbols, cf. ch02 on slot 3 = Ch3 symbols).
 CH03_HOST_INDEX = 4
+CH03_EVENT_GROUP = 'Ch4Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
 CH03_LAYOUT = ('Ch03TermalaineMineMap', 'ch03-the-termalaine-mine')  # (asset label, maps/ stem)
 CH03_CHAPTER_YAML = 'ch03-the-termalaine-mine.yaml'
 CH03_TILESET = 'cave-interior'   # stem 'Cave' (TILESET_STEMS); first chapter to use it -> self-registers
@@ -6345,6 +6358,12 @@ CH4_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventscript.h')
 # reinforcement pressure shape. The D&D creatures ground the encounter fiction, but
 # player-facing units deliberately keep their vanilla FE8 monster identities/names.
 CH04_HOST_INDEX = 5
+# The ChapterEventGroup this injector fills. NOT derivable from the slot index: vanilla's
+# slot index tracks the chapter number only up to 4, because FE8 inserts chapter 5X at
+# slot 5. So slot 5 ships pointing at Ch5XEvents, and every ch04 event below is written
+# into the Ch5* symbols -- _retarget_host_chapter repoints the slot or the chapter runs
+# 5X's roster and scripts underneath our map.
+CH04_EVENT_GROUP = 'Ch5EventData'
 CH04_LAYOUT = ('Ch04LonelywoodForestMap', 'ch04-lonelywood-forest')
 CH04_CHAPTER_YAML = 'ch04-the-white-moose.yaml'
 CH04_GOAL_DONOR = CH02_HOST_INDEX  # ch02 is already hosted with the stable DefeatAll/Rout goal
@@ -6679,7 +6698,7 @@ def inject_ch03(campaign, boot=False, verbose=True):
     host = _retarget_host_chapter(
         CH03_HOST_INDEX, CH03_GOAL_DONOR, 'defeat_boss',
         'ERROR: slot %d goal is not the vanilla defeat_boss template (ch03 DefeatBoss donor)'
-        % CH03_GOAL_DONOR, indices, chap['chapter_number'])
+        % CH03_GOAL_DONOR, indices, chap['chapter_number'], CH03_EVENT_GROUP)
 
     # 2. Rosters (events_udefs.c, vanilla Ch4 symbols):
     #    - UnitDef_Event_Ch4Ally: the deploy-cap TEMPLATE = THE CAP. NEVER LOADed; PREP reads
@@ -7044,7 +7063,7 @@ def inject_ch04(campaign, boot=False, verbose=True):
         CH04_HOST_INDEX, CH04_GOAL_DONOR, 'defeat_all',
         'ERROR: hosted ch02 slot %d is not the stable defeat_all goal donor for ch04'
         % CH04_GOAL_DONOR,
-        indices, chap['chapter_number'])
+        indices, chap['chapter_number'], CH04_EVENT_GROUP)
 
     # Fog is chapter state, not painted-map data. Battle terrain 0x15 is the shared
     # snowy rough platform family already used by the winter overworld chapters.

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -30,6 +30,10 @@ WANTED = [
     'sProcArray',               # proc pool: 64 x 0x6C (src/proc.c)
     'gBmMapMovement',           # u8** move-cost map, valid while a unit is selected
                                 # (include/bmmap.h; < 120 = reachable)
+    'gBmMapSize',               # struct Vec2 {s16 x, y} -- the LIVE map's tile dimensions
+                                # (include/bmmap.h). The harness must not assume a footprint:
+                                # ch04's 15x15 is smaller than the maps the drive loop was
+                                # first written against.
     'gBmMapUnit',               # u8** tile->unit grid (include/bmmap.h): gBmMapUnit[y][x] is the
                                 # on-tile unit id the engine uses for cursor selection. Relocating
                                 # a unit must update THIS, not just its xPos/yPos.

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -374,9 +374,33 @@ local function marchToward(u, tx, ty, maxx, maxy)
     return false
 end
 
-local EMPTY_TILE = { x = 2, y = 2 } -- far from both rosters on ch00
+-- gBmMapUnit[y][x] -- the engine's tile->unit grid (u8**, indexed like gBmMapMovement). It,
+-- not the unit's xPos/yPos, is what cursor-selection reads, so a relocate must update both.
+local function mapUnitRow(y) return ru32(ru32(SYM.gBmMapUnit) + y * 4) end
+local function mapUnitAt(x, y) return ru8(mapUnitRow(y) + x) end
+local function setMapUnit(x, y, v) emu:write8(mapUnitRow(y) + x, v) end
+
+-- The live map's tile dimensions (struct Vec2 gBmMapSize) -- never assume a footprint.
+local function mapSize() return rs16(SYM.gBmMapSize), rs16(SYM.gBmMapSize + 2) end
+
+-- A tile with NO unit on it, resolved against the live map. endTurn presses A to open the
+-- map menu, and A on an occupied tile SELECTS that unit instead -- no menu, so the turn can
+-- never be ended. A hardcoded tile cannot express this: (2,2) was empty on ch00 but is a
+-- deploy slot on ch04, which is also the smallest map so far. Reads the engine's own
+-- tile->unit grid (what cursor-selection itself consults), so green/NPC bodies count too.
+local function emptyTile()
+    local w, h = mapSize()
+    for y = 0, h - 1 do
+        for x = 0, w - 1 do
+            if mapUnitAt(x, y) == 0 then return { x = x, y = y } end
+        end
+    end
+    return nil
+end
+
 local function endTurn(tile)
-    tile = tile or EMPTY_TILE
+    tile = tile or emptyTile()
+    if not tile then log("  endTurn: no empty tile on this map"); return false end
     cursorTo(tile.x, tile.y)
     press(K.A)
     if not waitFor(menuOpen, 40) then press(K.B); return false end
@@ -2781,12 +2805,6 @@ local function reachRbgCh01()
     if not rbg then return false, "RBG not on the field after lord-select" end
     return rbg
 end
-
--- gBmMapUnit[y][x] -- the engine's tile->unit grid (u8**, indexed like gBmMapMovement). It,
--- not the unit's xPos/yPos, is what cursor-selection reads, so a relocate must update both.
-local function mapUnitRow(y) return ru32(ru32(SYM.gBmMapUnit) + y * 4) end
-local function mapUnitAt(x, y) return ru8(mapUnitRow(y) + x) end
-local function setMapUnit(x, y, v) emu:write8(mapUnitRow(y) + x, v) end
 
 -- Relocate the unit straight onto a free tile within [mn,mx] of a live enemy, so a unit that
 -- SPAWNS far from the fight doesn't have to march across the map (6 phases can't cross it -- a

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -6,6 +6,7 @@ patcher share, against real vanilla values read from fireemblem8u/src/data_chara
 Run:  python3 tools/test_build_campaign.py
 """
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -1261,6 +1262,88 @@ class Ch04RuntimeHost(unittest.TestCase):
         card = bc.gen_chapter_title.compose_title('Ch.4: The White Moose')
         self.assertEqual(card.size, (256, 16))
         self.assertIsNotNone(card.getbbox())
+
+
+class HostChapterEventGroup(unittest.TestCase):
+    """A hosted chapter must RUN the ChapterEventGroup its injector fills.
+
+    Vanilla's slot index tracks the chapter number only up to 4: FE8 inserts chapter 5X
+    at slot 5, so slot 5's mapEventDataId resolves to Ch5XEvents while inject_ch04 writes
+    every event into Ch5EventData. Retargeting a host slot rewrites the MAP ids, and the
+    map ids alone are enough to make the chapter look right -- so the failure is silent
+    and total: the slot presents OUR 15x15 map while running 5X's roster and scripts
+    (24 foreign reds off the footprint, the party never deployed, the cursor initialised
+    onto an off-map sentinel). Naming the event group is therefore mandatory, not optional.
+    """
+
+    TABLE = 'gChapterDataAssetTable'
+
+    def _vanilla_index(self, symbol):
+        """`symbol`'s index in the COMMITTED asset table (our injectors only append, so
+        vanilla indices are stable -- but read HEAD anyway, never the built tree)."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'asset_table.s')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(bc.vanilla_decomp_text('data/data_8B363C.s'))
+            return bc._asm_table_word_index(path, self.TABLE, symbol)
+
+    def _retarget(self, host_index, event_group):
+        """Run _retarget_host_chapter against a throwaway copy of vanilla's settings."""
+        vanilla = json.loads(bc.vanilla_decomp_text('src/data/chapter_settings.json'))
+        donor = 3
+        goal_type = vanilla['chapters'][donor]['goal']['windowDataType']
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'chapter_settings.json')
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump(vanilla, f)
+            original = bc.CHAPTER_SETTINGS_JSON
+            bc.CHAPTER_SETTINGS_JSON = path
+            try:
+                return bc._retarget_host_chapter(
+                    host_index, donor, goal_type, 'unreachable in this test',
+                    (0, 0, 0, 0), 4, event_group=event_group)
+            finally:
+                bc.CHAPTER_SETTINGS_JSON = original
+
+    def test_slot_five_is_chapter_5x_not_chapter_5(self):
+        # The trap itself, pinned against vanilla so a decomp bump can't quietly move it.
+        vanilla = json.loads(bc.vanilla_decomp_text('src/data/chapter_settings.json'))
+        self.assertEqual(vanilla['chapters'][bc.CH04_HOST_INDEX]['mapEventDataId'],
+                         self._vanilla_index('Ch5XEvents'))
+        self.assertNotEqual(self._vanilla_index('Ch5XEvents'),
+                            self._vanilla_index(bc.CH04_EVENT_GROUP))
+
+    def test_ch04_host_slot_is_repointed_off_ch5x_onto_its_own_event_group(self):
+        host = self._retarget(bc.CH04_HOST_INDEX, bc.CH04_EVENT_GROUP)
+        self.assertEqual(host['mapEventDataId'],
+                         self._vanilla_index(bc.CH04_EVENT_GROUP))
+
+    def test_every_hosted_chapter_names_the_event_group_it_fills(self):
+        # The earlier slots were correct only because slot index == chapter number there;
+        # they are now explicit, so the next hosted chapter cannot inherit the coincidence.
+        for host_index, group in (
+                (bc.CH01_HOST_INDEX, bc.CH01_EVENT_GROUP),
+                (bc.CH02_HOST_INDEX, bc.CH02_EVENT_GROUP),
+                (bc.CH03_HOST_INDEX, bc.CH03_EVENT_GROUP),
+                (bc.CH04_HOST_INDEX, bc.CH04_EVENT_GROUP)):
+            host = self._retarget(host_index, group)
+            self.assertEqual(host['mapEventDataId'], self._vanilla_index(group),
+                             'host slot %d must run %s' % (host_index, group))
+
+    def test_making_it_explicit_moves_ch04_alone(self):
+        """ch01-ch03 must be byte-identical after the repoint -- they were already right,
+        so naming the group is a no-op there and the ONLY behaviour change is slot 5."""
+        vanilla = json.loads(bc.vanilla_decomp_text('src/data/chapter_settings.json'))
+        for host_index, group in ((bc.CH01_HOST_INDEX, bc.CH01_EVENT_GROUP),
+                                  (bc.CH02_HOST_INDEX, bc.CH02_EVENT_GROUP),
+                                  (bc.CH03_HOST_INDEX, bc.CH03_EVENT_GROUP)):
+            self.assertEqual(vanilla['chapters'][host_index]['mapEventDataId'],
+                             self._vanilla_index(group),
+                             'slot %d already ran %s -- the repoint must not move it'
+                             % (host_index, group))
+        self.assertNotEqual(vanilla['chapters'][bc.CH04_HOST_INDEX]['mapEventDataId'],
+                            self._vanilla_index(bc.CH04_EVENT_GROUP),
+                            'ch04 is the one slot the repoint actually changes')
 
 
 class ItemIconPal2(unittest.TestCase):


### PR DESCRIPTION
## What was wrong

**ch04 never actually ran.** The slot presented our 15×15 Lonelywood map — correct `gBmMapSize`, correct snowy tileset, correct Rout banner — while executing vanilla **chapter 5X's** roster and scripts underneath it.

FE8 inserts chapter 5X at **slot 5**, so the slot index stops tracking the chapter number there. `chapter_settings.json` slot 5 ships with `mapEventDataId` → 30 (`Ch5XEvents`), while `inject_ch04` writes every event into the `Ch5*` symbols (`Ch5EventData`, index 33). `_retarget_host_chapter` rewrote the map ids and the goal but **never the event data id**, so our units, scripts and deploy table sat in the ROM unreferenced.

Slots 1–4 were right only by coincidence: index == chapter number holds up to 4 and breaks at 5.

## Why it was hard to see

It fails silently and totally, and every symptom points away from the cause:

| observed | actual meaning |
|---|---|
| `blue [4]` at `x=255` | FE8's not-on-map sentinel — the party never deployed, PREP never opened |
| `red [24]`, all pid `0x80`, coords to `(20,8)` | Ch5X's roster, off a 15×15 footprint |
| cursor pinned at `y=18`, 120 UP presses do nothing | cursor initialised onto an undeployed unit — reads as *the playtest harness* wedging |

That last row is why the previously recorded lead was wrong: it blamed a party unit standing on the harness's hardcoded `EMPTY_TILE` `(2,2)`. Instrumenting `endTurn` showed `(2,2)` **empty** and the cursor pinned off-map. Diagnosed instead from `gBmMapSize` + the live unit arrays and by resolving `mapEventDataId` through `gChapterDataAssetTable` — data, not screenshots, since the map genuinely *is* ours and the pixels mislead.

## The fix

`_retarget_host_chapter` takes a mandatory `event_group` and repoints `mapEventDataId` itself, so a hosted chapter's map and events stay **one** decision instead of two that can silently disagree. All four hosted chapters now name the group they fill; ch01–ch03 are unchanged (their explicit value equals vanilla's, asserted), and slot 5 is the only one that moves.

Also fixes the hazard the old lead described, which became **real** once the party started deploying — `(2,2)` is one of ch04's nine deploy slots. `endTurn` now resolves an empty tile against the live map via `gBmMapUnit` (the engine's own tile→unit grid, so green bodies count) bounded by `gBmMapSize`, instead of a constant only ever true for ch00. The `mapUnit*` readers are hoisted to their first use rather than duplicated.

## Verification (in-engine, `--ch04-boot`)

- PREP opens; **blue [9]** deploys on exactly the nine authored `deploy_slots`
- **red [10]** is the authored monsters-only opening — 4 mogalls clustered at (11,6)(13,7)(12,8)(13,11), 2 revenants, 3 bonewalkers, entombed tank deep at (13,13)
- cursor starts on the lord at (5,2); turns advance and enemy phases resolve
- regression: `smoke_ch03` still PASSes (clean loss, 21822f)
- 532 tests, `make check` clean, `git diff --check` clean

## Known remaining (separate defect, tracked on #24)

Now reachable for the first time: a soft-lock on **turn 4** inside an enemy-phase battle animation (Revenant/Rotten Claw vs Wolfram), state frozen from f020279 onward. Not addressed here — different root cause, deserves its own change.

Refs #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
