### PR TITLE
Playtest matrix runner: one manifest, one command (#231)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ tools/key_magenta.py
 # mGBA save-state checkpoints (per-ROM-build, regenerated) -- inline comments don't work
 # in .gitignore, so this must be on its own line
 tools/playtest/states/
+# which boot flags built the .gba currently in the tree (build_campaign writes it;
+# the playtest matrix reads it to refuse a wrong-ROM run) -- describes an artifact
+.build-config.json
 
 # battle-anim hand-paint scratch (tools/banim_paint.py) -- the painted FRAMES are what ships
 campaigns/*/battle_anims/*/.paint/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ The data is the doc — facts live in exactly one place, and indexes are generat
 | Adding a unit's art / battle anim / platform | the **`inject_battle_anims` / `inject_battle_platforms` docstrings** (how) + `decisions.md` Art & Audio (why) + the **`custom_unit` issue template** (checklist) |
 | Borrowable enemy reskin art (what the FE-Repo has) | **`docs/fe-repo-scouting.md`** (scouting log) + per-unit `skin:` fields in chapter YAML + `campaign.yaml` `enemy_class_reskins` |
 | Hosting a new chapter (map → slot → deploy → win → boot) | **`docs/adding-a-chapter.md`** (the repeatable runbook) + `inject_ch03` (lean reference impl) |
+| What a playtest scenario needs (ROM flag, host chapter, checkpoint, timing) | **`tools/playtest/matrix.yaml`** — the single source; `harness.lua` comments say what a scenario *proves*, not what it needs |
 | Prep screen / deploy cap / force-deployment | `decisions.md` → "How the deploy cap + prep screen are actually wired" + `inject_ch01`'s docstring. **Prep from ch01 on is standing protocol — the CAP is the parity, Pick Units only chooses which PCs fill it. Never re-derive this from the decomp, and never from `hasPrepScreen` (dead FE7 leftover, false everywhere).** |
 | FE8 cadence/reward grounding | `docs/fe8-pacing-reference.md` |
 | Post-MVP (Act II–V) plan | `docs/roadmap.md` |
@@ -138,7 +139,8 @@ file lean (operating instructions + pointers, not a fact store).
 |---|---|
 | `tools/build_campaign.py` | Inject campaign content (portraits, names, character class/stats) into the decomp before `make`. |
 | `tools/verify_text.py` | Decode message text from the built ROM (regression gate; no mGBA). |
-| `tools/playtest/run.sh win\|gameover\|retreat\|titlecard` | Automated in-emulator playtest of ch00 win/lose conditions + title-card capture (mGBA Lua scripting; memory-asserted PASS/FAIL). |
+| `tools/playtest/run.sh <scenario>` | Automated in-emulator playtest of ONE scenario (mGBA Lua scripting; memory-asserted PASS/FAIL). Takes the scenario's ROM flag, host chapter, checkpoint and timing from `tools/playtest/matrix.yaml`. |
+| `make matrix [SUITE=…]` | The live regression matrix (`tools/playtest/matrix.py`): builds each ROM configuration at most once, runs its scenarios, prints a verdict table. `SUITE=gate` (default), a chapter suite, or `all`. |
 | `tools/portrait_tool.py`, `tools/ref_to_bust.py` | Bust art pipeline (ref → indexed FE8 portrait). |
 | `tools/setup-toolchain.sh` | One-time macOS toolchain setup (brew deps, agbcc, python numpy/pillow/pyyaml). |
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PATH := $(BREW_PY):$(PATH)
 endif
 endif
 
-.PHONY: all clean verify check test difficulty difficulty-gate
+.PHONY: all clean verify check test matrix difficulty difficulty-gate
 
 all: fireemblem8.gba
 
@@ -55,6 +55,22 @@ test:
 	@if command -v lua >/dev/null 2>&1; then \
 		for t in tools/playtest/test_*.lua; do echo "== $$t =="; lua $$t || exit 1; done; \
 	else echo "== skipping Lua playtest tests (no 'lua'; brew install lua) =="; fi
+
+# Live playtest matrix (#231): build each ROM configuration at most once, run its
+# scenarios in mGBA, print a verdict table. The scenario -> ROM/host/checkpoint/timing
+# table is tools/playtest/matrix.yaml.
+#   make matrix                 # SUITE=gate -- what must be green before a merge
+#   make matrix SUITE=ch04      # every ch04 scenario off one CH04BOOT=1 build
+#   make matrix SUITE=all       # every non-manual verdict scenario (long)
+# Artifacts + results.json land in /tmp/playtest-matrix; per-scenario screenshots and
+# logs stay in /tmp/playtest-<scenario>/ as before.
+SUITE ?= gate
+matrix:
+ifeq ($(strip $(SUITE)),all)
+	@python3 tools/playtest/matrix.py run --all
+else
+	@python3 tools/playtest/matrix.py run --suite $(SUITE)
+endif
 
 # Static per-chapter difficulty / vanilla-parity report (no ROM build, no mGBA).
 #   make difficulty CH=ch01     # one chapter's report

--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -113,6 +113,13 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
     that calls the injector and `_configure_boot(CHNN_HOST_INDEX)` (New Game reroutes 0 → N), plus a
     `Makefile` `$(if $(CHNNBOOT),--chNN-boot)`.
 
+11. **Declare the new ROM configuration in `tools/playtest/matrix.yaml`** — add `chNNboot:
+    {CHNNBOOT: 1}` to `rom_configs`. Every scenario you then write for the chapter gets a row
+    (`rom: chNNboot`, `host_chapter: <slot>`), and the chapter gets a suite so `make matrix
+    SUITE=chNN` runs the lot off one build. `check.py check_playtest_matrix` fails the build if a
+    scenario in `harness.lua` has no row, so this is not optional bookkeeping — it is how
+    `run.sh chNNsomething` knows the flag and the host slot without you typing either.
+
 ## Load-test it (see the map with units)
 
 ```sh
@@ -122,8 +129,17 @@ PT_HOST_CHAPTER=4 tools/playtest/run.sh mapshot                    # New Game ->
 open /tmp/playtest-<scenario>/*-map-loaded.png
 ```
 
-`mapshot` (harness.lua) = the generic "boot to the map and screenshot the deployed field" scenario;
-`PT_HOST_CHAPTER=N` tells the harness which slot the fast-boot lands on (`inChapter` checks it).
+`mapshot` (harness.lua) = the generic "boot to the map and screenshot the deployed field" scenario.
+It is one of the two deliberately chapter-generic scenarios, so it is the one case where you still
+pass `PT_HOST_CHAPTER=N` by hand (`inChapter` checks it). Every chapter-specific scenario takes its
+host slot and its ROM flag from `matrix.yaml` instead — and `run.sh` refuses outright, in 0s, if the
+tree holds a ROM that cannot host it rather than failing seven minutes later for the wrong reason.
+
+Once the chapter has more than a couple of scenarios, drive them together:
+
+```sh
+make matrix SUITE=chNN     # one CHNNBOOT=1 build, every chNN scenario, one verdict table
+```
 
 ## Gotchas (learned the hard way)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1453,6 +1453,41 @@ feature branch for GitHub review, and must be pruned before merge unless a live 
 as evidence — [[feedback_sharing_visual_drafts]]).
 _Decided: 2026-06-17 (#21 ending review); updated 2026-08-03 for the #220 controller contract and #219 recorder cleanup._
 
+**One manifest owns "what a playtest scenario needs"; `run.sh` and the matrix runner both read it (#231).**
+`tools/playtest/matrix.yaml` is the single source of the scenario → ROM configuration / `PT_HOST_CHAPTER` /
+checkpoint / fps-vsync-deadline table. Before this, that table was split three ways — the ROM flag and host
+chapter existed only in `harness.lua`'s per-scenario `Run:` comments, the checkpoint map and the timing
+policy lived in two bash `case` blocks in `run.sh`, and nothing connected them — so the operator carried it
+in their head and "a failing playtest may be the WRONG ROM" was the standing top gotcha. `run.sh` now
+resolves through `matrix.py resolve` and keeps only its real job (run ONE scenario in mGBA);
+`matrix.py run --suite <name>` groups a selection by ROM configuration, builds each **at most once**, runs
+sequentially, and prints a `variant | scenario | verdict | time | artifacts` table with `results.json`
+beside it. Decisions worth keeping:
+- **Every scenario is enumerated in the manifest, defaults and all.** Absence is a `check.py` drift failure
+  (`check_playtest_matrix`), not a silent canonical/host-1 default that fails later in the emulator.
+- **Resolution is `defaults < class rules (in order) < the scenario's row`** — a direct port of `run.sh`'s
+  `case` semantics, including that a later rule overrides only the keys it names. So `record*` still means
+  60fps/vsync/300s, and `recordch02ending` still takes 600s on top of it, without restating either.
+- **Ordering is about checkpoints, not just builds.** Save states are ROM-hash-stamped, so switching ROM
+  configuration invalidates *all* of them, and `ckpt_ch02start` replays the whole ch00→ch01→ch02 chain to
+  rebuild one. Inside a group, checkpointless scenarios run first (a cheap failure surfaces before a long
+  checkpoint build) and checkpoint-sharing scenarios stay contiguous. The lint pins a checkpoint and its
+  `ckpt_*` builder to the same ROM configuration — a mismatch is an invisible double cost, since the
+  consumer would discard the state as hash-stale.
+- **`build_campaign.py` stamps `.build-config.json`** (gitignored) with the boot flags that produced the ROM
+  in the tree, because nothing in the `.gba` says how it was built. `run.sh` refuses a wrong-ROM run in 0s
+  with the exact `make` line instead of letting mGBA time out; an unrecognised or missing stamp stays out of
+  the way rather than blocking.
+- **A failed build blocks only its own group**, and a failed scenario does not stop the matrix — one broken
+  configuration must not hide the state of the others.
+- **Sequential by construction.** mGBA runs share emulator/save state, and two ROM builds in one tree corrupt
+  each other, so neither is parallelised; the win comes from not rebuilding and not re-earning checkpoints.
+- **Suites are curated, not derived.** `gate` is deliberately tight (controller contract + ch00/ch01 spine +
+  SMS budget + the current chapter); the per-chapter suites are each a single ROM build; `--all` runs every
+  non-manual verdict scenario. `llm` is `manual` (external sidecar) and never auto-selected.
+_Decided: 2026-08-05 (CLAUDE; #231 = #222 workstream 1. Workstreams 2–4 — state inspector, declarative
+scenario manifests, static chapter lint — stay deferred and get re-scoped from the ch05 build experience.)_
+
 **Chapter title cards are IMAGES, recomposed from vanilla glyphs.**
 FE8's intro/Status title banner is a 4bpp graphic (`chap_title_data[chapTitleId]`,
 `src/chapter_title.c`), not text — text ids (`chapTitleTextId`, 0x160+) only feed the

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -574,6 +574,28 @@ def _rewind_unchanged_mtimes(snap):
     return n
 
 
+BUILD_STAMP = os.path.join(REPO, '.build-config.json')
+
+
+def _stamp_build_config(campaign, flags):
+    """Record which boot flags produced the ROM now in the tree.
+
+    A playtest scenario is bound to a ROM configuration -- a CH04BOOT=1 build cannot
+    reach ch02's map -- and the most expensive failure mode in this repo is a scenario
+    that FAILs for the honest reason "you are running the wrong ROM". Nothing in the
+    .gba says how it was built, so record it here; tools/playtest/matrix.py reads this
+    and refuses the run instead of letting mGBA time out for 7 minutes.
+
+    Gitignored: it describes the working tree's build artifact, not the source."""
+    stamp = {'campaign': campaign,
+             'flags': {k: bool(v) for k, v in sorted(flags.items())}}
+    try:
+        with open(BUILD_STAMP, 'w') as fh:
+            json.dump(stamp, fh, indent=2)
+    except OSError as exc:      # never fail a build over the stamp
+        print('  (could not write %s: %s)' % (BUILD_STAMP, exc))
+
+
 def restore_vanilla_sources():
     # Restore explicitly from HEAD (not the index): `git checkout -- <file>` pulls from
     # the staging area, so a previously-staged patched file would survive and corrupt the
@@ -8960,6 +8982,11 @@ def main():
                          '"White Moose" snowy forest on slot 5 with an armed party, fog, '
                          'and the approved 16 + 4 + 3 vanilla-monster force.')
     args = ap.parse_args()
+    # Snapshot the flags AS PASSED, before --lord-boot implies --test-chapter below:
+    # the build stamp has to describe the `make` invocation, not the derived state.
+    _requested_flags = {'TESTCH': args.test_chapter, 'LORDBOOT': args.lord_boot,
+                        'MONTAGE': args.montage, 'CH03BOOT': args.ch03_boot,
+                        'CH04BOOT': args.ch04_boot}
     if args.lord_boot:
         args.test_chapter = True  # the fast-boot rides the sandbox
     if args.ch03_boot and args.ch04_boot:
@@ -9072,6 +9099,7 @@ def main():
     if rewound:
         print('idempotent injection: rewound %d unchanged file(s) -> make skips them'
               % rewound)
+    _stamp_build_config(args.campaign, _requested_flags)
     print('done. Run `make` to compile the ROM.')
 
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -322,6 +322,68 @@ def check_injection_order(fail):
         _injection_call_sequence(open(path, encoding='utf-8').read())))
 
 
+def check_playtest_matrix(fail):
+    """tools/playtest/matrix.yaml is the single source of "what does this scenario
+    need" (ROM configuration, host chapter, checkpoint, timing) -- so it has to keep
+    describing harness.lua. A scenario added to the harness without a manifest row
+    would otherwise inherit the canonical/host-1 defaults silently and fail in mGBA
+    for a reason that has nothing to do with the change under test (#231)."""
+    sys.path.insert(0, os.path.join(REPO, 'tools', 'playtest'))
+    try:
+        import matrix as mx
+    except ImportError as exc:
+        fail.append('tools/playtest/matrix.py does not import (%s)' % exc)
+        return
+    try:
+        m = mx.Manifest.load()
+    except Exception as exc:                      # noqa: BLE001 -- report, don't crash the lint
+        fail.append('tools/playtest/matrix.yaml does not load (%s)' % exc)
+        return
+
+    harness = mx.harness_scenarios()
+    for name in sorted(harness - set(m.scenarios)):
+        fail.append('harness.lua defines scenario %s with no matrix.yaml row' % name)
+    for name in sorted(set(m.scenarios) - harness):
+        fail.append('matrix.yaml has a row for %s, which harness.lua no longer defines' % name)
+
+    for name in m.scenarios:
+        if name not in harness:
+            continue
+        try:
+            s = m.resolve(name)
+        except mx.ManifestError as exc:
+            fail.append('matrix.yaml: %s' % exc)
+            continue
+        # A checkpoint built under one ROM configuration is discarded as hash-stale by a
+        # consumer running under another -- an invisible double cost, so pin the pair.
+        if s.checkpoint and not s.dynamic_checkpoint:
+            builder = s.checkpoint_builder
+            if builder not in m.scenarios:
+                fail.append('matrix.yaml: %s wants checkpoint %s but %s is not a scenario'
+                            % (name, s.checkpoint, builder))
+            elif m.resolve(builder).rom != s.rom:
+                fail.append('matrix.yaml: %s (%s) and its builder %s (%s) disagree on the ROM'
+                            % (name, s.rom, builder, m.resolve(builder).rom))
+
+    for suite, members in sorted(m.suites.items()):
+        if not members:
+            fail.append('matrix.yaml: suite %s is empty' % suite)
+        for name in members:
+            if name not in m.scenarios:
+                fail.append('matrix.yaml: suite %s names unknown scenario %s' % (suite, name))
+                continue
+            s = m.resolve(name)
+            if s.kind == 'checkpoint':
+                fail.append('matrix.yaml: suite %s names %s, a checkpoint builder'
+                            % (suite, name))
+            if s.rom == 'any':
+                fail.append('matrix.yaml: suite %s names %s, which is chapter-generic '
+                            'and has no ROM of its own' % (suite, name))
+            if s.manual:
+                fail.append('matrix.yaml: suite %s names %s, which needs manual setup'
+                            % (suite, name))
+
+
 def check_tool_refs_exist(fail):
     """A doc or code comment naming tools/<x>.py|rb, or a docs/<x>.md path, must
     point at a file that exists -- dangling pointers are the cheapest-to-catch form
@@ -814,7 +876,7 @@ def main():
     fail = []
     for check in (check_python_compiles, check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
-                  check_injection_order,
+                  check_injection_order, check_playtest_matrix,
                   check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
                   check_purple_bank_blankers_known,

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""The playtest matrix runner (#231, #222 workstream 1).
+
+One command runs a grouped live regression matrix: every ROM configuration is
+built at most once, its scenarios run sequentially, and the run ends in a compact
+verdict table plus artifacts on disk.
+
+    make matrix                        # the merge gate
+    make matrix SUITE=ch04             # everything ch04, one build
+    tools/playtest/matrix.py run --scenarios ch04moose,ch04snag
+    tools/playtest/matrix.py list
+
+`matrix.yaml` is the single source of truth for what a scenario needs: its ROM
+configuration, its PT_HOST_CHAPTER, its checkpoint, and its fps/vsync/deadline
+policy. `run.sh` resolves through this module rather than keeping a second copy
+of that table -- so "which ROM does ch04moose need" has exactly one answer, and
+`check.py` can prove the manifest still describes `harness.lua`.
+
+Why grouping matters more than it looks: checkpoints (`states/<name>.ss`) are
+ROM-hash-stamped, so switching ROM configuration invalidates every one of them,
+and `ckpt_ch02start` replays the whole ch00->ch01->ch02 chain to rebuild a single
+state. A badly ordered matrix costs far more than a duplicate `make`.
+"""
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+import yaml
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+MANIFEST = os.path.join(HERE, 'matrix.yaml')
+HARNESS = os.path.join(HERE, 'harness.lua')
+RUN_SH = os.path.join(HERE, 'run.sh')
+
+# The `make` invocation the runner builds each configuration with.
+CAMPAIGN = os.environ.get('CAMPAIGN', 'rime-of-the-frostmaiden')
+
+_SCENARIO_DEF = re.compile(r'^scenarios\.([A-Za-z0-9_]+)\s*=', re.M)
+
+
+class ManifestError(Exception):
+    """The manifest disagrees with reality -- a bad key, a bad reference, a bad ask."""
+
+
+class Scenario(object):
+    """One fully resolved row: defaults + class rules + the scenario's own entry."""
+
+    FIELDS = ('rom', 'host_chapter', 'fps', 'vsync', 'deadline', 'checkpoint',
+              'kind', 'manual')
+
+    def __init__(self, name, values, rom_configs, checkpoint_deadline):
+        self.name = name
+        self.rom = values['rom']
+        self.host_chapter = values['host_chapter']
+        self.fps = int(values['fps'])
+        self.vsync = int(values['vsync'])
+        self.deadline = int(values['deadline'])
+        self.kind = values['kind']
+        self.manual = bool(values.get('manual', False))
+        self.checkpoint_deadline = checkpoint_deadline
+        ckpt = values.get('checkpoint')
+        # recordscene picks its checkpoint at runtime from PT_STATE; there is no
+        # static builder to name, so the manifest says `dynamic` and run.sh asks
+        # the environment instead.
+        self.dynamic_checkpoint = (ckpt == 'dynamic')
+        self.checkpoint = None if ckpt in (None, 'dynamic') else ckpt
+        if self.dynamic_checkpoint:
+            self.checkpoint = 'dynamic'
+        self._rom_configs = rom_configs
+
+    @property
+    def checkpoint_builder(self):
+        """By convention (and run.sh's original case block) checkpoint X is minted
+        by scenario ckpt_X."""
+        if not self.checkpoint or self.dynamic_checkpoint:
+            return None
+        return 'ckpt_' + self.checkpoint
+
+    @property
+    def make_flags(self):
+        return _flags_for(self.rom, self._rom_configs)
+
+    def __repr__(self):
+        return '<Scenario %s rom=%s host=%s>' % (self.name, self.rom, self.host_chapter)
+
+
+def _flags_for(rom, rom_configs):
+    if rom == 'any':
+        return []
+    return ['%s=%s' % (k, v) for k, v in rom_configs[rom].items()]
+
+
+class Group(object):
+    """Every scenario that shares one ROM configuration -- i.e. one `make`."""
+
+    def __init__(self, rom, make_flags, scenarios):
+        self.rom = rom
+        self.make_flags = make_flags
+        self.scenarios = scenarios
+
+    def __repr__(self):
+        return '<Group %s x%d>' % (self.rom, len(self.scenarios))
+
+
+class Manifest(object):
+    def __init__(self, data):
+        self.defaults = data['defaults']
+        self.rom_configs = data['rom_configs']
+        self.classes = data.get('classes') or []
+        self.scenarios = data['scenarios']
+        self.suites = data.get('suites') or {}
+        self.checkpoint_deadline = data.get('checkpoint_deadline', 900)
+
+    @classmethod
+    def load(cls, path=None):
+        with open(path or MANIFEST) as fh:
+            return cls(yaml.safe_load(fh))
+
+    # -- resolution ---------------------------------------------------------
+
+    def resolve(self, name):
+        """defaults < class rules (in order) < the scenario's own entry.
+
+        The class rules are the direct port of run.sh's `case "$SCENARIO"`
+        statements, and they keep the same semantics: a later rule overrides an
+        earlier one key by key, and omitted keys fall through.
+        """
+        if name not in self.scenarios:
+            raise ManifestError(
+                '%s is not in matrix.yaml (if it is new in harness.lua, add a row)' % name)
+        values = dict(self.defaults)
+        for rule in self.classes:
+            if fnmatch.fnmatchcase(name, rule['match']):
+                values.update({k: v for k, v in rule.items() if k != 'match'})
+        values.update(self.scenarios[name] or {})
+        unknown = set(values) - set(Scenario.FIELDS)
+        if unknown:
+            raise ManifestError('%s: unknown key(s) %s' % (name, ', '.join(sorted(unknown))))
+        if values['rom'] != 'any' and values['rom'] not in self.rom_configs:
+            raise ManifestError('%s: unknown rom config %r' % (name, values['rom']))
+        return Scenario(name, values, self.rom_configs, self.checkpoint_deadline)
+
+    def resolve_rom(self, rom):
+        if rom != 'any' and rom not in self.rom_configs:
+            raise ManifestError('unknown rom config %r' % rom)
+        return _flags_for(rom, self.rom_configs)
+
+    # -- selection ----------------------------------------------------------
+
+    def select(self, suite=None, scenarios=None, all_verdicts=False):
+        if suite:
+            if suite not in self.suites:
+                raise ManifestError('unknown suite %r (have: %s)'
+                                    % (suite, ', '.join(sorted(self.suites))))
+            return list(self.suites[suite])
+        if scenarios:
+            for name in scenarios:
+                self.resolve(name)
+            return list(scenarios)
+        if all_verdicts:
+            return [n for n in self.scenarios
+                    if self.resolve(n).kind == 'verdict' and not self.resolve(n).manual]
+        raise ManifestError('nothing selected: pass --suite, --scenarios or --all')
+
+    # -- planning -----------------------------------------------------------
+
+    def plan(self, names, rom=None):
+        """Group the selection by ROM configuration and order it for cheapness.
+
+        Groups run in the manifest's `rom_configs` declaration order. Inside a
+        group, checkpointless scenarios go first so a cheap failure surfaces
+        before a long checkpoint build, and scenarios sharing a checkpoint stay
+        contiguous so each `.ss` is earned once and loaded repeatedly.
+        """
+        if rom:
+            self.resolve_rom(rom)
+        resolved = []
+        for name in names:
+            s = self.resolve(name)
+            if rom:
+                s.rom = rom
+            elif s.rom == 'any':
+                raise ManifestError(
+                    '%s is chapter-generic: say --rom <config> (and PT_HOST_CHAPTER)' % name)
+            resolved.append(s)
+
+        order = [r for r in self.rom_configs if r in {s.rom for s in resolved}]
+        groups = []
+        for rom_name in order:
+            members = [s for s in resolved if s.rom == rom_name]
+            groups.append(Group(rom_name, self.resolve_rom(rom_name), _order(members)))
+        return groups
+
+
+def _order(members):
+    """Checkpointless first, then checkpoint-backed grouped by first appearance."""
+    plain = [s for s in members if not s.checkpoint]
+    buckets = {}
+    for s in members:
+        if s.checkpoint:
+            buckets.setdefault(s.checkpoint, []).append(s)
+    backed = []
+    for bucket in buckets.values():
+        backed.extend(bucket)
+    return plain + backed
+
+
+# -- execution --------------------------------------------------------------
+
+class Outcome(object):
+    def __init__(self, scenario, rom, verdict, seconds, artifacts, log_tail=''):
+        self.scenario = scenario
+        self.rom = rom
+        self.verdict = verdict
+        self.seconds = seconds
+        self.artifacts = artifacts
+        self.log_tail = log_tail
+
+    def as_dict(self):
+        return {'scenario': self.scenario, 'rom': self.rom, 'verdict': self.verdict,
+                'seconds': round(self.seconds, 1), 'artifacts': self.artifacts}
+
+
+class Report(object):
+    def __init__(self, outcomes, builds, duplicate_builds, seconds):
+        self.outcomes = outcomes
+        self.builds = builds
+        self.duplicate_builds = duplicate_builds
+        self.seconds = seconds
+
+    @property
+    def failures(self):
+        return [o for o in self.outcomes if o.verdict != 'PASS']
+
+    @property
+    def ok(self):
+        return not self.failures
+
+    @property
+    def exit_code(self):
+        return 0 if self.ok else 1
+
+    def as_dict(self):
+        return {'ok': self.ok, 'builds': self.builds,
+                'duplicate_builds': self.duplicate_builds,
+                'seconds': round(self.seconds, 1),
+                'outcomes': [o.as_dict() for o in self.outcomes]}
+
+
+def execute(groups, build, run_scenario):
+    """Run the plan. `build` and `run_scenario` are injected so the ordering and
+    aggregation logic is testable without a ROM or an emulator.
+
+    A failed build blocks only its own group: the rest of the matrix still runs,
+    because one broken configuration should not hide the state of the others.
+    """
+    outcomes = []
+    built = []
+    started = time.time()
+    for group in groups:
+        built.append(group.rom)
+        if not build(group.rom, group.make_flags):
+            for s in group.scenarios:
+                outcomes.append(Outcome(s.name, group.rom, 'BLOCKED', 0.0, '',
+                                        'ROM configuration %s failed to build' % group.rom))
+            continue
+        for s in group.scenarios:
+            outcomes.append(run_scenario(s))
+    return Report(outcomes, builds=len(built),
+                  duplicate_builds=len(built) - len(set(built)),
+                  seconds=time.time() - started)
+
+
+# -- rendering --------------------------------------------------------------
+
+def human_duration(seconds):
+    seconds = int(round(seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return '%dh%02dm%02ds' % (h, m, s)
+    if m:
+        return '%dm%02ds' % (m, s)
+    return '%ds' % s
+
+
+def render_table(report):
+    rows = [(o.rom, o.scenario, o.verdict, human_duration(o.seconds), o.artifacts)
+            for o in report.outcomes]
+    head = ('variant', 'scenario', 'verdict', 'time', 'artifacts')
+    widths = [max(len(head[i]), max([len(r[i]) for r in rows] or [0])) for i in range(5)]
+    line = lambda cells: '  '.join(c.ljust(widths[i]) for i, c in enumerate(cells)).rstrip()
+    out = [line(head), '  '.join('-' * w for w in widths)]
+    out.extend(line(r) for r in rows)
+    out.append('')
+    out.append('%d scenario(s), %d build(s), %d duplicate build(s), %s wall'
+               % (len(report.outcomes), report.builds, report.duplicate_builds,
+                  human_duration(report.seconds)))
+    return '\n'.join(out)
+
+
+def render_failures(report):
+    if report.ok:
+        return ''
+    out = []
+    for o in report.failures:
+        out.append('%s [%s] -> %s' % (o.scenario, o.rom, o.verdict))
+        if o.artifacts:
+            out.append('  artifacts: %s' % o.artifacts)
+        for tail_line in (o.log_tail or '').splitlines():
+            out.append('  | %s' % tail_line)
+        out.append('')
+    return '\n'.join(out)
+
+
+# -- the run.sh interface ---------------------------------------------------
+
+def export_env(scenario):
+    """Shell assignments run.sh evals. Every value is single-quoted so an empty
+    checkpoint stays empty rather than becoming the word None."""
+    pairs = [
+        ('MX_ROM', scenario.rom),
+        ('MX_MAKE_FLAGS', ' '.join(scenario.make_flags)),
+        ('MX_HOST_CHAPTER', scenario.host_chapter),
+        ('MX_FPS', scenario.fps),
+        ('MX_VSYNC', scenario.vsync),
+        ('MX_DEADLINE', scenario.deadline),
+        ('MX_CHECKPOINT', '' if scenario.dynamic_checkpoint else (scenario.checkpoint or '')),
+        ('MX_CHECKPOINT_BUILDER', scenario.checkpoint_builder or ''),
+        ('MX_CHECKPOINT_DYNAMIC', '1' if scenario.dynamic_checkpoint else ''),
+        ('MX_CHECKPOINT_DEADLINE', scenario.checkpoint_deadline),
+        ('MX_KIND', scenario.kind),
+    ]
+    return '\n'.join("%s='%s'" % (k, '' if v is None else v) for k, v in pairs)
+
+
+def harness_scenarios(path=None):
+    """Every `scenarios.X = function()` defined in harness.lua."""
+    with open(path or HARNESS) as fh:
+        return set(_SCENARIO_DEF.findall(fh.read()))
+
+
+# -- the wrong-ROM guard ----------------------------------------------------
+
+BUILD_STAMP = os.path.join(REPO, '.build-config.json')
+
+
+def built_rom_config(rom_configs, stamp_path=None):
+    """Name the ROM configuration currently sitting in the tree, or None if the stamp
+    is missing (an old build) or matches nothing the manifest knows about.
+
+    build_campaign.py writes the stamp; matching is on the EXACT flag set, because
+    `canonical` is "no flags" and would otherwise match every build."""
+    try:
+        with open(stamp_path or BUILD_STAMP) as fh:
+            stamp = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    on = {k for k, v in (stamp.get('flags') or {}).items() if v}
+    for name, flags in rom_configs.items():
+        if set(flags) == on:
+            return name
+    return None
+
+
+def check_rom(manifest, scenario, stamp_path=None):
+    """Return an error string if the built ROM cannot host this scenario, else None."""
+    if scenario.rom == 'any':
+        return None
+    built = built_rom_config(manifest.rom_configs, stamp_path)
+    if built is None or built == scenario.rom:
+        return None     # unknown stamp: stay out of the way rather than block a run
+    want = ' '.join(scenario.make_flags) or '(no flags)'
+    return ('%s needs the %s ROM (make %s) but the tree holds a %s build.\n'
+            '  Build it first:  make CAMPAIGN=%s %s fireemblem8.gba -j$(nproc)'
+            % (scenario.name, scenario.rom, want, built, CAMPAIGN,
+               ' '.join(scenario.make_flags)))
+
+
+# -- live wiring ------------------------------------------------------------
+
+def _build(rom, make_flags, log_dir, quiet=True):
+    cmd = ['make', 'CAMPAIGN=' + CAMPAIGN] + list(make_flags) + [
+        'fireemblem8.gba', '-j%d' % (os.cpu_count() or 4)]
+    print('== building %s: %s' % (rom, ' '.join(cmd)))
+    log_path = os.path.join(log_dir, 'build-%s.log' % rom)
+    with open(log_path, 'w') as log:
+        proc = subprocess.run(cmd, cwd=REPO, stdout=log,
+                              stderr=subprocess.STDOUT if quiet else None)
+    if proc.returncode != 0:
+        print('   BUILD FAILED -- see %s' % log_path)
+        return False
+    return True
+
+
+def parse_verdict(text, returncode):
+    """Read run.sh's verdict out of its captured output.
+
+    The harness stamps every line with the frame it was logged on -- the verdict
+    line reads `[f007234] RESULT: PASS -- ...`, never starts with RESULT: -- so this
+    matches anywhere in the line. run.sh's exit status is the corroborating signal
+    (0 only on PASS); if the two disagree, the run did not end cleanly, so fail."""
+    verdict = None
+    for line in text.splitlines():
+        if 'RESULT:' in line:
+            verdict = 'PASS' if 'RESULT: PASS' in line else 'FAIL'
+    if verdict is None:
+        return 'ERROR'          # no verdict at all: crash, timeout, or a refused run
+    if verdict == 'PASS' and returncode != 0:
+        return 'FAIL'
+    return verdict
+
+
+def _run_scenario(scenario, log_dir):
+    env = dict(os.environ)
+    env['PT_HOST_CHAPTER'] = str(scenario.host_chapter)
+    started = time.time()
+    print('-- %s [%s]' % (scenario.name, scenario.rom))
+    proc = subprocess.run([RUN_SH, scenario.name], cwd=REPO, env=env,
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    seconds = time.time() - started
+    text = proc.stdout.decode('utf-8', 'replace')
+    with open(os.path.join(log_dir, '%s.log' % scenario.name), 'w') as fh:
+        fh.write(text)
+    verdict = parse_verdict(text, proc.returncode)
+    tail = '' if verdict == 'PASS' else '\n'.join(text.strip().splitlines()[-12:])
+    return Outcome(scenario.name, scenario.rom, verdict, seconds,
+                   '/tmp/playtest-%s' % scenario.name, tail)
+
+
+def cmd_run(args):
+    m = Manifest.load()
+    names = m.select(suite=args.suite,
+                     scenarios=args.scenarios.split(',') if args.scenarios else None,
+                     all_verdicts=args.all)
+    groups = m.plan(names, rom=args.rom)
+    log_dir = args.out
+    os.makedirs(log_dir, exist_ok=True)
+
+    total = sum(len(g.scenarios) for g in groups)
+    print('matrix: %d scenario(s) across %d ROM configuration(s) -> %s'
+          % (total, len(groups), log_dir))
+    for g in groups:
+        print('  %-10s %s' % (g.rom, ' '.join(s.name for s in g.scenarios)))
+    if args.dry_run:
+        return 0
+
+    report = execute(groups,
+                     build=lambda rom, flags: _build(rom, flags, log_dir),
+                     run_scenario=lambda s: _run_scenario(s, log_dir))
+    print('')
+    print(render_table(report))
+    if not report.ok:
+        print('')
+        print(render_failures(report))
+    with open(os.path.join(log_dir, 'results.json'), 'w') as fh:
+        json.dump(report.as_dict(), fh, indent=2)
+    print('results: %s' % os.path.join(log_dir, 'results.json'))
+    return report.exit_code
+
+
+def cmd_resolve(args):
+    print(export_env(Manifest.load().resolve(args.scenario)))
+    return 0
+
+
+def cmd_check_rom(args):
+    m = Manifest.load()
+    problem = check_rom(m, m.resolve(args.scenario))
+    if problem:
+        print('matrix: %s' % problem, file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_list(args):
+    m = Manifest.load()
+    if args.suites:
+        for name in sorted(m.suites):
+            print('%-10s %s' % (name, ' '.join(m.suites[name])))
+        return 0
+    for name in m.scenarios:
+        s = m.resolve(name)
+        print('%-20s %-10s host=%-4s %-10s %s'
+              % (name, s.rom, s.host_chapter, s.kind, s.checkpoint or ''))
+    return 0
+
+
+def main(argv=None):
+    # A matrix run is tens of minutes of builds and emulator time. Line-buffer so
+    # `make matrix > log` shows progress as it happens instead of dumping at the end.
+    try:
+        sys.stdout.reconfigure(line_buffering=True)
+    except AttributeError:      # pragma: no cover -- python < 3.7
+        pass
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest='cmd')
+
+    run = sub.add_parser('run', help='build each ROM config once, run its scenarios')
+    run.add_argument('--suite')
+    run.add_argument('--scenarios')
+    run.add_argument('--all', action='store_true', help='every non-manual verdict scenario')
+    run.add_argument('--rom', help='force one ROM config (needed for chapter-generic scenarios)')
+    run.add_argument('--out', default='/tmp/playtest-matrix')
+    run.add_argument('--dry-run', action='store_true')
+    run.set_defaults(fn=cmd_run)
+
+    res = sub.add_parser('resolve', help='emit shell assignments for run.sh')
+    res.add_argument('scenario')
+    res.set_defaults(fn=cmd_resolve)
+
+    chk = sub.add_parser('check-rom', help='does the built ROM host this scenario?')
+    chk.add_argument('scenario')
+    chk.set_defaults(fn=cmd_check_rom)
+
+    lst = sub.add_parser('list', help='list scenarios (or --suites)')
+    lst.add_argument('--suites', action='store_true')
+    lst.set_defaults(fn=cmd_list)
+
+    args = ap.parse_args(argv)
+    if not getattr(args, 'fn', None):
+        ap.print_help()
+        return 2
+    try:
+        return args.fn(args)
+    except ManifestError as exc:
+        print('matrix: %s' % exc, file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -1,0 +1,354 @@
+# The playtest matrix manifest (#231) -- what every scenario in harness.lua needs.
+#
+# This is the SINGLE SOURCE of the scenario -> ROM-configuration / host-chapter /
+# checkpoint / timing table. Both consumers read it:
+#   * tools/playtest/run.sh          (one scenario, via `matrix.py resolve`)
+#   * tools/playtest/matrix.py run   (the grouped matrix)
+# `check.py check_playtest_matrix` proves it still describes harness.lua, so a new
+# scenario without a row here is a drift failure, not a silent default.
+#
+# Resolution order:  defaults  <  classes (in order, key by key)  <  the scenario's row.
+# That is a direct port of run.sh's `case "$SCENARIO"` statements, including the fact
+# that a later case only overrides the keys it names.
+
+defaults:
+  rom: canonical        # a key in rom_configs, or `any` for chapter-generic scenarios
+  host_chapter: 1       # PT_HOST_CHAPTER; run.sh's historical default
+  fps: 240              # top speed
+  vsync: 0
+  deadline: 420         # seconds before run.sh calls the run timed-out
+  kind: verdict         # verdict | record | checkpoint | diagnostic
+  manual: false         # true = never auto-selected (needs a human or a sidecar)
+
+# Checkpoint builders always ran at 240fps with a long deadline: ckpt_ch02start
+# replays the entire ch00 -> ch01 -> ch02 chain to mint one save state.
+checkpoint_deadline: 900
+
+# The ROM configurations, in the order the matrix builds them. Canonical first: it is
+# the cheapest to be wrong about and the one most scenarios share.
+rom_configs:
+  canonical: {}
+  testch:
+    TESTCH: 1
+  lordboot:
+    LORDBOOT: 1
+  montage:
+    MONTAGE: 1
+  ch03boot:
+    CH03BOOT: 1
+  ch04boot:
+    CH04BOOT: 1
+
+# Ported verbatim from run.sh's two timing `case` statements.
+classes:
+  - match: "record*"          # faithful motion for a review GIF
+    fps: 60
+    vsync: 1
+    deadline: 300
+  - match: "smoke*"           # a full chapter's lead-in plus a long soak
+    deadline: 600
+  - match: "fuzz*"
+    deadline: 600
+  - match: "clear_ch02"
+    deadline: 600
+  - match: "clear_ch03"
+    deadline: 600
+  - match: "recordch02ending" # routs the whole band before it films
+    deadline: 600
+  - match: "llm"              # 18 turns x a 90s sidecar handshake budget
+    deadline: 2100
+  - match: "ckpt_*"           # the auto-build path always used 240fps / 900s
+    kind: checkpoint
+    deadline: 900
+
+# Rows carry only what differs from the resolved defaults.
+scenarios:
+  controller_turn: {}                                  # the #220 controller contract
+  smoke: {}
+  win: {}
+  goodberry: {}
+  ch01: {}
+  smoke_ch01: {}
+  clearprobe: {}
+  clear: {}
+  clear_ch01: {}
+  fuzz: {}
+  fuzz_ch01: {}
+  llm:                                                 # needs the external sidecar
+    manual: true
+  ch01win: {}
+  ckpt_prep: {}
+  ckpt_lordpinky: {}
+  lordfloor: {}
+  ckpt_seize: {}
+  recordprep:
+    kind: record
+    checkpoint: prep
+  recordsupply:                                        # asserts bench/deploy/count/Supply
+    checkpoint: lordpinky
+  recordrescue:
+    kind: record
+    checkpoint: prep
+  recordtrade:
+    kind: record
+    checkpoint: prep
+  recordfix:
+    kind: record
+    checkpoint: prep
+  recordending:
+    kind: record
+    checkpoint: seize
+  recordch01trail:
+    kind: record
+  recordlord:
+    kind: record
+  recordlordfast:
+    rom: lordboot
+    kind: record
+  ch01lord: {}
+  scenesch01:
+    kind: record
+  recordch01:
+    kind: record
+  scenes:
+    kind: record
+  record:
+    kind: record
+  bootobserve:
+    kind: diagnostic
+  mapshot:                                             # "any hosted chapter" by design
+    rom: any
+    host_chapter: null
+    kind: diagnostic
+  mapfull:
+    rom: ch03boot
+    host_chapter: 4
+    kind: record
+  recordopening:
+    rom: montage
+    kind: record
+  titlecard: {}
+  gameover: {}
+  retreat: {}
+  ckpt_rbgch01: {}
+  recordrbg:
+    kind: record
+    checkpoint: rbgch01
+  recordanim:
+    rom: testch
+    kind: record
+  recordrbgtest:                                       # back-compat alias of recordanim
+    rom: testch
+    kind: record
+  recordenemy:
+    rom: testch
+    kind: record
+  recordunitlist:                                      # FAILs if the SMS counters cross
+    rom: testch
+  ckpt_ch02start: {}
+  ch03win:
+    rom: ch03boot
+    host_chapter: 4
+  ch03midmap:
+    rom: ch03boot
+    host_chapter: 4
+  ch03talk:
+    rom: ch03boot
+    host_chapter: 4
+  ch03prep:
+    rom: ch03boot
+    host_chapter: 4
+  ch03door:
+    rom: ch03boot
+    host_chapter: 4
+  ch03chest:
+    rom: ch03boot
+    host_chapter: 4
+  ch03tourmaline:
+    rom: ch03boot
+    host_chapter: 4
+  koboldview:                                          # #23 art-review probe
+    rom: ch03boot
+    host_chapter: 4
+    kind: diagnostic
+  lzview:
+    rom: ch03boot
+    host_chapter: 4
+    kind: diagnostic
+  enemycheck:
+    rom: ch03boot
+    host_chapter: 4
+    kind: diagnostic
+  ch03:
+    rom: ch03boot
+    host_chapter: 4
+  smoke_ch03:
+    rom: ch03boot
+    host_chapter: 4
+  smoke_ch04:
+    rom: ch04boot
+    host_chapter: 5
+  clear_ch03:
+    rom: ch03boot
+    host_chapter: 4
+  ch02:
+    checkpoint: ch02start
+  smoke_ch02:
+    checkpoint: ch02start
+  ch02baxby:
+    checkpoint: ch02start
+  clear_ch02:
+    checkpoint: ch02start
+  recordchain:
+    kind: record
+    checkpoint: ch02start
+  ckpt_ch02intro: {}
+  recordscene:                                         # PT_STATE names the checkpoint
+    kind: record
+    checkpoint: dynamic
+  recordch02intro:
+    kind: record
+    checkpoint: ch02intro
+  recordch03open:
+    rom: ch03boot
+    host_chapter: 4
+    kind: record
+  recordch04moose:
+    rom: ch04boot
+    host_chapter: 5
+    kind: record
+  ch04moose:
+    rom: ch04boot
+    host_chapter: 5
+  ch04sprites:
+    rom: ch04boot
+    host_chapter: 5
+    kind: diagnostic
+  recordch04parley:                                    # asserts the pack converts in place
+    rom: ch04boot
+    host_chapter: 5
+  ch04packmath:
+    rom: ch04boot
+    host_chapter: 5
+  ch04village:
+    rom: ch04boot
+    host_chapter: 5
+  ch04cottage:
+    rom: ch04boot
+    host_chapter: 5
+  recordch04cottage:
+    rom: ch04boot
+    host_chapter: 5
+    kind: record
+  ch04snag:
+    rom: ch04boot
+    host_chapter: 5
+  attackprobe:                                         # reads whatever map it lands on
+    rom: any
+    host_chapter: null
+    kind: diagnostic
+  clear_ch04:
+    rom: ch04boot
+    host_chapter: 5
+  clear_ch04_parley:
+    rom: ch04boot
+    host_chapter: 5
+  recordch04open:
+    rom: ch04boot
+    host_chapter: 5
+    kind: record
+  recordch04reveal:
+    rom: ch04boot
+    host_chapter: 5
+    kind: record
+  recordch03talk:
+    rom: ch03boot
+    host_chapter: 4
+    kind: record
+  recordch03win:
+    rom: ch03boot
+    host_chapter: 4
+    kind: record
+  recordch03midmap:
+    rom: ch03boot
+    host_chapter: 4
+    kind: record
+  recordch02map:
+    kind: record
+    checkpoint: ch02start
+  recordch02combat:
+    kind: record
+    checkpoint: ch02start
+  recordch02ending:
+    kind: record
+    checkpoint: ch02start
+
+# Named selections. `gate` is what must be green before a merge; the chapter suites are
+# what you run while working one chapter (each is a single ROM build). Everything else
+# is `--all` (every non-manual verdict scenario) or an explicit --scenarios list.
+suites:
+  # Deliberately tight: the controller contract, the ch00/ch01 spine, the SMS budget,
+  # and the current chapter. ch02/ch03 stay out because their checkpoints and routs
+  # cost more than a gate should -- run those with their chapter suite or --all.
+  gate:
+    - controller_turn
+    - win
+    - gameover
+    - retreat
+    - ch01
+    - ch01win
+    - lordfloor
+    - recordunitlist
+    - ch04moose
+    - ch04packmath
+    - ch04village
+    - ch04cottage
+    - ch04snag
+    - clear_ch04_parley
+
+  ch01:
+    - controller_turn
+    - win
+    - gameover
+    - retreat
+    - ch01
+    - ch01win
+    - ch01lord
+    - lordfloor
+    - clearprobe
+    - titlecard
+    - goodberry
+    - smoke_ch01
+    - clear_ch01
+
+  ch02:
+    - ch02
+    - ch02baxby
+    - smoke_ch02
+    - clear_ch02
+
+  ch03:
+    - ch03
+    - ch03prep
+    - ch03talk
+    - ch03door
+    - ch03chest
+    - ch03tourmaline
+    - ch03midmap
+    - ch03win
+    - smoke_ch03
+    - clear_ch03
+
+  ch04:
+    - ch04moose
+    - ch04packmath
+    - ch04village
+    - ch04cottage
+    - ch04snag
+    - recordch04parley
+    - smoke_ch04
+    - clear_ch04
+    - clear_ch04_parley
+
+  sandbox:
+    - recordunitlist

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
-# Run an automated playtest scenario in mGBA (headed, but fully scripted).
+# Run ONE automated playtest scenario in mGBA (headed, but fully scripted).
 #
 #   tools/playtest/run.sh <scenario> [--keep-open]
+#
+# For a GROUP of scenarios use the matrix runner instead -- it builds each ROM
+# configuration at most once and prints a verdict table:
+#
+#   make matrix                 # the merge gate
+#   make matrix SUITE=ch04      # every ch04 scenario, one build
+#   tools/playtest/matrix.py run --scenarios ch04moose,ch04snag
+#
+# WHAT A SCENARIO NEEDS -- its ROM configuration (`make` flag), its PT_HOST_CHAPTER,
+# its checkpoint, and its fps/vsync/deadline -- is declared in tools/playtest/matrix.yaml
+# and resolved here. So `run.sh ch04moose` sets PT_HOST_CHAPTER=5 by itself, and refuses
+# outright if the tree holds a ROM that cannot host it. Setting PT_HOST_CHAPTER or PT_FPS
+# by hand still overrides the manifest. The per-scenario notes below say what each one
+# PROVES; the flags they mention are documentation, not something you have to type.
 #
 # Logic scenarios (assert PASS/FAIL):  win | gameover | retreat | ch01win | titlecard
 #   also: ch01 (entry asserts) | ch01lord | lordfloor | goodberry | clearprobe
@@ -142,6 +156,20 @@ if [ ! -x "$APP" ]; then
 fi
 [ -f "$ROM" ] || { echo "ROM not built; run make first" >&2; exit 2; }
 
+# What this scenario needs -- ROM configuration, host chapter, checkpoint, fps/vsync/
+# deadline -- comes from tools/playtest/matrix.yaml, which is the single source of that
+# table (see matrix.py). run.sh owns "run ONE scenario in mGBA" and nothing else.
+MX_RESOLVED="$(python3 "$HERE/matrix.py" resolve "$SCENARIO")" || {
+    echo "run.sh: '$SCENARIO' has no row in tools/playtest/matrix.yaml" >&2; exit 2; }
+eval "$MX_RESOLVED"
+
+# The most expensive failure in this repo is a scenario that FAILs because the tree
+# holds the wrong ROM (a CH04BOOT=1 build cannot reach ch02's map). Refuse in 0s
+# instead of timing out in 7 minutes. MX_SKIP_ROM_CHECK=1 opts out.
+if [ -z "${MX_SKIP_ROM_CHECK:-}" ]; then
+    python3 "$HERE/matrix.py" check-rom "$SCENARIO" || exit 2
+fi
+
 python3 "$HERE/gen_symbols.py"
 pkill -9 -i mgba 2>/dev/null || true
 ROMHASH=$(shasum "$ROM" | cut -c1-12)
@@ -161,7 +189,7 @@ PLAYTEST_SHOTDIR = "$out"
 PLAYTEST_STATEDIR = "$STATE_DIR"
 PLAYTEST_SEED = "${PT_SEED:-1}"
 PLAYTEST_CHAR = "${PT_CHAR:-}"
-PLAYTEST_HOST_CHAPTER = ${PT_HOST_CHAPTER:-1}
+PLAYTEST_HOST_CHAPTER = ${PT_HOST_CHAPTER:-${MX_HOST_CHAPTER:-1}}
 PLAYTEST_LLMDIR = "$LLM_DIR"
 PLAYTEST_STATE = "${PT_STATE:-}"
 PLAYTEST_TAG = "${PT_TAG:-}"
@@ -194,30 +222,19 @@ EOF
     echo "artifacts: $out"
 }
 
-# Checkpoint dependency: a record scenario loads a save state built fast by a ckpt_*
-# scenario. Build it (240fps) if the state is missing or was made for a different ROM.
-BUILDER=""; CKPT=""
-case "$SCENARIO" in
-    recordending) BUILDER=ckpt_seize;     CKPT=seize ;;
-    recordprep)   BUILDER=ckpt_prep;      CKPT=prep ;;
-    recordsupply) BUILDER=ckpt_lordpinky; CKPT=lordpinky ;;
-    recordrescue) BUILDER=ckpt_prep;      CKPT=prep ;;
-    recordtrade)  BUILDER=ckpt_prep;      CKPT=prep ;;
-    recordfix)    BUILDER=ckpt_prep;      CKPT=prep ;;
-    recordrbg)    BUILDER=ckpt_rbgch01;   CKPT=rbgch01 ;;
-    # ch02 (#22) scenarios LOAD the ch02start state (the real ch00->ch01->ch02 chain, paid once).
-    ch02|smoke_ch02|clear_ch02|ch02baxby|recordch02map|recordch02combat|recordch02ending|recordchain) BUILDER=ckpt_ch02start; CKPT=ch02start ;;
-    # recordch02intro needs its OWN checkpoint (ckpt_ch02intro, harness.lua) saved just BEFORE the
-    # ch02 opening plays -- ckpt_ch02start is captured at turn 1, after the opening is already over.
-    recordch02intro) BUILDER=ckpt_ch02intro; CKPT=ch02intro ;;
-    # recordscene (generic cutscene recorder): PT_STATE names the checkpoint; its builder is
-    # ckpt_<PT_STATE> by convention (matches every ckpt_* above). e.g. PT_STATE=ch02intro.
-    recordscene) CKPT="${PT_STATE:?recordscene needs PT_STATE=<checkpoint> (e.g. PT_STATE=ch02intro)}"; BUILDER="ckpt_${PT_STATE}" ;;
-esac
+# Checkpoint dependency: a scenario may load a save state built fast by a ckpt_* scenario.
+# Build it (240fps) if the state is missing or was made for a different ROM. The
+# scenario -> checkpoint map lives in matrix.yaml; recordscene is the one dynamic case,
+# where PT_STATE names the checkpoint and its builder is ckpt_<PT_STATE> by convention.
+BUILDER="$MX_CHECKPOINT_BUILDER"; CKPT="$MX_CHECKPOINT"
+if [ -n "$MX_CHECKPOINT_DYNAMIC" ]; then
+    CKPT="${PT_STATE:?$SCENARIO needs PT_STATE=<checkpoint> (e.g. PT_STATE=ch02intro)}"
+    BUILDER="ckpt_${PT_STATE}"
+fi
 if [ -n "$BUILDER" ]; then
     if [ ! -f "$STATE_DIR/$CKPT.ss" ] || [ "$(cat "$STATE_DIR/$CKPT.romhash" 2>/dev/null || true)" != "$ROMHASH" ]; then
         echo "== checkpoint '$CKPT' missing/stale -> building at top speed (240fps) =="
-        run_mgba "$BUILDER" 240 0 900   # ch02start plays the whole ch00->ch01->ch02 chain
+        run_mgba "$BUILDER" 240 0 "$MX_CHECKPOINT_DEADLINE"  # ch02start plays the whole ch00->ch01->ch02 chain
         case "$VERDICT" in
             *PASS*) echo "$ROMHASH" > "$STATE_DIR/$CKPT.romhash" ;;
             *) echo "checkpoint build FAILED -- aborting"; exit 1 ;;
@@ -227,17 +244,9 @@ if [ -n "$BUILDER" ]; then
     fi
 fi
 
-# Main run: record* at 60fps (faithful motion); everything else at 240fps (top speed).
-# The checkpoint-backed record* scenarios (table above) skip the grind; the rest replay
-# their full lead-in and simply have to fit the record deadline.
-FPS=240; VSYNC=0; DEADLINE_S=420
-case "$SCENARIO" in record*) FPS=60; VSYNC=1; DEADLINE_S=300 ;; esac
-# smoke_* / fuzz_* / clear_ch02 play a full chapter (lead-in + a long soak) -> longer
-# wall. recordch02ending routs the whole band, so it needs the same headroom. llm waits
-# wall-clock on the sidecar EVERY turn (18 turns x 90s handshake budget), and a --record run
-# against a slow local model legitimately uses it -- so its deadline covers the harness's own
-# worst case instead of killing a healthy run.
-case "$SCENARIO" in smoke*|fuzz*|clear_ch02|clear_ch03|recordch02ending) DEADLINE_S=600 ;; llm) DEADLINE_S=2100 ;; esac
+# Rate + deadline also come from matrix.yaml (record* film at 60fps for faithful motion;
+# everything else runs at top speed; soaks and routs get a longer wall).
+FPS="$MX_FPS"; VSYNC="$MX_VSYNC"; DEADLINE_S="$MX_DEADLINE"
 # PT_FPS overrides the rate. 60fps+videoSync is only needed to capture smooth cutscene
 # FADES; verification captures of static text/boxes (sign, death quote) read fine at top
 # speed, so `PT_FPS=240 ... recordfix` runs ~4x faster.

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Tests for tools/playtest/matrix.py -- the #231 playtest matrix runner.
+
+Two layers:
+
+  * the PURE layer (resolution, selection, grouping, ordering, aggregation) is
+    tested against synthetic manifests with hand-written oracles, so a test never
+    builds a ROM or launches mGBA;
+  * the REAL-DATA layer asserts the shipped `matrix.yaml` still describes
+    `harness.lua` -- that is the drift guard `check.py` also runs.
+
+Run:
+
+    python3 tools/test_playtest_matrix.py
+"""
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, 'playtest'))
+import matrix as mx
+
+
+def manifest(**over):
+    """A small hand-written manifest; each test overrides just what it exercises."""
+    data = {
+        'defaults': {'rom': 'canonical', 'host_chapter': 1, 'fps': 240,
+                     'vsync': 0, 'deadline': 420, 'kind': 'verdict'},
+        'checkpoint_deadline': 900,
+        'rom_configs': {
+            'canonical': {},
+            'testch': {'TESTCH': 1},
+            'ch04boot': {'CH04BOOT': 1},
+        },
+        'classes': [],
+        'scenarios': {'win': {}},
+        'suites': {},
+    }
+    data.update(over)
+    return mx.Manifest(data)
+
+
+class Resolution(unittest.TestCase):
+    def test_bare_scenario_takes_every_default(self):
+        s = manifest().resolve('win')
+        self.assertEqual((s.rom, s.host_chapter, s.fps, s.vsync, s.deadline),
+                         ('canonical', 1, 240, 0, 420))
+        self.assertIsNone(s.checkpoint)
+
+    def test_scenario_entry_overrides_the_defaults(self):
+        m = manifest(scenarios={'ch04moose': {'rom': 'ch04boot', 'host_chapter': 5}})
+        s = m.resolve('ch04moose')
+        self.assertEqual(s.rom, 'ch04boot')
+        self.assertEqual(s.host_chapter, 5)
+
+    def test_class_rule_applies_by_glob(self):
+        # ports run.sh's `case "$SCENARIO" in record*) FPS=60; VSYNC=1; DEADLINE_S=300`
+        m = manifest(classes=[{'match': 'record*', 'fps': 60, 'vsync': 1, 'deadline': 300}],
+                     scenarios={'recordending': {}, 'win': {}})
+        self.assertEqual(m.resolve('recordending').fps, 60)
+        self.assertEqual(m.resolve('recordending').vsync, 1)
+        self.assertEqual(m.resolve('recordending').deadline, 300)
+        self.assertEqual(m.resolve('win').fps, 240)
+
+    def test_a_later_class_rule_wins_like_a_second_bash_case(self):
+        # run.sh sets record*=300s, then a SECOND case bumps recordch02ending to 600s.
+        m = manifest(classes=[{'match': 'record*', 'fps': 60, 'deadline': 300},
+                              {'match': 'recordch02ending', 'deadline': 600}],
+                     scenarios={'recordch02ending': {}})
+        s = m.resolve('recordch02ending')
+        self.assertEqual(s.deadline, 600)
+        self.assertEqual(s.fps, 60, 'the earlier rule still supplies what the later one omits')
+
+    def test_scenario_entry_beats_a_class_rule(self):
+        m = manifest(classes=[{'match': 'record*', 'deadline': 300}],
+                     scenarios={'recordslow': {'deadline': 999}})
+        self.assertEqual(m.resolve('recordslow').deadline, 999)
+
+    def test_unknown_scenario_is_an_error(self):
+        with self.assertRaises(mx.ManifestError):
+            manifest().resolve('nosuchscenario')
+
+    def test_unknown_rom_config_is_an_error(self):
+        m = manifest(scenarios={'win': {'rom': 'nosuchrom'}})
+        with self.assertRaises(mx.ManifestError):
+            m.resolve('win')
+
+    def test_checkpoint_implies_its_ckpt_builder_by_convention(self):
+        m = manifest(scenarios={'recordending': {'checkpoint': 'seize'}})
+        s = m.resolve('recordending')
+        self.assertEqual(s.checkpoint, 'seize')
+        self.assertEqual(s.checkpoint_builder, 'ckpt_seize')
+
+    def test_make_flags_render_from_the_rom_config(self):
+        m = manifest(scenarios={'ch04moose': {'rom': 'ch04boot'}})
+        self.assertEqual(m.resolve('ch04moose').make_flags, ['CH04BOOT=1'])
+        self.assertEqual(m.resolve_rom('canonical'), [])
+
+
+class Selection(unittest.TestCase):
+    def test_suite_expands_to_its_members(self):
+        m = manifest(scenarios={'a': {}, 'b': {}, 'c': {}},
+                     suites={'gate': ['a', 'c']})
+        self.assertEqual(m.select(suite='gate'), ['a', 'c'])
+
+    def test_explicit_scenarios_pass_through_in_order(self):
+        m = manifest(scenarios={'a': {}, 'b': {}})
+        self.assertEqual(m.select(scenarios=['b', 'a']), ['b', 'a'])
+
+    def test_all_selects_every_verdict_scenario_only(self):
+        m = manifest(scenarios={'a': {}, 'recordx': {'kind': 'record'},
+                                'ckpt_y': {'kind': 'checkpoint'},
+                                'probe': {'kind': 'diagnostic'}, 'b': {}})
+        self.assertEqual(m.select(all_verdicts=True), ['a', 'b'])
+
+    def test_unknown_suite_is_an_error(self):
+        with self.assertRaises(mx.ManifestError):
+            manifest().select(suite='nope')
+
+    def test_selecting_nothing_is_an_error(self):
+        with self.assertRaises(mx.ManifestError):
+            manifest().select()
+
+
+class Grouping(unittest.TestCase):
+    def test_each_rom_configuration_is_built_at_most_once(self):
+        m = manifest(scenarios={'a': {'rom': 'ch04boot'}, 'b': {}, 'c': {'rom': 'ch04boot'}})
+        groups = m.plan(['a', 'b', 'c'])
+        self.assertEqual([g.rom for g in groups], ['canonical', 'ch04boot'])
+        self.assertEqual(len(groups), 2, 'interleaved roms must still collapse to one build each')
+        self.assertEqual([s.name for s in groups[1].scenarios], ['a', 'c'])
+
+    def test_group_order_follows_the_rom_configs_declaration_order(self):
+        m = manifest(scenarios={'a': {'rom': 'ch04boot'}, 'b': {'rom': 'testch'}, 'c': {}})
+        self.assertEqual([g.rom for g in m.plan(['a', 'b', 'c'])],
+                         ['canonical', 'testch', 'ch04boot'])
+
+    def test_checkpointless_scenarios_run_before_checkpoint_backed_ones(self):
+        # a cheap failure must surface before a 15-minute ckpt_ch02start replay
+        m = manifest(scenarios={'heavy': {'checkpoint': 'ch02start'}, 'cheap': {}})
+        self.assertEqual([s.name for s in m.plan(['heavy', 'cheap'])[0].scenarios],
+                         ['cheap', 'heavy'])
+
+    def test_scenarios_sharing_a_checkpoint_are_contiguous(self):
+        m = manifest(scenarios={'p': {'checkpoint': 'prep'}, 's': {'checkpoint': 'seize'},
+                                'p2': {'checkpoint': 'prep'}})
+        order = [s.name for s in m.plan(['p', 's', 'p2'])[0].scenarios]
+        self.assertEqual(order, ['p', 'p2', 's'],
+                         'switching checkpoints back and forth re-earns nothing but costs a load')
+
+    def test_a_generic_scenario_needs_an_explicit_rom(self):
+        m = manifest(scenarios={'attackprobe': {'rom': 'any'}})
+        with self.assertRaises(mx.ManifestError):
+            m.plan(['attackprobe'])
+        groups = m.plan(['attackprobe'], rom='ch04boot')
+        self.assertEqual(groups[0].rom, 'ch04boot')
+
+    def test_an_explicit_rom_override_regroups_everything(self):
+        m = manifest(scenarios={'a': {'rom': 'canonical'}, 'b': {'rom': 'ch04boot'}})
+        groups = m.plan(['a', 'b'], rom='testch')
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].rom, 'testch')
+
+
+class Aggregation(unittest.TestCase):
+    def run_plan(self, m, names, verdicts, build_fails=()):
+        """Drive execute() with fakes: no make, no mGBA."""
+        self.built = []
+
+        def build(rom, flags):
+            self.built.append(rom)
+            return rom not in build_fails
+
+        def run_scenario(scn):
+            v = verdicts[scn.name]
+            return mx.Outcome(scenario=scn.name, rom=scn.rom, verdict=v, seconds=1.0,
+                              artifacts='/tmp/playtest-' + scn.name,
+                              log_tail='' if v == 'PASS' else 'boom')
+
+        return mx.execute(m.plan(names), build=build, run_scenario=run_scenario)
+
+    def test_all_pass_reports_ok_and_exit_zero(self):
+        m = manifest(scenarios={'a': {}, 'b': {}})
+        report = self.run_plan(m, ['a', 'b'], {'a': 'PASS', 'b': 'PASS'})
+        self.assertEqual(report.exit_code, 0)
+        self.assertTrue(report.ok)
+        self.assertEqual([o.verdict for o in report.outcomes], ['PASS', 'PASS'])
+
+    def test_one_failure_fails_the_whole_run(self):
+        m = manifest(scenarios={'a': {}, 'b': {}})
+        report = self.run_plan(m, ['a', 'b'], {'a': 'PASS', 'b': 'FAIL'})
+        self.assertEqual(report.exit_code, 1)
+        self.assertFalse(report.ok)
+        self.assertEqual([o.scenario for o in report.failures], ['b'])
+
+    def test_a_failing_scenario_does_not_stop_the_rest_of_the_matrix(self):
+        m = manifest(scenarios={'a': {}, 'b': {}, 'c': {}})
+        report = self.run_plan(m, ['a', 'b', 'c'], {'a': 'FAIL', 'b': 'PASS', 'c': 'PASS'})
+        self.assertEqual(len(report.outcomes), 3, 'the matrix reports every scenario, not the first')
+
+    def test_a_failed_build_blocks_only_its_own_group(self):
+        m = manifest(scenarios={'a': {}, 'b': {'rom': 'ch04boot'}})
+        report = self.run_plan(m, ['a', 'b'], {'a': 'PASS'}, build_fails={'ch04boot'})
+        self.assertEqual(report.exit_code, 1)
+        by_name = {o.scenario: o.verdict for o in report.outcomes}
+        self.assertEqual(by_name['a'], 'PASS')
+        self.assertEqual(by_name['b'], 'BLOCKED')
+
+    def test_each_rom_is_built_exactly_once_during_execution(self):
+        m = manifest(scenarios={'a': {'rom': 'ch04boot'}, 'b': {}, 'c': {'rom': 'ch04boot'}})
+        self.run_plan(m, ['a', 'b', 'c'], {'a': 'PASS', 'b': 'PASS', 'c': 'PASS'})
+        self.assertEqual(self.built, ['canonical', 'ch04boot'])
+        self.assertEqual(len(self.built), len(set(self.built)))
+
+    def test_duplicate_build_count_is_reported_for_the_222_metric(self):
+        m = manifest(scenarios={'a': {'rom': 'ch04boot'}, 'b': {}, 'c': {'rom': 'ch04boot'}})
+        report = self.run_plan(m, ['a', 'b', 'c'], {'a': 'PASS', 'b': 'PASS', 'c': 'PASS'})
+        self.assertEqual(report.duplicate_builds, 0)
+        self.assertEqual(report.builds, 2)
+
+
+class TableRendering(unittest.TestCase):
+    def outcome(self, name, verdict, seconds=61.0, rom='canonical'):
+        return mx.Outcome(scenario=name, rom=rom, verdict=verdict, seconds=seconds,
+                          artifacts='/tmp/playtest-' + name, log_tail='tail here')
+
+    def test_success_table_is_one_line_per_scenario(self):
+        report = mx.Report([self.outcome('a', 'PASS'), self.outcome('b', 'PASS')],
+                           builds=1, duplicate_builds=0, seconds=122.0)
+        body = mx.render_table(report)
+        self.assertEqual(len([l for l in body.splitlines() if 'PASS' in l]), 2)
+        self.assertIn('1m01s', body, 'durations read as human time, not raw seconds')
+
+    def test_failure_output_names_the_artifact_and_the_tail(self):
+        report = mx.Report([self.outcome('a', 'PASS'), self.outcome('b', 'FAIL')],
+                           builds=1, duplicate_builds=0, seconds=10.0)
+        body = mx.render_failures(report)
+        self.assertIn('/tmp/playtest-b', body)
+        self.assertIn('tail here', body)
+        self.assertNotIn('/tmp/playtest-a', body, 'passing scenarios stay quiet')
+
+    def test_duration_formatting(self):
+        self.assertEqual(mx.human_duration(9), '9s')
+        self.assertEqual(mx.human_duration(61), '1m01s')
+        self.assertEqual(mx.human_duration(3725), '1h02m05s')
+
+
+class ShellEnvExport(unittest.TestCase):
+    """`run.sh` consumes matrix.py resolve -- so the export must be eval-safe."""
+
+    def test_export_emits_assignments_run_sh_can_eval(self):
+        m = manifest(scenarios={'ch04moose': {'rom': 'ch04boot', 'host_chapter': 5}})
+        env = dict(line.split('=', 1) for line in
+                   mx.export_env(m.resolve('ch04moose')).splitlines())
+        self.assertEqual(env['MX_HOST_CHAPTER'], "'5'")
+        self.assertEqual(env['MX_FPS'], "'240'")
+        self.assertEqual(env['MX_ROM'], "'ch04boot'")
+        self.assertEqual(env['MX_MAKE_FLAGS'], "'CH04BOOT=1'")
+
+    def test_absent_checkpoint_exports_empty_not_the_word_none(self):
+        env = dict(line.split('=', 1) for line in
+                   mx.export_env(manifest().resolve('win')).splitlines())
+        self.assertEqual(env['MX_CHECKPOINT'], "''")
+        self.assertEqual(env['MX_CHECKPOINT_BUILDER'], "''")
+
+    def test_every_exported_value_is_single_quoted(self):
+        for line in mx.export_env(manifest().resolve('win')).splitlines():
+            _, value = line.split('=', 1)
+            self.assertTrue(value.startswith("'") and value.endswith("'"), line)
+
+
+class VerdictParsing(unittest.TestCase):
+    """Regression: the first live matrix run reported every scenario FAIL because the
+    parser looked for a line STARTING with RESULT:. The harness stamps a frame counter
+    on every line, so it never does."""
+
+    REAL_PASS = ("wrote tools/playtest/symbols.lua (77 symbols)\n"
+                 "running 'controller_turn' (pid 34280, 240fps)\n"
+                 "----------------------------------------\n"
+                 "[f000092] scenario: controller_turn\n"
+                 "[f007234] RESULT: PASS -- no-prep boot -> move -> semantic Wait\n"
+                 "artifacts: /tmp/playtest-controller_turn")
+    REAL_FAIL = ("[f000092] scenario: ch04snag\n"
+                 "[f004660] RESULT: FAIL -- the snag broke but (4,9) is terrain 0x10\n"
+                 "artifacts: /tmp/playtest-ch04snag")
+
+    def test_frame_stamped_pass_is_read_as_pass(self):
+        self.assertEqual(mx.parse_verdict(self.REAL_PASS, 0), 'PASS')
+
+    def test_frame_stamped_fail_is_read_as_fail(self):
+        self.assertEqual(mx.parse_verdict(self.REAL_FAIL, 1), 'FAIL')
+
+    def test_the_word_pass_elsewhere_in_the_line_does_not_count(self):
+        text = '[f001] RESULT: FAIL -- the PASS condition never held\n'
+        self.assertEqual(mx.parse_verdict(text, 1), 'FAIL')
+
+    def test_the_last_result_line_wins(self):
+        # run.sh cats the log and then echoes the verdict again
+        text = '[f001] RESULT: FAIL -- first try\n[f002] RESULT: PASS -- retried\n'
+        self.assertEqual(mx.parse_verdict(text, 0), 'PASS')
+
+    def test_no_verdict_at_all_is_an_error_not_a_failure(self):
+        self.assertEqual(mx.parse_verdict('mGBA exited early\n', 1), 'ERROR')
+
+    def test_a_pass_line_with_a_nonzero_exit_is_not_trusted(self):
+        self.assertEqual(mx.parse_verdict(self.REAL_PASS, 1), 'FAIL')
+
+
+class WrongRomGuard(unittest.TestCase):
+    """build_campaign stamps which flags built the ROM; a scenario bound to a different
+    configuration must be refused in 0s rather than time out in mGBA."""
+
+    def stamp(self, **flags):
+        import json
+        import tempfile
+        path = os.path.join(tempfile.mkdtemp(), 'build-config.json')
+        with open(path, 'w') as fh:
+            json.dump({'campaign': 'x', 'flags': flags}, fh)
+        return path
+
+    def test_names_the_configuration_in_the_tree(self):
+        m = manifest()
+        path = self.stamp(TESTCH=False, CH04BOOT=True)
+        self.assertEqual(mx.built_rom_config(m.rom_configs, path), 'ch04boot')
+
+    def test_no_flags_set_is_the_canonical_build(self):
+        m = manifest()
+        path = self.stamp(TESTCH=False, CH04BOOT=False)
+        self.assertEqual(mx.built_rom_config(m.rom_configs, path), 'canonical',
+                         'canonical must not match every build just because it has no flags')
+
+    def test_a_missing_stamp_is_unknown_not_canonical(self):
+        self.assertIsNone(mx.built_rom_config(manifest().rom_configs, '/nonexistent/stamp'))
+
+    def test_matching_rom_is_allowed(self):
+        m = manifest(scenarios={'ch04moose': {'rom': 'ch04boot'}})
+        path = self.stamp(CH04BOOT=True)
+        self.assertIsNone(mx.check_rom(m, m.resolve('ch04moose'), path))
+
+    def test_mismatched_rom_is_refused_and_says_how_to_fix_it(self):
+        m = manifest(scenarios={'ch04moose': {'rom': 'ch04boot'}})
+        problem = mx.check_rom(m, m.resolve('ch04moose'), self.stamp(TESTCH=True))
+        self.assertIsNotNone(problem)
+        self.assertIn('CH04BOOT=1', problem)
+        self.assertIn('testch', problem)
+
+    def test_an_unknown_stamp_does_not_block_the_run(self):
+        m = manifest(scenarios={'ch04moose': {'rom': 'ch04boot'}})
+        self.assertIsNone(mx.check_rom(m, m.resolve('ch04moose'), '/nonexistent/stamp'))
+
+    def test_a_chapter_generic_scenario_is_never_refused(self):
+        m = manifest(scenarios={'attackprobe': {'rom': 'any'}})
+        self.assertIsNone(mx.check_rom(m, m.resolve('attackprobe'), self.stamp(TESTCH=True)))
+
+
+class RealManifest(unittest.TestCase):
+    """The drift guard: matrix.yaml must still describe harness.lua."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.m = mx.Manifest.load()
+        cls.harness = mx.harness_scenarios()
+
+    def test_every_harness_scenario_has_a_manifest_row(self):
+        missing = sorted(self.harness - set(self.m.scenarios))
+        self.assertEqual(missing, [], 'new scenarios in harness.lua need a matrix.yaml row')
+
+    def test_every_manifest_row_still_exists_in_harness(self):
+        stale = sorted(set(self.m.scenarios) - self.harness)
+        self.assertEqual(stale, [], 'matrix.yaml rows for scenarios harness.lua no longer defines')
+
+    def test_every_scenario_resolves(self):
+        for name in self.m.scenarios:
+            self.m.resolve(name)
+
+    def test_every_suite_member_exists_and_is_runnable(self):
+        for suite, members in self.m.suites.items():
+            self.assertTrue(members, 'suite %s is empty' % suite)
+            for name in members:
+                s = self.m.resolve(name)   # raises if unknown
+                self.assertNotEqual(s.kind, 'checkpoint',
+                                    '%s: %s is a checkpoint builder, not a scenario' % (suite, name))
+                self.assertNotEqual(s.rom, 'any',
+                                    '%s: %s is chapter-generic and needs an explicit rom' % (suite, name))
+
+    def test_the_gate_suite_exists_and_spans_more_than_one_rom(self):
+        gate = self.m.select(suite='gate')
+        roms = {self.m.resolve(n).rom for n in gate}
+        self.assertGreater(len(roms), 1, 'a single-ROM gate would not exercise the grouping')
+
+    def test_the_gate_suite_plans_one_build_per_rom(self):
+        groups = self.m.plan(self.m.select(suite='gate'))
+        roms = [g.rom for g in groups]
+        self.assertEqual(len(roms), len(set(roms)))
+
+    def test_checkpoint_builders_are_all_marked_as_such(self):
+        for name in self.m.scenarios:
+            if name.startswith('ckpt_'):
+                self.assertEqual(self.m.resolve(name).kind, 'checkpoint', name)
+
+    def test_every_referenced_checkpoint_has_a_builder_scenario(self):
+        for name in self.m.scenarios:
+            s = self.m.resolve(name)
+            if s.checkpoint and not s.dynamic_checkpoint:
+                self.assertIn(s.checkpoint_builder, self.m.scenarios,
+                              '%s wants checkpoint %s but ckpt_%s is not a scenario'
+                              % (name, s.checkpoint, s.checkpoint))
+
+    def test_a_checkpoint_and_its_builder_share_a_rom_configuration(self):
+        # a builder run under a different flag would produce a state the consumer
+        # then discards as ROM-hash-stale -- an invisible double cost
+        for name in self.m.scenarios:
+            s = self.m.resolve(name)
+            if s.checkpoint and not s.dynamic_checkpoint:
+                b = self.m.resolve(s.checkpoint_builder)
+                self.assertEqual(b.rom, s.rom, '%s vs %s' % (name, s.checkpoint_builder))
+
+    def test_the_ch04_scenarios_carry_the_flag_and_host_the_comments_document(self):
+        for name in ('ch04moose', 'ch04packmath', 'ch04village', 'ch04cottage',
+                     'ch04snag', 'clear_ch04', 'clear_ch04_parley', 'smoke_ch04'):
+            s = self.m.resolve(name)
+            self.assertEqual(s.rom, 'ch04boot', name)
+            self.assertEqual(s.host_chapter, 5, name)
+
+    def test_the_ch03_scenarios_carry_the_flag_and_host_the_comments_document(self):
+        for name in ('ch03', 'ch03win', 'ch03talk', 'ch03door', 'ch03chest',
+                     'ch03prep', 'ch03midmap', 'ch03tourmaline', 'smoke_ch03', 'clear_ch03'):
+            s = self.m.resolve(name)
+            self.assertEqual(s.rom, 'ch03boot', name)
+            self.assertEqual(s.host_chapter, 4, name)
+
+    def test_the_sandbox_scenarios_need_the_testch_rom(self):
+        for name in ('recordanim', 'recordrbgtest', 'recordenemy', 'recordunitlist'):
+            self.assertEqual(self.m.resolve(name).rom, 'testch', name)
+
+    def test_run_sh_checkpoint_map_survived_the_port(self):
+        # the exact table run.sh used to own, asserted row by row
+        expected = {'recordending': 'seize', 'recordprep': 'prep', 'recordsupply': 'lordpinky',
+                    'recordrescue': 'prep', 'recordtrade': 'prep', 'recordfix': 'prep',
+                    'recordrbg': 'rbgch01', 'ch02': 'ch02start', 'smoke_ch02': 'ch02start',
+                    'clear_ch02': 'ch02start', 'ch02baxby': 'ch02start',
+                    'recordch02map': 'ch02start', 'recordch02combat': 'ch02start',
+                    'recordch02ending': 'ch02start', 'recordchain': 'ch02start',
+                    'recordch02intro': 'ch02intro'}
+        for name, ckpt in expected.items():
+            self.assertEqual(self.m.resolve(name).checkpoint, ckpt, name)
+
+    def test_run_sh_timing_policy_survived_the_port(self):
+        # record* -> 60fps/vsync/300s; smoke*|fuzz*|clear_ch02|clear_ch03|recordch02ending -> 600s
+        self.assertEqual(self.m.resolve('recordending').fps, 60)
+        self.assertEqual(self.m.resolve('recordending').vsync, 1)
+        self.assertEqual(self.m.resolve('recordending').deadline, 300)
+        self.assertEqual(self.m.resolve('win').fps, 240)
+        self.assertEqual(self.m.resolve('win').deadline, 420)
+        for name in ('smoke', 'smoke_ch02', 'fuzz', 'clear_ch02', 'clear_ch03'):
+            self.assertEqual(self.m.resolve(name).deadline, 600, name)
+        self.assertEqual(self.m.resolve('recordch02ending').deadline, 600)
+        self.assertEqual(self.m.resolve('recordch02ending').fps, 60)
+        self.assertEqual(self.m.resolve('llm').deadline, 2100)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #231 — #222 workstream 1. Workstreams 2–4 stay deferred and get re-scoped from the ch05 build experience, as agreed.

## The problem

"Which ROM does `ch04moose` need, and which slot hosts it" had no single answer. The flag and host chapter existed only in `harness.lua`'s per-scenario `Run:` comments; the checkpoint map and the fps/deadline policy lived in two bash `case` blocks in `run.sh`; nothing connected them. The operator carried the table in their head — which is exactly why *"a failing playtest may be the WRONG ROM"* has been the standing top gotcha in HANDOFF.

## What this does

**`tools/playtest/matrix.yaml` is that table now** — all 88 scenarios, defaults and all, so a missing row is a `check.py` drift failure rather than a silent `canonical`/host-1 default that fails later inside the emulator. Resolution is `defaults < class rules (in order) < the scenario's row`, a key-for-key port of `run.sh`'s `case` semantics including that a later rule overrides only what it names.

**`run.sh` resolves through it** and keeps only its real job — run ONE scenario in mGBA. Both `case` blocks are gone. Practical effect: `tools/playtest/run.sh ch04moose` sets `PT_HOST_CHAPTER=5` by itself, and `PT_HOST_CHAPTER`/`PT_FPS` still override by hand.

**`matrix.py run`** groups a selection by ROM configuration, builds each **at most once**, runs sequentially, prints `variant | scenario | verdict | time | artifacts`, and drops `results.json` beside the artifacts.

```
make matrix                 # SUITE=gate, the merge gate
make matrix SUITE=ch04      # every ch04 scenario off one CH04BOOT=1 build
make matrix SUITE=all       # every non-manual verdict scenario
```

**Ordering is about checkpoints, not builds.** Save states are ROM-hash-stamped, so switching configuration invalidates *all* of them, and `ckpt_ch02start` replays the whole ch00→ch01→ch02 chain to rebuild one. Inside a group, checkpointless scenarios run first (a cheap failure surfaces before a long checkpoint build) and checkpoint-sharing scenarios stay contiguous. The lint pins a checkpoint and its `ckpt_*` builder to the same configuration — a mismatch is an invisible double cost, since the consumer discards the state as hash-stale.

**`build_campaign.py` stamps `.build-config.json`** (gitignored) with the boot flags that produced the ROM in the tree, because nothing in the `.gba` says how it was built. `run.sh` refuses a wrong-ROM run in 0s with the exact `make` line instead of letting mGBA time out for seven minutes. An unrecognised or missing stamp stays out of the way rather than blocking a run.

## Verification

`make matrix SUITE=gate`, live on this tree:

```
variant    scenario           verdict  time  artifacts
---------  -----------------  -------  ----  -------------------------------
canonical  controller_turn    PASS     10s   /tmp/playtest-controller_turn
canonical  win                FAIL     7s    /tmp/playtest-win
canonical  gameover           PASS     10s   /tmp/playtest-gameover
canonical  retreat            PASS     10s   /tmp/playtest-retreat
canonical  ch01               FAIL     7s    /tmp/playtest-ch01
canonical  ch01win            FAIL     7s    /tmp/playtest-ch01win
canonical  lordfloor          FAIL     7s    /tmp/playtest-lordfloor
testch     recordunitlist     PASS     34s   /tmp/playtest-recordunitlist
ch04boot   ch04moose          PASS     10s   /tmp/playtest-ch04moose
ch04boot   ch04packmath       FAIL     13s   /tmp/playtest-ch04packmath
ch04boot   ch04village        PASS     7s    /tmp/playtest-ch04village
ch04boot   ch04cottage        PASS     7s    /tmp/playtest-ch04cottage
ch04boot   ch04snag           FAIL     7s    /tmp/playtest-ch04snag
ch04boot   clear_ch04_parley  FAIL     22s   /tmp/playtest-clear_ch04_parley

14 scenario(s), 3 build(s), 0 duplicate build(s), 3m16s wall
```

**Those 7 failures are pre-existing on `main`, not from this PR** — verified by re-running `ch04snag` through `main`'s own `run.sh` against the identical `CH04BOOT=1` ROM: byte-identical failure. Nothing here touches `harness.lua` or `controller.lua`. Filed with evidence as **#232**; five of the seven are a single defect (the #220 controller's `confirm_target` postcondition), which will hit ch05 the same way since it is the shared attack path.

Also green: 59 new unit tests in `tools/test_playtest_matrix.py` (grouping, ordering, verdict aggregation, the wrong-ROM guard, manifest↔harness completeness), all 28 `tools/test_*.py` files, `make check` = `drift check: clean`, `git diff --check` clean. The new lint was verified to have teeth by perturbing the manifest — it caught a dropped row and a broken suite reference.

## One bug found and fixed in flight

The first live run scored **every** scenario FAIL. The runner read verdicts with `line.startswith('RESULT:')`, but the harness frame-stamps every line (`[f007234] RESULT: PASS -- ...`). `parse_verdict` is now a pure function with the real output shape as a regression fixture, and it corroborates against `run.sh`'s exit status.

## Follow-ups deliberately not in scope

- **#232** — the gate failures above.
- Adding a `ch05boot` row + suite is now step 11 of `docs/adding-a-chapter.md`.
- `HANDOFF.md` is untouched (it is `main`-only, per `check_handoff_only_on_main`); it wants a refresh after merge, since its Quick-commands block still types `PT_HOST_CHAPTER=5` by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
