### PR TITLE
tools: codify the two gotchas this session kept re-paying for

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2439,7 +2439,11 @@ on each screen**: `CpuFastFill(0, PAL_OBJ(0x0B), 0x20)` in `prep_unitselect.c` (
 `CpuFastFill(0, gPaletteBuffer + 0x1B0, PLTT_SIZE_4BPP)` in `unitlistscreen.c` (the Character list) — `0x1B0` is
 `0x100 + 0x0B*0x10`, the same bank by arithmetic. Missing that second spelling is exactly why the 2026-07 Pick Units
 fix did not generalise, and the Character screen — which players open constantly — stayed broken until #218.
-**Any new screen that draws cast map sprites goes in that table, not in a new hook.**
+**Any new screen that draws cast map sprites goes in that table, not in a new hook.** Finding the second site by hand
+is not a strategy, so `check.py check_purple_bank_blankers_known` now greps the decomp **at HEAD** (the working tree has
+the fills patched out, so linting it would pass vacuously) for any literal bank-`0x0B` palette fill and fails the build
+unless that file is already in `PURPLE_BANK_BLANKERS`. A third screen — new, or arriving with a decomp bump — is now
+caught by CI instead of by a player noticing black silhouettes.
 
 **Enemy map sprites: clone the class into an unused slot, don't reskin the shared class (#21, 2026-06-16).**
 The cast's per-CHARACTER override is the wrong tool for ENEMIES: generic grunts share a pid (`0x80`), so there is no
@@ -2931,9 +2935,13 @@ step and reverts the montage sources → a no-opener ROM byte-identical to the t
 won't compile / stale-objects" bug for a whole session; it was never a compile problem). The montage flavour MUST be one
 command: `make MONTAGE=1`, wrapped as `tools/build.sh dist` (test = `tools/build.sh test`). A correct montage ROM's md5 is
 NOT the no-opener `142971e3`. Sanity check after a build: `grep -c "skip intro monologue" fireemblem8u/src/gamecontrol.c`
-= 0 for dist, 1 for test. Also: the decomp ships Linux `#!/bin/python3` shebangs that `setup-toolchain.sh` rewrites for
-macOS, but any `git checkout` inside the `fireemblem8u` submodule reverts them (`bad interpreter` on the next build);
-`build.sh` re-applies the fix idempotently. _Decided: 2026-06-17; root-caused + dist (with opener) GIF-verified end-to-end
+= 0 for dist, 1 for test. Also: the decomp ships Linux `#!/bin/python3` shebangs that do not exist on macOS, and any
+`git checkout` inside the `fireemblem8u` submodule reverts the fix — the next build then dies on `bad interpreter`,
+minutes in, from a Makefile rule that looks unrelated. `setup-toolchain.sh` and `build.sh` both rewrite them, but the
+DOCUMENTED build command is plain `make`, which bypassed both, so the failure kept recurring (three times in one session,
+2026-08-05). **`build_campaign.normalise_decomp_shebangs` now re-applies it idempotently on EVERY build** — the hole is
+closed at the one place every build passes through, rather than in wrappers a caller has to remember.
+_Decided: 2026-06-17; root-caused + dist (with opener) GIF-verified end-to-end
 (`run.sh recordopening`: title → New Game → lore crawl → Ten Towns tour → prologue map)._
 
 **World-map tour rides vanilla's drawn-map slot with two Icewind Dale backdrops, selected by a free mask bit.**

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -27,6 +27,7 @@ import glob
 import hashlib
 import json
 import os
+import platform
 import re
 import shutil
 import struct
@@ -8897,6 +8898,40 @@ def inject_battle_platforms(campaign, verbose=True):
         print('  Tileset16=CAVE (vanilla siroyuka1 stone / gake1 rock); ch03->0x16')
 
 
+def normalise_decomp_shebangs(verbose=False):
+    """Rewrite the decomp's Linux `#!/bin/python3` shebangs for macOS. Idempotent.
+
+    fireemblem8u/scripts/ ships `#!/bin/python3`, which does not exist on macOS (and /bin is
+    SIP-protected, so it cannot be created). setup-toolchain.sh rewrites them once -- but ANY
+    `git checkout` inside the submodule reverts them: restore_vanilla_sources, a manual reset,
+    a branch switch, `git checkout -- .` after a build. The NEXT build then dies on
+    `bad interpreter: No such file or directory`, several minutes in, from a Makefile rule
+    that looks unrelated (tsa_generator.py on a BG image).
+
+    tools/build.sh already re-applies it, but the DOCUMENTED build command is plain `make`
+    (CLAUDE.md), which bypassed the wrapper -- so the failure kept recurring. Every build
+    runs this module via the Makefile, so doing it here closes the hole for good rather than
+    relying on remembering the wrapper."""
+    if platform.system() != 'Darwin':
+        return 0
+    fixed = 0
+    for path in glob.glob(os.path.join(DECOMP, 'scripts', '**', '*.py'), recursive=True):
+        try:
+            with open(path, encoding='utf-8') as f:
+                text = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not text.startswith('#!/bin/python3'):
+            continue
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('#!/usr/bin/env python3' + text[len('#!/bin/python3'):])
+        fixed += 1
+    if fixed and verbose:
+        print('  normalised %d Linux #!/bin/python3 shebang(s) in fireemblem8u/scripts '
+              '(reverted by the last submodule checkout)' % fixed)
+    return fixed
+
+
 def main():
     ap = argparse.ArgumentParser(description='Inject campaign content into the decomp build.')
     ap.add_argument('--campaign', default='rime-of-the-frostmaiden')
@@ -8931,6 +8966,9 @@ def main():
         sys.exit('ERROR: --ch03-boot and --ch04-boot are mutually exclusive')
 
     print('build_campaign: injecting "%s" into %s' % (args.campaign, DECOMP))
+    # Before anything else: undo whatever the last submodule checkout did to the decomp's
+    # Linux shebangs, or this build dies minutes later on `bad interpreter`.
+    normalise_decomp_shebangs(verbose=True)
     # Snapshot the previous build's injection footprint BEFORE we touch anything, so
     # we can rewind mtimes for whatever comes out byte-identical (fast warm rebuilds).
     _mtime_snapshot = _snapshot_mtimes(_decomp_footprint())

--- a/tools/check.py
+++ b/tools/check.py
@@ -490,6 +490,65 @@ def _engine_name_hits(ids, text):
     return hits
 
 
+def check_purple_bank_blankers_known(fail):
+    """No vanilla screen may blank the cast map-sprite OBJ bank (0x0B) unnoticed.
+
+    #218: our custom cast render from purple OBJ bank 0x0B. Vanilla treats that bank as
+    scratch -- a screen calls ApplyUnitSpritePalettes() and then zeroes it, because nothing
+    of vanilla's own renders from there. A zeroed 16-colour bank draws every index as
+    colour 0, so the whole cast comes out as correctly shaped BLACK SILHOUETTES: right
+    sheet, right position, no colour.
+
+    We found two such screens by hand (Pick Units, then the Character list) and only found
+    the second because the first was reported as a bug -- they are spelled differently
+    (`PAL_OBJ(0x0B)` vs the raw `gPaletteBuffer + 0x1B0`, which is 0x100 + 0x0B*0x10). This
+    check closes that: every literal reference to bank 0x0B in a palette fill anywhere in
+    the decomp must be a site build_campaign.PURPLE_BANK_BLANKERS already patches out. A
+    third screen -- new, or arriving with a decomp bump -- fails here instead of silently
+    blackening a roster.
+    """
+    src_dir = os.path.join(REPO, 'fireemblem8u', 'src')
+    if not os.path.isdir(src_dir):
+        print('check_purple_bank_blankers_known: skipping (fireemblem8u submodule not '
+              'checked out)')
+        return
+    bc = open(os.path.join(REPO, 'tools', 'build_campaign.py'), encoding='utf-8').read()
+    # Which decomp files PURPLE_BANK_BLANKERS covers. Its entries are (PATH_CONST, orig,
+    # hooked), so read the constant names out of the tuple rather than importing
+    # build_campaign (which would pull in Pillow/yaml for a lint).
+    block = bc[bc.index('PURPLE_BANK_BLANKERS = ('):]
+    block = block[:block.index('\n)')]
+    known = {name.lower() for name in re.findall(r'^\s*\((\w+)_C,', block, re.M)}
+
+    # MUST read HEAD, not the working tree: the build patches these very fills out, so a
+    # post-build tree shows nothing and the check would pass vacuously. (Same doctrine as
+    # vanilla_decomp_text -- our decomp edits are build artifacts.)
+    import subprocess
+    env = {k: v for k, v in os.environ.items()
+           if not k.startswith('GIT_')}
+    # bank 0x0B, both spellings: PAL_OBJ(0x0B|0xB|11) and the raw gPaletteBuffer offset
+    # (0x1B0 == 0x100 + 0x0B*0x10).
+    pattern = (r'CpuFastFill\( *0, *(PAL_OBJ\( *(0x0?[Bb]|11) *\)'
+               r'|gPaletteBuffer \+ 0x1B0)')
+    r = subprocess.run(['git', '-C', os.path.join(REPO, 'fireemblem8u'), 'grep', '-nE',
+                        pattern, 'HEAD', '--', 'src'],
+                       capture_output=True, text=True, env=env)
+    if r.returncode not in (0, 1):                   # 1 == no matches, which is fine
+        fail.append('check_purple_bank_blankers_known: git grep failed: %s'
+                    % (r.stderr or '').strip())
+        return
+    for line in r.stdout.splitlines():
+        m = re.match(r'HEAD:src/(\w+)\.c:', line)
+        if not m:
+            continue
+        if m.group(1).lower() not in known:
+            fail.append(
+                'src/%s.c blanks the cast map-sprite OBJ bank 0x0B but is not in '
+                'build_campaign.PURPLE_BANK_BLANKERS -- the cast would render as black '
+                'silhouettes on that screen (#218). Add it there, do not silence this.'
+                % m.group(1))
+
+
 def check_engine_campaign_agnostic(fail):
     ids = _campaign_character_ids()
     if not ids:
@@ -758,6 +817,7 @@ def main():
                   check_injection_order,
                   check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
+                  check_purple_bank_blankers_known,
                   check_engine_campaign_agnostic,
                   check_save_layout_stable, check_handoff_only_on_main,
                   check_lane_ownership):

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -2341,3 +2341,51 @@ class Ch04Stage4Scenes(unittest.TestCase):
         speakers = [next(iter(b)) for b in beats[0]]
         self.assertNotIn('white-moose', speakers)
         self.assertNotIn('moose', speakers)
+
+
+class DecompShebangsSurviveASubmoduleCheckout(unittest.TestCase):
+    """The decomp ships Linux `#!/bin/python3` shebangs that do not exist on macOS, and ANY
+    `git checkout` inside the submodule reverts the fix -- so the next build dies on
+    `bad interpreter`, minutes in, from a Makefile rule that looks unrelated.
+
+    tools/build.sh handled it, but CLAUDE.md documents plain `make`, which bypassed the
+    wrapper -- so the failure kept recurring. Every build runs build_campaign, so the fix
+    lives there now and this pins it.
+    """
+
+    def test_the_build_normalises_shebangs_before_injecting(self):
+        src = open(os.path.join(bc.REPO, 'tools', 'build_campaign.py'),
+                   encoding='utf-8').read()
+        body = src[src.index('def main():'):]
+        self.assertIn('normalise_decomp_shebangs(', body,
+                      'every build must re-apply the fix, not just tools/build.sh')
+
+    def test_it_rewrites_only_the_linux_shebang_and_is_idempotent(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            scripts = os.path.join(tmp, 'scripts')
+            os.makedirs(scripts)
+            broken = os.path.join(scripts, 'gen.py')
+            fine = os.path.join(scripts, 'ok.py')
+            other = os.path.join(scripts, 'nohash.py')
+            with open(broken, 'w') as f:
+                f.write('#!/bin/python3\nprint(1)\n')
+            with open(fine, 'w') as f:
+                f.write('#!/usr/bin/env python3\nprint(2)\n')
+            with open(other, 'w') as f:
+                f.write('print(3)\n')
+            with mock.patch.object(bc, 'DECOMP', tmp), \
+                    mock.patch.object(bc.platform, 'system', lambda: 'Darwin'):
+                self.assertEqual(bc.normalise_decomp_shebangs(), 1)
+                self.assertEqual(bc.normalise_decomp_shebangs(), 0, 'must be idempotent')
+            self.assertTrue(open(broken).read().startswith('#!/usr/bin/env python3'))
+            self.assertEqual(open(broken).read().splitlines()[1], 'print(1)',
+                             'only the shebang line may change')
+            self.assertTrue(open(fine).read().startswith('#!/usr/bin/env python3'))
+            self.assertEqual(open(other).read(), 'print(3)\n')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_it_is_a_no_op_off_macos(self):
+        with mock.patch.object(bc.platform, 'system', lambda: 'Linux'):
+            self.assertEqual(bc.normalise_decomp_shebangs(), 0)


### PR DESCRIPTION
Nicolas asked whether any of this session's recorded constraints needed codifying rather than leaving as prose. Two did — both are failures we hit by hand and would hit again, and neither was enforced. The rest already are.

## 1. `check_purple_bank_blankers_known`

#218's black silhouettes were vanilla zeroing OBJ bank `0x0B` right after `ApplyUnitSpritePalettes` loaded our cast palette into it. We found the **second** such screen only because the first was reported as a bug — and the two are spelled differently:

```c
prep_unitselect.c:  CpuFastFill(0, PAL_OBJ(0x0B), 0x20);
unitlistscreen.c:   CpuFastFill(0, gPaletteBuffer + 0x1B0, PLTT_SIZE_4BPP);   // 0x100 + 0x0B*0x10
```

Grepping for one can never find the other. The check now greps the decomp for **any** literal bank-`0x0B` palette fill and fails unless that file is already in `PURPLE_BANK_BLANKERS`. Decomp-wide there are exactly four such fills: our two, plus two `face.c` ones that don't touch `0x0B`.

**It reads `HEAD`, not the working tree** — the build patches these very fills out, so linting the tree would pass vacuously. That was a real bug in my first draft.

Verified both directions: clean as shipped, and it correctly names `unitlistscreen.c` when that entry is removed from the table.

## 2. `normalise_decomp_shebangs`

The decomp's Linux `#!/bin/python3` shebangs don't exist on macOS, and **any** `git checkout` in the submodule reverts the fix. The next build then dies on `bad interpreter`, minutes in, from a Makefile rule that looks unrelated (a BG image).

`setup-toolchain.sh` and `build.sh` both rewrite them — but CLAUDE.md documents plain `make`, which bypassed both. So it kept recurring: **three times in this session alone.**

Every build runs `build_campaign`, so the fix lives there now — idempotent, macOS-only. Verified by reverting all 19 shebangs and running a plain `make`:

```
normalised 19 Linux #!/bin/python3 shebang(s) in fireemblem8u/scripts
BUILD EXIT 0
```

## Deliberately not codified

- **Branching promotions (`gPromoJidLut` vs `.promotion`)** — only `build_campaign` reasons about promotions anywhere in the repo, and it's tested. No second consumer to drift.
- **"Read decomp facts from HEAD"** — no working-tree decomp *read* remains after #227 fixed `donor_sms_geometry`. A general lint would be mostly false positives, since the write paths are legitimate.
- **The accepted 32×32 overlap** and **the conservative reclaim policy** — the latter already fails tests if narrowed; the former is a judgement call, not an invariant.

Prose in `decisions.md` is the right weight for those.

657 python tests, `make check` → `drift check: clean`, full ROM build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
