### PR TITLE
map sprites: guard the engine's 127-id ceiling at the append (#225)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2372,6 +2372,21 @@ so a standard-palette sheet is the only way to add a custom sprite alongside the
 compare its 16-colour palette to `unit_icon_pal_player.agbpal` — exact match ⇒ guest path (no override); custom colours
 ⇒ it must be re-indexed to `cast_palette.png` and join the cast bank.
 
+**Custom SMS ids are capped at 127 by the engine, and the cap is enforced at the append (#225, 2026-08-05).**
+FE8 resolves every map sprite's geometry through a masked index — `#define GetInfo(id) (unit_icon_wait_table[(id) &
+((1<<7)-1)])` in `src/bmudisp.c`. An id ≥ 128 therefore reads a **vanilla** row: id 128 draws Ephraim Lord's sheet at
+Ephraim Lord's size class. It does not crash, does not warn, and fails no test — the unit simply renders as somebody
+else. Critically **the mask is not the array bound**: `gUnitSpriteSlots` is `u8[0xD0]` and `UNITSPRITE_MAX` is `0xD0`,
+so ids 128–207 remain valid *slot-cache* indices; nothing downstream can notice. Vanilla ships 107 rows and
+`CUSTOM_SMS_BASE = 107`, so the whole custom budget is **ids 107–127 — 21 sprites**, and every pass spends from it
+(cast idle, guests, pre-recruit variants, scripted neutrals, the chwinga reskin, `enemy_class_reskins`).
+So: **`_append_wait_rows` is the only way to add a wait row**, it `sys.exit`s naming the id and the unit that would
+overflow, and it prints the remaining headroom (loudly under `SMS_ID_LOW_WATER`). The ceiling itself is *read from the
+decomp* (`_sms_id_mask_bits` parses the `GetInfo` define out of HEAD) rather than hardcoded, so a decomp bump moves the
+guard with it instead of leaving a stale `127` behind. Going past 127 for real is a much larger job — widen or re-point
+the mask and audit every `UseUnitSprite` / `StartUiSMS` / `StartWorldMapSMS` caller — and is deliberately not done here.
+Live budget at the time of writing: **126 used, 2 left**; ch05's Basil + Sahnar are exactly those two.
+
 **Loading the cast bank is only half the job — several vanilla screens BLANK it again (#218, 2026-08-05).**
 Bank `0xB` is free in vanilla precisely because nothing renders from it, and vanilla exploits that: a screen calls
 `ApplyUnitSpritePalettes()` and then immediately zeroes bank `0xB` as scratch cleanup. Harmless in vanilla; for us a

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -2766,8 +2766,8 @@ def _inject_pre_recruit_variants(campaign, idle, pointer_externs, verbose=True):
         macro, _, _, _ = map_sprite_tool.sheet_info(wait_png, (dfw, dfh))
 
         sms = _wait_table_len()
-        _append_table_rows(UNIT_ICON_WAIT_C, 'unit_icon_wait_table[]',
-                           ['\t{0, %s, %s}, // %d %s (pre-recruit)' % (macro, sym, sms, uid)])
+        _append_wait_rows(
+            ['\t{0, %s, %s}, // %d %s (pre-recruit)' % (macro, sym, sms, uid)])
         with open(UNIT_ICON_WAIT_S, 'a', encoding='utf-8') as f:
             f.write('\n/* Manchego Stars pre-recruit idle sprite: %s (#24) */\n'
                     '\t.global %s\n%s:\n\t.incbin "graphics/unit_icon/wait/%s.4bpp.lz"\n'
@@ -2907,9 +2907,8 @@ def _inject_scripted_neutral_sprites(campaign, asset_dir, pointer_externs, verbo
         shutil.copyfile(idle_png, os.path.join(WAIT_GFX_DIR, wait_sym + '.png'))
         shutil.copyfile(mu_png, os.path.join(MOVE_GFX_DIR, move_sym + '.png'))
         sms = _wait_table_len()
-        _append_table_rows(UNIT_ICON_WAIT_C, 'unit_icon_wait_table[]',
-                           ['\t{0, %s, %s}, // %d %s (scripted neutral)'
-                            % (macro, wait_sym, sms, uid)])
+        _append_wait_rows(
+            ['\t{0, %s, %s}, // %d %s (scripted neutral)' % (macro, wait_sym, sms, uid)])
         with open(UNIT_ICON_WAIT_S, 'a', encoding='utf-8') as f:
             f.write('\n/* Manchego Stars scripted-neutral idle sprite: %s (#24) */\n'
                     '\t.global %s\n%s:\n\t.incbin "graphics/unit_icon/wait/%s.4bpp.lz"\n'
@@ -2961,8 +2960,8 @@ def _inject_ch02_chwinga_sprites(campaign, verbose=True):
     macro, _, _, _ = map_sprite_tool.sheet_info(role_idle, (dfw, dfh))
 
     sms = _wait_table_len()
-    _append_table_rows(UNIT_ICON_WAIT_C, 'unit_icon_wait_table[]',
-                       ['\t{0, %s, %s}, // %d chwinga (green NPC)' % (macro, wait_sym, sms)])
+    _append_wait_rows(
+        ['\t{0, %s, %s}, // %d chwinga (green NPC)' % (macro, wait_sym, sms)])
     with open(UNIT_ICON_WAIT_S, 'a', encoding='utf-8') as f:
         f.write('\n/* Manchego Stars green chwinga idle sprite (#38) */\n'
                 '\t.global %s\n%s:\n\t.incbin "graphics/unit_icon/wait/%s.4bpp.lz"\n'
@@ -3071,7 +3070,7 @@ def _inject_idle_sprites(campaign, asset_dir, idle, pointer_externs, guest_bases
         pointer_externs.append('extern char %s[];' % sym)
         overrides.append('\tCHARACTER_%s, %d,' % (slot.upper(), sms))
 
-    _append_table_rows(UNIT_ICON_WAIT_C, 'unit_icon_wait_table[]', wait_rows)
+    _append_wait_rows(wait_rows)
     with open(UNIT_ICON_WAIT_S, 'a', encoding='utf-8') as f:
         f.write('\n/* Manchego Stars custom idle sprites (#38) */\n' + '\n'.join(incbin) + '\n')
 
@@ -3171,6 +3170,71 @@ def _wait_table_len():
         lines = f.read().splitlines()
     di, ci = _table_close_line(lines, 'unit_icon_wait_table[]')
     return sum(1 for i in range(di + 1, ci) if lines[i].lstrip().startswith('{'))
+
+
+# How close to the ceiling we let a build get before saying so out loud. Two is the number
+# that matters today: ch05's Basil + Sahnar are the last two ids (#225).
+SMS_ID_LOW_WATER = 4
+_SMS_MASK_BITS = None
+
+
+def _sms_id_mask_bits():
+    """Bit width of the mask the ENGINE applies to every SMS id, read from the decomp:
+
+        src/bmudisp.c:  #define GetInfo(id) (unit_icon_wait_table[(id) & ((1<<7)-1)])
+
+    Read from HEAD, never the working tree -- our injections are build artifacts. Grounding
+    the ceiling in the engine that enforces it means a decomp bump moves the guard with it
+    instead of leaving a stale literal behind."""
+    global _SMS_MASK_BITS
+    if _SMS_MASK_BITS is None:
+        m = re.search(r'#define\s+GetInfo\(id\)\s*\(unit_icon_wait_table\[\(id\)\s*&\s*'
+                      r'\(\(1\s*<<\s*(\d+)\)\s*-\s*1\)\]\)',
+                      vanilla_decomp_text('src/bmudisp.c'))
+        if not m:
+            sys.exit('ERROR: the GetInfo SMS-id mask is not in its expected form in '
+                     'src/bmudisp.c -- re-derive the custom SMS id ceiling before building '
+                     '(#225), an id past the mask silently renders a VANILLA sprite')
+        _SMS_MASK_BITS = int(m.group(1))
+    return _SMS_MASK_BITS
+
+
+def sms_id_max():
+    """Highest SMS id the engine can look up without wrapping (127 today)."""
+    return (1 << _sms_id_mask_bits()) - 1
+
+
+def _append_wait_rows(rows, verbose=False):
+    """Append rows to unit_icon_wait_table[] -- the ONLY way any sprite pass may do so.
+
+    Enforces the engine's id ceiling (#225). `GetInfo` masks the id, so a row past the mask
+    does not crash or warn: the unit silently renders another class's sheet at that class's
+    size. The mask is not the array bound either (gUnitSpriteSlots is u8[0xD0], so ids
+    128-207 are perfectly valid slot-cache indices) -- nothing downstream can catch this,
+    which is why it has to be caught here, at the append."""
+    limit = sms_id_max()
+    first = _wait_table_len()                       # rows are 0-indexed BY SMS id
+    if first + len(rows) - 1 > limit:
+        over = [(first + i, r) for i, r in enumerate(rows) if first + i > limit]
+        named = ', '.join('id %d (%s)' % (i, _wait_row_label(r)) for i, r in over)
+        sys.exit('ERROR: custom map sprite would take SMS id past the engine ceiling of %d: '
+                 '%s.\nFE8 looks these up as unit_icon_wait_table[id & 0x%X], so id %d would '
+                 'silently draw VANILLA row %d instead. Free an id, or widen the GetInfo mask '
+                 'and audit every UseUnitSprite caller (#225).'
+                 % (limit, named, limit, over[0][0], over[0][0] & limit))
+    _append_table_rows(UNIT_ICON_WAIT_C, 'unit_icon_wait_table[]', rows)
+    left = limit - (_wait_table_len() - 1)
+    if verbose or left <= SMS_ID_LOW_WATER:
+        print('  SMS ids: %d used, %d left before the engine ceiling (%d)%s'
+              % (_wait_table_len(), left, limit,
+                 '  <-- NEARLY FULL' if left <= SMS_ID_LOW_WATER else ''))
+
+
+def _wait_row_label(row):
+    """The unit a generated wait row names, for an error message. Rows carry a trailing
+    `// <id> <label>` / `/* <id> <label> */` comment written by the pass that emitted them."""
+    m = re.search(r'(?://|/\*)\s*\d+\s+([^*\n]+?)\s*(?:\*/)?$', row.strip())
+    return m.group(1).strip() if m else row.strip()
 
 
 def _move_table_len():
@@ -3832,8 +3896,8 @@ def inject_enemy_class_reskins(campaign, verbose=True):
             map_sprite_tool.validate_mu_sheet(os.path.join(MOVE_GFX_DIR, move_sym + '.png'))
 
             sms_id = _wait_table_len()
-            _append_table_rows(UNIT_ICON_WAIT_C, 'unit_icon_wait_table[]',
-                               ['\t{0, %s, %s}, // %d %s (reskin)' % (macro, wait_sym, sms_id, sprite)])
+            _append_wait_rows(
+                ['\t{0, %s, %s}, // %d %s (reskin)' % (macro, wait_sym, sms_id, sprite)])
             with open(UNIT_ICON_WAIT_S, 'a', encoding='utf-8') as f:
                 f.write('\n/* Manchego Stars enemy class reskin idle (#21) */\n'
                         '\t.global %s\n%s:\n'

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from PIL import Image
 
@@ -1768,6 +1769,97 @@ class IdempotentInjectionMtimes(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class CustomSmsIdsStayUnderTheEngineMask(unittest.TestCase):
+    """FE8 looks up a map sprite's geometry through a MASKED index:
+
+        #define GetInfo(id) (unit_icon_wait_table[(id) & ((1<<7)-1)])
+
+    so an SMS id >= 128 silently reads a VANILLA row -- id 128 draws Ephraim Lord's
+    sheet at Ephraim Lord's size class. It does not crash and it does not warn: the
+    unit just renders as somebody else. The mask is NOT the array bound either
+    (gUnitSpriteSlots is u8[0xD0] and ids 128-207 are valid slot-cache indices), which
+    is exactly why nothing else catches it (#225).
+
+    Our custom ids start at CUSTOM_SMS_BASE = 107, so the budget is small and finite.
+    """
+
+    def test_the_limit_is_read_from_the_decomp_not_hardcoded(self):
+        """Ground the ceiling in the engine that enforces it -- if a decomp bump widens
+        or narrows the mask, the guard must follow it rather than assert a stale 127."""
+        self.assertEqual(bc._sms_id_mask_bits(), 7)
+        self.assertEqual(bc.sms_id_max(), 127)
+
+    def test_the_mask_read_fails_loudly_if_the_define_moves(self):
+        src = open(os.path.join(bc.REPO, 'tools', 'build_campaign.py'),
+                   encoding='utf-8').read()
+        body = src[src.index('def _sms_id_mask_bits('):]
+        body = body[:body.index('\ndef ')]
+        self.assertIn('sys.exit', body)
+        self.assertIn('vanilla_decomp_text', body,
+                      'read the mask from HEAD -- the working tree is our own artifact')
+
+    def test_every_wait_table_append_goes_through_the_guarded_helper(self):
+        """A new sprite pass must not be able to append a row unguarded. The choke point
+        is _append_wait_rows; nothing else may append to unit_icon_wait_table[]."""
+        src = open(os.path.join(bc.REPO, 'tools', 'build_campaign.py'),
+                   encoding='utf-8').read()
+        helper = src[src.index('def _append_wait_rows('):]
+        helper = helper[:helper.index('\ndef ')]
+        outside = src.replace(helper, '')
+        self.assertNotIn('_append_table_rows(UNIT_ICON_WAIT_C', outside,
+                         'append wait rows via _append_wait_rows, not _append_table_rows')
+        self.assertIn('_append_table_rows(UNIT_ICON_WAIT_C', helper,
+                      'the helper is the one place allowed to do the raw append')
+        self.assertGreaterEqual(outside.count('_append_wait_rows('), 5,
+                                'all five sprite passes must route through the guard')
+
+    def test_the_guard_rejects_a_row_past_the_mask(self):
+        """The regression: overflowing must fail the BUILD, naming the id and the unit,
+        rather than shipping a sprite that renders as a vanilla class."""
+        tmp = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp, 'unit_icon_wait_data.c')
+            rows = ''.join('\t{0, UNIT_ICON_SIZE_16x16, sheet_%d},\n' % i for i in range(128))
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('UnitIconWait unit_icon_wait_table[] = {\n%s};\n' % rows)
+            with mock.patch.object(bc, 'UNIT_ICON_WAIT_C', path):
+                self.assertEqual(bc._wait_table_len(), 128)   # ids 0..127: exactly full
+                with self.assertRaises(SystemExit) as cm:
+                    bc._append_wait_rows(['\t{0, UNIT_ICON_SIZE_16x16, x}, // 128 basil'])
+            msg = str(cm.exception)
+            self.assertIn('128', msg, 'name the overflowing id')
+            self.assertIn('basil', msg, 'name the unit that overflowed')
+            self.assertIn('127', msg, 'state the ceiling')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_the_guard_allows_the_last_usable_id(self):
+        """127 is usable -- an off-by-one here would cost us a sprite we own."""
+        tmp = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp, 'unit_icon_wait_data.c')
+            rows = ''.join('\t{0, UNIT_ICON_SIZE_16x16, sheet_%d},\n' % i for i in range(127))
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('UnitIconWait unit_icon_wait_table[] = {\n%s};\n' % rows)
+            with mock.patch.object(bc, 'UNIT_ICON_WAIT_C', path):
+                bc._append_wait_rows(['\t{0, UNIT_ICON_SIZE_16x16, x}, // 127 sahnar'])
+                self.assertEqual(bc._wait_table_len(), 128)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_the_remaining_headroom_is_reported_while_it_is_still_cheap_to_act_on(self):
+        """Two ids left is worth knowing BEFORE the build that spends them, so the
+        injector prints the headroom and says so loudly when it is nearly gone. (The
+        "does the live campaign fit" question is answered end-to-end by the guard
+        itself firing during a real build, which CI runs.)"""
+        src = open(os.path.join(bc.REPO, 'tools', 'build_campaign.py'),
+                   encoding='utf-8').read()
+        body = src[src.index('def _append_wait_rows('):]
+        body = body[:body.index('\ndef ')]
+        self.assertIn('SMS_ID_LOW_WATER', body)
+        self.assertIn('print(', body, 'report the headroom, do not only enforce it')
 
 
 class CastPaletteBankSurvivesEveryRosterScreen(unittest.TestCase):


### PR DESCRIPTION
Found while ruling out an id-wrap theory for #218. Not that bug's cause — but a real ceiling we are **two sprites away from**, and ch05 is what spends them.

## The trap

```c
#define GetInfo(id) (unit_icon_wait_table[(id) & ((1<<7)-1)])
```

An SMS id ≥ 128 silently reads a **vanilla** row — id 128 draws Ephraim Lord's sheet at Ephraim Lord's size class. No crash, no warning, no failing test.

Nothing downstream can catch it, because **the mask is not the array bound**: `gUnitSpriteSlots` is `u8[0xD0]` and `UNITSPRITE_MAX` is `0xD0`, so ids 128–207 remain perfectly valid slot-cache indices. That mismatch is the whole reason this is invisible.

## The guard

`_append_wait_rows` is now the **only** way to add a row to `unit_icon_wait_table[]`. All five sprite passes route through it — cast idle, pre-recruit variant, scripted neutral, chwinga, enemy reskins — and a test asserts no pass can bypass it.

It `sys.exit`s naming the id **and the unit** that would overflow, and prints remaining headroom, loudly under `SMS_ID_LOW_WATER`:

```
  SMS ids: 126 used, 2 left before the engine ceiling (127)  <-- NEARLY FULL
```

The ceiling is **read from the decomp** — `_sms_id_mask_bits` parses the `GetInfo` define out of `HEAD` — rather than hardcoded, so a decomp bump moves the guard with it instead of leaving a stale `127` behind.

## Budget

Vanilla ships 107 rows; `CUSTOM_SMS_BASE = 107`. The custom budget is ids **107–127, 21 sprites**. Currently **126 used, 2 left**. `basil.png` and `sahnar.png` already sit in `map_sprites/`, uninjected only because neither is classed cast yet — #25 makes them so, and that is exactly the last two.

ch05 fits. The sprite *after* it would have wrapped silently; now it fails the build instead.

## Not done here, on purpose

Actually raising the ceiling (widen or re-point the mask, then audit every `UseUnitSprite` / `StartUiSMS` / `StartWorldMapSMS` caller) is a much bigger job and isn't needed yet. This is the guard that makes running out **visible** rather than silent.

641 python tests, `make check` → `drift check: clean`, full ROM build green.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
