### PR TITLE
Name the state instead of guessing at it: playtest inspector + first-divergence report (#236)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ campaigns/*/map_sprites/.base/
 /references
 tools/emulator/
 tools/playtest/symbols.lua
+# the other two gen_symbols.py outputs: exact proc-script names for the Lua side,
+# every ROM code symbol for inspect.py (#236). Regenerated after every make.
+tools/playtest/procscr.lua
+tools/playtest/symbols.json
 # local session scratch tool (HANDOFF references it; intentionally unversioned)
 tools/key_magenta.py
 # mGBA save-state checkpoints (per-ROM-build, regenerated) -- inline comments don't work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ file lean (operating instructions + pointers, not a fact store).
 | `tools/build_campaign.py` | Inject campaign content (portraits, names, character class/stats) into the decomp before `make`. |
 | `tools/verify_text.py` | Decode message text from the built ROM (regression gate; no mGBA). |
 | `tools/playtest/run.sh <scenario>` | Automated in-emulator playtest of ONE scenario (mGBA Lua scripting; memory-asserted PASS/FAIL). Takes the scenario's ROM flag, host chapter, checkpoint and timing from `tools/playtest/matrix.yaml`. |
+| `tools/playtest/inspect_state.py` | Read a playtest log semantically: `render` prints what FE8 was doing and why the controller classified it that way (procs named by exact symbol); `diff` reports the first divergence between two runs. |
 | `make matrix [SUITE=…]` | The live regression matrix (`tools/playtest/matrix.py`): builds each ROM configuration at most once, runs its scenarios, prints a verdict table. `SUITE=gate` (default), a chapter suite, or `all`. |
 | `tools/portrait_tool.py`, `tools/ref_to_bust.py` | Bust art pipeline (ref → indexed FE8 portrait). |
 | `tools/setup-toolchain.sh` | One-time macOS toolchain setup (brew deps, agbcc, python numpy/pillow/pyyaml). |

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ verify:
 # Run the Python unit tests (combat math + stat resolution + difficulty engine).
 # Also run by `make check` / CI / the pre-commit hook.
 test:
-	@for t in tools/test_*.py; do echo "== $$t =="; python3 $$t || exit 1; done
+	@for t in tools/test_*.py tools/playtest/test_*.py; do echo "== $$t =="; python3 $$t || exit 1; done
 	@if command -v lua >/dev/null 2>&1; then \
 		for t in tools/playtest/test_*.lua; do echo "== $$t =="; lua $$t || exit 1; done; \
 	else echo "== skipping Lua playtest tests (no 'lua'; brew install lua) =="; fi

--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -141,6 +141,31 @@ Once the chapter has more than a couple of scenarios, drive them together:
 make matrix SUITE=chNN     # one CHNNBOOT=1 build, every chNN scenario, one verdict table
 ```
 
+## When a scenario fails, read the state before you rebuild
+
+Every terminal controller failure and every proven stall dumps an inspector snapshot into the log
+(#236). Read it first — it usually names the defect outright, and it costs no build:
+
+```sh
+tools/playtest/inspect_state.py render /tmp/playtest-<scenario>/playtest.log
+tools/playtest/inspect_state.py diff /tmp/playtest-<good>/playtest.log /tmp/playtest-<bad>/playtest.log
+```
+
+`render` prints the verdict, the rule that produced it, **every rule that was rejected and why**, and
+the live procs named by exact script symbol with their idle callbacks resolved. A verdict flagged
+`*** UNCLASSIFIED WAIT ***` means FE8 is waiting on something the controller has no name for: add
+the proc + its input callback to `gen_symbols.py`, `CALLBACK_NAMES`, `observeController` and a
+`classify` rule, and let the *scenario* decide the answer. That is the whole fix for a wait, and it
+is how ch01's lord-select Yes/No prompt was closed (#232).
+
+Two traps this replaces, both of which cost real sessions:
+
+- **Do not re-run a scenario to re-test a hypothesis the evidence already killed.** A budget-bounded
+  loop exits at the same frame no matter what is on screen, so an identical frame number proves
+  nothing. Instrument for the answer instead.
+- **A `transition` is not "nothing is happening".** It is the classifier saying it has no name for
+  this. The snapshot's `considered` list tells you what it looked for.
+
 ## Gotchas (learned the hard way)
 
 - **Tutorial-list terminator is per-chapter typed.** Slot 4's `EventListScr_ChM_Tutorial` is an

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3273,6 +3273,38 @@ session state. `HANDOFF.md` points here._
   `run.sh` refuses a mismatch in 0s with the exact `make` line. So this should no longer be a
   judgement call — but `MX_SKIP_ROM_CHECK=1` disables the guard and puts you straight back here
   (which is exactly what happened once inside the session that built it).
+- **A proc's identity is its script ADDRESS, never its `PROC_NAME` string** (2026-08-06, #236).
+  Freeze reports named a proc from the string pointer at proc+0x10, and that string is not an
+  identity: the decomp gives `gProcScr_E_FACE` and `gProcScr_E_FACE_ExtraFrame` the same
+  `PROC_NAME("E_FACE")`, and reuses `"bmenu"` and `"E_config"` three times each. Live capture was
+  worse still — the field goes stale, so the proc actually running `gProcScr_Talk` printed as
+  `E_FACE`, `ProcScr_StdEventEngine` printed as `MAPTASK`, and `gProcScr_TalkSkipListener` printed
+  as `ekrBattleEnding`. `gen_symbols.py` now emits `procscr.lua` (952 script addresses → their
+  exact symbols) and `symbols.json` (every ROM code symbol, for `inspect_state.py` to name idle
+  callbacks). **Resolution is exact-match only, and an unmatched address prints
+  `unknown@0x…`** — silence beats a confident wrong name, which is what cost #232 its last failure.
+- **An unclassified `transition` must say what it rejected** (2026-08-06, #236). `classify()` is
+  an ordered rule table, and `explain()` runs the same rules to return the verdict *plus* every
+  rule considered and the predicate that failed. Five of #232's six defects were input waits
+  nothing had a name for; each read as a passive transition and cost a full build-and-run cycle
+  to identify. The classification is now the cheap half: `INSPECT.watch` arms only on an
+  *unclassified* transition holding a byte-identical proc pool, and dumps the snapshot the moment
+  the stall is provable.
+- **A loop budget must not be the thing that decides failure** (2026-08-06, #232/#236). `ch01`
+  stayed open for three sessions on a diagnosis that turned out to be wrong — "no page wait is
+  ever classified as `dialogue_wait`, so nothing advances it". The inspector disproved it in one
+  run: page waits were classified and advanced **74 times**, all passing, and the flow was still
+  advancing 263 frames before the old 12000-step cap expired. A cap that fires mid-scene reports
+  a timeout that names nothing, and a budget-bounded loop exits at the same frame whatever is on
+  screen — so the number looks like evidence and is not. Caps are now sized far above any real
+  scene (`TUNE.bootSteps`), and `INSPECT.watch` is the failure oracle.
+- **A Yes/No prompt inside a scene is its own input state** (2026-08-06, #232). With the above in
+  place the real `ch01` blocker took one run to name: `gProcScr_YesNoChoice` in
+  `YesNoChoice_Loop_KeyHandler` — lord select's "Will \<lead\> lead the party?". It runs *inside* a
+  live event scene, so the `std_event` passive rule swallowed it as a transition and nothing ever
+  answered. It is classified as `yes_no_choice` and ordered above the passive rules;
+  `currentChoice` (s16 @ +0x2A, `TALK_CHOICE_YES`=1/`NO`=2) decides which answer carries `A`, and
+  the *scenario* chooses the answer — the controller only says what is legal.
 - **Comments inside a YAML folded scalar are CONTENT, not comments** (2026-08-02, #214). Authoring
   a chapter's `visit_text: >` with `#` lines indented underneath silently folded them into the
   string, and the chapter YAML then failed to load for every test that reads it. Comments belong

--- a/tools/check.py
+++ b/tools/check.py
@@ -105,8 +105,15 @@ def check_python_compiles(fail):
 
 
 def check_tests_pass(fail):
-    """Run the Python unit tests (tools/test_*.py). The combat math in fe_combat.py is
-    the difficulty engine's arbiter -- a silent regression there mis-grades every chapter."""
+    """Run the Python unit tests (tools/test_*.py AND tools/playtest/test_*.py). The combat
+    math in fe_combat.py is the difficulty engine's arbiter -- a silent regression there
+    mis-grades every chapter.
+
+    The playtest directory was outside this glob until 2026-08-06 (#236), so its Python
+    tests -- the pure formatting/diff logic that is supposed to keep the emulator out of
+    the loop -- ran only when someone invoked them by hand. `unittest discover -s tools`
+    does not reach them either (the directory is not an importable package), so the glob
+    is the only gate. Coverage nothing runs is not coverage."""
     import subprocess
     # Several tests read the FE8 decomp via `git -C fireemblem8u show HEAD:...`
     # (vanilla_decomp_text). When the submodule isn't checked out -- the lightweight CI
@@ -118,7 +125,8 @@ def check_tests_pass(fail):
         print('check_tests_pass: skipping unit tests (fireemblem8u submodule not checked '
               'out; the CI build job runs `make test`)')
         return
-    for t in sorted(glob.glob(os.path.join(REPO, 'tools', 'test_*.py'))):
+    for t in sorted(glob.glob(os.path.join(REPO, 'tools', 'test_*.py'))
+                    + glob.glob(os.path.join(REPO, 'tools', 'playtest', 'test_*.py'))):
         r = subprocess.run([sys.executable, t], capture_output=True, text=True)
         if r.returncode != 0:
             tail = (r.stderr or r.stdout).strip().splitlines()

--- a/tools/check.py
+++ b/tools/check.py
@@ -21,6 +21,7 @@ Exit 0 = clean, 1 = drift found. Run from the repo root.
 import glob
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -132,6 +133,54 @@ def check_tests_pass(fail):
             tail = (r.stderr or r.stdout).strip().splitlines()
             fail.append('unit tests fail: %s (%s)' % (
                 os.path.relpath(t, REPO), tail[-1] if tail else 'see output'))
+
+
+LUA_CHUNKS = ('tools/playtest/harness.lua', 'tools/playtest/controller.lua',
+              'tools/playtest/clearbot.lua', 'tools/playtest/json.lua')
+
+
+def lua_compile_error(path):
+    """None if the chunk COMPILES, else the interpreter's message.
+
+    Two traps, both of which make this silently useless if you get them wrong:
+      * `loadfile` returns `nil, err`; it does not raise. The probe must test the
+        result explicitly or it exits 0 on a broken file and asserts nothing.
+      * the path goes in through the environment, not as an argv tail. `lua -e CODE
+        FILE` treats FILE as a script to *execute*, so the probe would run harness.lua
+        -- which fails on missing emulator globals and looks like a compile error.
+    """
+    env = dict(os.environ, LUA_CHUNK_PATH=path)
+    probe = ('local f, err = loadfile(os.getenv("LUA_CHUNK_PATH"))\n'
+             'if not f then io.stderr:write(tostring(err)) os.exit(1) end\n')
+    r = subprocess.run([shutil.which('lua') or 'lua', '-e', probe],
+                       capture_output=True, text=True, env=env)
+    if r.returncode == 0:
+        return None
+    detail = (r.stderr or r.stdout).strip().splitlines()
+    return detail[-1] if detail else 'unknown error'
+
+
+def check_lua_chunks_load(fail):
+    """The playtest Lua must COMPILE. Nothing else checks this: check_playtest_matrix
+    only parses harness.lua textually for scenario names, and a syntax/limit error is
+    invisible until mGBA loads it minutes later.
+
+    The specific hazard is Lua's ceiling of 200 local variables per function. harness.lua
+    is one ~6,700-line main chunk with only TWO free slots (measured 2026-08-06: +2
+    top-level locals still compiles, +3 does not), so a routine edit can cross it -- and
+    crossing it kills every scenario simultaneously, a total outage rather than a single
+    red row. #236 crossed it and caught it only by hand.
+
+    loadfile COMPILES without executing, so the emulator globals the chunk needs at
+    runtime (emu, SYM, PLAYTEST_*) are irrelevant here."""
+    if shutil.which('lua') is None:
+        # CI's lightweight `checks` job has no Lua, same reasoning as check_tests_pass.
+        print('check_lua_chunks_load: skipping (no lua on PATH; brew install lua)')
+        return
+    for rel in LUA_CHUNKS:
+        err = lua_compile_error(os.path.join(REPO, rel))
+        if err:
+            fail.append('%s does not compile: %s' % (rel, err))
 
 
 def check_yaml_parses(fail):
@@ -882,7 +931,8 @@ def check_lane_ownership(fail):
 
 def main():
     fail = []
-    for check in (check_python_compiles, check_tests_pass, check_yaml_parses,
+    for check in (check_python_compiles, check_lua_chunks_load,
+                  check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
                   check_injection_order, check_playtest_matrix,
                   check_tool_refs_exist, check_no_dead_concepts,

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -52,96 +52,298 @@ local function menuKinds(observation)
     return unit, map, weapon
 end
 
+-- ---------------------------------------------------------------- classification rules
+-- Ordered rules, evaluated top to bottom. One rule list serves both classify() (the
+-- verdict) and explain() (the verdict PLUS what every earlier rule rejected and why),
+-- so the two can never drift apart. #232 spent a full build-and-run cycle per hypothesis
+-- because a `transition` verdict said nothing about what had been considered.
+--
+-- A rule returns exactly one of:
+--   matched(state, detail, unclassified)  this is the state; detail says how we know
+--   rejected(reason)                      not this state, and why -- the diagnostic payload
+--   unsupported(why)                      fail closed; the observation makes no sense
+--
+-- `unclassified` marks a transition matched purely on a proc EXISTING, without
+-- recognizing what it is currently waiting in. Those are the ones that hide an input
+-- wait nothing can advance -- ch01's Northlook scene is exactly this shape.
+local function matched(state, detail, unclassified)
+    return { state = state, detail = detail, unclassified = unclassified or false }
+end
+local function rejected(reason) return { reject = reason } end
+local function unsupported(why) return { error = why } end
+
+local function idleOf(observation, name)
+    local p = proc(observation, name)
+    return p and p.idle or nil
+end
+
+-- "absent" and "live but in another callback" are different bugs with different fixes,
+-- so the rejection has to distinguish them by name.
+local function missIs(observation, name, wanted)
+    local idle = idleOf(observation, name)
+    if idle == nil then return name .. " proc absent" end
+    return string.format("%s idle=%s, not %s", name, tostring(idle), wanted)
+end
+
+-- The boot/menu states that are identified by one proc sitting in one exact callback.
+local SIMPLE_INPUT_RULES = {
+    { rule = "health_safety_wait", proc = "game_early_start", idle = "health_safety_wait" },
+    { rule = "title_idle", proc = "title", idle = "title_idle" },
+    { rule = "save_menu_input", proc = "save_menu", idle = "save_menu_input" },
+    { rule = "save_slot_input", proc = "save_menu", idle = "save_slot_input" },
+    { rule = "difficulty_input", proc = "difficulty", idle = "difficulty_input" },
+    { rule = "chapter_intro_input", proc = "chapter_intro", idle = "chapter_intro_input" },
+}
+
+-- Procs that make the game passive without ever offering an input. A match here means
+-- "something is running and we have no name for what it wants" -- the blind spot.
+local PASSIVE_PROCS = { "talk_wait", "std_event", "battle_forecast", "battle" }
+local BOOT_PROCS = {
+    "game_control", "game_early_start", "title", "save_menu", "difficulty", "chapter_intro",
+    "talk_wait", "std_event", "map_fade", "battle_forecast", "battle", "at_menu", "sally",
+}
+
+local function anyLive(observation, names)
+    for _, name in ipairs(names) do
+        if proc(observation, name) then
+            return string.format("%s live (idle=%s)", name, tostring(idleOf(observation, name)))
+        end
+    end
+    return nil
+end
+
+local RULES = {
+    {
+        name = "observation",
+        check = function(observation)
+            if observation.error then return unsupported(observation.error) end
+            return rejected("the observer reported no malformed structure")
+        end,
+    },
+    {
+        name = "pre_boot",
+        check = function(observation)
+            if observation.world and observation.world.chapter == 0 and observation.world.turn == 0
+                and next(observation.procs or {}) == nil then
+                return matched("transition", "empty proc pool before FE8 startup")
+            end
+            return rejected("the proc pool is not empty, or the game is past startup")
+        end,
+    },
+    {
+        name = "dialogue_wait",
+        check = function(observation)
+            if idleIs(observation, "talk_wait", "talk_wait_input") then
+                return matched("dialogue_wait", "talk_wait in talk_wait_input")
+            end
+            return rejected(missIs(observation, "talk_wait", "talk_wait_input"))
+        end,
+    },
+    {
+        -- Ordered ABOVE the passive rules on purpose: this prompt runs INSIDE a live
+        -- event scene, so `std_event` would otherwise swallow it as a transition -- which
+        -- is exactly how ch01's lord-select prompt stayed invisible through #232.
+        name = "yes_no_choice",
+        check = function(observation)
+            if not proc(observation, "yes_no") then return rejected("yes_no proc absent") end
+            if not idleIs(observation, "yes_no", "yes_no_input") then
+                return matched("transition", string.format("yes_no idle=%s, not its key handler",
+                    tostring(idleOf(observation, "yes_no"))))
+            end
+            if not observation.choice then
+                return matched("transition", "yes_no live with no observed choice")
+            end
+            return matched("yes_no_choice", "yes_no in its key handler")
+        end,
+    },
+    {
+        name = "target_selection",
+        check = function(observation)
+            if not proc(observation, "target_selection") then
+                return rejected("target_selection proc absent")
+            end
+            if not idleIs(observation, "target_selection", "target_selection_input") then
+                return matched("transition", string.format("target_selection idle=%s, not its input loop",
+                    tostring(idleOf(observation, "target_selection"))))
+            end
+            if not observation.target then
+                return matched("transition", "target_selection live with no observed target")
+            end
+            if observation.target.frozen then
+                return matched("transition", "target_selection is frozen")
+            end
+            if observation.target.kind ~= "attack" and observation.target.kind ~= "talk" then
+                return unsupported("unsupported target selection kind")
+            end
+            return matched("target_selection", "target_selection in its input loop")
+        end,
+    },
+    {
+        name = "menu",
+        check = function(observation)
+            local menuProc = proc(observation, "menu")
+            if not menuProc then return rejected("menu proc absent") end
+            if not idleIs(observation, "menu", "menu_input") then
+                return matched("transition", string.format("menu idle=%s, not menu_input",
+                    tostring(menuProc.idle)))
+            end
+            for _, flag in ipairs({ "locked", "frozen", "ending", "doomed" }) do
+                if menuProc[flag] then
+                    return matched("transition", "menu is " .. flag)
+                end
+            end
+            if not observation.menu then
+                return matched("transition", "menu proc live with no observed menu structure")
+            end
+            local unit, map, weapon = menuKinds(observation)
+            if weapon and (unit or map) then
+                return unsupported("ambiguous standard menu mixes weapon and command items")
+            end
+            if unit and map then
+                return unsupported("ambiguous standard menu contains unit and map commands")
+            end
+            if weapon then return matched("weapon_menu", "menu offers weapon items") end
+            if unit then return matched("unit_command_menu", "menu offers unit commands") end
+            if map then return matched("map_command_menu", "menu offers map commands") end
+            local enabled = enabledMenuItems(observation)
+            local callbacks = #enabled > 0
+            for _, item in ipairs(enabled) do
+                if not item.on_selected then callbacks = false break end
+            end
+            if callbacks then return matched("generic_menu", "every enabled item has a callback") end
+            return unsupported("unsupported standard menu has no recognized semantic commands")
+        end,
+    },
+    {
+        name = "prep_units",
+        check = function(observation)
+            if not proc(observation, "prep_units") then return rejected("prep_units proc absent") end
+            if idleIs(observation, "prep_units", "prep_units_input") then
+                return matched("prep_pick_units", "prep_units in its input loop")
+            end
+            return matched("transition", string.format("prep_units idle=%s, not prep_units_input",
+                tostring(idleOf(observation, "prep_units"))))
+        end,
+    },
+    {
+        name = "prep_menu",
+        check = function(observation)
+            if not proc(observation, "prep_menu") then return rejected("prep_menu proc absent") end
+            if not idleIs(observation, "prep_menu", "prep_menu_input") then
+                return matched("transition", string.format("prep_menu idle=%s, not prep_menu_input",
+                    tostring(idleOf(observation, "prep_menu"))))
+            end
+            if not observation.prep then
+                return matched("transition", "prep_menu live with no observed prep structure")
+            end
+            if observation.prep.help_open then return matched("transition", "prep help window is open") end
+            if proc(observation, "at_menu") then return matched("prep_main", "at_menu owns the prep list") end
+            if proc(observation, "sally") then return matched("prep_map_menu", "sally owns the prep list") end
+            return unsupported("preparations menu has no recognized owner")
+        end,
+    },
+    {
+        name = "simple_input",
+        check = function(observation)
+            -- Two rules watch save_menu (New Game vs the between-chapters prompt), so the
+            -- same "absent" reason would otherwise be reported twice.
+            local misses, seen = {}, {}
+            for _, spec in ipairs(SIMPLE_INPUT_RULES) do
+                if idleIs(observation, spec.proc, spec.idle) then
+                    return matched(spec.rule, spec.proc .. " in " .. spec.idle)
+                end
+                local miss = missIs(observation, spec.proc, spec.idle)
+                if not seen[miss] then
+                    seen[miss] = true
+                    misses[#misses + 1] = miss
+                end
+            end
+            return rejected(table.concat(misses, "; "))
+        end,
+    },
+    {
+        name = "map_fade",
+        check = function(observation)
+            if proc(observation, "map_fade") then
+                return matched("transition", "map_fade is animating")
+            end
+            return rejected("map_fade proc absent")
+        end,
+    },
+    {
+        name = "passive_proc",
+        check = function(observation)
+            local live = anyLive(observation, PASSIVE_PROCS)
+            if live then return matched("transition", live, true) end
+            return rejected("no passive proc live (" .. table.concat(PASSIVE_PROCS, ", ") .. ")")
+        end,
+    },
+    {
+        name = "player_phase",
+        check = function(observation)
+            if not proc(observation, "player_phase") then return rejected("player_phase proc absent") end
+            if idleIs(observation, "player_phase", "player_main_idle") then
+                return matched("player_map_idle", "player_phase in player_main_idle")
+            end
+            if idleIs(observation, "player_phase", "player_range_idle") then
+                return matched("unit_selected", "player_phase in player_range_idle")
+            end
+            if idleIs(observation, "player_phase", "player_move_wait") then
+                return matched("unit_moving", "player_phase in player_move_wait")
+            end
+            return matched("transition", string.format("player_phase idle=%s is not a known callback",
+                tostring(idleOf(observation, "player_phase"))), true)
+        end,
+    },
+    {
+        name = "boot_proc",
+        check = function(observation)
+            local live = anyLive(observation, BOOT_PROCS)
+            if live then return matched("transition", live, true) end
+            return rejected("no boot-owner proc live")
+        end,
+    },
+}
+
+local function evaluate(observation)
+    local considered = {}
+    for _, rule in ipairs(RULES) do
+        local verdict = rule.check(observation)
+        if verdict.state then
+            return verdict.state, nil, considered, rule.name, verdict.detail, verdict.unclassified
+        end
+        if verdict.error then
+            return nil, verdict.error, considered, rule.name, nil, false
+        end
+        considered[#considered + 1] = { rule = rule.name, reason = verdict.reject }
+    end
+    return nil, "unsupported FE8 state", considered, nil, nil, false
+end
+
 function M.classify(observation)
+    local state, why = evaluate(observation or {})
+    return state, why
+end
+
+-- The same verdict, with the reasoning attached. Pure, so the emulator is never needed
+-- to answer "why did this read as a transition" (#236).
+function M.explain(observation)
     observation = observation or {}
-    if observation.error then return nil, observation.error end
-
-    if observation.world and observation.world.chapter == 0 and observation.world.turn == 0
-        and next(observation.procs or {}) == nil then
-        return "transition"
+    local state, why, considered, rule, detail, unclassified = evaluate(observation)
+    local live = {}
+    for name, p in pairs(observation.procs or {}) do
+        live[#live + 1] = { name = name, idle = p.idle, addr = p.addr }
     end
-
-    if idleIs(observation, "talk_wait", "talk_wait_input") then
-        return "dialogue_wait"
-    end
-
-    if proc(observation, "target_selection") then
-        if not idleIs(observation, "target_selection", "target_selection_input")
-            or not observation.target or observation.target.frozen then
-            return "transition"
-        end
-        if observation.target.kind ~= "attack" and observation.target.kind ~= "talk" then
-            return nil, "unsupported target selection kind"
-        end
-        return "target_selection"
-    end
-
-    if proc(observation, "menu") then
-        local menuProc = proc(observation, "menu")
-        if not idleIs(observation, "menu", "menu_input") or menuProc.locked or menuProc.frozen
-            or menuProc.ending or menuProc.doomed or not observation.menu then
-            return "transition"
-        end
-        local unit, map, weapon = menuKinds(observation)
-        if weapon and (unit or map) then return nil, "ambiguous standard menu mixes weapon and command items" end
-        if unit and map then return nil, "ambiguous standard menu contains unit and map commands" end
-        if weapon then return "weapon_menu" end
-        if unit then return "unit_command_menu" end
-        if map then return "map_command_menu" end
-        local enabled = enabledMenuItems(observation)
-        local callbacks = #enabled > 0
-        for _, item in ipairs(enabled) do
-            if not item.on_selected then callbacks = false break end
-        end
-        if callbacks then return "generic_menu" end
-        return nil, "unsupported standard menu has no recognized semantic commands"
-    end
-
-    if proc(observation, "prep_units") then
-        if idleIs(observation, "prep_units", "prep_units_input") then return "prep_pick_units" end
-        return "transition"
-    end
-
-    if proc(observation, "prep_menu") then
-        if not idleIs(observation, "prep_menu", "prep_menu_input") or not observation.prep then
-            return "transition"
-        end
-        if observation.prep.help_open then return "transition" end
-        if proc(observation, "at_menu") then return "prep_main" end
-        if proc(observation, "sally") then return "prep_map_menu" end
-        return nil, "preparations menu has no recognized owner"
-    end
-
-    if idleIs(observation, "game_early_start", "health_safety_wait") then
-        return "health_safety_wait"
-    end
-    if idleIs(observation, "title", "title_idle") then return "title_idle" end
-    if idleIs(observation, "save_menu", "save_menu_input") then return "save_menu_input" end
-    if idleIs(observation, "save_menu", "save_slot_input") then return "save_slot_input" end
-    if idleIs(observation, "difficulty", "difficulty_input") then return "difficulty_input" end
-    if idleIs(observation, "chapter_intro", "chapter_intro_input") then return "chapter_intro_input" end
-
-    if proc(observation, "map_fade") then return "transition" end
-
-    for _, name in ipairs({ "talk_wait", "std_event", "battle_forecast", "battle" }) do
-        if proc(observation, name) then return "transition" end
-    end
-
-    if proc(observation, "player_phase") then
-        if idleIs(observation, "player_phase", "player_main_idle") then return "player_map_idle" end
-        if idleIs(observation, "player_phase", "player_range_idle") then return "unit_selected" end
-        if idleIs(observation, "player_phase", "player_move_wait") then return "unit_moving" end
-        return "transition"
-    end
-
-    for _, name in ipairs({
-        "game_control", "game_early_start", "title", "save_menu", "difficulty", "chapter_intro",
-        "talk_wait", "std_event", "map_fade", "battle_forecast", "battle", "at_menu", "sally",
-    }) do
-        if proc(observation, name) then return "transition" end
-    end
-
-    return nil, "unsupported FE8 state"
+    table.sort(live, function(a, b) return a.name < b.name end)
+    return {
+        state = state,
+        error = why,
+        matched = rule,
+        detail = detail,
+        considered = considered,
+        live_procs = live,
+        unclassified_wait = state == "transition" and unclassified or false,
+    }
 end
 
 local function add(actions, intention, key, source, target)
@@ -207,6 +409,16 @@ function M.legalActions(observation)
         add(actions, "continue_chapter_intro", "A", "chapter_intro.chapter_intro_input")
     elseif state == "dialogue_wait" then
         add(actions, "advance_dialogue", "A", "talk_wait.talk_wait_input")
+    elseif state == "yes_no_choice" then
+        -- A commits whatever is highlighted (YesNoChoice_Loop_KeyHandler, cgtext.c), so
+        -- only the highlighted answer carries a key; the other is legal but must be
+        -- selected first. Same contract as a menu command that needs navigating to.
+        local current = observation.choice.current
+        add(actions, "answer_yes", current == "yes" and "A" or nil, "choice.current")
+        add(actions, "answer_no", current == "no" and "A" or nil, "choice.current")
+        if current == "no" then add(actions, "select_yes", "LEFT", "choice.current=no") end
+        if current == "yes" then add(actions, "select_no", "RIGHT", "choice.current=yes") end
+        add(actions, "cancel_choice", "B", "yes_no.cancel")
     elseif state == "prep_main" then
         if observation.prep.on_start == "prep_main_fight" then
             add(actions, "fight", "START", "prep.on_start")
@@ -314,6 +526,10 @@ local function jsonEncode(value)
     for _, key in ipairs(keys) do out[#out + 1] = jsonString(key) .. ":" .. jsonEncode(value[key]) end
     return "{" .. table.concat(out, ",") .. "}"
 end
+
+-- Deterministic (sorted-key) JSON. The trace format and the #236 inspector snapshot are
+-- the same wire format, so they share one encoder -- two would drift.
+M.encode = jsonEncode
 
 function M.formatTrace(record)
     return jsonEncode({

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -1,16 +1,49 @@
 #!/usr/bin/env python3
-"""Emit tools/playtest/symbols.lua from the built ELF.
+"""Emit the harness symbol tables from the built ELF.
 
 Run after every `make` (run.sh does this) -- BSS/EWRAM addresses shift when
 engine code changes, so the Lua harness must never hard-code them.
+
+Three outputs, one nm pass:
+
+  symbols.lua   the named symbols the harness reads/scans (SYM)
+  procscr.lua   every proc-script address -> its exact symbol (PROCSCR), so a live
+                proc is identified by SCRIPT ADDRESS instead of by the PROC_NAME
+                string at proc+0x10. Those strings are not unique -- the decomp
+                gives gProcScr_E_FACE and gProcScr_E_FACE_ExtraFrame both
+                PROC_NAME("E_FACE"), and reuses "bmenu" and "E_config" three times
+                each -- which is why freeze reports could not say which proc was
+                waiting (#236, blocking #232).
+  symbols.json  every ROM code symbol, for inspect.py. Idle callbacks are ordinary
+                functions (~35k of them): too many for a Lua table, so the Lua side
+                dumps raw addresses and the Python renderer names them.
+
+Resolution against these tables is EXACT-MATCH ONLY. An address that matches no
+symbol is reported as unknown; a nearest-preceding guess is worse than silence.
 """
+import json
 import os
+import re
 import subprocess
 import sys
+from collections import namedtuple
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 ELF = os.path.join(REPO, 'fireemblem8u', 'fireemblem8.elf')
-OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'symbols.lua')
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(HERE, 'symbols.lua')
+OUT_PROCSCR = os.path.join(HERE, 'procscr.lua')
+OUT_JSON = os.path.join(HERE, 'symbols.json')
+
+ROM_START = 0x08000000
+ROM_END = 0x0A000000
+
+# Proc scripts are `struct ProcCmd[]` in ROM: gProcScr_*/ProcScr_*/sProcScr_* plus the
+# handful named sProc_*/gProc_*. Keying by address makes a stray non-script match inert
+# (nothing ever looks up its address), while a missed one degrades to an honest unknown.
+PROC_SCRIPT_RE = re.compile(r'ProcScr|^[a-z]?Proc_')
+
+Symbol = namedtuple('Symbol', 'name type addr')
 
 # Symbols the harness reads/scans. Struct offsets live in harness.lua next to
 # the decomp header they came from.
@@ -78,6 +111,14 @@ WANTED = [
     'ChapterIntro_KeyListen_Loop', # exact chapter-title input callback
     'gProcScr_TalkWaitForInput', # dialogue waits for a real player key
     'TalkWaitForInput_OnIdle',  # exact dialogue input callback
+    'gProcScr_YesNoChoice',     # in-scene Yes/No prompt (src/cgtext.c). Distinct from the
+                                # page wait above: it runs INSIDE a live event scene, so
+                                # without it the scene reads as a passive std_event
+                                # transition and nothing ever answers -- ch01's lord-select
+                                # "Will <lead> lead the party?" parked here (#232/#236).
+    'YesNoChoice_Loop_KeyHandler', # exact Yes/No input callback. currentChoice is s16 at
+                                # +0x2A: TALK_CHOICE_YES = 1, TALK_CHOICE_NO = 2
+                                # (include/scene.h); A commits whichever is highlighted.
     'ProcScr_AtMenu',           # preparations main-menu owner
     'ProcScr_PrepMenu',         # live semantic preparations command list
     'PrepMenu_CtrlLoop',        # exact preparations input callback
@@ -152,18 +193,74 @@ WANTED = [
 ]
 
 
+def parse_nm(text):
+    """nm output -> Symbols. Undefined entries carry no address and are dropped."""
+    out = []
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            continue
+        try:
+            addr = int(parts[0], 16)
+        except ValueError:
+            continue
+        out.append(Symbol(parts[2], parts[1], addr))
+    return out
+
+
+def wanted_symbols(symbols, wanted):
+    """The named symbols, or KeyError naming every one the ELF does not have."""
+    found = {s.name: s.addr for s in symbols if s.name in set(wanted)}
+    missing = [w for w in wanted if w not in found]
+    if missing:
+        raise KeyError('symbols not found in ELF: %s' % ', '.join(missing))
+    return found
+
+
+def _rom_code(symbols):
+    return [s for s in symbols
+            if s.type in ('T', 't') and ROM_START <= s.addr < ROM_END]
+
+
+def _by_address(symbols):
+    # Aliases put two names on one address. Prefer the shorter (then lexically first)
+    # name so the table is deterministic across builds and reads as the canonical one.
+    out = {}
+    for s in symbols:
+        prev = out.get(s.addr)
+        if prev is None or (len(s.name), s.name) < (len(prev), prev):
+            out[s.addr] = s.name
+    return out
+
+
+def proc_scripts(symbols):
+    """Proc-script address -> exact symbol name."""
+    return _by_address([s for s in _rom_code(symbols) if PROC_SCRIPT_RE.search(s.name)])
+
+
+def code_symbols(symbols):
+    """Every ROM code address -> exact symbol name (idle callbacks live here)."""
+    return _by_address(_rom_code(symbols))
+
+
+def render_lua(varname, mapping):
+    lines = ['-- generated by gen_symbols.py from fireemblem8.elf; do not edit',
+             '%s = {' % varname]
+    for addr in sorted(mapping):
+        lines.append('    [0x%08X] = "%s",' % (addr, mapping[addr]))
+    lines.append('}')
+    return '\n'.join(lines) + '\n'
+
+
 def main():
     if not os.path.exists(ELF):
         sys.exit('ERROR: %s not built (run make first)' % ELF)
     nm = subprocess.run(['arm-none-eabi-nm', ELF], capture_output=True, text=True, check=True)
-    addrs = {}
-    for line in nm.stdout.splitlines():
-        parts = line.split()
-        if len(parts) == 3 and parts[2] in WANTED:
-            addrs[parts[2]] = int(parts[0], 16)
-    missing = [w for w in WANTED if w not in addrs]
-    if missing:
-        sys.exit('ERROR: symbols not found in ELF: %s' % ', '.join(missing))
+    symbols = parse_nm(nm.stdout)
+    try:
+        addrs = wanted_symbols(symbols, WANTED)
+    except KeyError as missing:
+        sys.exit('ERROR: %s' % missing.args[0])
     with open(OUT, 'w', encoding='utf-8') as f:
         f.write('-- generated by gen_symbols.py from fireemblem8.elf; do not edit\n')
         f.write('SYM = {\n')
@@ -171,6 +268,17 @@ def main():
             f.write('    %s = 0x%08X,\n' % (name, addrs[name]))
         f.write('}\n')
     print('wrote %s (%d symbols)' % (OUT, len(addrs)))
+
+    scripts = proc_scripts(symbols)
+    with open(OUT_PROCSCR, 'w', encoding='utf-8') as f:
+        f.write(render_lua('PROCSCR', scripts))
+    print('wrote %s (%d proc scripts)' % (OUT_PROCSCR, len(scripts)))
+
+    code = code_symbols(symbols)
+    with open(OUT_JSON, 'w', encoding='utf-8') as f:
+        json.dump({'code': {'0x%08X' % a: n for a, n in code.items()}}, f,
+                  indent=0, sort_keys=True)
+    print('wrote %s (%d code symbols)' % (OUT_JSON, len(code)))
 
 
 if __name__ == '__main__':

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -271,9 +271,11 @@ end
 --     post       optional fn(reachedEnd) run once after the loop (e.g. a final "title" shot)
 local controllerState, guardedInput, freezeReport
 -- The #236 state inspector, as ONE table rather than three top-level locals: this file
--- is at Lua's 200-local ceiling for a main chunk, and crossing it stops the whole harness
--- loading (every scenario dies at once). Fields are assigned further down, next to the
--- proc-pool reader they build on.
+-- is against Lua's 200-local ceiling for a main chunk, and crossing it stops the whole
+-- harness loading (every scenario dies at once). Consolidating here bought back 2 slots,
+-- and 2 is all the headroom there is -- measured 2026-08-06, +2 top-level locals still
+-- compiles and +3 does not. `check_lua_chunks_load` now fails the build on it in 0s.
+-- Fields are assigned further down, next to the proc-pool reader they build on.
 local INSPECT = {}
 local function recordCutscene(o)
     o = o or {}

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -17,6 +17,10 @@
 -- engine demands real combat (deaths must go through battle, not HP pokes).
 
 dofile(PLAYTEST_DIR .. "/symbols.lua")
+-- PROCSCR: proc-script address -> exact symbol. Proc identity must never come from the
+-- PROC_NAME string at proc+0x10 -- the decomp reuses those (E_FACE twice, bmenu three
+-- times), which is why freeze reports could not say which proc was waiting (#236).
+dofile(PLAYTEST_DIR .. "/procscr.lua")
 local Controller = dofile(PLAYTEST_DIR .. "/controller.lua")
 local Recorder = dofile(PLAYTEST_DIR .. "/recorder.lua")
 
@@ -50,6 +54,20 @@ local TUNE = {
     stuckRecoveries = 2,
     -- A save slot takes TWO confirms; the prompt must be gone within this allowance.
     saveConfirms = 4,
+    -- Steps a boot/scene loop may take before it gives up. This must NOT be the thing
+    -- that decides failure: a cap that expires mid-scene reports a timeout naming nothing,
+    -- which is exactly how ch01 stayed open through #232 (it was still advancing dialogue
+    -- 263 frames before the old 12000-step cap ran out). INSPECT.watch is the failure oracle
+    -- -- it speaks in stallFrames -- so this only has to be larger than any real scene.
+    bootSteps = 36000,
+    -- Frames between the two proc-pool samples an inspector snapshot takes. One sample
+    -- cannot tell a frozen proc from a live one; two, a gap apart, can.
+    inspectGap = 90,
+    -- How long an UNCLASSIFIED transition may hold a byte-identical proc pool before the
+    -- inspector calls it a stalled input wait. 600 frames is 10s of wall clock at 60fps --
+    -- longer than any fade or animation, and far cheaper than the 12000-iteration boot
+    -- loop that used to time out saying nothing (#232 ch01, #236).
+    stallFrames = 600,
 }
 local CHAR_HLIN, CHAR_SCRAMSAX, CHAR_SEPHEK = 0x0D, 0x11, 0x68 -- NATASHA/KYLE/ONEILL slots
 -- prologue/sandbox host on chapter slot 1; a chapter load-test (e.g. --ch03-boot on slot 4)
@@ -252,6 +270,11 @@ end
 --     afterPre   optional cleanup fn, guaranteed after pre returns or raises
 --     post       optional fn(reachedEnd) run once after the loop (e.g. a final "title" shot)
 local controllerState, guardedInput, freezeReport
+-- The #236 state inspector, as ONE table rather than three top-level locals: this file
+-- is at Lua's 200-local ceiling for a main chunk, and crossing it stops the whole harness
+-- loading (every scenario dies at once). Fields are assigned further down, next to the
+-- proc-pool reader they build on.
+local INSPECT = {}
 local function recordCutscene(o)
     o = o or {}
     local tag = o.tag or "scene"
@@ -331,6 +354,7 @@ local CALLBACK_NAMES = {
     [SYM.DifficultySelect_Loop_KeyHandler] = "difficulty_input",
     [SYM.ChapterIntro_KeyListen_Loop] = "chapter_intro_input",
     [SYM.TalkWaitForInput_OnIdle] = "talk_wait_input",
+    [SYM.YesNoChoice_Loop_KeyHandler] = "yes_no_input",
     [SYM.Menu_OnIdle] = "menu_input",
     [SYM.PrepMenu_CtrlLoop] = "prep_menu_input",
     [SYM.ProcPrepUnit_Idle] = "prep_units_input",
@@ -474,7 +498,12 @@ local function observeController()
         local script = ru32(addr)
         if script ~= 0 then
             observation.raw_procs[#observation.raw_procs + 1] = {
-                slot = i, script = script, idle = ru32(addr + 0x0C), lock = ru8(addr + 0x28),
+                -- scrCur is the script command the proc sits on (include/proc.h). It is the
+                -- liveness signal the stall detector keys on: a pool whose every proc holds
+                -- the same command, idle and lock for TUNE.stallFrames is not slow, it is
+                -- waiting for an input nothing will send (#236).
+                slot = i, script = script, scr_cur = ru32(addr + 0x04),
+                idle = ru32(addr + 0x0C), lock = ru8(addr + 0x28),
             }
         end
     end
@@ -492,6 +521,20 @@ local function observeController()
     local introKey = observedProc(SYM.ProcScr_ChapterIntro_KeyListen)
     put("chapter_intro", introKey or observedProc(SYM.gProcScr_ChapterIntro))
     put("talk_wait", observedProc(SYM.gProcScr_TalkWaitForInput))
+    local yesNo = observedProc(SYM.gProcScr_YesNoChoice)
+    put("yes_no", yesNo)
+    if yesNo then
+        -- struct YesNoChoiceProc.currentChoice (include/cgtext.h): s16 @ +0x2A,
+        -- TALK_CHOICE_YES = 1 / TALK_CHOICE_NO = 2 (include/scene.h).
+        local choice = rs16(yesNo.addr + 0x2A)
+        observation.choice = {
+            current = (choice == 1 and "yes") or (choice == 2 and "no") or nil,
+            raw = choice,
+        }
+        if not observation.choice.current then
+            observation.error = string.format("malformed YesNoChoiceProc currentChoice=%d", choice)
+        end
+    end
     local rawMenu = anyMenuProc()
     put("menu", rawMenu and { addr = rawMenu, idle = callbackName(ru32(rawMenu + 0x0C)),
         locked = ru8(rawMenu + 0x28) ~= 0, frozen = (ru8(rawMenu + 0x63) & 0x40) ~= 0,
@@ -588,6 +631,9 @@ local function traceFailure(intention, expected, verdict, observation, tag)
     local actions = Controller.legalActions(observation)
     traceInput(observation, actions, intention, "none", expected, verdict, observation)
     shot(tag or "controller-failure")
+    -- Every terminal controller failure carries its inspector snapshot, so diagnosing one
+    -- costs a log read instead of another build-and-run cycle (#236).
+    INSPECT.snapshot(tag or "controller-failure")
 end
 guardedInput = function(intention, key, expected, predicate, frames)
     local before = observeController()
@@ -977,6 +1023,38 @@ local function driveSaveSlot()
     return false
 end
 
+-- A `transition` the classifier has no name for, holding a byte-identical proc pool, is
+-- not a slow scene -- it is an input wait nothing will ever send. #232's ch01 burned a
+-- 12000-iteration loop and then reported a timeout that named nothing; this dumps the
+-- inspector snapshot the moment the stall is provable, so the NEXT question is which
+-- proc to classify rather than which hypothesis to rebuild for. Returns a per-loop
+-- closure: call it with each observation, and act on the first true.
+INSPECT.watch = function(what)
+    local signature, held = nil, 0
+    return function(observation, state)
+        if state ~= "transition" then signature, held = nil, 0 return false end
+        local explanation = Controller.explain(observation)
+        -- Only an UNCLASSIFIED transition can stall this way. A named one (a map fade, a
+        -- menu animating in) is a state we can already wait out, and arming on those
+        -- would trade a silent hang for a noisy false positive.
+        if not explanation.unclassified_wait then signature, held = nil, 0 return false end
+        local parts = {}
+        for _, p in ipairs(observation.raw_procs or {}) do
+            parts[#parts + 1] = string.format("%d:%08X:%08X:%08X:%d",
+                p.slot, p.script, p.scr_cur, p.idle, p.lock)
+        end
+        local now = table.concat(parts, ",")
+        if now ~= signature then signature, held = now, 0 return false end
+        held = held + 1
+        if held < TUNE.stallFrames then return false end
+        held = 0
+        log(string.format("STALL: %s held an unclassified wait for %d frames -- %s",
+            what, TUNE.stallFrames, tostring(explanation.detail)))
+        INSPECT.snapshot(what .. "-stall", explanation)
+        return true
+    end
+end
+
 local function advanceBootState(observation, state)
     if state == "health_safety_wait" then
         return guardedInput("continue", "A", "health/safety wait clears", function(after)
@@ -1013,9 +1091,14 @@ end
 
 local function bootToMap(stopAtPrep)
     log("booting to map with observed FE8 states")
+    local stalled = INSPECT.watch("boot")
     for _ = 1, 12000 do
         local observation = observeController()
         local state, why = controllerState(observation)
+        if stalled(observation, state) then
+            result("FAIL", "boot parked on an unclassified wait (see the inspect snapshot)")
+            return false
+        end
         if state == "player_map_idle" then
             if inChapter() then
                 log(string.format("in chapter %d turn %d", chapter(), turn()))
@@ -1096,9 +1179,10 @@ end
 -- A soft-lock is never a stopped CPU -- it is the proc scheduler still running while one
 -- proc stops advancing. The proc pool carries its own diagnosis (include/proc.h): scrCur
 -- is the script command it sits on, lockCnt is the wait semaphore (nonzero = blocked by a
--- child//other proc that never released it), sleepTime is a timed wait, and proc_name is
--- the PROC_NAME string. Sampling the pool TWICE across a gap separates "this proc is
--- frozen" from "the whole scheduler is spinning", which is the first fork in the diagnosis.
+-- child//other proc that never released it), and sleepTime is a timed wait. Sampling the
+-- pool TWICE across a gap separates "this proc is frozen" from "the whole scheduler is
+-- spinning", which is the first fork in the diagnosis. Identity comes from the script
+-- ADDRESS via PROCSCR, never from the PROC_NAME string the decomp reuses (#236).
 local PROC_STRIDE = 0x6C
 local function readCStr(addr, maxLen)
     if addr == 0 then return nil end
@@ -1134,6 +1218,13 @@ local function procPool()
     return pool
 end
 
+-- Exact-match only. A script address that matches no symbol is reported as unknown:
+-- a confidently wrong name (the old PROC_NAME string, where three distinct scripts all
+-- read as "E_FACE") cost #232 its last failure, and silence would have been cheaper.
+INSPECT.scriptName = function(addr)
+    return PROCSCR[addr] or string.format("unknown@0x%08X", addr)
+end
+
 local function procLine(i, p, prev)
     -- scrCur as an offset from the script head: the exact PROC_* command it sits on.
     local step = (p.scrCur >= p.script) and ((p.scrCur - p.script) // 12) or -1
@@ -1143,8 +1234,8 @@ local function procLine(i, p, prev)
             and " FROZEN" or " moving"
     end
     return string.format(
-        "  [%02d] %-22s scr=%08X cmd#%-3d idle=%08X sleep=%-4d mark=%-3d flags=%02X lock=%d%s",
-        i, p.name or "(unnamed)", p.script, step, p.idleCb, p.sleep, p.mark, p.flags, p.lock, moved)
+        "  [%02d] %-34s cmd#%-3d idle=%08X sleep=%-4d mark=%-3d flags=%02X lock=%d%s",
+        i, INSPECT.scriptName(p.script), step, p.idleCb, p.sleep, p.mark, p.flags, p.lock, moved)
 end
 
 -- The BattleUnit pair the engine is resolving/animating right now.
@@ -1187,7 +1278,61 @@ freezeReport = function(tag, gap)
     for i = 0, 63 do
         if after[i] then log(procLine(i, after[i], before[i])) end
     end
+    INSPECT.snapshot(tag)
 end
+
+-- ---- state inspector (#236): one machine-readable snapshot of what FE8 is doing.
+-- The controller observer already builds the semantic state; this formats it, adds the
+-- reasoning behind the classification, and pairs it with the raw proc inventory named by
+-- exact symbol. Rendered by tools/playtest/inspect_state.py, which resolves the idle-callback
+-- addresses (ordinary functions -- ~35k of them, too many for a Lua table) out of the ELF.
+INSPECT.snapshot = function(tag, explanation)
+    local observation = observeController()
+    explanation = explanation or Controller.explain(observation)
+    local before = procPool()
+    wait(TUNE.inspectGap)
+    local after = procPool()
+    local procs = {}
+    for i = 0, 63 do
+        local p = after[i]
+        if p then
+            local prev = before[i]
+            procs[#procs + 1] = {
+                slot = i,
+                script = string.format("0x%08X", p.script),
+                script_name = INSPECT.scriptName(p.script),
+                -- The decomp's PROC_NAME string: colour only, never identity.
+                proc_name = p.name,
+                step = (p.scrCur >= p.script) and ((p.scrCur - p.script) // 12) or -1,
+                idle = string.format("0x%08X", codeAddr(p.idleCb)),
+                sleep = p.sleep, mark = p.mark, flags = p.flags, lock = p.lock,
+                frozen = prev ~= nil and prev.scrCur == p.scrCur and prev.sleep == p.sleep
+                    and prev.lock == p.lock,
+            }
+        end
+    end
+    -- raw_procs is the stall detector's signature source; the named inventory supersedes it.
+    observation.raw_procs = nil
+    log(Controller.encode({
+        event = "inspect",
+        tag = tag,
+        scenario = PLAYTEST_SCENARIO,
+        state = explanation.state or "unsupported",
+        classification_error = explanation.error,
+        matched_rule = explanation.matched,
+        detail = explanation.detail,
+        unclassified_wait = explanation.unclassified_wait,
+        considered = explanation.considered,
+        world = observation.world,
+        cursor = observation.cursor,
+        menu = observation.menu,
+        prep = observation.prep,
+        target = observation.target,
+        procs = procs,
+    }))
+    shot(tag)
+end
+
 
 -- CONTROLLER_TURN (#220): the compact live contract gate on the normal no-prep boot.
 -- It proves a real unit move closes through semantic Wait, then semantic End Phase reaches
@@ -1515,9 +1660,20 @@ local function reachCh01Map()
         result("FAIL", "chapter slot 2 never loaded after the ch00 win"); return false
     end
     log("in ch01 (chapter slot 2); observing post-chapter flow to Preparations")
-    for _ = 1, 12000 do
+    -- The Beat-1 Northlook scene is 29 script lines -> 67 text pages, and at normal speed
+    -- it costs ~170 frames a page. Nothing here is looked at, so set gameSpeed (gPlaySt
+    -- +0x40 bit 7) and type it fast. Written inline, not as a helper: harness.lua is at
+    -- the 200-local ceiling, and one more top-level `local` stops the whole file loading.
+    -- Only gameSpeed -- animationType is left alone so winCh00's combat is unaffected.
+    emu:write32(SYM.gPlaySt + 0x40, ru32(SYM.gPlaySt + 0x40) | (1 << 7))
+    local stalled = INSPECT.watch("reach_ch01")
+    for _ = 1, TUNE.bootSteps do
         local observation = observeController()
         local state, why = controllerState(observation)
+        if stalled(observation, state) then
+            result("FAIL", "ch01 parked on an unclassified wait (see the inspect snapshot)")
+            return false
+        end
         if state == "prep_main" then
             shot("ch01-prep-menu")
             if not driveThroughPrep() then
@@ -1534,6 +1690,15 @@ local function reachCh01Map()
                 return after.menu == nil
             end, 300) then
                 result("FAIL", "could not choose the highlighted lead"); return false
+            end
+        elseif state == "yes_no_choice" then
+            -- Lord select confirms the pick with "Will <lead> lead the party?". Same
+            -- scenario policy as the menu above -- accept the default -- and Yes is the
+            -- highlighted answer, so the controller offers it directly on A.
+            if not guardedInput("answer_yes", "A", "the yes/no prompt closes", function(after)
+                return after.procs.yes_no == nil
+            end, 300) then
+                result("FAIL", "could not answer the lord-select prompt"); return false
             end
         else
             local advanced = advanceBootState(observation, state)

--- a/tools/playtest/inspect_state.py
+++ b/tools/playtest/inspect_state.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Read a playtest log semantically: what FE8 was doing, why the controller classified it
+that way, and where two runs first diverge (#236).
+
+    tools/playtest/inspect_state.py render /tmp/playtest-ch01/playtest.log
+    tools/playtest/inspect_state.py diff /tmp/accepted.log /tmp/playtest-ch01/playtest.log
+
+The harness emits the state; this names and formats it. Addresses resolve against
+symbols.json (written by gen_symbols.py after every make) by EXACT match -- idle callbacks
+are ordinary functions, ~35k of them, which is why the Lua side dumps raw addresses and
+the naming happens here. An address that matches no symbol is reported as unknown; a
+nearest-preceding guess is what made #232's freeze reports untrustworthy.
+
+Named inspect_state.py, not inspect.py: the playtest directory goes on sys.path, and a
+module called `inspect` there would shadow the standard library's for everything that
+imports it, unittest included.
+"""
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SYMBOLS_JSON = os.path.join(HERE, 'symbols.json')
+
+# The transition fields that make two runs meaningfully different, in the order a reader
+# wants them: what state the game was in, what the controller did, what came of it.
+DIVERGENCE_FIELDS = ('state', 'action', 'result')
+
+
+def parse_records(text):
+    """The JSON events in a playtest log, in order. Plain log lines are skipped, and so
+    is anything malformed -- a truncated log (mGBA killed at its deadline) is normal
+    input, not an error."""
+    out = []
+    for line in text.splitlines():
+        # Every harness line is stamped with the frame it happened on -- `[f021071] {...}`
+        # -- so a record never starts at column 0.
+        brace = line.find('{')
+        if brace < 0:
+            continue
+        try:
+            record = json.loads(line[brace:])
+        except ValueError:
+            continue
+        if isinstance(record, dict) and 'event' in record:
+            out.append(record)
+    return out
+
+
+def load_symbols(path=SYMBOLS_JSON):
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding='utf-8') as f:
+        raw = json.load(f)
+    return {int(a, 16): n for a, n in raw.get('code', {}).items()}
+
+
+def resolve(symbols, addr):
+    """An address (hex string or int) as `Symbol(0x...)`, `none`, or an honest unknown."""
+    if addr is None:
+        return 'none'
+    value = addr if isinstance(addr, int) else int(str(addr), 16)
+    if value == 0:
+        return 'none'
+    name = symbols.get(value)
+    if name is None:
+        return 'unknown@0x%08X' % value
+    return '%s(0x%08X)' % (name, value)
+
+
+def _world_line(world):
+    if not world:
+        return '  world:  -'
+    return '  world:  chapter=%s turn=%s faction=0x%02X host_chapter=%s' % (
+        world.get('chapter'), world.get('turn'), world.get('faction') or 0,
+        world.get('host_chapter'))
+
+
+def _cursor_line(cursor):
+    if not cursor:
+        return '  cursor: -  (no live map)'
+    return '  cursor: (%s,%s) unit=0x%02X %s select=%s reachable=%s' % (
+        cursor.get('x'), cursor.get('y'), cursor.get('unit') or 0,
+        cursor.get('unit_faction') or '-', cursor.get('unit_select_kind') or '-',
+        cursor.get('reachable'))
+
+
+def _menu_line(menu):
+    if not menu:
+        return '  menu:   -'
+    items = ' '.join('0x%02X%s' % (i.get('override_id') or 0,
+                                   '' if i.get('availability') == 1 else '(disabled)')
+                     for i in menu.get('items', []))
+    return '  menu:   current=%s [%s] on_b=%s' % (
+        menu.get('current'), items, menu.get('on_b') or '-')
+
+
+def render_inspect(record, symbols):
+    """One snapshot as a human-readable block."""
+    lines = ['== INSPECT (%s) scenario=%s ==' % (record.get('tag') or '?',
+                                                 record.get('scenario') or '?')]
+    verdict = '  state:  %s' % (record.get('state') or 'unsupported')
+    if record.get('matched_rule'):
+        verdict += '   [rule: %s]' % record['matched_rule']
+    if record.get('unclassified_wait'):
+        verdict += '   *** UNCLASSIFIED WAIT ***'
+    lines.append(verdict)
+    if record.get('classification_error'):
+        lines.append('  error:  %s' % record['classification_error'])
+    if record.get('detail'):
+        lines.append('  detail: %s' % record['detail'])
+    lines.append(_world_line(record.get('world')))
+    lines.append(_cursor_line(record.get('cursor')))
+    lines.append(_menu_line(record.get('menu')))
+    if record.get('target'):
+        target = record['target']
+        lines.append('  target: kind=%s at (%s,%s) uid=0x%02X frozen=%s' % (
+            target.get('kind'), target.get('x'), target.get('y'),
+            target.get('uid') or 0, target.get('frozen')))
+    if record.get('prep'):
+        prep = record['prep']
+        lines.append('  prep:   current=%s help_open=%s on_start=%s' % (
+            prep.get('current'), prep.get('help_open'), prep.get('on_start')))
+
+    considered = record.get('considered') or []
+    if considered:
+        lines.append('  considered (in order, all rejected before the verdict):')
+        for entry in considered:
+            lines.append('    %-18s %s' % (entry.get('rule'), entry.get('reason')))
+
+    procs = record.get('procs') or []
+    if procs:
+        # FROZEN means the proc held the same script command, sleep and lock across both
+        # samples -- the difference between a scene that is slow and one that is waiting.
+        lines.append('  live procs (sampled twice):')
+        for p in procs:
+            lines.append('    [%02d] %-32s cmd#%-4s idle=%-34s sleep=%-4s lock=%s%s' % (
+                p.get('slot') or 0, p.get('script_name') or '?', p.get('step'),
+                resolve(symbols, p.get('idle')), p.get('sleep'), p.get('lock'),
+                '  FROZEN' if p.get('frozen') else ''))
+    return '\n'.join(lines)
+
+
+def render_log(text, symbols):
+    snapshots = [r for r in parse_records(text) if r.get('event') == 'inspect']
+    if not snapshots:
+        return 'no inspect snapshots in this log (the run never faulted or stalled)'
+    return '\n\n'.join(render_inspect(r, symbols) for r in snapshots)
+
+
+def _steps(records):
+    return [r for r in records if r.get('event') == 'transition']
+
+
+def first_divergence(baseline, candidate):
+    """The first step where two runs stop agreeing, or None. Only `transition` records
+    count as steps -- inspect snapshots are diagnostics and may appear in one run and not
+    the other without meaning the runs differ."""
+    left, right = _steps(baseline), _steps(candidate)
+    for index in range(max(len(left), len(right))):
+        if index >= len(left) or index >= len(right):
+            return {
+                'index': index,
+                'field': 'length',
+                'baseline': left[index].get('state') if index < len(left) else None,
+                'candidate': right[index].get('state') if index < len(right) else None,
+                'baseline_record': left[index] if index < len(left) else None,
+                'candidate_record': right[index] if index < len(right) else None,
+            }
+        for field in DIVERGENCE_FIELDS:
+            if left[index].get(field) != right[index].get(field):
+                return {
+                    'index': index,
+                    'field': field,
+                    'baseline': left[index].get(field),
+                    'candidate': right[index].get(field),
+                    'baseline_record': left[index],
+                    'candidate_record': right[index],
+                }
+    return None
+
+
+def _evidence(record):
+    if not record:
+        return '      (the run had no step here)'
+    before = (record.get('before') or {}).get('classification')
+    after = (record.get('after') or {}).get('classification')
+    return ('      state=%s action=%s input=%s result=%s\n'
+            '      before=%s after=%s expected=%s' % (
+                record.get('state'), record.get('action'), record.get('input'),
+                record.get('result'), before, after, record.get('expected')))
+
+
+def format_divergence(divergence, baseline_name, candidate_name):
+    if divergence is None:
+        return 'no divergence: both runs took the same semantic steps'
+    lines = [
+        'first divergence at step %d (%s)' % (divergence['index'], divergence['field']),
+        '  %s: %s' % (baseline_name, divergence['baseline']),
+        _evidence(divergence['baseline_record']),
+        '  %s: %s' % (candidate_name, divergence['candidate']),
+        _evidence(divergence['candidate_record']),
+    ]
+    return '\n'.join(lines)
+
+
+def _read(path):
+    with open(path, encoding='utf-8') as f:
+        return f.read()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    parser.add_argument('--symbols', default=SYMBOLS_JSON,
+                        help='symbols.json from gen_symbols.py (default: alongside this tool)')
+    sub = parser.add_subparsers(dest='command', required=True)
+    render = sub.add_parser('render', help='human-readable state snapshots from a log')
+    render.add_argument('log')
+    diff = sub.add_parser('diff', help='first semantic divergence between two runs')
+    diff.add_argument('baseline')
+    diff.add_argument('candidate')
+    args = parser.parse_args(argv)
+
+    if args.command == 'render':
+        print(render_log(_read(args.log), load_symbols(args.symbols)))
+        return 0
+    divergence = first_divergence(parse_records(_read(args.baseline)),
+                                  parse_records(_read(args.candidate)))
+    print(format_divergence(divergence, args.baseline, args.candidate))
+    return 1 if divergence else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -361,6 +361,100 @@ for _, field in ipairs({ '"event":"transition"', '"state":"unit_command_menu"',
     check(trace:find(field, 1, true) ~= nil, true, "trace includes " .. field)
 end
 
+-- Yes/No choice (cgtext.c gProcScr_YesNoChoice). The lord-select prompt "Will Braulo lead
+-- the party?" rides this, and nothing classified it -- so ch01 parked on it for the whole
+-- of #232 while the event engine stayed live and read as a passive transition (#236 found
+-- it by name). currentChoice is TALK_CHOICE_YES/NO; A commits whichever is highlighted.
+local yesHighlighted = {
+    procs = proc("yes_no", "yes_no_input"),
+    choice = { current = "yes" },
+}
+classify(yesHighlighted, "yes_no_choice", "yes/no prompt in its key handler")
+local yes = action(yesHighlighted, "answer_yes")
+check(yes and yes.key, "A", "A commits the highlighted Yes")
+local no = action(yesHighlighted, "answer_no")
+check(no ~= nil, true, "No is legal, but not by pressing A")
+check(no and no.key, nil, "No must be selected before it can be committed")
+check(action(yesHighlighted, "select_no").key, "RIGHT", "RIGHT moves the choice to No")
+check(action(yesHighlighted, "cancel_choice").key, "B", "B cancels the prompt")
+
+local noHighlighted = {
+    procs = proc("yes_no", "yes_no_input"),
+    choice = { current = "no" },
+}
+check(action(noHighlighted, "answer_no").key, "A", "A commits the highlighted No")
+check(action(noHighlighted, "answer_yes").key, nil, "Yes is not committable while No is up")
+check(action(noHighlighted, "select_yes").key, "LEFT", "LEFT moves the choice back to Yes")
+
+-- The prompt animating in offers nothing, and says so by name.
+classify({ procs = proc("yes_no", "yes_no_fade"), choice = { current = "yes" } }, "transition",
+    "a yes/no prompt outside its key handler is passive")
+check(action({ procs = proc("yes_no", "yes_no_fade") }, "answer_yes"), nil,
+    "a passive yes/no prompt exposes no answer")
+
+-- A live event engine must not mask the prompt: the yes/no rule is evaluated first.
+classify({
+    procs = { std_event = { idle = "event_engine" }, yes_no = { idle = "yes_no_input" } },
+    choice = { current = "yes" },
+}, "yes_no_choice", "the yes/no prompt outranks the passive event engine")
+
+-- explain(): the same verdict, plus WHY. Every #232 defect but one was an input wait
+-- nothing had a name for; each read as a passive `transition` and cost a full
+-- build-and-run cycle to identify. An unclassified wait has to say what it rejected.
+local function reasonFor(explanation, rule)
+    for _, entry in ipairs(explanation.considered) do
+        if entry.rule == rule then return entry.reason end
+    end
+    return nil
+end
+
+local dialogue = C.explain({ procs = proc("talk_wait", "talk_wait_input") })
+check(dialogue.state, "dialogue_wait", "explain agrees with classify on a match")
+check(dialogue.matched, "dialogue_wait", "explain names the rule that matched")
+check(dialogue.error, nil, "a matched explanation carries no error")
+
+-- The ch01 acceptance case: a live event engine and nothing else, which classify calls
+-- `transition`. The explanation must name the proc that made it one, and show that the
+-- dialogue-wait rule was considered and why it was rejected.
+local scene = C.explain({
+    procs = { std_event = { idle = "event_engine", addr = 0x02024F00 } },
+    world = { chapter = 2, turn = 0, faction = 0 },
+})
+check(scene.state, "transition", "a live event engine still classifies as transition")
+check(scene.matched, "passive_proc", "explain names which rule produced the transition")
+check(scene.detail:find("std_event", 1, true) ~= nil, true,
+    "the transition detail names the live proc responsible")
+check(reasonFor(scene, "dialogue_wait"):find("talk_wait", 1, true) ~= nil, true,
+    "dialogue_wait rejection names the proc it looked for")
+check(reasonFor(scene, "menu"):find("absent", 1, true) ~= nil, true,
+    "menu rejection says the proc is absent")
+check(scene.unclassified_wait, true,
+    "a transition with no live input proc is flagged as an unclassified wait")
+check(#scene.live_procs, 1, "explain lists the live procs it saw")
+check(scene.live_procs[1].name, "std_event", "live proc entries carry their name")
+check(scene.live_procs[1].idle, "event_engine", "live proc entries carry their idle callback")
+
+-- A proc that IS live but in the wrong callback must say so -- "absent" and "present but
+-- not in its input callback" are different bugs and cost different fixes.
+local fadingMenu = C.explain({ procs = proc("menu", "menu_fade_in"), menu = { current = 0, items = {} } })
+check(fadingMenu.state, "transition", "a menu outside its input callback is a transition")
+check(fadingMenu.matched, "menu", "the menu rule owns that transition")
+check(fadingMenu.detail:find("menu_fade_in", 1, true) ~= nil, true,
+    "the detail names the callback the menu is actually sitting in")
+check(fadingMenu.unclassified_wait, false,
+    "a transition a rule explained is not an unclassified wait")
+
+-- A hard error explains itself the same way classify does.
+local broken = C.explain({ error = "malformed live menu", procs = proc("menu", "menu_input") })
+check(broken.state, nil, "explain fails closed on a malformed observation")
+check(broken.error, "malformed live menu", "explain preserves the observer rejection")
+
+-- Fallthrough: no rule matched at all.
+local unknown = C.explain({ procs = { mystery = { idle = "mystery_idle" } } })
+check(unknown.state, nil, "an unrecognised proc set fails closed")
+check(type(unknown.error), "string", "the fallthrough explains itself")
+check(#unknown.considered > 5, true, "the fallthrough reports every rule it rejected")
+
 if fails > 0 then
     print(string.format("\n%d/%d FAILED", fails, tests))
     os.exit(1)

--- a/tools/playtest/test_gen_symbols.py
+++ b/tools/playtest/test_gen_symbols.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for tools/playtest/gen_symbols.py pure helpers -- nm parsing and the two
+generated symbol tables the inspector resolves addresses against (#236). Run:
+python3 tools/playtest/test_gen_symbols.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import gen_symbols as gs
+
+
+NM = '\n'.join([
+    '085b1890 T gProcScr_PlayerPhase',
+    '085a7ef4 T gProcScr_E_FACE',
+    '085a7f2c T gProcScr_E_FACE_ExtraFrame',
+    '08a39190 T ProcScr_PrepMenu',
+    '0801c9e0 T PlayerPhase_MainIdle',
+    '08007ca0 T TalkWaitForInput_OnIdle',
+    '0202bcf0 B gPlaySt',
+    '         U SomeUndefined',
+    '00000004 a .gcc2_compiled.',
+])
+
+
+class ParseNm(unittest.TestCase):
+    def test_keeps_addressed_symbols_with_their_type(self):
+        syms = gs.parse_nm(NM)
+        self.assertIn(('gPlaySt', 'B', 0x0202BCF0), [(s.name, s.type, s.addr) for s in syms])
+
+    def test_drops_undefined_symbols_that_carry_no_address(self):
+        self.assertNotIn('SomeUndefined', [s.name for s in gs.parse_nm(NM)])
+
+
+class WantedSymbols(unittest.TestCase):
+    def test_resolves_each_wanted_name_to_its_address(self):
+        got = gs.wanted_symbols(gs.parse_nm(NM), ['gPlaySt', 'ProcScr_PrepMenu'])
+        self.assertEqual(got, {'gPlaySt': 0x0202BCF0, 'ProcScr_PrepMenu': 0x08A39190})
+
+    def test_missing_symbol_is_reported_not_silently_dropped(self):
+        with self.assertRaises(KeyError) as raised:
+            gs.wanted_symbols(gs.parse_nm(NM), ['gPlaySt', 'NoSuchSymbol'])
+        self.assertIn('NoSuchSymbol', str(raised.exception))
+
+
+class ProcScripts(unittest.TestCase):
+    """The #236 defect: proc identity came from the PROC_NAME string at proc+0x10, and
+    the decomp reuses those (E_FACE twice, bmenu three times). Script ADDRESSES are
+    unique, so the table is keyed by address and resolution is exact-match only."""
+
+    def test_collects_proc_script_symbols_by_address(self):
+        got = gs.proc_scripts(gs.parse_nm(NM))
+        self.assertEqual(got[0x085B1890], 'gProcScr_PlayerPhase')
+        self.assertEqual(got[0x08A39190], 'ProcScr_PrepMenu')
+
+    def test_separates_scripts_that_share_one_proc_name_string(self):
+        got = gs.proc_scripts(gs.parse_nm(NM))
+        self.assertEqual(got[0x085A7EF4], 'gProcScr_E_FACE')
+        self.assertEqual(got[0x085A7F2C], 'gProcScr_E_FACE_ExtraFrame')
+
+    def test_excludes_ordinary_functions(self):
+        self.assertNotIn(0x0801C9E0, gs.proc_scripts(gs.parse_nm(NM)))
+
+    def test_excludes_ram_symbols(self):
+        self.assertNotIn(0x0202BCF0, gs.proc_scripts(gs.parse_nm(NM)))
+
+
+class CodeSymbols(unittest.TestCase):
+    """Idle callbacks are ordinary functions -- ~35k of them, too many for a Lua table,
+    so they resolve Python-side out of symbols.json."""
+
+    def test_collects_rom_code_symbols_by_address(self):
+        got = gs.code_symbols(gs.parse_nm(NM))
+        self.assertEqual(got[0x0801C9E0], 'PlayerPhase_MainIdle')
+        self.assertEqual(got[0x08007CA0], 'TalkWaitForInput_OnIdle')
+
+    def test_excludes_ram_symbols(self):
+        self.assertNotIn(0x0202BCF0, gs.code_symbols(gs.parse_nm(NM)))
+
+    def test_prefers_the_shorter_name_when_two_symbols_share_an_address(self):
+        syms = gs.parse_nm('08000100 T Foo_Alias_LongName\n08000100 T Foo\n')
+        self.assertEqual(gs.code_symbols(syms)[0x08000100], 'Foo')
+
+
+class RenderLua(unittest.TestCase):
+    def test_emits_a_do_not_edit_header_and_sorted_hex_keys(self):
+        out = gs.render_lua('PROCSCR', {0x085B1890: 'gProcScr_PlayerPhase',
+                                        0x08007CA0: 'Early'})
+        self.assertIn('do not edit', out.splitlines()[0])
+        self.assertLess(out.index('0x08007CA0'), out.index('0x085B1890'))
+        self.assertIn('[0x085B1890] = "gProcScr_PlayerPhase",', out)
+        self.assertTrue(out.rstrip().endswith('}'))
+
+    def test_output_is_loadable_lua(self):
+        out = gs.render_lua('PROCSCR', {0x085B1890: 'gProcScr_PlayerPhase'})
+        self.assertRegex(out, r'PROCSCR = \{')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/playtest/test_inspect.py
+++ b/tools/playtest/test_inspect.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for tools/playtest/inspect.py -- the #236 state inspector's pure formatting and
+first-divergence logic. No emulator, no ROM, no ELF: the renderer is handed the symbol
+table it resolves against. Run: python3 tools/playtest/test_inspect.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import inspect_state as ins
+
+
+SYMBOLS = {
+    0x08007CA0: 'TalkWaitForInput_OnIdle',
+    0x0801C9E0: 'PlayerPhase_MainIdle',
+}
+
+SNAPSHOT = {
+    'event': 'inspect',
+    'tag': 'reach_ch01-stall',
+    'scenario': 'ch01',
+    'state': 'transition',
+    'matched_rule': 'passive_proc',
+    'detail': 'std_event live (idle=event_engine)',
+    'unclassified_wait': True,
+    'considered': [
+        {'rule': 'dialogue_wait', 'reason': 'talk_wait proc absent'},
+        {'rule': 'menu', 'reason': 'menu proc absent'},
+    ],
+    'world': {'chapter': 2, 'turn': 0, 'faction': 0, 'host_chapter': 1},
+    'procs': [
+        {'slot': 3, 'script': '0x085A8858', 'script_name': 'ProcScr_StdEventEngine',
+         'proc_name': 'E_config', 'step': 12, 'idle': '0x08007CA0',
+         'sleep': 0, 'mark': 0, 'flags': 0, 'lock': 1, 'frozen': True},
+        {'slot': 9, 'script': '0x085A7EF4', 'script_name': 'gProcScr_E_FACE',
+         'proc_name': 'E_FACE', 'step': 2, 'idle': '0x00000000',
+         'sleep': 0, 'mark': 0, 'flags': 0, 'lock': 0, 'frozen': False},
+    ],
+}
+
+
+class ParseRecords(unittest.TestCase):
+    """A playtest log interleaves plain lines with the JSON the harness emits."""
+
+    def test_picks_json_events_out_of_a_mixed_log(self):
+        log = ('booting to map with observed FE8 states\n'
+               '{"event":"transition","state":"player_map_idle"}\n'
+               'RESULT: PASS -- fine\n')
+        got = ins.parse_records(log)
+        self.assertEqual([r['event'] for r in got], ['transition'])
+
+    def test_ignores_malformed_json_instead_of_raising(self):
+        self.assertEqual(ins.parse_records('{"event":"transition"\nnot json\n'), [])
+
+    def test_reads_the_frame_prefix_the_harness_actually_writes(self):
+        # log() stamps every line with the frame it happened on: `[f021071] {...}`.
+        log = '[f021071] {"event":"inspect","tag":"ch01-no-prep"}\n'
+        self.assertEqual([r['tag'] for r in ins.parse_records(log)], ['ch01-no-prep'])
+
+    def test_a_brace_inside_a_plain_log_line_is_not_a_record(self):
+        self.assertEqual(ins.parse_records('[f001] freeze: gAnims[0]={x}\n'), [])
+
+    def test_keeps_log_order(self):
+        log = '{"event":"transition","n":1}\n{"event":"inspect","n":2}\n'
+        self.assertEqual([r['n'] for r in ins.parse_records(log)], [1, 2])
+
+
+class ResolveSymbol(unittest.TestCase):
+    """Exact match or an honest unknown -- never a nearest-preceding guess."""
+
+    def test_names_a_known_address(self):
+        self.assertEqual(ins.resolve(SYMBOLS, '0x08007CA0'),
+                         'TalkWaitForInput_OnIdle(0x08007CA0)')
+
+    def test_reports_an_unmatched_address_as_unknown(self):
+        self.assertEqual(ins.resolve(SYMBOLS, '0x08123456'), 'unknown@0x08123456')
+
+    def test_null_is_not_an_unknown_symbol(self):
+        self.assertEqual(ins.resolve(SYMBOLS, '0x00000000'), 'none')
+
+
+class RenderInspect(unittest.TestCase):
+    def setUp(self):
+        self.out = ins.render_inspect(SNAPSHOT, SYMBOLS)
+
+    def test_leads_with_the_tag_and_the_verdict(self):
+        self.assertIn('reach_ch01-stall', self.out)
+        self.assertIn('transition', self.out)
+
+    def test_flags_an_unclassified_wait_loudly(self):
+        self.assertIn('UNCLASSIFIED WAIT', self.out)
+
+    def test_names_the_rule_that_produced_the_verdict_and_its_detail(self):
+        self.assertIn('passive_proc', self.out)
+        self.assertIn('std_event live (idle=event_engine)', self.out)
+
+    def test_lists_what_was_rejected_and_why(self):
+        self.assertIn('dialogue_wait', self.out)
+        self.assertIn('talk_wait proc absent', self.out)
+
+    def test_names_procs_by_exact_script_symbol(self):
+        self.assertIn('ProcScr_StdEventEngine', self.out)
+        self.assertIn('gProcScr_E_FACE', self.out)
+
+    def test_resolves_the_idle_callback_to_a_symbol(self):
+        self.assertIn('TalkWaitForInput_OnIdle', self.out)
+
+    def test_marks_the_frozen_proc(self):
+        frozen = [l for l in self.out.splitlines() if 'ProcScr_StdEventEngine' in l][0]
+        self.assertIn('FROZEN', frozen)
+        moving = [l for l in self.out.splitlines() if 'gProcScr_E_FACE' in l][0]
+        self.assertNotIn('FROZEN', moving)
+
+    def test_carries_the_world_position(self):
+        self.assertIn('chapter=2', self.out)
+        self.assertIn('turn=0', self.out)
+
+    def test_is_stable_across_renders(self):
+        self.assertEqual(self.out, ins.render_inspect(SNAPSHOT, SYMBOLS))
+
+
+def step(state, action, result, **kw):
+    rec = {'event': 'transition', 'state': state, 'action': action, 'result': result}
+    rec.update(kw)
+    return rec
+
+
+class FirstDivergence(unittest.TestCase):
+    def test_identical_runs_do_not_diverge(self):
+        run = [step('player_map_idle', 'select_unit', 'pass'),
+               step('unit_selected', 'confirm_move', 'pass')]
+        self.assertIsNone(ins.first_divergence(run, list(run)))
+
+    def test_reports_the_first_differing_classification(self):
+        a = [step('player_map_idle', 'select_unit', 'pass'),
+             step('unit_selected', 'confirm_move', 'pass')]
+        b = [step('player_map_idle', 'select_unit', 'pass'),
+             step('target_selection', 'confirm_target', 'pass')]
+        got = ins.first_divergence(a, b)
+        self.assertEqual(got['index'], 1)
+        self.assertEqual(got['field'], 'state')
+        self.assertEqual(got['baseline'], 'unit_selected')
+        self.assertEqual(got['candidate'], 'target_selection')
+
+    def test_a_differing_action_diverges_even_when_the_state_matches(self):
+        a = [step('unit_command_menu', 'attack', 'pass')]
+        b = [step('unit_command_menu', 'wait', 'pass')]
+        self.assertEqual(ins.first_divergence(a, b)['field'], 'action')
+
+    def test_a_failed_postcondition_diverges_from_a_passing_one(self):
+        a = [step('target_selection', 'confirm_target', 'pass')]
+        b = [step('target_selection', 'confirm_target', 'fail:postcondition')]
+        got = ins.first_divergence(a, b)
+        self.assertEqual(got['field'], 'result')
+        self.assertEqual(got['candidate'], 'fail:postcondition')
+
+    def test_a_run_that_stops_early_diverges_at_the_missing_step(self):
+        a = [step('player_map_idle', 'select_unit', 'pass'),
+             step('unit_selected', 'confirm_move', 'pass')]
+        b = [step('player_map_idle', 'select_unit', 'pass')]
+        got = ins.first_divergence(a, b)
+        self.assertEqual(got['index'], 1)
+        self.assertEqual(got['field'], 'length')
+        self.assertEqual(got['candidate'], None)
+
+    def test_inspect_snapshots_do_not_count_as_steps(self):
+        a = [step('player_map_idle', 'select_unit', 'pass')]
+        b = [SNAPSHOT, step('player_map_idle', 'select_unit', 'pass')]
+        self.assertIsNone(ins.first_divergence(a, b))
+
+
+class FormatDivergence(unittest.TestCase):
+    def test_no_divergence_says_so(self):
+        self.assertIn('no divergence', ins.format_divergence(None, 'a.log', 'b.log').lower())
+
+    def test_shows_both_sides_with_their_evidence(self):
+        a = [step('unit_selected', 'confirm_move', 'pass',
+                  before={'classification': 'unit_selected'},
+                  after={'classification': 'player_map_idle'})]
+        b = [step('target_selection', 'confirm_target', 'fail:postcondition',
+                  before={'classification': 'target_selection'},
+                  after={'classification': 'target_selection'})]
+        out = ins.format_divergence(ins.first_divergence(a, b), 'base.log', 'cand.log')
+        self.assertIn('base.log', out)
+        self.assertIn('cand.log', out)
+        self.assertIn('unit_selected', out)
+        self.assertIn('target_selection', out)
+        self.assertIn('step 0', out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_check_lua_loads.py
+++ b/tools/test_check_lua_loads.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Tests for check.py's Lua load gate (#236 -> #138).
+
+The gate exists because harness.lua is one ~6,700-line main chunk sitting AT Lua's
+ceiling of 200 locals per function. Crossing it is a COMPILE error, so it does not fail
+one scenario -- every scenario dies at once, minutes later, inside mGBA. Nothing else
+catches it: check_playtest_matrix only parses the file textually for scenario names.
+
+Run: python3 tools/test_check_lua_loads.py
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check
+
+HAVE_LUA = shutil.which('lua') is not None
+
+
+@unittest.skipUnless(HAVE_LUA, 'no lua on PATH')
+class LuaCompileError(unittest.TestCase):
+    def _write(self, body):
+        fd, path = tempfile.mkstemp(suffix='.lua')
+        with os.fdopen(fd, 'w') as f:
+            f.write(body)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_a_valid_chunk_reports_no_error(self):
+        self.assertIsNone(check.lua_compile_error(self._write('local x = 1\nreturn x\n')))
+
+    def test_a_syntax_error_is_reported(self):
+        err = check.lua_compile_error(self._write('local x = = 1\n'))
+        self.assertIsNotNone(err)
+
+    def test_crossing_the_200_local_ceiling_is_caught(self):
+        """The exact failure mode this gate is for -- valid syntax, dead file."""
+        body = ''.join('local v%d = %d\n' % (i, i) for i in range(205))
+        err = check.lua_compile_error(self._write(body))
+        self.assertIsNotNone(err, '205 top-level locals must not compile')
+        self.assertIn('too many local variables', err)
+
+    def test_199_locals_still_compiles(self):
+        """Guards the boundary from the other side: the gate must not cry wolf."""
+        body = ''.join('local v%d = %d\n' % (i, i) for i in range(199))
+        self.assertIsNone(check.lua_compile_error(self._write(body)))
+
+    def test_it_compiles_rather_than_executes(self):
+        """The trap that made the first version of this gate useless: `lua -e CODE FILE`
+        RUNS the file. A chunk that compiles but explodes on load must still pass --
+        harness.lua is exactly that (it needs emulator globals that do not exist here)."""
+        path = self._write('error("this chunk must never be executed")\n')
+        self.assertIsNone(check.lua_compile_error(path))
+
+
+class LiveRepo(unittest.TestCase):
+    def test_every_declared_chunk_exists(self):
+        for rel in check.LUA_CHUNKS:
+            self.assertTrue(os.path.isfile(os.path.join(check.REPO, rel)),
+                            '%s is declared in LUA_CHUNKS but does not exist' % rel)
+
+    def test_harness_is_covered(self):
+        self.assertIn('tools/playtest/harness.lua', check.LUA_CHUNKS)
+
+    def test_the_live_repo_compiles(self):
+        fail = []
+        check.check_lua_chunks_load(fail)
+        self.assertEqual(fail, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Diagnosing a playtest failure cost a ROM build and an emulator run per hypothesis, because the only way to ask "what is the game doing right now" was to edit `harness.lua` and re-run. #231 made *running* the matrix cheap; this makes *diagnosing* it cheap.

**Gate: 13/14 → 14/14 — the first fully green gate.**

## What it does

| | |
|---|---|
| **Exact proc identity** | `gen_symbols.py` emits `procscr.lua` (952 script addresses → exact symbols) + `symbols.json` (every ROM code symbol, for naming idle callbacks). Exact match only; an unmatched address prints `unknown@0x…`. |
| **Named unclassified waits** | `classify()` is an ordered rule table; `explain()` runs the same rules to return the verdict **plus** every rule considered and the predicate that failed. |
| **Snapshot + stall detector** | `INSPECT.snapshot` dumps that reasoning with the proc inventory, sampled twice so FROZEN is distinguishable from moving. `INSPECT.watch` arms only on an *unclassified* transition holding a byte-identical proc pool. |
| **Render + first-divergence diff** | `inspect_state.py render` / `diff`. Pure logic, unit-tested, no emulator. |

## The `E_FACE` defect was worse than reported

`#232` said three scripts resolve to `E_FACE`. In live capture the `PROC_NAME` field is not just ambiguous, it is **stale**:

| what was running | what the old report printed |
|---|---|
| `gProcScr_Talk` | `E_FACE` |
| `ProcScr_StdEventEngine` | `MAPTASK` |
| `gProcScr_TalkSkipListener` | `ekrBattleEnding` |

Identity now comes from the script address. This is what unblocked everything below.

## The acceptance case, and two things it disproved

`ch01`'s real blocker took one run to name: **`gProcScr_YesNoChoice` in `YesNoChoice_Loop_KeyHandler`** — lord select's *"Will \<lead\> lead the party?"*. It runs *inside* a live event scene, so the `std_event` passive rule swallowed it and nothing ever answered. Classified as `yes_no_choice`, ordered above the passive rules; the controller says what is legal, the scenario picks the answer.

Both of these contradict what the issues recorded, and both are in `decisions.md`:

- **#232's stated cause for ch01 was wrong.** Not "no page wait is ever classified as `dialogue_wait`" — page waits were classified and advanced **74 times, all passing**, and the flow was still advancing **263 frames** before the old 12000-step cap expired. A cap that fires mid-scene reports a timeout that names nothing. Caps are now sized above any real scene (`TUNE.bootSteps`); `INSPECT.watch` is the failure oracle.
- **The boot flow read 74 pages of text it never looks at**, at normal typewriter speed. `reachCh01Map` now sets `gameSpeed` only, leaving combat animation alone.

## Two things worth a reviewer's eye

- **`tools/playtest/test_*.py` was gated by nothing.** Not `make test`, not `check.py` (globs `tools/test_*.py`), not `unittest discover -s tools` (the directory is not an importable package). The pure-logic tests this issue asks for ran only by hand. Both globs now include it, which picks up the pre-existing `test_make_gif.py` too.
- **`harness.lua` is at Lua's 200-local ceiling.** I crossed it mid-change and the whole file stopped loading. The inspector therefore ships as one `INSPECT` table rather than three top-level locals, netting two slots back.

## Verification

- `make matrix` → **14/14**, 3 builds, 5m34s
- `make test` (now including the playtest Python tests) → green
- `make check` → `drift check: clean`
- `git diff --check` → clean

Closes #236. Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
