### PR TITLE
fix(banim): an attacking mode must ARM the HP depletion, or the opponent hangs (#24)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/battle_anims/pinky/Pinky.txt
+++ b/campaigns/rime-of-the-frostmaiden/battle_anims/pinky/Pinky.txt
@@ -139,6 +139,12 @@ C25
 4 p- Pinky_004.png
 3 p- Pinky_005.png
 2 p- Pinky_005.png
+C04                               #prepare_hp_deplete — REQUIRED even though nothing connects:
+                                  #the DEFENDER's dodge waits on C01 for the depletion THIS mode
+                                  #arms, and C01 "freezes if no HP depletion is occurring/has
+                                  #occurred" (banim_code.inc). Missing here in the community
+                                  #source; its absence soft-locked ch04 on turn 4 (#24). Placed
+                                  #exactly where modes 1/3 put it: after contact, before C06.
 C06
 3 p- Pinky_003.png
 3 p- Pinky_001.png

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1940,6 +1940,45 @@ Tuned entirely on the TESTCH `recordanim` capture (class 0x48); `PT_CHAR=pinky`.
 body-slam dive, matching his lanceless map sprite.
 _Decided: 2026-07-18 (Pinky, PR #190)_
 
+**Every ATTACKING banim mode must ARM the HP depletion — the unit it starves is the OPPONENT (#24)**
+C01 `banim_code_wait_hp_deplete` (`0x85000001`) "freezes if no HP depletion is occurring/has occurred" —
+the decomp states the hazard on the macro itself (`include/banim_code.inc`). The non-obvious half is **who
+hangs**: every vanilla dodge/stand mode waits *bare* on C01 and relies on the **attacker's** script having
+armed a depletion, with `prepare_hp_deplete` (C04, melee) or `call_spell_anim` (C05, projectile/spell).
+So an attacking mode must arm one **even when nothing connects, and even when it never waits itself** —
+a miss is exactly the case an author skips. Every vanilla donor we clone obeys this: `banim_pirm_ax1` and
+`banim_armm_sp1` keep C04 in `attack_miss` and drop only `hit_normal`; `banim_arcm_ar1` / `banim_sham_mg1`
+make `attack_miss` their *attack* body, arrow and all.
+
+Four of our generated/imported paths broke it, and all four soft-lock — the whole proc tree wedges with
+`GAMECTRL` at `lock=1`, `ekrBattleInRoundIdle` spinning on `(gBanimDoneFlag[0] + gBanimDoneFlag[1]) == 2`:
+- **Faked MELEE `attack_miss`** emitted the wait with no C04. *This is what froze ch04 turn 4:* Braulo's
+  counter missed Lupin, both anims stuck on C01, `gBanimDoneFlag = [0, 0]`.
+- **Faked MELEE `attack_range`/`_critical`** ran the DEFENDER "stand" body (waits, arms nothing) on the
+  assumption "a melee unit can't strike at range". False for us — `CLASS_PIRATE` ships a **Hand Axe** and
+  `CLASS_ARMOR_KNIGHT`/`PEGASUS` a **Javelin**. Now the vanilla Armor Knight's thrown shape (C05).
+- **Faked RANGED/MAGIC `attack_miss`** held a still frame and armed nothing; now the attack body, per the
+  archer/shaman donors.
+- **IMPORTED `Pinky.txt` mode 12** — the *community source* omitted C04. Her miss ended early while the
+  Mauthe Doog's dodge blocked forever: `gBanimDoneFlag = [0, 1]`, the asymmetric signature of "the
+  attacker finished, the defender is still waiting for a depletion nobody armed".
+
+Guarded, not just fixed: `feditor_to_banim.validate_hp_deplete_arming` runs at `emit_motion_s` (the one
+choke point every import crosses) and **fails the build** on any mode that opens with C03 and arms nothing,
+so a community script's hole can never again surface as one unlucky combat mid-playtest. Auditing all 11
+vendored/imported scripts found Pinky's the only offender. `TestHpDepleteArming` pins both halves of the
+contract on both generators (attackers arm; dodge/stand deliberately do NOT).
+
+**Method note (this is how a banim freeze gets diagnosed).** Read it as DATA, never pixels
+([[feedback_verify_via_data_not_pixels]]): the proc pool carries its own diagnosis — `proc_lockCnt`
+(the wait semaphore), `proc_scrCur` (which PROC_* command it sits on) and `proc_name` — and
+`gBanimDoneFlag` + `gAnims[n].currentRoundType` name the stuck **side** and **round** outright. The
+harness's `freezeReport` (smoke driver, fires on any SOFTLOCK verdict) prints all of it, so one run turns
+"the game froze" into "the right side is playing MISS_CLOSE and never signals done". The inherited lead
+said "Revenant vs Wolfram / check `battleTileSet 0x15`"; the actual pair was Lupin vs Braulo and the
+tileset was irrelevant — [[feedback_inherited_leads_are_hypotheses]] again.
+_Decided: 2026-07-31 (ch04 turn-4 soft-lock, #24)_
+
 **Character-scoped spell colours are campaign data; the tint rides a dedicated overlay global (#165, #168)**
 Marty's `battle_anim.spell_palette_tint` declares a character + weapon-type match in YAML, so one
 row covers every Dark tome he can wield without naming Marty in engine code or changing the tome's

--- a/tools/feditor_to_banim.py
+++ b/tools/feditor_to_banim.py
@@ -100,6 +100,39 @@ def mode_table_slots(anim):
     return slots
 
 
+# Command codes the arming contract is written in (banim_code.inc; a Cxx line IS the low byte).
+_C_START_ATTACK_1 = 0x03      # banim_code_start_attack_1 -- heads any mode that SWINGS
+_C_PREPARE_HP_DEPLETE = 0x04  # banim_code_prepare_hp_deplete -- arms the depletion (melee)
+_C_CALL_SPELL_ANIM = 0x05     # banim_code_call_spell_anim -- arms it via the projectile (ranged)
+
+
+def validate_hp_deplete_arming(anim):
+    """Reject an import whose ATTACKING mode never arms the HP-depletion routine (#24).
+
+    C01 `banim_code_wait_hp_deplete` "freezes if no HP depletion is occurring/has occurred"
+    (fireemblem8u/include/banim_code.inc). The unit that gets starved is usually the OTHER
+    one: every vanilla dodge/stand mode waits bare on C01 and relies on the ATTACKER's script
+    having armed a depletion with C04 (melee) or C05 (a projectile). So a mode that opens with
+    C03 must contain one of them -- whether or not it waits itself, and even when nothing
+    connects, which is exactly the case a community author is most likely to skip.
+
+    Community sources DO get this wrong: the vendored Pinky.txt shipped a mode 12 of
+    C03 C07 C25 C25 C06 C0D, and the first monster to dodge her counter hung ch04's turn 4
+    with gBanimDoneFlag stuck at [0, 1]. Validated at import so a bad script fails the BUILD
+    instead of one unlucky combat 20 minutes into a playtest.
+    """
+    for mode, insns in anim.modes.items():
+        codes = [i.code for i in insns if isinstance(i, Cmd)]
+        if _C_START_ATTACK_1 not in codes:
+            continue        # a dodge/stand mode: the attacker arms the depletion, not this one
+        if _C_PREPARE_HP_DEPLETE in codes or _C_CALL_SPELL_ANIM in codes:
+            continue
+        raise ValueError(
+            "FEditor mode %d attacks (C03) but never arms the HP depletion (no C04 / C05): "
+            "the opposing dodge/stand mode blocks on C01 forever and soft-locks the chapter"
+            % mode)
+
+
 def emit_command(cmd):
     """A FEditor `Cxx` command -> the byte-exact raw `banim_code_85 0xXX` escape.
 
@@ -132,6 +165,7 @@ def emit_motion_s(abbr, anim, frames):
     table (slot i -> mode i+1, with the auto-handled 2 & 4 pointing at their 1 & 3 siblings).
     Byte-shape identical to ref_to_battleframe.emit_motion_s so the same banim build links it.
     """
+    validate_hp_deplete_arming(anim)
     files = unique_frames(anim)
     findex = {f: i for i, f in enumerate(files)}
 

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -66,6 +66,26 @@ WANTED = [
     'gProc_ekrBattle',          # proc script: the on-map battle (EKR) animation engine
                                 # (src/banim-ekrbattle.c). A live instance == a combat is
                                 # actually animating -> used to confirm an attack committed.
+    'gBattleActor',             # struct BattleUnit (include/bmbattle.h): the attacking side of
+                                # the combat being resolved/animated. unit at +0x00,
+                                # terrainId +0x55, weapon +0x48. Names WHO is on screen when a
+                                # battle animation freezes.
+    'gBattleTarget',            # struct BattleUnit: the defending side of that same combat.
+    'gBanimTerrain',            # u8[2] terrain ids the battle animation resolved for the two
+                                # sides (POS_L/POS_R; src/banim-ekrbattleintro.c). These are what
+                                # GetBanimTerrainGround/GetBanimBackgroundIndex are indexed with.
+    'gBanimDoneFlag',           # u32[2] -- the EXACT soft-lock condition. ekrBattleInRoundIdle
+                                # (src/banim-ekrbattle.c) spins until both sides' flags are set,
+                                # so a battle anim that never signals done wedges the whole proc
+                                # tree. Which of the two is 0 names the side that hung.
+    'gEkrDistanceType',         # s16 -- CLOSE/FAR/FARFAR/PROMOTION (enum in include/ekrbattle.h);
+                                # picks which round-type family the anim scripts must supply.
+    'gAnims',                   # struct Anim *[4] (include/anime.h). [0]/[2] are the two combat
+                                # anims; currentRoundType +0x12 and state/state2/state3 say which
+                                # round each side thinks it is playing.
+    'gpEkrBattleUnitLeft',      # struct BattleUnit * -- the LEFT screen side of the animation
+    'gpEkrBattleUnitRight',     # struct BattleUnit * -- ...and the RIGHT. Which one maps to the
+                                # actor depends on faction, so print both to read a freeze.
 ]
 
 

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -523,6 +523,103 @@ local function procFingerprint()
     return fp
 end
 
+-- ---- freeze report: name WHAT is stuck, not just THAT something is (#24).
+-- A soft-lock is never a stopped CPU -- it is the proc scheduler still running while one
+-- proc stops advancing. The proc pool carries its own diagnosis (include/proc.h): scrCur
+-- is the script command it sits on, lockCnt is the wait semaphore (nonzero = blocked by a
+-- child//other proc that never released it), sleepTime is a timed wait, and proc_name is
+-- the PROC_NAME string. Sampling the pool TWICE across a gap separates "this proc is
+-- frozen" from "the whole scheduler is spinning", which is the first fork in the diagnosis.
+local PROC_STRIDE = 0x6C
+local function readCStr(addr, maxLen)
+    if addr == 0 then return nil end
+    local out = {}
+    for i = 0, (maxLen or 24) - 1 do
+        local c = ru8(addr + i)
+        if c == 0 or c < 0x20 or c > 0x7E then break end
+        out[#out + 1] = string.char(c)
+    end
+    if #out == 0 then return nil end
+    return table.concat(out)
+end
+
+-- Every live proc as a stable one-line signature, keyed by pool index.
+local function procPool()
+    local pool = {}
+    for i = 0, 63 do
+        local a = SYM.sProcArray + i * PROC_STRIDE
+        local scr = ru32(a)
+        if scr ~= 0 then
+            pool[i] = {
+                script = scr,
+                scrCur = ru32(a + 0x04),
+                idleCb = ru32(a + 0x0C),
+                name = readCStr(ru32(a + 0x10)),
+                sleep = rs16(a + 0x24),
+                mark = ru8(a + 0x26),
+                flags = ru8(a + 0x27),
+                lock = ru8(a + 0x28),
+            }
+        end
+    end
+    return pool
+end
+
+local function procLine(i, p, prev)
+    -- scrCur as an offset from the script head: the exact PROC_* command it sits on.
+    local step = (p.scrCur >= p.script) and ((p.scrCur - p.script) // 12) or -1
+    local moved = ""
+    if prev then
+        moved = (prev.scrCur == p.scrCur and prev.sleep == p.sleep and prev.lock == p.lock)
+            and " FROZEN" or " moving"
+    end
+    return string.format(
+        "  [%02d] %-22s scr=%08X cmd#%-3d idle=%08X sleep=%-4d mark=%-3d flags=%02X lock=%d%s",
+        i, p.name or "(unnamed)", p.script, step, p.idleCb, p.sleep, p.mark, p.flags, p.lock, moved)
+end
+
+-- The BattleUnit pair the engine is resolving/animating right now.
+local function battleSide(base)
+    if base == nil or base == 0 then return "(null)" end
+    local chptr = ru32(base)
+    if chptr == 0 then return "(none)" end
+    return string.format("pid=0x%02X class=0x%02X hp=%d at(%d,%d) terrain=0x%02X weapon=0x%02X",
+        ru8(chptr + 4), ru8(ru32(base + 4) + 4), ru8(base + 0x13),
+        ru8(base + 0x10), ru8(base + 0x11), ru8(base + 0x55), ru16(base + 0x48) & 0xFF)
+end
+
+-- Dump everything that localizes a freeze. Sampled twice, `gap` frames apart.
+local function freezeReport(tag, gap)
+    local before = procPool()
+    wait(gap or 90)
+    local after = procPool()
+    log(string.format("== FREEZE REPORT (%s) ch=%d turn=%d faction=0x%02X ==",
+        tag, chapter(), turn(), faction()))
+    log(string.format("  battleActor: %s", battleSide(SYM.gBattleActor)))
+    log(string.format("  battleTarget: %s", battleSide(SYM.gBattleTarget)))
+    log(string.format("  gBanimTerrain: L=0x%02X R=0x%02X   ekrBattle=%s",
+        ru8(SYM.gBanimTerrain), ru8(SYM.gBanimTerrain + 1),
+        tostring(procActive(SYM.gProc_ekrBattle))))
+    -- The wait condition itself: ekrBattleInRoundIdle spins until BOTH done flags are set.
+    log(string.format("  gBanimDoneFlag: [0]=%d [1]=%d   gEkrDistanceType=%d",
+        ru32(SYM.gBanimDoneFlag), ru32(SYM.gBanimDoneFlag + 4), rs16(SYM.gEkrDistanceType)))
+    log(string.format("  ekrBattleUnit: left=%s", battleSide(ru32(SYM.gpEkrBattleUnitLeft))))
+    log(string.format("  ekrBattleUnit: right=%s", battleSide(ru32(SYM.gpEkrBattleUnitRight))))
+    for i = 0, 3 do
+        local an = ru32(SYM.gAnims + i * 4)
+        if an ~= 0 then
+            log(string.format("  gAnims[%d]=%08X roundType=0x%02X state=%04X state2=%04X "
+                .. "state3=%04X nextRound=%d timer=%d scr=%08X (+%d) queue=%d",
+                i, an, ru8(an + 0x12), ru16(an), ru16(an + 0x0C), ru16(an + 0x10),
+                ru16(an + 0x0E), rs16(an + 0x06), ru32(an + 0x20),
+                ru32(an + 0x20) - ru32(an + 0x24), ru8(an + 0x14)))
+        end
+    end
+    for i = 0, 63 do
+        if after[i] then log(procLine(i, after[i], before[i])) end
+    end
+end
+
 -- ---- greedy clear-bot (#60): real-combat chapter completion. Generic boss detection
 -- (no hardcoded char ids) + the pure pickTarget core; the scenario owns the driving.
 local CLEARBOT = dofile(PLAYTEST_DIR .. "/clearbot.lua")
@@ -632,7 +729,16 @@ local function smokeDrive(startChapter)
     local snaps = {}
     log(string.format("smoke: chapter %d, budget %d turns, softlock %d frames",
         startChapter, budgetTurns, cfg.softlock_frames))
+    -- Trace every turn/phase transition: a freeze report is only readable next to the
+    -- phase it happened in ("turn 4 enemy phase" vs "turn 4 player phase").
+    local lastPhase = nil
     for _ = 1, 100000 do
+        local phase = string.format("t%d/f%02X", turn(), faction())
+        if phase ~= lastPhase then
+            log(string.format("phase -> turn %d faction 0x%02X (hpsum %d)",
+                turn(), faction(), hpSum()))
+            lastPhase = phase
+        end
         local over = gameOverActive()
         local won = (not over) and chapter() ~= startChapter and chapter() ~= 0
         snaps[#snaps + 1] = {
@@ -652,7 +758,9 @@ local function smokeDrive(startChapter)
         elseif v.state == "TERMINAL_LOSS" then
             shot("smoke-loss"); return result("PASS", "clean loss -- " .. v.why)
         elseif v.state == "SOFTLOCK" then
-            shot("smoke-softlock"); return result("FAIL", "soft-lock -- " .. v.why)
+            shot("smoke-softlock")
+            freezeReport("smoke soft-lock")
+            return result("FAIL", "soft-lock -- " .. v.why)
         end
         if turn() > budgetTurns then
             shot("smoke-budget")

--- a/tools/ref_to_battleframe.py
+++ b/tools/ref_to_battleframe.py
@@ -196,10 +196,15 @@ def _mode_order(motion):
     """The 12 modes in banim-table order, with the kind picked for `motion`.
 
     The engine's mode ORDER is fixed; only each mode's body kind varies. A melee unit
-    can't strike at range, so its attack_range/_critical modes hold the ready frame
-    (kind "stand") instead of running the lunge-and-swing (cadence: FE8 Pirate axe)."""
+    still reaches its attack_range modes, because our melee loadouts carry a THROWN
+    option (CLASS_PIRATE ships a Hand Axe, CLASS_ARMOR_KNIGHT/PEGASUS a Javelin), so
+    those slots run the "throw" body -- the vanilla Armor Knight's thrown shape, whose
+    projectile arms the HP depletion (banim_armm_sp1's attack_range: cadence sounds ->
+    call_spell_anim -> wait_hp_deplete). They used to hold the ready frame (kind "stand"),
+    which waits on C01 with nothing armed and soft-locks the moment the axe is thrown --
+    the same defect that froze ch04 through attack_miss (#24)."""
     if motion == "melee":
-        return [(n, "stand" if n.startswith("attack_range") else k)
+        return [(n, "throw" if n.startswith("attack_range") else k)
                 for n, k in _MODE_ORDER]
     return list(_MODE_ORDER)
 
@@ -255,14 +260,32 @@ def _melee_mode_body(abbr, kind, cadence="axe"):
                 "\tbanim_code_start_dodge", _frame_cmd(abbr, 3, 1),
                 "\tbanim_code_wait_hp_deplete", _frame_cmd(abbr, 3, 0),
                 "\tbanim_code_end_dodge", "\tbanim_code_end_mode"]
-    if kind == "stand":    # hold the ready frame (also melee's "attack at range")
+    if kind == "throw":    # thrown weapon (Hand Axe / Javelin): the projectile lands the hit,
+        # so call_spell_anim arms the depletion instead of prepare_hp_deplete + hit_normal.
+        # Shape mirrors the vanilla Armor Knight's own thrown mode (banim_armm_sp1
+        # attack_range): wind up on the cadence, release, wait, hand the turn back.
+        return ["\tbanim_code_start_attack_1", "\tbanim_code_start_attack_2",
+                _frame_cmd(abbr, 1, 0)] + c["windup"] + [
+                _frame_cmd(abbr, 20, 1)] + c["swing"] + [
+                _frame_cmd(abbr, 3, 2),
+                "\tbanim_code_call_spell_anim", _frame_cmd(abbr, 1, 2),
+                "\tbanim_code_wait_hp_deplete", "\tbanim_code_start_opposite_turn",
+                _frame_cmd(abbr, 3, 0)] + c["back"] + [_frame_cmd(abbr, 3, 0),
+                "\tbanim_code_end_dodge", "\tbanim_code_end_mode"]
+    if kind == "stand":    # hold the ready frame (the DEFENDING modes)
         return [_frame_cmd(abbr, 1, 0), "\tbanim_code_wait_hp_deplete",
                 "\tbanim_code_end_mode"]
-    # miss: lunge and swing through, hold the forward beat (like the hit), but no contact lands
+    # miss: lunge and swing through, hold the forward beat (like the hit), but no contact lands.
+    # prepare_hp_deplete is NOT optional just because nothing connects: C01 (wait_hp_deplete)
+    # "freezes if no HP depletion is occurring/has occurred" (banim_code.inc), so the miss has to
+    # arm the routine exactly like the hit does -- both vanilla melee donors keep it in
+    # attack_miss and drop only hit_normal (banim_pirm_ax1 / banim_armm_sp1). Omitting it
+    # soft-locked ch04 on turn 4 (#24).
     return ["\tbanim_code_start_attack_1", "\tbanim_code_start_attack_2",
             _frame_cmd(abbr, 1, 0)] + c["windup"] + [
             _frame_cmd(abbr, 20, 1)] + c["swing"] + [
             _frame_cmd(abbr, 3, 2),
+            "\tbanim_code_prepare_hp_deplete",
             _frame_cmd(abbr, 4, 2),                                 # hold forward (matches the hit beat)
             "\tbanim_code_wait_hp_deplete", "\tbanim_code_start_opposite_turn",
             _frame_cmd(abbr, 3, 0), _frame_cmd(abbr, 3, 0), "\tbanim_code_end_dodge",
@@ -273,6 +296,13 @@ def _mode_body(abbr, kind, motion="ranged", cadence="axe"):
     """Emit one mode's script lines for the 3-beat (Ready/Wind-up/Peak) fake."""
     if motion == "melee":
         return _melee_mode_body(abbr, kind, cadence)
+    # A ranged/magic MISS still looses the arrow or casts the spell -- it simply doesn't
+    # connect -- so vanilla reuses the attack body verbatim (banim_arcm_ar1 and banim_sham_mg1
+    # attack_miss are their attack modes, call_spell_anim and all). That projectile is also
+    # what arms the depletion the DEFENDER's dodge waits on, so a miss that skipped it left
+    # the dodger blocked on C01 forever (#24).
+    if kind == "miss":
+        kind = "attack"
     if motion == "magic" and kind == "attack":
         # Shaman (banim_sham_mg1) settles, then lingers in a stationary charge before
         # releasing the spell. The Flux effect, not a painted projectile, owns the impact.

--- a/tools/test_feditor_to_banim.py
+++ b/tools/test_feditor_to_banim.py
@@ -94,6 +94,50 @@ class TestModeTable(unittest.TestCase):
         self.assertEqual(slots[11], 12)  # miss             <- mode 12
 
 
+class TestHpDepleteArming(unittest.TestCase):
+    """An imported mode that SWINGS must arm the HP depletion (#24).
+
+    C01 `banim_code_wait_hp_deplete` "freezes if no HP depletion is occurring/has occurred"
+    (banim_code.inc), and every vanilla dodge/stand mode waits bare on C01 -- so the unit an
+    unarmed attack starves is the OPPONENT, not the attacker. Community scripts really do
+    ship this hole: the vendored Pinky.txt's mode 12 was C03 C07 C25 C25 C06 C0D, and the
+    first Mauthe Doog to dodge her counter hung ch04's turn 4 (gBanimDoneFlag [0]=0 [1]=1).
+    """
+
+    def _script(self, mode12_cmds):
+        head = "".join("/// - Mode %d\n1 p- f.png\n~~~\n" % n
+                       for n in (1, 3, 5, 6, 7, 8, 9, 10, 11))
+        return head + "/// - Mode 12\n" + "".join(
+            "%s\n" % c for c in mode12_cmds) + "1 p- f.png\n~~~\n"
+
+    def test_rejects_an_attacking_mode_that_arms_nothing(self):
+        # exactly the shipped-broken Pinky shape: opens the attack, never arms, hands back
+        anim = fb.parse_feditor(self._script(["C03", "C07", "C25", "C06", "C0D"]))
+        with self.assertRaises(ValueError) as cm:
+            fb.validate_hp_deplete_arming(anim)
+        self.assertIn("mode 12", str(cm.exception))
+
+    def test_accepts_melee_arming_via_prepare_hp_deplete(self):
+        anim = fb.parse_feditor(self._script(["C03", "C07", "C04", "C06", "C0D"]))
+        fb.validate_hp_deplete_arming(anim)      # C04 -- must not raise
+
+    def test_accepts_ranged_arming_via_call_spell_anim(self):
+        anim = fb.parse_feditor(self._script(["C03", "C07", "C05", "C06", "C0D"]))
+        fb.validate_hp_deplete_arming(anim)      # C05 -- must not raise
+
+    def test_ignores_defending_modes_which_never_open_an_attack(self):
+        # a dodge/stand mode (no C03) legitimately waits bare -- the attacker armed it
+        anim = fb.parse_feditor(self._script(["C02", "C0E", "C01", "C0D"]))
+        fb.validate_hp_deplete_arming(anim)      # must not raise
+
+    def test_emit_motion_s_enforces_it(self):
+        # the guard rides the single choke point every import goes through
+        anim = fb.parse_feditor(self._script(["C03", "C07", "C25", "C06", "C0D"]))
+        frames = [{"oam_l": [], "oam_r": []} for _ in fb.unique_frames(anim)]
+        with self.assertRaises(ValueError):
+            fb.emit_motion_s("bad_an1", anim, frames)
+
+
 class TestEmitLines(unittest.TestCase):
     def test_command_is_raw_0x85_escape(self):
         # C1A (hit_normal, 0x8500001A) emitted as the byte-exact raw escape.

--- a/tools/test_ref_to_battleframe.py
+++ b/tools/test_ref_to_battleframe.py
@@ -282,10 +282,11 @@ class TestEmitMotionS(unittest.TestCase):
 class TestMeleeMotionS(unittest.TestCase):
     """The melee cadence (FE8 Pirate axe study): lunge in, swing, hit on contact, return.
 
-    Differs from the ranged (archer) cadence cloned for RBG: NO projectile
-    (call_spell_anim); the hit is banim_code_hit_normal on the swing-through; the unit
-    lunges (start_attack_1/2 + start_opposite_turn) and dodges BACKWARD (dodge_to_back); and
-    a melee unit cannot strike at range, so attack_range just holds the ready frame.
+    Differs from the ranged (archer) cadence cloned for RBG: the CLOSE modes carry no
+    projectile (call_spell_anim); the hit is banim_code_hit_normal on the swing-through; and
+    the unit lunges (start_attack_1/2 + start_opposite_turn) and dodges BACKWARD
+    (dodge_to_back). The RANGE modes do throw, because our melee loadouts carry a thrown
+    option (Hand Axe / Javelin) -- see test_melee_at_range_throws_instead_of_striking.
     """
 
     def _frames(self):
@@ -319,11 +320,17 @@ class TestMeleeMotionS(unittest.TestCase):
         s = rb.emit_motion_s("brau_an1", self._frames(), motion="melee")
         self.assertIn("banim_code_dodge_to_back", self._mode(s, "dodge_close"))
 
-    def test_melee_cannot_strike_at_range(self):
+    def test_melee_at_range_throws_instead_of_striking(self):
+        # A melee unit DOES reach these modes -- CLASS_PIRATE ships a Hand Axe and
+        # CLASS_ARMOR_KNIGHT/PEGASUS a Javelin -- so the slot runs the vanilla Armor Knight's
+        # thrown shape: the weapon's own projectile connects (call_spell_anim), never a melee
+        # contact. It used to hold the ready frame and wait on C01 with nothing armed, which
+        # soft-locks the moment the axe is actually thrown (#24).
         s = rb.emit_motion_s("brau_an1", self._frames(), motion="melee")
         body = self._mode(s, "attack_range")
-        self.assertNotIn("banim_code_start_attack_1", body)     # no lunge
-        self.assertNotIn("banim_code_hit_normal", body)         # no hit at range
+        self.assertIn("banim_code_call_spell_anim", body)       # the thrown weapon
+        self.assertNotIn("banim_code_hit_normal", body)         # no melee contact at range
+        self.assertNotIn("banim_code_prepare_hp_deplete", body)  # the projectile arms it
 
     def test_lance_cadence_uses_armored_thrust_not_axe_swing(self):
         # Knight (Armor Knight, decomp banim_armm_sp1) lance cadence: heavy armored steps +
@@ -358,6 +365,81 @@ class TestMeleeMotionS(unittest.TestCase):
         s = rb.emit_motion_s("rbg_ar1", self._frames())         # no motion= -> ranged
         self.assertIn("banim_code_call_spell_anim", s)
         self.assertNotIn("banim_code_dodge_to_back", s)
+
+
+class TestHpDepleteArming(unittest.TestCase):
+    """An ATTACKING mode must arm the HP depletion before it waits on one (#24).
+
+    The decomp states the hazard on the macro itself (include/banim_code.inc): C01
+    `banim_code_wait_hp_deplete` -- "Wait for HP to deplete (FREEZES if no HP depletion is
+    occurring/has occurred)". A DEFENDING mode (dodge/stand) may wait bare, because the
+    attacker's script armed the depletion; that is what vanilla's own dodge_close and stand
+    modes do. An ATTACKING mode has to arm its own, and every vanilla donor we clone does:
+    the melee pair (banim_pirm_ax1, banim_armm_sp1) issue `banim_code_prepare_hp_deplete` in
+    attack_close AND attack_miss, and the ranged/magic pair (banim_arcm_ar1, banim_sham_mg1)
+    arm via `banim_code_call_spell_anim` -- including in their miss modes.
+
+    Shipped as ch04's turn-4 soft-lock: Braulo's faked Pirate anim missed a counter-attack,
+    ran attack_miss, and wedged the whole proc tree with gBanimDoneFlag stuck at [0, 0] and
+    both anims flagged ANIM_BIT3_C01_BLOCKING_IN_BATTLE.
+    """
+
+    # The attack half of _MODE_ORDER: the slots the engine runs for the unit that is SWINGING.
+    ATTACK_MODES = ["attack_close", "attack_close_back", "attack_close_critical",
+                    "attack_close_critical_back", "attack_range",
+                    "attack_range_critical", "attack_miss"]
+    ARMING = ("banim_code_prepare_hp_deplete", "banim_code_call_spell_anim")
+    # Every cadence the faked generator can emit (donor -> emit_motion_s kwargs).
+    CADENCES = [("brau_an1", {"motion": "melee"}),
+                ("wolf_ln1", {"motion": "melee", "cadence": "lance"}),
+                ("rbg_ar1", {}),
+                ("mees_mg1", {"motion": "magic"})]
+
+    def _frames(self):
+        e0 = [{"attr0": 0, "attr1": 0x4000, "attr2": 0, "dx": -8, "dy": -8}]
+        return [{"oam_r": e0, "oam_l": rb.mirror_oam(e0)} for _ in range(3)]
+
+    def _mode(self, s, abbr, name):
+        after = s.split("banim_%s_mode_%s:" % (abbr, name))[1]
+        return after.split("\nbanim_%s_mode_" % abbr)[0]
+
+    def test_every_attacking_mode_arms_a_depletion(self):
+        # NOT "arms it before its own wait": the starved unit is usually the OTHER one. Every
+        # vanilla dodge/stand mode waits bare on C01 and relies on the ATTACKER having armed a
+        # depletion, so an attacking mode must arm one even when it never waits itself and even
+        # when nothing connects. Both halves of that bit ch04 (#24).
+        for abbr, kwargs in self.CADENCES:
+            s = rb.emit_motion_s(abbr, self._frames(), **kwargs)
+            for name in self.ATTACK_MODES:
+                body = self._mode(s, abbr, name)
+                self.assertTrue(
+                    any(arm in body for arm in self.ARMING),
+                    "%s mode %s swings without arming a depletion (no prepare_hp_deplete / "
+                    "call_spell_anim) -- the opponent's dodge blocks on C01 forever and "
+                    "soft-locks the chapter" % (abbr, name))
+
+    def test_arming_precedes_its_own_wait(self):
+        # The self-consistent half: where a mode DOES wait, the arming has to come first.
+        for abbr, kwargs in self.CADENCES:
+            s = rb.emit_motion_s(abbr, self._frames(), **kwargs)
+            for name in self.ATTACK_MODES:
+                body = self._mode(s, abbr, name)
+                if "banim_code_wait_hp_deplete" not in body:
+                    continue
+                before = body.split("banim_code_wait_hp_deplete")[0]
+                self.assertTrue(
+                    any(arm in before for arm in self.ARMING),
+                    "%s mode %s waits on C01 before anything arms a depletion" % (abbr, name))
+
+    def test_defending_modes_may_wait_bare_like_vanilla(self):
+        # The other half of the contract: dodge/stand DON'T arm (vanilla's dodge_close is
+        # exactly dodge_to_back / start_dodge / wait_hp_deplete / end_dodge / end_mode). This
+        # pins the asymmetry so a future "fix" doesn't sprinkle prepare_hp_deplete everywhere.
+        s = rb.emit_motion_s("brau_an1", self._frames(), motion="melee")
+        for name in ("dodge_close", "stand_close", "stand"):
+            body = self._mode(s, "brau_an1", name)
+            self.assertIn("banim_code_wait_hp_deplete", body)
+            self.assertNotIn("banim_code_prepare_hp_deplete", body)
 
 
 class TestMeleeLunge(unittest.TestCase):


### PR DESCRIPTION
Fixes ch04's turn-4 soft-lock (#24's next-session item) — and three more instances of the same rule that were sitting live in the campaign.

## The rule

`C01 banim_code_wait_hp_deplete` **"freezes if no HP depletion is occurring/has occurred"** — the decomp says so on the macro itself (`include/banim_code.inc`).

The non-obvious half is **who** it starves. Every vanilla dodge/stand mode waits *bare* on C01 and relies on the **attacker's** script having armed a depletion — `C04 prepare_hp_deplete` (melee) or `C05 call_spell_anim` (projectile/spell). So an attacking mode must arm one **even when nothing connects, and even when it never waits itself**. A miss is exactly the case an author skips.

Every donor we clone obeys it: `pirm_ax1` / `armm_sp1` keep C04 in `attack_miss` and drop only `hit_normal`; `arcm_ar1` / `sham_mg1` make `attack_miss` their *attack* body, arrow and all.

## What was broken

Each of these wedges the entire proc tree — `GAMECTRL` at `lock=1`, `ekrBattleInRoundIdle` spinning forever on `(gBanimDoneFlag[0] + gBanimDoneFlag[1]) == 2`:

| Path | Defect | Signature |
|---|---|---|
| faked **melee** `attack_miss` | waited with no C04 | **the ch04 freeze** — Braulo's counter missed Lupin; `gBanimDoneFlag [0,0]` |
| faked **melee** `attack_range*` | ran the *defender* "stand" body — assumed "a melee unit can't strike at range", but `CLASS_PIRATE` ships a **Hand Axe** | reachable the moment Braulo throws |
| faked **ranged/magic** `attack_miss` | held a still frame, armed nothing | opponent's dodge starves |
| imported **`Pinky.txt` mode 12** | the *community source* omitted C04 | `gBanimDoneFlag [0,1]` — "attacker done, defender starved" |

## Guarded, not just fixed

`feditor_to_banim.validate_hp_deplete_arming` runs at `emit_motion_s` — the single choke point every import crosses — and **fails the build** on any mode that opens with C03 and arms nothing. A community script's hole can no longer surface as one unlucky combat mid-playtest. Audited all 11 vendored/imported scripts: Pinky's was the only offender.

## Diagnostics kept for next time

`freezeReport()` fires on any SOFTLOCK verdict in the smoke driver and dumps the proc pool (`proc_name` / `proc_scrCur` / `proc_lockCnt` — the pool carries its own diagnosis) plus `gBanimDoneFlag`, `gEkrDistanceType`, and each `gAnims[]` round type. One run turns "the game froze" into "the right side is playing MISS_CLOSE and never signals done".

Worth recording: the inherited lead ("Revenant / Rotten Claw `0xaa` vs Wolfram; check `battleTileSet 0x15`") was wrong on **both** counts — the pair was Lupin (Duessel/Cavalier) vs Braulo (Eirika/Pirate), and the tileset was irrelevant.

## Verification

- `smoke_ch04`: **FAIL (soft-lock, turn 4) → PASS** — turn 4's enemy phase now completes (f014244 → f021986) and the chapter runs on through turns 5–6 to a clean terminal
- `smoke_ch03`: **PASS** (regression held)
- 540 unit tests OK · `make check` drift clean · `git diff --check` clean

ADR in `docs/decisions.md` (Art & Audio). Checklist item on #24 — not `Closes`, the slice has Stages 4–5 left.

## One thing to eyeball

Two changes are **art-visible** and haven't had a look-test: a ranged miss now looses the arrow (vanilla behaviour) instead of holding a still frame, and a melee unit at range now throws instead of standing. Happy to capture `recordanim` GIFs for sign-off if you want them before this merges — the freeze fix itself doesn't depend on that choreography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
