### PR TITLE
unit list: the cast render in colour again (#218)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2372,6 +2372,20 @@ so a standard-palette sheet is the only way to add a custom sprite alongside the
 compare its 16-colour palette to `unit_icon_pal_player.agbpal` — exact match ⇒ guest path (no override); custom colours
 ⇒ it must be re-indexed to `cast_palette.png` and join the cast bank.
 
+**Loading the cast bank is only half the job — several vanilla screens BLANK it again (#218, 2026-08-05).**
+Bank `0xB` is free in vanilla precisely because nothing renders from it, and vanilla exploits that: a screen calls
+`ApplyUnitSpritePalettes()` and then immediately zeroes bank `0xB` as scratch cleanup. Harmless in vanilla; for us a
+zeroed 16-colour bank draws every index as colour 0, so the cast come out as **correctly shaped BLACK SILHOUETTES** —
+right sheet, right chr, right position, no colour. That is the signature to recognise: *shape correct, colour absent
+⇒ the bank was blanked, not the sprite mis-injected.* Every such site is listed in `build_campaign.PURPLE_BANK_BLANKERS`
+and deleted by `_drop_purple_bank_fills`, which `sys.exit`s if a site stops matching verbatim (a decomp bump must fail
+loudly, not silently blacken a roster). **The list is per-site and not a grep because the idiom is spelled differently
+on each screen**: `CpuFastFill(0, PAL_OBJ(0x0B), 0x20)` in `prep_unitselect.c` (Pick Units) but the raw
+`CpuFastFill(0, gPaletteBuffer + 0x1B0, PLTT_SIZE_4BPP)` in `unitlistscreen.c` (the Character list) — `0x1B0` is
+`0x100 + 0x0B*0x10`, the same bank by arithmetic. Missing that second spelling is exactly why the 2026-07 Pick Units
+fix did not generalise, and the Character screen — which players open constantly — stayed broken until #218.
+**Any new screen that draws cast map sprites goes in that table, not in a new hook.**
+
 **Enemy map sprites: clone the class into an unused slot, don't reskin the shared class (#21, 2026-06-16).**
 The cast's per-CHARACTER override is the wrong tool for ENEMIES: generic grunts share a pid (`0x80`), so there is no
 character to key on, and the cast bank forces the cast palette (enemies want their faction palette). Reskinning the

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -120,6 +120,7 @@ UNIT_ICON_MOVE_S = os.path.join(DECOMP, 'data', 'const_data_unit_icon_move.s')
 MOVE_GFX_DIR = os.path.join(DECOMP, 'graphics', 'unit_icon', 'move')
 BMUDISP_C = os.path.join(DECOMP, 'src', 'bmudisp.c')
 PREP_UNITSELECT_C = os.path.join(DECOMP, 'src', 'prep_unitselect.c')
+UNITLISTSCREEN_C = os.path.join(DECOMP, 'src', 'unitlistscreen.c')
 # New-game boots straight into the test chapter (skip the vanilla prologue) so the
 # spawn is one "New Game" away. CHAPTER_L_1 = 0x01 (constants/chapters.h).
 TEST_CHAPTER_INDEX = 1
@@ -399,6 +400,9 @@ PATCHED_DECOMP_FILES = ['texts/texts.txt', 'src/data_characters.c', 'src/portrai
                         'src/bmcamadjust.c',
                         'src/unit_icon_wait_data.c', 'src/unit_icon_move_data.c', 'src/mu.c',
                         'src/bmudisp.c', 'src/prep_unitselect.c',
+                        # #218: both roster screens that blank the purple OBJ bank
+                        # (PURPLE_BANK_BLANKERS); prep_unitselect.c is listed above
+                        'src/unitlistscreen.c',
                         # lord-select (#46): CallLordSelectMenu decl for eventscripts
                         'include/eventcall.h',
                         # enemy class reskins (#21): cloned goblin classes in gClassData;
@@ -2381,6 +2385,54 @@ def _read_cast_palette(path):
     return out[1:] + out[:1]
 
 
+# Screens that load the unit-sprite palettes and then immediately ZERO the purple OBJ bank
+# (0x0B). In vanilla that bank is scratch -- no vanilla unit renders from it -- but our custom
+# cast map sprites do, and a zeroed 16-colour bank draws every index as colour 0, so the cast
+# come out as correctly shaped BLACK SILHOUETTES (#218). Every entry is (file, exact vanilla
+# text, replacement); the fill is DELETED, never re-spelled, because ApplyUnitSpritePalettes
+# has already left the correct cast palette in the bank.
+#
+# This is a LIST and not a grep because the same idiom is spelled differently per screen --
+# `PAL_OBJ(0x0B)` in prep_unitselect, the raw `gPaletteBuffer + 0x1B0` (0x100 + 0x0B*0x10) in
+# unitlistscreen. Missing the second spelling is exactly how the Pick Units fix failed to
+# generalise to the Character screen. A new roster screen goes here, not in a new hook.
+PURPLE_BANK_BLANKERS = (
+    (PREP_UNITSELECT_C,                                  # PrepUnit_InitSMS -- Pick Units
+     '    ApplyUnitSpritePalettes();\n'
+     '    CpuFastFill(0, PAL_OBJ(0x0B), 0x20);\n',
+     '    ApplyUnitSpritePalettes();\n'
+     '    /* Manchego Stars: vanilla zeros the purple OBJ bank (0x0B) here -- unused in\n'
+     '     * vanilla prep -- but our custom cast map sprites render from it, so keep the\n'
+     '     * cast palette ApplyUnitSpritePalettes just loaded instead of blanking it\n'
+     '     * (else the roster goes black). */\n'),
+    (UNITLISTSCREEN_C,                                   # UnitList_Init -- the Character list
+     '    ApplyUnitSpritePalettes();\n'
+     '\n'
+     '    CpuFastFill(0, gPaletteBuffer + 0x1B0, PLTT_SIZE_4BPP);\n',
+     '    ApplyUnitSpritePalettes();\n'
+     '\n'
+     '    /* Manchego Stars (#218): same blanking as PrepUnit_InitSMS, spelled as a raw\n'
+     '     * gPaletteBuffer offset -- 0x1B0 == 0x100 + 0x0B*0x10 == OBJ bank 0x0B. The\n'
+     '     * unit list draws each row with PutUnitSprite, so zeroing the cast bank here\n'
+     '     * turned the whole roster into black silhouettes. */\n'),
+)
+
+
+def _drop_purple_bank_fills():
+    """Delete every vanilla "zero the purple OBJ bank" fill listed in PURPLE_BANK_BLANKERS.
+
+    Fails the build loudly if a site no longer matches verbatim: a decomp bump that reworks
+    one of these screens must not silently leave that screen's roster black."""
+    for path, orig, hooked in PURPLE_BANK_BLANKERS:
+        with open(path, encoding='utf-8') as f:
+            text = f.read()
+        if orig not in text:
+            sys.exit('ERROR: purple-bank (0x0B) fill not in expected form in %s -- the cast '
+                     'map-sprite palette would be blanked on that screen (#218)' % path)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text.replace(orig, hooked, 1))
+
+
 def _inject_palette_bank_hook():
     """Patch bmudisp.c so the custom cast share a bespoke palette in the campaign-unused
     purple OBJ bank (0xB / OBJPAL_UNITSPRITE_PURPLE), leaving the shared player palette
@@ -2389,7 +2441,10 @@ def _inject_palette_bank_hook():
         the faction switch. StartMu uses this too, so it covers idle + hover/walk; the
         grey "acted" tint is handled upstream in GetUnitDisplayedSpritePalette.
       * ApplyUnitSpritePalettes -- load gCastMapPalette into the purple bank (replacing
-        the single-player Light-Rune load; Light Rune is an unused DUMMY item)."""
+        the single-player Light-Rune load; Light Rune is an unused DUMMY item).
+
+    Loading the bank is only half the job: several screens blank it again right after.
+    _drop_purple_bank_fills (PURPLE_BANK_BLANKERS) is what keeps it loaded."""
     with open(BMUDISP_C, encoding='utf-8') as f:
         text = f.read()
 
@@ -2444,26 +2499,7 @@ def _inject_palette_bank_hook():
     with open(BMUDISP_C, 'w', encoding='utf-8') as f:
         f.write(text)
 
-    # prep_unitselect.c: PrepUnit_InitSMS loads the unit-sprite palettes (incl. our cast
-    # palette into the purple bank 0x0B) then immediately zeros bank 0x0B -- vanilla
-    # cleanup that's harmless there (no purple-faction units in prep) but blanks our
-    # custom cast map sprites to BLACK silhouettes on the Pick Units roster. Drop the
-    # fill: ApplyUnitSpritePalettes already left bank 0x0B holding the correct cast palette.
-    with open(PREP_UNITSELECT_C, encoding='utf-8') as f:
-        prep = f.read()
-    fill_orig = ('    ApplyUnitSpritePalettes();\n'
-                 '    CpuFastFill(0, PAL_OBJ(0x0B), 0x20);\n')
-    fill_hooked = ('    ApplyUnitSpritePalettes();\n'
-                   '    /* Manchego Stars: vanilla zeros the purple OBJ bank (0x0B) here --\n'
-                   '     * unused in vanilla prep -- but our custom cast map sprites render\n'
-                   '     * from it, so keep the cast palette ApplyUnitSpritePalettes just\n'
-                   '     * loaded instead of blanking it (else the roster goes black). */\n')
-    if fill_orig not in prep:
-        sys.exit('ERROR: PrepUnit_InitSMS purple-bank fill not in expected form in %s'
-                 % PREP_UNITSELECT_C)
-    prep = prep.replace(fill_orig, fill_hooked, 1)
-    with open(PREP_UNITSELECT_C, 'w', encoding='utf-8') as f:
-        f.write(prep)
+    _drop_purple_bank_fills()
 
 
 def _inject_cast_palette(palette_u16, char_slots, extra_char_ids=()):

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -16,6 +16,7 @@ local MENU_BALLISTA_ATTACK = 0x50
 local MENU_TALK = 0x5A
 local MENU_VISIT = 0x5C
 local MENU_WAIT = 0x6B
+local MENU_UNIT_LIST = 0x6E
 local MENU_STATUS = 0x6F
 local MENU_END_PHASE = 0x78
 
@@ -226,6 +227,7 @@ function M.legalActions(observation)
         addMenuCommand(actions, observation, MENU_WAIT, "wait")
     elseif state == "map_command_menu" then
         addMenuNavigation(actions, observation)
+        addMenuCommand(actions, observation, MENU_UNIT_LIST, "unit_list")
         addMenuCommand(actions, observation, MENU_STATUS, "status")
         addMenuCommand(actions, observation, MENU_END_PHASE, "end_phase")
     elseif state == "weapon_menu" then

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -105,6 +105,14 @@ WANTED = [
                                 # In a --montage build this carries the #43 lore crawl, so a
                                 # live instance == the montage opener actually played.
     'ProcScr_PrepUnitScreen',   # proc script: the prep "Pick Units" screen (deploy/bench).
+    'ProcScr_UnitListScreen_Field', # proc script: the map-menu "Unit" list, i.e. the Character
+                                # screen (src/unitlistscreen.c, started by StartUnitListScreenField
+                                # off gMapMenuItems[0], overrideId 0x6E). A live instance == the
+                                # unit list is actually on screen -> the #218 capture point.
+    'unit_icon_wait_table',     # UnitIconWait[] (include/unit_icon_data.h): {pattern, size, sheet}
+                                # per SMS id. `size` is the UNIT_ICON_SIZE_* PutUnitSprite switches
+                                # on, so reading it in-engine proves what the ROM believes about a
+                                # custom slot -- not what the injector meant to write (#218).
     'ProcScr_BmSupplyScreen',   # proc script: the in-map Supply (convoy) screen, opened by
                                 # the unit-menu Supply command (src/prep_itemsupply.c). A live
                                 # instance == a unit actually opened the convoy on the field.

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -3886,6 +3886,113 @@ scenarios.recordenemy = function()
 end
 
 
+-- ================================================================ unit list / SMS budget (#218)
+-- The map-menu "Unit" screen (Character list) draws every roster unit's MAP SPRITE at a 16px
+-- row pitch (unitlistscreen.c: PutUnitSprite(4, 8, 56 + i*16 + r8, ...)). Two things can make
+-- that render wrong and only the ROM can tell them apart:
+--
+--   1. GEOMETRY -- PutUnitSprite (bmudisp.c) switches on unit_icon_wait_table[id].size and draws
+--      a 16x32 at y-16 and a 32x32 at (x-8, y-16). A 32x32 entry therefore reaches a full 16px
+--      into the row above, which no vanilla PLAYER unit ever does (vanilla's 32x32 sheets are
+--      monsters, and monsters are never on your roster).
+--   2. VRAM BUDGET -- UseUnitSprite hands out one shared 0x40-slot space: gSMS16xGfxIndexCounter
+--      walks DOWN from 0x3F one slot per 16x16, gSMS32xGfxIndexCounter walks UP from 0 by 2 per
+--      16x32 and 4 per 32x32. They are not checked against each other, so once they cross, later
+--      sprites overwrite earlier ones and the whole list goes wrong at once.
+--
+-- Both are read here, before and after the screen opens: the list allocates sprites for roster
+-- units that are NOT on the map, so it can push the counters well past what the map needed.
+local UNITLIST_ROWS = 6                -- visible rows per page (the draw loop's `i < 6`)
+local SMS_SLOT_SPACE = 0x40            -- ResetUnitSprites: 16x counter starts at 0x40-1, 32x at 0
+local SMS_SIZE_NAME = { [0] = "16x16", [1] = "16x32", [2] = "32x32" }
+
+-- unit_icon_wait_table[] is UnitIconWait {u16 pattern, u16 size, char *sheet} -- 8 bytes.
+local function smsSize(id) return ru16(SYM.unit_icon_wait_table + id * 8 + 2) end
+
+-- Everything UseUnitSprite has handed out so far, plus the two counters that ration it. A slot
+-- of 0xFF means "never allocated on this map"; anything else is a live chr index.
+local function dumpSmsBudget(when)
+    local c32 = ru32(SYM.gSMS32xGfxIndexCounter)
+    local c16 = ru32(SYM.gSMS16xGfxIndexCounter)
+    log(string.format("SMS budget %s: 32x counter=%d (grows up from 0), 16x counter=%d "
+        .. "(grows down from %d), headroom=%d slots%s",
+        when, c32, c16, SMS_SLOT_SPACE - 1, c16 - c32,
+        c32 >= c16 and "  <-- EXHAUSTED: the two counters have CROSSED" or ""))
+    local live = {}
+    for id = 0, 0xCF do
+        local slot = ru8(SYM.gUnitSpriteSlots + id)
+        if slot ~= 0xFF then
+            live[#live + 1] = string.format("%d(%s)@chr%d", id, SMS_SIZE_NAME[smsSize(id)] or "?", slot * 2)
+        end
+    end
+    log(string.format("SMS allocated %s (%d sprites): %s", when, #live, table.concat(live, " ")))
+    return c32, c16
+end
+
+-- RECORDUNITLIST (#218): open the Character list on a `make TESTCH=1` ROM -- New Game boots
+-- STRAIGHT into the Ch1 sandbox with the whole classed cast deployed, so the screen a player
+-- opens constantly is ~30s from boot instead of a playthrough per capture. Shoots every page
+-- of the roster and dumps the SMS geometry + VRAM budget on both sides of the transition.
+scenarios.recordunitlist = function()
+    if not bootToMap() then return result("FAIL", "never reached the map") end
+    wait(60)
+    local mapC32, mapC16 = dumpSmsBudget("on the map, before the list opens")
+
+    local tile = emptyTile()
+    if not tile then return result("FAIL", "live map has no empty tile to open its menu from") end
+    if not cursorTo(tile.x, tile.y) then return result("FAIL", "cursor never reached the empty tile") end
+    if not guardedInput("open_map_menu", "A", "live map command menu opens", function(after)
+        return controllerState(after) == "map_command_menu"
+    end, 120) then return result("FAIL", "the map command menu never opened") end
+    if not selectSemantic("unit_list", "the Character (unit list) screen starts", function()
+        return procActive(SYM.ProcScr_UnitListScreen_Field)
+    end, 300) then return result("FAIL", "the map menu's Unit command never reached the list screen") end
+
+    wait(90)                                   -- let the screen settle before the first frame
+    shot("unitlist-page1")
+    local listC32, listC16 = dumpSmsBudget("with the unit list open")
+
+    -- Walk the roster. Each DOWN is one input with a real postcondition (the highlighted row or
+    -- the scroll offset must move); when neither moves we are at the end of the list, not stuck.
+    local proc = findProc(SYM.ProcScr_UnitListScreen_Field)
+    if not proc then return result("FAIL", "the unit list proc vanished after it started") end
+    local allies = ru8(proc + 0x3A)
+    log(string.format("unit list: %d allies on the roster, %d visible rows per page",
+        allies, UNITLIST_ROWS))
+    local shots = 1
+    for _ = 1, allies + UNITLIST_ROWS do
+        local row, scroll = ru8(proc + 0x2C), ru8(proc + 0x38)
+        press(K.DOWN, 4); wait(10)
+        if ru8(proc + 0x2C) == row and ru8(proc + 0x38) == scroll then break end
+        shots = shots + 1
+        shot(string.format("unitlist-row%02d", shots))
+    end
+    wait(20); shot("unitlist-end")
+    dumpSmsBudget("after scrolling the whole roster")
+
+    -- The verdict is the BUDGET, which is a fact the ROM can state. How the pixels read is
+    -- Nicolas's call off the frames, so it is reported, never asserted.
+    local oversize = {}
+    for id = 107, 0xCF do
+        if ru8(SYM.gUnitSpriteSlots + id) ~= 0xFF and smsSize(id) == 2 then
+            oversize[#oversize + 1] = id
+        end
+    end
+    log(string.format("custom SMS ids drawn as 32x32 in a 16px-pitch list: %s",
+        #oversize > 0 and table.concat(oversize, ",") or "none"))
+    if listC32 >= listC16 then
+        return result("FAIL", string.format(
+            "SMS VRAM exhausted: the unit list drove the 32x counter to %d past the 16x counter at %d "
+            .. "(map alone reached %d/%d) -- later sprites overwrote earlier ones",
+            listC32, listC16, mapC32, mapC16))
+    end
+    return result("PASS", string.format(
+        "unit list captured in %d frames; SMS budget held (32x=%d < 16x=%d, %d slots spare); "
+        .. "%d custom id(s) draw 32x32 into a 16px row pitch",
+        shots, listC32, listC16, listC16 - listC32, #oversize))
+end
+
+
 -- ================================================================ ch02 load-test (#22)
 -- The structural half of the Ch2 "Cold Welcome" load-test: does ch02 LOAD off the real
 -- ch01->ch02 chain (MNC2(0x3)), not soft-lock, and is it winnable -- with the 3 GREEN chwinga

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -82,6 +82,13 @@
 #                      tools/playtest/make_gif.py recordanim braulo --name braulo-anim --open
 #                    A staff-only unit (sclorbo) FAILs cleanly: no attack = no combat anim.
 #                    Build TESTCH=1 first. (recordrbgtest is the back-compat alias for RBG.)
+#   recordunitlist -- the map-menu "Unit" screen (Character list) on a `make TESTCH=1` ROM (#218):
+#                    boots straight into the Ch1 sandbox with the whole cast deployed, opens the
+#                    list semantically off gMapMenuItems[0] (overrideId 0x6E), shoots every page,
+#                    and dumps the SMS geometry + the shared 0x40-slot VRAM budget before/after.
+#                    FAILs if the two UseUnitSprite counters cross (later sprites overwrite earlier).
+#                      tools/playtest/run.sh recordunitlist
+#                      tools/playtest/make_gif.py recordunitlist unitlist --name unit-list
 #   recordenemy   -- the ENEMY analogue of recordanim on the SAME TESTCH sandbox (#90): a
 #                    reskinned enemy CLASS's battle anim. The sandbox deploys one hostile of
 #                    each enemy_class_reskins slot; a harmless player baits the chosen foe into

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1770,6 +1770,55 @@ if __name__ == '__main__':
     unittest.main()
 
 
+class CastPaletteBankSurvivesEveryRosterScreen(unittest.TestCase):
+    """The cast map-sprite palette lives in the purple OBJ bank (0x0B), which vanilla
+    treats as scratch: several screens call ApplyUnitSpritePalettes() and then
+    immediately ZERO that bank, because no vanilla unit renders from it. A zeroed
+    16-colour bank draws every index as colour 0 -- our cast come out as correctly
+    shaped BLACK SILHOUETTES (#218; the same failure was fixed once for Pick Units).
+
+    The idiom is spelled differently per screen (`PAL_OBJ(0x0B)` in prep_unitselect,
+    `gPaletteBuffer + 0x1B0` in unitlistscreen), so it must be listed per site rather
+    than grepped for -- hence PURPLE_BANK_BLANKERS, which is what these tests pin.
+    """
+
+    def test_every_known_blanker_names_a_real_decomp_site(self):
+        """Each entry must match the CURRENT vanilla source, read from HEAD -- the
+        working tree is a build artifact of our own injections."""
+        for path, orig, _ in bc.PURPLE_BANK_BLANKERS:
+            vanilla = bc.vanilla_decomp_text(os.path.relpath(path, bc.DECOMP))
+            self.assertIn(orig, vanilla,
+                          '%s no longer contains its purple-bank fill verbatim'
+                          % os.path.basename(path))
+
+    def test_the_unit_list_screen_is_covered(self):
+        """The regression this class exists for: the Character screen players open
+        constantly blanked the whole cast (#218)."""
+        sites = [os.path.basename(p) for p, _, _ in bc.PURPLE_BANK_BLANKERS]
+        self.assertIn('unitlistscreen.c', sites)
+        self.assertIn('prep_unitselect.c', sites)
+
+    def test_each_patch_drops_the_fill_and_keeps_the_palette_load(self):
+        """The fix is to delete the zeroing, NOT to reorder or re-load: whatever
+        ApplyUnitSpritePalettes just put in bank 0x0B is already correct."""
+        for path, orig, hooked in bc.PURPLE_BANK_BLANKERS:
+            where = os.path.basename(path)
+            self.assertIn('ApplyUnitSpritePalettes();', orig, where)
+            self.assertIn('ApplyUnitSpritePalettes();', hooked, where)
+            self.assertNotIn('CpuFastFill', hooked,
+                             '%s must DROP the fill, not re-spell it' % where)
+            self.assertIn('/*', hooked, '%s: say WHY the fill is gone' % where)
+
+    def test_the_hook_rejects_a_site_that_drifted(self):
+        """A decomp bump that reworks one of these screens must FAIL the build loudly,
+        not silently leave that screen's roster black."""
+        src = open(os.path.join(bc.REPO, 'tools', 'build_campaign.py'),
+                   encoding='utf-8').read()
+        body = src[src.index('def _drop_purple_bank_fills('):]
+        body = body[:body.index('\ndef ')]
+        self.assertIn('sys.exit', body)
+
+
 class PreRecruitVariant(unittest.TestCase):
     """A cast member on the field BEFORE he joins you (ch04's Lupin: red as the pack's
     leader, the finalized grey once Marty's parley brings him over).


### PR DESCRIPTION
The Character screen (map menu → Unit) drew every cast member as a correctly shaped **black silhouette** — right sheet, right chr, right row, no colour.

## Root cause

`UnitList_Init` (`src/unitlistscreen.c`) calls `ApplyUnitSpritePalettes()` — which loads our bespoke cast palette into the purple OBJ bank `0x0B` — and then immediately **zeroes that bank**. Vanilla can do that: nothing of its own renders from `0x0B`. Our custom cast do, and a zeroed 16-colour bank draws every index as colour 0.

It is the **same vanilla idiom already patched out of `prep_unitselect.c`** for Pick Units. It never generalised because it is spelled differently per screen:

| screen | spelling |
|---|---|
| `prep_unitselect.c` (Pick Units) | `CpuFastFill(0, PAL_OBJ(0x0B), 0x20)` |
| `unitlistscreen.c` (Character list) | `CpuFastFill(0, gPaletteBuffer + 0x1B0, PLTT_SIZE_4BPP)` |

`0x1B0` is `0x100 + 0x0B*0x10` — the same bank, by arithmetic. A grep for the first spelling can never find the second.

## The fix

Both sites now live in one table, `PURPLE_BANK_BLANKERS`, applied by `_drop_purple_bank_fills`, which `sys.exit`s if a site stops matching verbatim — a decomp bump must fail the build loudly rather than silently blacken a roster. **A future roster screen is one tuple, not a new hook.**

## Ruled out on the way — by reading the ROM, not by reasoning

- **SMS sizes are declared correctly.** The injector reads donor geometry from the decomp wait table, so the `32x32` vs `16x16` framing in the issue was not an injector defect.
- **The SMS VRAM budget is not exhausted.** The two `UseUnitSprite` counters land at `32x=26` vs `16x=57` — 31 slots spare.

## Verification — a fast boot, not a playthrough

New `recordunitlist` scenario opens the list on a `TESTCH=1` ROM ~30s from New Game, navigates **semantically** off `gMapMenuItems[0]` (overrideId `0x6E`, added to the controller's vocabulary — no blind presses), shoots every page, and dumps SMS geometry + VRAM budget on both sides of the transition. It FAILs if the counters ever cross.

635 python tests, 8 lua suites, `make check` → `drift check: clean`. Confirmed in-engine on a rebuilt TESTCH ROM.

## Still open, deliberately not fixed here

Five cast members legitimately declare `UNIT_ICON_SIZE_32x32` (Braulo, Wolfram, Meesmickle, Baxby, Lupin — monster donors). `PutUnitSprite` draws a 32x32 at `y-16`, so in the list's 16px row pitch their art reaches into the row above. Vanilla never hits this (no vanilla *player* unit is 32x32). Cosmetic and separate — Nicolas's call.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
