### PR TITLE
Repair the playtest waits the #220 rewrite left broken: gate 7/14 -> 13/14 (#232)

### DIFF
--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -248,6 +248,10 @@ function M.legalActions(observation)
         end
     elseif state == "target_selection" then
         add(actions, "confirm_target", "A", "target.currentTarget", observation.target.uid)
+        -- B backs out of target selection to the command menu. Enumerating it is what
+        -- lets a driver RECOVER from a selector it cannot commit instead of wedging
+        -- there for the rest of the run (#232).
+        add(actions, "cancel_target", "B", "target.selection")
     elseif state == "player_map_idle" then
         addCursorActions(actions, observation.cursor)
         if observation.cursor then

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -65,6 +65,10 @@ WANTED = [
     'GameIntroHealthSafetyWaitButton', # exact health/safety input wait
     'Title_IDLE',               # exact title-screen input callback
     'ProcScr_SaveMenu',         # save/New Game menu
+    # The BETWEEN-CHAPTERS save prompt is a SECOND proc script (savemenu.c) sharing the
+    # same slot-select callback. Watching only ProcScr_SaveMenu left it unclassified, so
+    # the ch00 -> ch01 flow parked on it forever (#232).
+    'gProcScr_SaveMenuPostChapter',
     'SameMenu_CtrlLoop',        # exact save-menu input callback
     'SaveMenu_SaveSlotSelectLoop', # exact New Game save-slot input callback
     'ProcScr_NewGameDifficultySelect', # New Game difficulty menu

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -31,10 +31,26 @@ local Recorder = dofile(PLAYTEST_DIR .. "/recorder.lua")
 --   src/proc.c sProcArray: 64 procs x 0x6C; +0x00 = proc_script
 local UNIT_SIZE = 0x48
 local US_DEAD = 4 -- include/bmunit.h (1 << 2)
--- How long one attack may take before the combat wait gives up. Measured: an UNSKIPPED
--- ch00 boss animation is 1238 frames, and vanilla's worst cases (crit, a double, a
--- level-up, a promotion) run well past that -- see chooseAttack (#232).
-local COMBAT_WAIT_FRAMES = 3600
+-- Harness tuning, in ONE table rather than one local apiece: harness.lua is a single Lua
+-- chunk and its main function sits near Lua's 200-local ceiling, so a handful of new
+-- top-level locals stops the WHOLE FILE loading and every scenario dies at once (#232).
+local TUNE = {
+    -- How many times one guarded input may be re-pressed into an unchanged, still-legal
+    -- state before failing closed. FE8 drops input during window fade-ins, so a single
+    -- press can be lost outright -- see guardedInput.
+    inputAttempts = 3,
+    -- Frames a RETRY waits. Only ever reached after the caller's own budget has already
+    -- elapsed, so this lengthens failures -- it never shortens a success.
+    retrySettle = 60,
+    -- How long one attack may take before the combat wait gives up. Measured: an
+    -- UNSKIPPED ch00 boss animation is 1238 frames, and vanilla's worst cases (crit, a
+    -- double, a level-up, a promotion) run well past that -- see chooseAttack.
+    combatFrames = 3600,
+    -- How many times a wait may back out of an unwanted screen before failing closed.
+    stuckRecoveries = 2,
+    -- A save slot takes TWO confirms; the prompt must be gone within this allowance.
+    saveConfirms = 4,
+}
 local CHAR_HLIN, CHAR_SCRAMSAX, CHAR_SEPHEK = 0x0D, 0x11, 0x68 -- NATASHA/KYLE/ONEILL slots
 -- prologue/sandbox host on chapter slot 1; a chapter load-test (e.g. --ch03-boot on slot 4)
 -- overrides via PT_HOST_CHAPTER so bootToMap/inChapter recognize the right slot.
@@ -582,14 +598,37 @@ guardedInput = function(intention, key, expected, predicate, frames)
         shot("controller-illegal-input")
         return false
     end
-    press(K[key], 3)
-    local after = observeController()
-    local passed = predicate(after, before)
-    for _ = 1, (frames or 60) do
-        if passed then break end
-        yield()
+    -- FE8 drops input while a window is still animating in -- a battle forecast, a menu
+    -- fading up. A single press that lands in that window is simply LOST, and the wait
+    -- then burns its whole budget on a state nothing will ever move (#232: attacks that
+    -- never committed, and the run wedged in target_selection from then on). So re-press,
+    -- but only while this is still the SAME state offering the SAME legal action -- every
+    -- attempt is re-observed and re-authorised, and the postcondition is unchanged. That
+    -- is a bounded retry of one verified input, not the blind cadence #220 retired.
+    -- The FIRST attempt keeps the caller's whole budget, so every input that already
+    -- worked behaves exactly as before; a retry only happens where the old code had
+    -- already failed. (Getting this wrong -- splitting the budget across attempts -- made
+    -- the first press give up early and fire a second real action, which walked Marty off
+    -- his parley tile and broke ch04packmath.)
+    local budget = frames or 60
+    local after, passed = before, false
+    for attempt = 1, TUNE.inputAttempts do
+        press(K[key], 3)
         after = observeController()
         passed = predicate(after, before)
+        for _ = 1, (attempt == 1 and budget or TUNE.retrySettle) do
+            if passed then break end
+            yield()
+            after = observeController()
+            passed = predicate(after, before)
+        end
+        if passed or attempt == TUNE.inputAttempts then break end
+        -- Only retry into an unchanged, still-legal state; anything else means the input
+        -- DID land and the postcondition is simply wrong, which must stay a failure.
+        local now = observeController()
+        local nowActions = Controller.legalActions(now)
+        if controllerState(now) ~= controllerState(before) then break end
+        if not (nowActions and Controller.findAction(nowActions, intention)) then break end
     end
     traceInput(before, actions, intention, key, expected, passed and "pass" or "fail:postcondition", after)
     if not passed then shot("controller-postcondition") end
@@ -669,7 +708,7 @@ end
 local STALL_CEILING = 40
 local function awaitControllerState(want, frames)
     local budget = frames or 300
-    local idle, total = 0, 0
+    local idle, total, recoveries = 0, 0, 0
     local last
     while idle < budget and total < budget * STALL_CEILING do
         total = total + 1
@@ -688,9 +727,27 @@ local function awaitControllerState(want, frames)
                 return controllerState(after) ~= "dialogue_wait"
             end, 60) then return false end
         elseif state ~= "transition" then
-            traceFailure("await_state", want, "fail:unexpected-state:" .. tostring(state), last,
-                "controller-unexpected-state")
-            return false
+            -- Nicolas's call, and it is how studios keep a suite moving: if we are parked
+            -- somewhere the caller did not want, BACK OUT rather than die here -- a menu or
+            -- a target selector we cannot commit is recoverable, and one wedged screen used
+            -- to cost the entire remaining run (#232). This is not a blanket rescue: the
+            -- cancel is a legal enumerated action, every recovery is TRACED so a real defect
+            -- cannot hide behind it, and the allowance is small so a genuinely stuck screen
+            -- still fails closed. (A silent version of this is precisely what let five
+            -- defects sit unnoticed behind the old blind cadence.)
+            local cancel = Controller.findAction(Controller.legalActions(last), "cancel_menu")
+                or Controller.findAction(Controller.legalActions(last), "cancel_target")
+                or Controller.findAction(Controller.legalActions(last), "cancel_selection")
+            if cancel and recoveries < TUNE.stuckRecoveries then
+                recoveries = recoveries + 1
+                traceInput(last, Controller.legalActions(last), cancel.intention, cancel.key,
+                    "backing out of an unwanted " .. tostring(state), "recovered", last)
+                press(K[cancel.key], 3)
+            else
+                traceFailure("await_state", want, "fail:unexpected-state:" .. tostring(state), last,
+                    "controller-unexpected-state")
+                return false
+            end
         else
             yield()
         end
@@ -759,7 +816,7 @@ local function chooseAttack(actorAddr, stopWhen)
     local done = waitFor(function()
         return (ru32(actorAddr + 0x0C) & 0x2) ~= 0 -- US_UNSELECTABLE
             or (stopWhen ~= nil and stopWhen())
-    end, COMBAT_WAIT_FRAMES, true)
+    end, TUNE.combatFrames, true)
     if not done then
         traceFailure("await_combat", "actor becomes unavailable or scenario terminal fires",
             "fail:combat-timeout", nil, "controller-combat-timeout")
@@ -898,9 +955,8 @@ end
 -- save menu is gone, and it fails closed if the prompt outlives the allowance. Bounded and
 -- outcome-verified, so this is not the blind cadence #220 retired.
 -- Without it the ch00 -> ch01 hand-off parked on the post-chapter prompt forever (#232).
-local SAVE_CONFIRMS = 4
 local function driveSaveSlot()
-    for _ = 1, SAVE_CONFIRMS do
+    for _ = 1, TUNE.saveConfirms do
         local observation = observeController()
         if not observation.procs.save_menu then return true end
         local actions = Controller.legalActions(observation)

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -31,6 +31,10 @@ local Recorder = dofile(PLAYTEST_DIR .. "/recorder.lua")
 --   src/proc.c sProcArray: 64 procs x 0x6C; +0x00 = proc_script
 local UNIT_SIZE = 0x48
 local US_DEAD = 4 -- include/bmunit.h (1 << 2)
+-- How long one attack may take before the combat wait gives up. Measured: an UNSKIPPED
+-- ch00 boss animation is 1238 frames, and vanilla's worst cases (crit, a double, a
+-- level-up, a promotion) run well past that -- see chooseAttack (#232).
+local COMBAT_WAIT_FRAMES = 3600
 local CHAR_HLIN, CHAR_SCRAMSAX, CHAR_SEPHEK = 0x0D, 0x11, 0x68 -- NATASHA/KYLE/ONEILL slots
 -- prologue/sandbox host on chapter slot 1; a chapter load-test (e.g. --ch03-boot on slot 4)
 -- overrides via PT_HOST_CHAPTER so bootToMap/inChapter recognize the right slot.
@@ -462,7 +466,12 @@ local function observeController()
     put("game_control", observedProc(SYM.gProcScr_GameControl, "game_control_root"))
     put("game_early_start", observedProc(SYM.ProcScr_GameEarlyStartUI))
     put("title", observedProc(SYM.gProcScr_TitleScreen))
-    put("save_menu", observedProc(SYM.ProcScr_SaveMenu))
+    -- Two different proc scripts draw a save screen: the New Game one and the
+    -- between-chapters prompt. They share SaveMenu_SaveSlotSelectLoop, so classify()
+    -- needs no new state -- but watching only the first left the post-chapter prompt
+    -- invisible, and the ch00 -> ch01 flow sat on it until it timed out (#232).
+    put("save_menu", observedProc(SYM.ProcScr_SaveMenu)
+        or observedProc(SYM.gProcScr_SaveMenuPostChapter))
     put("difficulty", observedProc(SYM.ProcScr_NewGameDifficultySelect))
     local introKey = observedProc(SYM.ProcScr_ChapterIntro_KeyListen)
     put("chapter_intro", introKey or observedProc(SYM.gProcScr_ChapterIntro))
@@ -650,18 +659,41 @@ local function waitFor(pred, frames, tapA)
     return false
 end
 
+-- Wait until FE8 reaches `want`. `frames` bounds how long we tolerate NOTHING HAPPENING;
+-- it is not a wall-clock cap, because waiting for the map to become playable routinely
+-- spans a scene -- a chapter opening, a turn event -- and no fixed budget fits every
+-- cutscene (#232: the ch01 opening outran 300 frames, so ch01win/lordfloor logged a
+-- controller fault on a chapter they went on to clear). The event engine running is
+-- productive work, so it does not burn the budget; STALL_CEILING keeps a genuinely
+-- wedged engine failing closed here rather than at run.sh's wall-clock deadline.
+local STALL_CEILING = 40
 local function awaitControllerState(want, frames)
+    local budget = frames or 300
+    local idle, total = 0, 0
     local last
-    for _ = 1, (frames or 300) do
+    while idle < budget and total < budget * STALL_CEILING do
+        total = total + 1
         last = observeController()
         local state = controllerState(last)
         if state == want then return true end
-        if state ~= "transition" then
+        if not (last.procs and last.procs.std_event) then idle = idle + 1 end
+        -- Dialogue is never what a caller waits AT -- the targets are player_map_idle,
+        -- unit_selected or a menu -- and FE8 interleaves text with play constantly: a
+        -- turn event, a village line, a post-combat quote. Advancing it is a CLASSIFIED
+        -- state with a legal action, driven through the same guarded single input as
+        -- everything else, so this is the #220 contract, not the blind cadence #220
+        -- retired. Without it every ch01 flow bailed on the first line of text (#232).
+        if state == "dialogue_wait" and want ~= "dialogue_wait" then
+            if not guardedInput("advance_dialogue", "A", "dialogue input wait clears", function(after)
+                return controllerState(after) ~= "dialogue_wait"
+            end, 60) then return false end
+        elseif state ~= "transition" then
             traceFailure("await_state", want, "fail:unexpected-state:" .. tostring(state), last,
                 "controller-unexpected-state")
             return false
+        else
+            yield()
         end
-        yield()
     end
     traceFailure("await_state", want, "fail:state-timeout", last, "controller-state-timeout")
     return false
@@ -708,14 +740,26 @@ local function chooseAttack(actorAddr, stopWhen)
         return controllerState(after) == "target_selection"
             and after.target and after.target.kind == "attack"
     end, 300) then return false end
-    if not guardedInput("confirm_target", "A", "target selection starts the battle proc", function(after)
-        return after.procs.battle ~= nil
+    -- Commit proof has to be mode-agnostic. procs.battle is gProc_ekrBattle, the battle
+    -- ANIMATION proc: a scenario that called pokeFastConfig() runs MAP combat, where it
+    -- never spawns, so requiring it alone fails an attack that in fact resolved (#232 --
+    -- it took out ch04packmath/ch04snag/clear_ch04 while the attacks all landed). The
+    -- target selector closing is the signal common to both modes; the combat wait below
+    -- is what proves the attack actually resolved, so this stays honest.
+    if not guardedInput("confirm_target", "A", "target selection commits the attack", function(after)
+        return after.procs.battle ~= nil or controllerState(after) ~= "target_selection"
     end, 300) then return false end
-    -- combat (with battle anims) ends when the actor is greyed out
+    -- Combat (with battle anims) ends when the actor is greyed out. The budget has to fit
+    -- an animation NOBODY IS SKIPPING: the old 1200 was sized when waitFor still mashed A
+    -- on a 50-frame cadence, which advanced the in-battle quote text. #220 retired that
+    -- cadence on principle, and the ch00 boss animation then measured 1238 frames -- 38
+    -- over, so every ch00/ch01 combat scenario timed out on a fight it had already won
+    -- (#232). Vanilla's real worst cases are far longer than one clean round (crit, a
+    -- double, a level-up, a promotion), so size this for those, not for the measurement.
     local done = waitFor(function()
         return (ru32(actorAddr + 0x0C) & 0x2) ~= 0 -- US_UNSELECTABLE
             or (stopWhen ~= nil and stopWhen())
-    end, 1200, true)
+    end, COMBAT_WAIT_FRAMES, true)
     if not done then
         traceFailure("await_combat", "actor becomes unavailable or scenario terminal fires",
             "fail:combat-timeout", nil, "controller-combat-timeout")
@@ -846,6 +890,37 @@ end
 
 -- Execute at most one input for a recognized boot state. `nil` means the state is unsupported;
 -- false means a guarded input failed; true means one input passed or a transition yielded.
+-- A save slot takes TWO confirms: A picks the slot, then a Save/Cancel bar appears and a
+-- second A commits it. Both presses are the same legal action on the same classified state
+-- (SaveMenu_SaveSlotSelectLoop stays the idle callback throughout), so one guardedInput
+-- cannot verify the first press -- there is no state change to check it against. Verify the
+-- OUTCOME instead: legality is re-checked before every press, the loop stops the instant the
+-- save menu is gone, and it fails closed if the prompt outlives the allowance. Bounded and
+-- outcome-verified, so this is not the blind cadence #220 retired.
+-- Without it the ch00 -> ch01 hand-off parked on the post-chapter prompt forever (#232).
+local SAVE_CONFIRMS = 4
+local function driveSaveSlot()
+    for _ = 1, SAVE_CONFIRMS do
+        local observation = observeController()
+        if not observation.procs.save_menu then return true end
+        local actions = Controller.legalActions(observation)
+        local chosen = actions and Controller.findAction(actions, "select_save_slot") or nil
+        if not chosen or chosen.key ~= "A" then
+            traceInput(observation, actions, "select_save_slot", "none",
+                "the save prompt offers its slot-confirm input", "fail:not-legal", observation)
+            shot("controller-illegal-input")
+            return false
+        end
+        press(K.A, 3)
+        if waitFor(function() return observeController().procs.save_menu == nil end, 240) then
+            return true
+        end
+    end
+    traceFailure("select_save_slot", "the save prompt closes within its confirm allowance",
+        "fail:postcondition", nil, "controller-save-prompt")
+    return false
+end
+
 local function advanceBootState(observation, state)
     if state == "health_safety_wait" then
         return guardedInput("continue", "A", "health/safety wait clears", function(after)
@@ -860,9 +935,7 @@ local function advanceBootState(observation, state)
             return controllerState(after) ~= "save_menu_input"
         end, 600)
     elseif state == "save_slot_input" then
-        return guardedInput("select_save_slot", "A", "save-slot input clears", function(after)
-            return controllerState(after) ~= "save_slot_input"
-        end, 600)
+        return driveSaveSlot()
     elseif state == "difficulty_input" then
         return guardedInput("confirm_difficulty", "A", "difficulty input clears", function(after)
             return controllerState(after) ~= "difficulty_input"
@@ -1299,7 +1372,13 @@ local function winCh00()
             return false
         end
         shot("attacking-sephek")
-        if not chooseAttack(scram.addr) then
+        -- Stop on the OUTCOME, not on the actor. Sephek's death fires DefeatBoss on the
+        -- spot, so the chapter tears the map down and Scramsax never becomes
+        -- US_UNSELECTABLE -- the win succeeds and the combat wait times out anyway
+        -- (#232). chooseAttack takes stopWhen for exactly this case.
+        if not chooseAttack(scram.addr, function()
+            return isDead(red(CHAR_SEPHEK)) or chapter() ~= HOST_CHAPTER
+        end) then
             result("FAIL", "combat did not reach its verified postcondition")
             return false
         end

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -434,6 +434,21 @@ def _run_scenario(scenario, log_dir):
                    '/tmp/playtest-%s' % scenario.name, tail)
 
 
+RESULTS_NAME = 'results.json'
+
+
+def results_path(log_dir):
+    return os.path.join(log_dir, RESULTS_NAME)
+
+
+def clear_results(log_dir):
+    """Drop a previous run's verdict file so nothing can read it as this run's."""
+    try:
+        os.remove(results_path(log_dir))
+    except OSError:
+        pass
+
+
 def cmd_run(args):
     m = Manifest.load()
     names = m.select(suite=args.suite,
@@ -442,6 +457,11 @@ def cmd_run(args):
     groups = m.plan(names, rom=args.rom)
     log_dir = args.out
     os.makedirs(log_dir, exist_ok=True)
+    # A run takes minutes, so the verdict file is what everything downstream polls for.
+    # Leaving the last run's copy in place means a poller reads STALE verdicts the
+    # instant it starts -- and a crashed run leaves them there looking authoritative.
+    # (Same hazard run.sh already clears for the LLM handshake files.)
+    clear_results(log_dir)
 
     total = sum(len(g.scenarios) for g in groups)
     print('matrix: %d scenario(s) across %d ROM configuration(s) -> %s'
@@ -459,9 +479,9 @@ def cmd_run(args):
     if not report.ok:
         print('')
         print(render_failures(report))
-    with open(os.path.join(log_dir, 'results.json'), 'w') as fh:
+    with open(results_path(log_dir), 'w') as fh:
         json.dump(report.as_dict(), fh, indent=2)
-    print('results: %s' % os.path.join(log_dir, 'results.json'))
+    print('results: %s' % results_path(log_dir))
     return report.exit_code
 
 

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -236,12 +236,19 @@ classify(attackTarget, "target_selection", "live attack target selector")
 a = action(attackTarget, "confirm_target")
 check(a and a.key, "A", "live unfrozen target can be confirmed")
 check(a and a.target, 0x81, "target confirmation records the live unit id")
+-- #232: a selector we cannot commit must be escapable, or a driver wedges in it for the
+-- rest of the run. B backs out to the command menu; enumerating it is what makes the
+-- recovery a legal observed action rather than a guessed key.
+a = action(attackTarget, "cancel_target")
+check(a and a.key, "B", "a live target selector can be backed out of")
+
 local frozenTarget = {
     procs = proc("target_selection", "target_selection_input"),
     target = { kind = "talk", x = 7, y = 5, uid = 0x41, frozen = true },
 }
 classify(frozenTarget, "transition", "frozen target selector is passive")
 check(action(frozenTarget, "confirm_target"), nil, "frozen target exposes no input")
+check(action(frozenTarget, "cancel_target"), nil, "a frozen selector exposes no escape either")
 
 -- The battle forecast is display-only. TargetSelection_Loop owns confirmation; the
 -- forecast's callbacks must be observed as passive transitions and never expose a

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -8,6 +8,94 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 HARNESS = os.path.join(REPO, 'tools/playtest/harness.lua')
 
 
+def _read_harness():
+    with open(HARNESS, encoding='utf-8') as source:
+        return source.read()
+
+
+def _block(harness, start_marker, end_marker):
+    start = harness.index(start_marker)
+    return harness[start:harness.index(end_marker, start + len(start_marker))]
+
+
+class TestChooseAttackContract(unittest.TestCase):
+    """#232. chooseAttack is the shared attack path -- every combat scenario in the
+    campaign routes through it -- so both of its waits have to hold in every mode the
+    scenarios actually run in."""
+
+    def test_confirm_target_postcondition_is_not_battle_animation_only(self):
+        # gProc_ekrBattle (observed as procs.battle) is the battle ANIMATION proc. Any
+        # scenario that called pokeFastConfig() runs map combat, where it never spawns
+        # -- so a postcondition of `after.procs.battle ~= nil` alone can never hold and
+        # the attack fails despite having resolved (ch04packmath/ch04snag/clear_ch04).
+        body = _block(_read_harness(), 'local function chooseAttack(',
+                      '-- March a unit toward')
+        self.assertIn('confirm_target', body)
+        commit = body[body.index('"confirm_target"'):]
+        commit = commit[:commit.index('end,')]
+        self.assertIn('procs.battle', commit,
+                      'the animated path should still be accepted as proof of commit')
+        self.assertIn('target_selection', commit,
+                      'map-combat scenarios need the mode-agnostic proof too: the '
+                      'target selector closing')
+
+    def test_combat_wait_budget_fits_an_unskipped_animation(self):
+        # #220 retired waitFor's 50-frame A cadence, which had been advancing the
+        # in-battle quote text. The ch00 boss animation then measured 1238 frames against
+        # a 1200 budget, so every ch00/ch01 combat scenario timed out on a fight it had
+        # already won. The budget must clear the measurement with real margin, because
+        # vanilla's worst cases (crit, double, level-up, promotion) are much longer.
+        harness = _read_harness()
+        self.assertIn('local COMBAT_WAIT_FRAMES = ', harness)
+        budget = int(harness.split('local COMBAT_WAIT_FRAMES = ')[1].split('\n')[0])
+        self.assertGreaterEqual(budget, 2400,
+                                'a budget this close to the measured 1238 will flake on '
+                                'any longer combat')
+        self.assertIn('end, COMBAT_WAIT_FRAMES, true)', harness,
+                      'the combat wait must use the named budget, not a literal')
+
+    def test_win_ch00_gives_the_combat_wait_a_chapter_ending_escape(self):
+        # chooseAttack waits for the actor to be greyed out (US_UNSELECTABLE). Killing
+        # Sephek fires DefeatBoss on the spot, so the chapter tears the unit down and it
+        # never greys -- the win succeeds and the wait times out anyway. chooseAttack
+        # takes a stopWhen for exactly this; winCh00 has to pass one.
+        body = _block(_read_harness(), 'local function winCh00()', '\nlocal function ')
+        call = body[body.index('chooseAttack('):]
+        call = call[:call.index('\n')]
+        self.assertIn('function()', call,
+                      'winCh00 must pass chooseAttack a stopWhen: the boss kill ends the '
+                      'chapter, so the actor never becomes US_UNSELECTABLE')
+
+
+class TestAwaitControllerState(unittest.TestCase):
+    def test_dialogue_is_advanced_while_waiting_not_treated_as_a_fault(self):
+        # #232. FE8 interleaves text with play (turn events, village lines, post-combat
+        # quotes), so a wait for player_map_idle routinely passes through dialogue_wait.
+        # Bailing there failed every ch01 flow on its first line of text. dialogue_wait is
+        # a classified state with a legal guarded action, so advancing it is the #220
+        # contract -- unlike the 50-frame blind cadence #220 removed.
+        body = _block(_read_harness(), 'local function awaitControllerState(',
+                      '\n-- Select unit at')
+        self.assertIn('dialogue_wait', body)
+        self.assertIn('advance_dialogue', body)
+        self.assertIn('want ~= "dialogue_wait"', body,
+                      'a caller that explicitly waits FOR dialogue must still get it')
+        self.assertIn('fail:unexpected-state:', body,
+                      'every other unexpected state must still fail closed')
+
+    def test_the_budget_counts_stall_not_wall_clock(self):
+        # #232. A wait for the map to become playable spans whole cutscenes, and no fixed
+        # budget fits every one -- the ch01 opening outran 300 frames and logged a fault
+        # on a chapter the scenario went on to clear. So the event engine running must not
+        # burn the budget, while a genuinely wedged engine still fails closed here rather
+        # than at run.sh's wall-clock deadline.
+        body = _block(_read_harness(), 'local function awaitControllerState(',
+                      '\n-- Select unit at')
+        self.assertIn('std_event', body, 'event-engine progress must be recognised')
+        self.assertIn('STALL_CEILING', body, 'the wait must still terminate on its own')
+        self.assertIn('fail:state-timeout', body)
+
+
 class TestPlaytestHarness(unittest.TestCase):
     def test_moose_recorder_wires_fast_setup_to_guaranteed_cleanup(self):
         with open(HARNESS, encoding='utf-8') as source:

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -18,6 +18,24 @@ def _block(harness, start_marker, end_marker):
     return harness[start:harness.index(end_marker, start + len(start_marker))]
 
 
+class TestHarnessLoads(unittest.TestCase):
+    def test_harness_lua_compiles(self):
+        # #232, caught by Nicolas watching the run: harness.lua is ONE Lua chunk, and its
+        # main function sits near Lua's 200-local ceiling. A few new top-level constants
+        # pushed it over and the whole file stopped loading -- every scenario dies at once,
+        # and nothing in a source-text assertion notices. Compile it for real.
+        import shutil
+        import subprocess
+        lua = shutil.which('lua') or shutil.which('luac')
+        if not lua:
+            self.skipTest('no lua interpreter (brew install lua)')
+        probe = ('local f, err = loadfile(%r); if not f then io.stderr:write(err) '
+                 'os.exit(1) end' % HARNESS)
+        done = subprocess.run([lua, '-e', probe], capture_output=True)
+        self.assertEqual(done.returncode, 0,
+                         'harness.lua does not load: %s' % done.stderr.decode())
+
+
 class TestChooseAttackContract(unittest.TestCase):
     """#232. chooseAttack is the shared attack path -- every combat scenario in the
     campaign routes through it -- so both of its waits have to hold in every mode the
@@ -46,12 +64,12 @@ class TestChooseAttackContract(unittest.TestCase):
         # already won. The budget must clear the measurement with real margin, because
         # vanilla's worst cases (crit, double, level-up, promotion) are much longer.
         harness = _read_harness()
-        self.assertIn('local COMBAT_WAIT_FRAMES = ', harness)
-        budget = int(harness.split('local COMBAT_WAIT_FRAMES = ')[1].split('\n')[0])
+        self.assertIn('combatFrames = ', harness)
+        budget = int(harness.split('combatFrames = ')[1].split(',')[0])
         self.assertGreaterEqual(budget, 2400,
                                 'a budget this close to the measured 1238 will flake on '
                                 'any longer combat')
-        self.assertIn('end, COMBAT_WAIT_FRAMES, true)', harness,
+        self.assertIn('end, TUNE.combatFrames, true)', harness,
                       'the combat wait must use the named budget, not a literal')
 
     def test_win_ch00_gives_the_combat_wait_a_chapter_ending_escape(self):
@@ -82,6 +100,20 @@ class TestAwaitControllerState(unittest.TestCase):
                       'a caller that explicitly waits FOR dialogue must still get it')
         self.assertIn('fail:unexpected-state:', body,
                       'every other unexpected state must still fail closed')
+
+    def test_an_unwanted_screen_is_backed_out_of_and_the_recovery_is_traced(self):
+        # #232, Nicolas's call: one screen the driver cannot commit used to cost the whole
+        # remaining run. Backing out keeps the suite moving -- but it must be a legal
+        # enumerated cancel, it must be TRACED, and the allowance must be small, or it
+        # becomes the blanket rescue that hid five defects behind the old blind cadence.
+        body = _block(_read_harness(), 'local function awaitControllerState(',
+                      '\n-- Select unit at')
+        self.assertIn('cancel_target', body)
+        self.assertIn('cancel_menu', body)
+        self.assertIn('TUNE.stuckRecoveries', body, 'recovery must be bounded')
+        self.assertIn('"recovered"', body, 'every recovery must land in the trace')
+        self.assertIn('fail:unexpected-state:', body,
+                      'a screen that outlives the allowance must still fail closed')
 
     def test_the_budget_counts_stall_not_wall_clock(self):
         # #232. A wait for the map to become playable spans whole cutscenes, and no fixed

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -307,6 +307,23 @@ class VerdictParsing(unittest.TestCase):
         self.assertEqual(mx.parse_verdict(self.REAL_PASS, 1), 'FAIL')
 
 
+class StaleResults(unittest.TestCase):
+    """Regression: a run takes minutes and results.json is what everything downstream
+    polls for, so last run's copy must not survive into this one."""
+
+    def test_clearing_removes_a_previous_runs_verdicts(self):
+        import tempfile
+        d = tempfile.mkdtemp()
+        with open(mx.results_path(d), 'w') as fh:
+            fh.write('{"ok": true}')
+        mx.clear_results(d)
+        self.assertFalse(os.path.exists(mx.results_path(d)))
+
+    def test_clearing_an_empty_directory_is_not_an_error(self):
+        import tempfile
+        mx.clear_results(tempfile.mkdtemp())      # must not raise
+
+
 class WrongRomGuard(unittest.TestCase):
     """build_campaign stamps which flags built the ROM; a scenario bound to a different
     configuration must be refused in 0s rather than time out in mGBA."""


### PR DESCRIPTION
Fixes six of the seven gate failures in #232. **Gate: 7/14 → 13/14.**

> Follows #233 (now merged), which is what makes `make matrix` available to verify this. Rebased onto `main`. Supersedes the auto-closed #234, which GitHub closed when its base branch was deleted on merge.

## What was actually wrong

Not one defect — **six**, sharing one story. #220 correctly replaced blind cadence input with observed, guarded input. But `waitFor` had been mashing A every 50 frames, and that cadence was **load-bearing**: several waits were sized or written around it. When it went, they broke — and nobody noticed, because the ch00/ch01 scenarios aren't in HANDOFF's hand-run gate list and there is no CI for in-emulator playtests.

Every fix below is backed by a measurement, not a guess. Two of my early hypotheses were disproved by the evidence and are not in this PR.

| # | Root cause | Evidence that found it |
|---|---|---|
| 1 | `chooseAttack`'s combat budget was **1200** frames; an *unskipped* ch00 boss animation is **1238**. The old A cadence advanced the in-battle quote and pulled it under the wire. | Probe: battle proc alive at elapsed 0, gone at elapsed 1238 |
| 2 | `winCh00` passed no `stopWhen`. Killing Sephek fires DefeatBoss immediately, the chapter tears the map down, and the actor never becomes `US_UNSELECTABLE`. | A 9000-frame run ended at the **save menu** — win achieved — with the wait still spinning |
| 3 | `confirm_target` proved commit via `procs.battle` = `gProc_ekrBattle`, the battle *animation* proc. Every `pokeFastConfig()` scenario runs map combat, where it never spawns. | All three failures call `pokeFastConfig()`; trace `after` shows the attacker already `turn_ended` |
| 4 | `awaitControllerState` treated `dialogue_wait` as a fault and burned a flat 300-frame budget that no cutscene fits. | Stalls were `std_event` at chapter 2 turn 1 — the ch01 opening — on chapters the scenario went on to clear |
| 5 | The between-chapters save prompt is a **second** proc script (`gProcScr_SaveMenuPostChapter`) sharing `SaveMenu_SaveSlotSelectLoop`; the observer watched only `ProcScr_SaveMenu`. | Screenshot of the run parked on the save screen |
| 6 | `guardedInput` pressed **once**. FE8 drops input during window fade-ins, so a lost press was lost for good and the run wedged in `target_selection` for the rest of the scenario. | Both stuck cases had the battle forecast up and never left `target_selection` |

Waits are now **progress-based** where a fixed budget cannot work: a running event engine is productive work and does not burn the stall budget, with `STALL_CEILING` still failing closed.

## Recovery from a wedged screen

Nicolas's suggestion: if the driver is parked somewhere it never wanted, back out instead of dying. Built with guards, because a *blanket* rescue is exactly what let six defects hide behind the old cadence:

- the cancel is a **legal enumerated action** — `controller.lua` now exposes `cancel_target`, so a selector we cannot commit is escapable at all;
- every recovery is **traced**, so a real defect cannot hide behind it;
- the allowance is small, so a genuinely stuck screen still fails closed.

Honest note: **it has not fired in a passing run.** It is insurance, not a fix — the retry (#6) is what actually turned those scenarios green.

## The bug my own tests missed

`harness.lua` is one Lua chunk and its main function sits near Lua's **200-local ceiling**. Five new top-level constants pushed it over and the whole file stopped loading — every scenario dies at once, and no source-text assertion notices. Nicolas caught it watching a run; my `loadfile` check had been piped to `head` without asserting, so `nil, err` looked like success.

Tuning now lives in one `TUNE` table, and `test_playtest_harness.py` **compiles** `harness.lua`, so `make test` catches this before anything reaches the emulator.

## Verification

`make matrix SUITE=gate`, clean run:

```
canonical  controller_turn    PASS     13s     ch04boot   ch04moose          PASS     13s
canonical  win                PASS     13s     ch04boot   ch04packmath       PASS     19s
canonical  gameover           PASS     13s     ch04boot   ch04village        PASS     10s
canonical  retreat            PASS     13s     ch04boot   ch04cottage        PASS     13s
canonical  ch01               FAIL     31s     ch04boot   ch04snag           PASS     16s
canonical  ch01win            PASS     46s     ch04boot   clear_ch04_parley  PASS     37s
canonical  lordfloor          PASS     22s
testch     recordunitlist     PASS     34s     14 scenarios, 3 builds, 0 duplicate builds, 5m55s
```

Also green: all 28 `tools/test_*.py`, all 8 Lua suites (132 controller assertions), `make check` = `drift check: clean`, `git diff --check` clean.

## Still red — `ch01`, and what it needs

It clears ch00, rides the post-chapter save prompt, then **parks inside the Beat-1 Northlook cutscene** until the flow budget runs out. The event engine stays live but no page wait is ever classified as `dialogue_wait`, so nothing advances it. `ch01win` survives the same scene only because it predates the controller contract and rides it on a blind A cadence.

Fixing it properly means identifying the scene-text input wait and classifying it. I could not pin it down reliably: the freeze report's proc naming is currently untrustworthy (three distinct scripts all resolve to `E_FACE`). **This is precisely what #222's state-inspector workstream is for**, and it is the first concrete argument for taking that workstream rather than deferring it.

Note `reachCh01Map` is shared by `smoke_ch01`, `clear_ch01` and `fuzz_ch01`, so this one blocks more than the single gate row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
