### PR TITLE
Discover hosted chapters instead of listing them, so the ch04 guard covers ch05 (#138)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -58,6 +58,12 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
    `_asm_table_word_index(ASSET_TABLE_S, 'gChapterDataAssetTable', ...)`; `HostChapterEventGroup`
    in `tools/test_build_campaign.py` pins it.
 
+   **You get this guard for free — but only if you declare both constants.** `hosted_chapters()`
+   discovers chapters from `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP`, so writing the pair is what
+   enrols your chapter in the event-group check; there is no list to update. Declaring a host slot
+   without naming its event group fails `make check` in 0s, and so does two chapters claiming one
+   slot (#138).
+
    Pick a donor slot whose goal type matches and that our injectors don't overwrite:
 
    | Goal | `windowDataType` | Clean donor slots (vanilla, post-inject) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3273,6 +3273,25 @@ session state. `HANDOFF.md` points here._
   `run.sh` refuses a mismatch in 0s with the exact `make` line. So this should no longer be a
   judgement call — but `MX_SKIP_ROM_CHECK=1` disables the guard and puts you straight back here
   (which is exactly what happened once inside the session that built it).
+- **A guard that lists what it covers stops covering things** (2026-08-06, #138). The
+  `HostChapterEventGroup` test was written after the ch04 disaster — a host slot retargeted by map
+  ids alone, presenting our map while running the host slot's roster — and it iterated a
+  hand-written tuple of `(HOST_INDEX, EVENT_GROUP)` pairs. It was correct and useless going
+  forward: **ch05 would have been the first chapter not covered by the very test written to prevent
+  its failure mode**, and ch05 hosts deeper into the divergence than ch04 did, because vanilla's
+  slot index stops tracking chapter number at 4. `build_campaign.hosted_chapters()` now DISCOVERS
+  chapters from `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP`, so declaring the constants is what enrols a
+  chapter; it refuses a host slot with no named event group, and refuses two chapters claiming one
+  slot. The general rule: **when a guard enumerates its subjects, derive the list from the data the
+  subjects are already made of — never restate it.** A hand-maintained list of what to check is a
+  second source of truth that silently drifts the moment someone adds the thing you were guarding.
+- **The host-slot facts were already data; the refactor was not what made them lintable**
+  (2026-08-06, #138). Worth recording because the epic's re-scope argued the opposite and was
+  wrong: `CHNN_HOST_INDEX` / `CHNN_EVENT_GROUP` / `CHNN_GOAL_DONOR` have been module constants all
+  along, so the lint never needed config-driven `inject_chapter(N)` to exist. Config-driven hosting
+  is still worth doing — 2,626 LOC across five per-chapter functions with a 15-helper shared spine —
+  but it is a *readability and repetition* argument, not a prerequisite for validation. Check what a
+  refactor actually unblocks before sequencing work behind it.
 - **A proc's identity is its script ADDRESS, never its `PROC_NAME` string** (2026-08-06, #236).
   Freeze reports named a proc from the string pointer at proc+0x10, and that string is not an
   identity: the decomp gives `gProcScr_E_FACE` and `gProcScr_E_FACE_ExtraFrame` the same

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -23,6 +23,7 @@ Milestones B+ (characters, chapter, dialogue codegen) hang off the same CLI.
 """
 
 import argparse
+import collections
 import glob
 import hashlib
 import json
@@ -8238,6 +8239,48 @@ def inject_ch03(campaign, boot=False, verbose=True):
               'DefeatBoss(grell) WIN wired, PREP deploy cap %d%s + %d enemies (grell@14,1); opening/entrance/midmap/ending cutscenes wired'
               % (obj_idx, pal_idx, cfg_idx, layout_idx, CH03_HOST_INDEX, len(cap_rows),
                  ' (boot-seeded party)' if boot else '', len(enemies)))
+
+
+HostedChapter = collections.namedtuple(
+    'HostedChapter', 'name number host_index event_group')
+
+
+def hosted_chapters():
+    """Every chapter this build hosts, DISCOVERED from the module's own constants.
+
+    Declaring `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP` is what enrols a chapter -- there is
+    no list to remember to update. That is the whole point: the guard written after the
+    ch04 disaster (HostChapterEventGroup in tools/test_build_campaign.py) iterated a
+    hand-written tuple, so ch05 would have been the first chapter NOT covered by the very
+    test written to prevent that failure -- and ch05 hosts deeper into the divergence than
+    ch04 did, since vanilla's slot index stops tracking chapter number at 4 (#138).
+
+    Raises ValueError rather than sys.exit: the lints and tests that consume this need to
+    assert on the failure, not die inside it.
+    """
+    found, by_slot = [], {}
+    scope = globals()
+    for name in sorted(scope):
+        match = re.match(r'^(CH(\d+))_HOST_INDEX$', name)
+        if not match:
+            continue
+        prefix, number = match.group(1), int(match.group(2))
+        group = scope.get('%s_EVENT_GROUP' % prefix)
+        if group is None:
+            raise ValueError(
+                '%s_HOST_INDEX is declared with no %s_EVENT_GROUP. A hosted slot must NAME '
+                'the ChapterEventGroup its injector fills -- never assume the slot already '
+                'points there. Retargeting the map ids alone still makes the chapter LOOK '
+                'right while it runs the host slot\'s roster and scripts (see '
+                'docs/adding-a-chapter.md step 4).' % (prefix, prefix))
+        slot = scope[name]
+        if slot in by_slot:
+            raise ValueError(
+                'host slot %d is claimed by both %s and %s -- one chapter would overwrite '
+                'the other\'s events' % (slot, by_slot[slot], prefix))
+        by_slot[slot] = prefix
+        found.append(HostedChapter(prefix.lower(), number, slot, group))
+    return found
 
 
 def inject_ch04(campaign, boot=False, verbose=True):

--- a/tools/check.py
+++ b/tools/check.py
@@ -183,6 +183,31 @@ def check_lua_chunks_load(fail):
             fail.append('%s does not compile: %s' % (rel, err))
 
 
+def check_hosted_chapters_declared(fail):
+    """Every hosted chapter must declare the ChapterEventGroup its injector fills, and no
+    two may claim one host slot.
+
+    `build_campaign.hosted_chapters()` enforces both while DISCOVERING chapters from the
+    module's constants; this runs it early, without the decomp submodule, so a bad
+    declaration fails in 0s rather than at ROM-build time. The deeper check -- that the
+    retargeted slot actually resolves to that group in the vanilla asset table -- lives in
+    HostChapterEventGroup (tools/test_build_campaign.py), which needs the submodule.
+
+    Why it is worth a rule at all: retargeting a host slot's MAP ids alone is enough to
+    make a chapter look right while it runs the host slot's roster and scripts, so this
+    class of mistake is silent and total (docs/adding-a-chapter.md step 4)."""
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    try:
+        import build_campaign
+    except Exception as exc:                      # pragma: no cover - import guard
+        fail.append('build_campaign does not import: %s' % exc)
+        return
+    try:
+        build_campaign.hosted_chapters()
+    except ValueError as exc:
+        fail.append('hosted chapters: %s' % exc)
+
+
 def check_yaml_parses(fail):
     import yaml
     for f in glob.glob(os.path.join(REPO, 'campaigns/**/*.yaml'), recursive=True):
@@ -932,6 +957,7 @@ def check_lane_ownership(fail):
 def main():
     fail = []
     for check in (check_python_compiles, check_lua_chunks_load,
+                  check_hosted_chapters_declared,
                   check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
                   check_injection_order, check_playtest_matrix,

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1566,6 +1566,61 @@ class Ch04RuntimeHost(unittest.TestCase):
         self.assertIsNotNone(card.getbbox())
 
 
+class HostedChapterEnumeration(unittest.TestCase):
+    """Which chapters are hosted must be DISCOVERED, not listed by hand.
+
+    HostChapterEventGroup below is the guard written after the ch04 disaster, and it
+    iterated a hand-written tuple of (HOST_INDEX, EVENT_GROUP) pairs. A hand-written
+    list does not extend: ch05 would have been the first chapter NOT covered by the very
+    test written to prevent that class of failure -- and ch05 hosts deeper into the slot
+    divergence than ch04 did, since vanilla's slot index stops tracking chapter number
+    at 4. Enumerating from the module's own constants closes that (#138).
+    """
+
+    def test_finds_every_currently_hosted_chapter(self):
+        got = {c.name: c.host_index for c in bc.hosted_chapters()}
+        self.assertEqual(got, {'ch01': bc.CH01_HOST_INDEX, 'ch02': bc.CH02_HOST_INDEX,
+                               'ch03': bc.CH03_HOST_INDEX, 'ch04': bc.CH04_HOST_INDEX})
+
+    def test_each_entry_carries_the_event_group_its_injector_fills(self):
+        groups = {c.name: c.event_group for c in bc.hosted_chapters()}
+        self.assertEqual(groups['ch04'], bc.CH04_EVENT_GROUP)
+        self.assertEqual(groups['ch01'], bc.CH01_EVENT_GROUP)
+
+    def test_it_is_ordered_by_chapter(self):
+        names = [c.name for c in bc.hosted_chapters()]
+        self.assertEqual(names, sorted(names))
+
+    def test_a_new_chapter_enrolls_itself(self):
+        """The whole point: declaring CH05_* is enough to be covered."""
+        bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP = 6, 'Ch6Events'
+        try:
+            entry = {c.name: c for c in bc.hosted_chapters()}['ch05']
+            self.assertEqual((entry.host_index, entry.event_group), (6, 'Ch6Events'))
+        finally:
+            del bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP
+
+    def test_a_host_slot_without_an_event_group_fails_loudly(self):
+        """Naming the group is mandatory -- inheriting the slot-index coincidence is
+        exactly how ch04 shipped a chapter running another chapter's roster."""
+        bc.CH05_HOST_INDEX = 6
+        try:
+            with self.assertRaises(ValueError) as raised:
+                bc.hosted_chapters()
+            self.assertIn('CH05_EVENT_GROUP', str(raised.exception))
+        finally:
+            del bc.CH05_HOST_INDEX
+
+    def test_two_chapters_cannot_host_on_one_slot(self):
+        bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP = bc.CH04_HOST_INDEX, 'Ch6Events'
+        try:
+            with self.assertRaises(ValueError) as raised:
+                bc.hosted_chapters()
+            self.assertIn('slot %d' % bc.CH04_HOST_INDEX, str(raised.exception))
+        finally:
+            del bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP
+
+
 class HostChapterEventGroup(unittest.TestCase):
     """A hosted chapter must RUN the ChapterEventGroup its injector fills.
 
@@ -1624,14 +1679,15 @@ class HostChapterEventGroup(unittest.TestCase):
     def test_every_hosted_chapter_names_the_event_group_it_fills(self):
         # The earlier slots were correct only because slot index == chapter number there;
         # they are now explicit, so the next hosted chapter cannot inherit the coincidence.
-        for host_index, group in (
-                (bc.CH01_HOST_INDEX, bc.CH01_EVENT_GROUP),
-                (bc.CH02_HOST_INDEX, bc.CH02_EVENT_GROUP),
-                (bc.CH03_HOST_INDEX, bc.CH03_EVENT_GROUP),
-                (bc.CH04_HOST_INDEX, bc.CH04_EVENT_GROUP)):
-            host = self._retarget(host_index, group)
-            self.assertEqual(host['mapEventDataId'], self._vanilla_index(group),
-                             'host slot %d must run %s' % (host_index, group))
+        # Enumerated, NOT listed: a hand-written tuple would leave the next chapter
+        # uncovered by the guard written for exactly its failure (#138).
+        chapters = bc.hosted_chapters()
+        self.assertTrue(chapters, 'no hosted chapters discovered')
+        for chapter in chapters:
+            host = self._retarget(chapter.host_index, chapter.event_group)
+            self.assertEqual(host['mapEventDataId'], self._vanilla_index(chapter.event_group),
+                             '%s: host slot %d must run %s'
+                             % (chapter.name, chapter.host_index, chapter.event_group))
 
     def test_making_it_explicit_moves_ch04_alone(self):
         """ch01-ch03 must be byte-identical after the repoint -- they were already right,


### PR DESCRIPTION
Delivers the protective half of #138 — the half that actually serves ch05 — and corrects the premise the rest of it was sequenced on.

> **Stacked on `feat/236-state-inspector` (#237)**, which touches the same `check.py`. Merge #237 first; this branch's own diff is the 5 files below.

## The defect

`HostChapterEventGroup` is the test written after the ch04 disaster — a host slot retargeted by map ids alone, presenting our map while running the host slot's roster and scripts. It iterated a **hand-written tuple** of `(HOST_INDEX, EVENT_GROUP)` pairs.

That list does not extend:

> **ch05 would have been the first chapter not covered by the very test written to prevent its failure mode** — and ch05 hosts *deeper* into the divergence than ch04 did, because vanilla's slot index stops tracking chapter number at 4.

## The fix

`hosted_chapters()` **discovers** chapters from `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP`. Declaring the constants is what enrols a chapter — there is no list to update. It refuses a host slot with no named event group, and refuses two chapters claiming one slot. The guard iterates it, so **ch05 is covered the moment its constants exist**.

`check_hosted_chapters_declared` runs the same enumeration without the decomp submodule, so a bad declaration fails in **0s** instead of at ROM-build time. The deeper assertion — that the slot resolves to that group in the vanilla asset table — stays in the test, which needs the submodule.

## Two corrections to the record (both in `decisions.md`)

- **The host-slot facts were already data.** `CHNN_HOST_INDEX` / `CHNN_EVENT_GROUP` / `CHNN_GOAL_DONOR` have been module constants all along, so the lint never needed config-driven `inject_chapter(N)`. My #222 re-scope argued the opposite and sequenced the two together on a bad premise. **The refactor no longer gates ch05.**
- **The general rule:** when a guard enumerates its subjects, derive the list from the data they are already made of. A hand-maintained list of what to check is a second source of truth that drifts silently the moment someone adds the thing you were guarding.

## What remains on #138

Only the refactor itself, now a readability argument on its own merits. Measured today: **2,626 LOC across 5 functions** over a **15-helper shared spine**, with small variation (ch01 lord-select, ch02 `_stage_beat`, ch03 tileset + bespoke tile-changes, ch04 force-deploy). `inject_prologue` is a genuine outlier and should stay out. One finding for whoever takes it: ch03 has a bespoke `_inject_ch03_tile_changes` while ch04 uses a generic `_inject_tile_changes` — ch03 should migrate onto the generic one.

## Verification

| gate | result |
|---|---|
| `make test` | green (6 new tests) |
| `make check` | `drift check: clean` |
| canonical ROM | **byte-identical** to the pre-change build, `42cd82360be3c186c60f9366d57c7608d3d83548` — this is inert in the build path, as it must be |
| `git diff --check` | clean |

Both failure modes proved live rather than asserted: a host slot with no event group, and two chapters claiming one slot, each produce the intended error.

CI has not run — GitHub Actions is still in a `major_outage`. Same situation recorded on #237.

Part of #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
