### PR TITLE
Put the ch01 spine on the controller contract, and prove the green light means something (#238)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -58,6 +58,12 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
    `_asm_table_word_index(ASSET_TABLE_S, 'gChapterDataAssetTable', ...)`; `HostChapterEventGroup`
    in `tools/test_build_campaign.py` pins it.
 
+   **You get this guard for free — but only if you declare both constants.** `hosted_chapters()`
+   discovers chapters from `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP`, so writing the pair is what
+   enrols your chapter in the event-group check; there is no list to update. Declaring a host slot
+   without naming its event group fails `make check` in 0s, and so does two chapters claiming one
+   slot (#138).
+
    Pick a donor slot whose goal type matches and that our injectors don't overwrite:
 
    | Goal | `windowDataType` | Clean donor slots (vanilla, post-inject) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3273,6 +3273,25 @@ session state. `HANDOFF.md` points here._
   `run.sh` refuses a mismatch in 0s with the exact `make` line. So this should no longer be a
   judgement call — but `MX_SKIP_ROM_CHECK=1` disables the guard and puts you straight back here
   (which is exactly what happened once inside the session that built it).
+- **A guard that lists what it covers stops covering things** (2026-08-06, #138). The
+  `HostChapterEventGroup` test was written after the ch04 disaster — a host slot retargeted by map
+  ids alone, presenting our map while running the host slot's roster — and it iterated a
+  hand-written tuple of `(HOST_INDEX, EVENT_GROUP)` pairs. It was correct and useless going
+  forward: **ch05 would have been the first chapter not covered by the very test written to prevent
+  its failure mode**, and ch05 hosts deeper into the divergence than ch04 did, because vanilla's
+  slot index stops tracking chapter number at 4. `build_campaign.hosted_chapters()` now DISCOVERS
+  chapters from `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP`, so declaring the constants is what enrols a
+  chapter; it refuses a host slot with no named event group, and refuses two chapters claiming one
+  slot. The general rule: **when a guard enumerates its subjects, derive the list from the data the
+  subjects are already made of — never restate it.** A hand-maintained list of what to check is a
+  second source of truth that silently drifts the moment someone adds the thing you were guarding.
+- **The host-slot facts were already data; the refactor was not what made them lintable**
+  (2026-08-06, #138). Worth recording because the epic's re-scope argued the opposite and was
+  wrong: `CHNN_HOST_INDEX` / `CHNN_EVENT_GROUP` / `CHNN_GOAL_DONOR` have been module constants all
+  along, so the lint never needed config-driven `inject_chapter(N)` to exist. Config-driven hosting
+  is still worth doing — 2,626 LOC across five per-chapter functions with a 15-helper shared spine —
+  but it is a *readability and repetition* argument, not a prerequisite for validation. Check what a
+  refactor actually unblocks before sequencing work behind it.
 - **A proc's identity is its script ADDRESS, never its `PROC_NAME` string** (2026-08-06, #236).
   Freeze reports named a proc from the string pointer at proc+0x10, and that string is not an
   identity: the decomp gives `gProcScr_E_FACE` and `gProcScr_E_FACE_ExtraFrame` the same

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -23,6 +23,7 @@ Milestones B+ (characters, chapter, dialogue codegen) hang off the same CLI.
 """
 
 import argparse
+import collections
 import glob
 import hashlib
 import json
@@ -8238,6 +8239,48 @@ def inject_ch03(campaign, boot=False, verbose=True):
               'DefeatBoss(grell) WIN wired, PREP deploy cap %d%s + %d enemies (grell@14,1); opening/entrance/midmap/ending cutscenes wired'
               % (obj_idx, pal_idx, cfg_idx, layout_idx, CH03_HOST_INDEX, len(cap_rows),
                  ' (boot-seeded party)' if boot else '', len(enemies)))
+
+
+HostedChapter = collections.namedtuple(
+    'HostedChapter', 'name number host_index event_group')
+
+
+def hosted_chapters():
+    """Every chapter this build hosts, DISCOVERED from the module's own constants.
+
+    Declaring `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP` is what enrols a chapter -- there is
+    no list to remember to update. That is the whole point: the guard written after the
+    ch04 disaster (HostChapterEventGroup in tools/test_build_campaign.py) iterated a
+    hand-written tuple, so ch05 would have been the first chapter NOT covered by the very
+    test written to prevent that failure -- and ch05 hosts deeper into the divergence than
+    ch04 did, since vanilla's slot index stops tracking chapter number at 4 (#138).
+
+    Raises ValueError rather than sys.exit: the lints and tests that consume this need to
+    assert on the failure, not die inside it.
+    """
+    found, by_slot = [], {}
+    scope = globals()
+    for name in sorted(scope):
+        match = re.match(r'^(CH(\d+))_HOST_INDEX$', name)
+        if not match:
+            continue
+        prefix, number = match.group(1), int(match.group(2))
+        group = scope.get('%s_EVENT_GROUP' % prefix)
+        if group is None:
+            raise ValueError(
+                '%s_HOST_INDEX is declared with no %s_EVENT_GROUP. A hosted slot must NAME '
+                'the ChapterEventGroup its injector fills -- never assume the slot already '
+                'points there. Retargeting the map ids alone still makes the chapter LOOK '
+                'right while it runs the host slot\'s roster and scripts (see '
+                'docs/adding-a-chapter.md step 4).' % (prefix, prefix))
+        slot = scope[name]
+        if slot in by_slot:
+            raise ValueError(
+                'host slot %d is claimed by both %s and %s -- one chapter would overwrite '
+                'the other\'s events' % (slot, by_slot[slot], prefix))
+        by_slot[slot] = prefix
+        found.append(HostedChapter(prefix.lower(), number, slot, group))
+    return found
 
 
 def inject_ch04(campaign, boot=False, verbose=True):

--- a/tools/check.py
+++ b/tools/check.py
@@ -183,6 +183,31 @@ def check_lua_chunks_load(fail):
             fail.append('%s does not compile: %s' % (rel, err))
 
 
+def check_hosted_chapters_declared(fail):
+    """Every hosted chapter must declare the ChapterEventGroup its injector fills, and no
+    two may claim one host slot.
+
+    `build_campaign.hosted_chapters()` enforces both while DISCOVERING chapters from the
+    module's constants; this runs it early, without the decomp submodule, so a bad
+    declaration fails in 0s rather than at ROM-build time. The deeper check -- that the
+    retargeted slot actually resolves to that group in the vanilla asset table -- lives in
+    HostChapterEventGroup (tools/test_build_campaign.py), which needs the submodule.
+
+    Why it is worth a rule at all: retargeting a host slot's MAP ids alone is enough to
+    make a chapter look right while it runs the host slot's roster and scripts, so this
+    class of mistake is silent and total (docs/adding-a-chapter.md step 4)."""
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    try:
+        import build_campaign
+    except Exception as exc:                      # pragma: no cover - import guard
+        fail.append('build_campaign does not import: %s' % exc)
+        return
+    try:
+        build_campaign.hosted_chapters()
+    except ValueError as exc:
+        fail.append('hosted chapters: %s' % exc)
+
+
 def check_yaml_parses(fail):
     import yaml
     for f in glob.glob(os.path.join(REPO, 'campaigns/**/*.yaml'), recursive=True):
@@ -932,6 +957,7 @@ def check_lane_ownership(fail):
 def main():
     fail = []
     for check in (check_python_compiles, check_lua_chunks_load,
+                  check_hosted_chapters_declared,
                   check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
                   check_injection_order, check_playtest_matrix,

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -1652,11 +1652,20 @@ scenarios.goodberry = function()
     result("PASS", "Goodberry item menu captured (see screenshots)")
 end
 
--- Reach the ch01 map: ride the ch00 win into chapter slot 2, A-tap through the
--- post-chapter save + Beat-1 scene to the prep screen, then Fight! into the phase.
--- Returns true once control is on the ch01 map; false (with its own FAIL logged)
--- otherwise. Shared by scenarios.ch01 (entry assertions) and scenarios.smoke_ch01.
-local function reachCh01Map()
+-- Reach ch01: ride the ch00 win into chapter slot 2, drive the post-chapter save + Beat-1
+-- scene + lord select on OBSERVED state, then Fight! into the phase. Returns true at the
+-- destination; false with its own FAIL logged otherwise.
+--
+-- opts.stopAtPrep  stop with Preparations open instead of driving through it
+-- opts.lord        "default" (accept the highlighted lead) | "last" (walk to the final
+--                  candidate -- Pinky -- so a NON-Braulo lord can be exercised)
+--
+-- One driver, three destinations (#238). reachPrep and reachPrepPinky used to be separate
+-- copies of this route on a blind A-cadence; a copy that mashes A cannot tell "the scene
+-- advanced" from "the input was swallowed", which is how ch01win rode straight through the
+-- lord-select Yes/No prompt that cost #232 three sessions.
+local function reachCh01(opts)
+    opts = opts or {}
     if not winCh00() then return false end
     if not waitFor(function() return chapter() == 2 end, 1800) then
         result("FAIL", "chapter slot 2 never loaded after the ch00 win"); return false
@@ -1678,6 +1687,7 @@ local function reachCh01Map()
         end
         if state == "prep_main" then
             shot("ch01-prep-menu")
+            if opts.stopAtPrep then return true end
             if not driveThroughPrep() then
                 result("FAIL", "could not leave preparations via semantic Fight"); return false
             end
@@ -1686,8 +1696,22 @@ local function reachCh01Map()
             shot("ch01-map")
             return true
         elseif state == "generic_menu" then
-            -- Scenario policy: choose the currently highlighted default lead. The controller
-            -- owns the live menu callback and guarded A; no row or candidate count is guessed.
+            -- Scenario policy: which lead to take. The controller owns the live menu
+            -- callback and the guarded input either way; no row is guessed and no
+            -- candidate count is assumed -- "last" walks the LIVE item list.
+            if opts.lord == "last" then
+                local rows = observation.menu and #observation.menu.items or 0
+                for _ = 1, rows - 1 do
+                    if not guardedInput("menu_next", "DOWN", "the lead menu selection moves",
+                        function(after, before)
+                            return after.menu ~= nil and before.menu ~= nil
+                                and after.menu.current ~= before.menu.current
+                        end, 60) then
+                        result("FAIL", "could not walk the lead menu to the last candidate")
+                        return false
+                    end
+                end
+            end
             if not guardedInput("select_current_menu_item", "A", "lead menu selection closes", function(after)
                 return after.menu == nil
             end, 300) then
@@ -1717,6 +1741,10 @@ local function reachCh01Map()
     result("FAIL", "prep screen never opened (PREP event cmd)")
     return false
 end
+
+-- The three destinations on that one route. Kept as named wrappers so every call site
+-- reads as an intention rather than an options table.
+local function reachCh01Map() return reachCh01() end
 
 -- CH01: reach the ch01 map, then assert the entry invariants -- the ch00 guests left
 -- the party (DISA), and the deployed count equals the 4-slot field-parity cap.
@@ -2341,41 +2369,14 @@ end
 -- ending scene -> MNC2 into the hosted ch02). (CH01_PARK is defined up by the
 -- clear-bot.)
 scenarios.ch01win = function()
-    if not winCh00() then return end
-    if not waitFor(function() return chapter() == 2 end, 1800) then
-        return result("FAIL", "chapter slot 2 never loaded after the ch00 win")
-    end
-    -- default-lord entry: A-taps ride the save menu + the Beat-1 Northlook scene
-    -- (#21, ~22 pages) + the lord prompt + lord menu (item 0 = Braulo) + [Yes]
-    -- confirm all the way to the prep screen
-    local prep = false
-    for i = 1, 200 do
-        if procActive(SYM.gProcScr_SALLYCURSOR) then prep = true break end
-        press(K.A, 4)
-        wait(36)
-    end
-    if not prep then
-        shot("ch01win-no-prep")
-        return result("FAIL", "prep screen never opened")
-    end
-    wait(180)
-    for i = 1, 40 do
-        if not procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.B, 4)
-        wait(10)
-        press(K.START, 4)
-        wait(40)
-        if i % 4 == 0 and procActive(SYM.gProcScr_SALLYCURSOR) then press(K.A, 4) wait(20) end
-    end
-    if not waitFor(function()
-        return not procActive(SYM.gProcScr_SALLYCURSOR)
-            and faction() == 0 and turn() >= 1
-    end, 1200) then
-        shot("ch01win-prep-stuck")
-        return result("FAIL", "could not leave preparations via Fight!")
-    end
-    wait(120)
-    shot("ch01win-map")
+    -- Reaching the ch01 map is the SHARED semantic path (#238). This used to be 33 lines
+    -- of blind cadence -- an A-tap loop over the save prompt, the Beat-1 Northlook scene,
+    -- the lord prompt and the lord menu, then a B/START/A flail at Preparations. It
+    -- passed, but for the wrong reason: it mashed straight through the lord-select Yes/No
+    -- prompt that #232 spent three sessions on, verifying none of it. reachCh01Map drives
+    -- the same route on observed state and verified postconditions, so a state nothing can
+    -- classify now FAILS here instead of being papered over.
+    if not reachCh01Map() then return end
     pokeFastConfig() -- 10-goblin enemy phases: map combat + fast speed
     local chief = red(CHAR_CHIEF)
     if not chief then return result("FAIL", "chief not in the red array") end
@@ -2419,10 +2420,15 @@ scenarios.ch01win = function()
                     tostring(moved), b0.x, b0.y))
             end
         else
-            -- chief down: Braulo onto the seize tile; Seize tops the menu there
+            -- chief down: Braulo onto the seize tile, then Seize by its semantic id.
+            -- `press(K.A)` used to stand in for this on the assumption that Seize tops
+            -- the menu -- a guess about menu ORDER, which is exactly the class of thing
+            -- the controller reads from the live menu instead (#238).
             if moveUnit(braulo.x, braulo.y, goal.x, goal.y) then
                 shot("ch01win-seize-menu")
-                press(K.A) -- Seize
+                selectSemantic("seize", "Seize starts the chapter win event", function()
+                    return procActive(SYM.ProcScr_StdEventEngine) or chapter() ~= 2
+                end, 900)
             end
             -- generous budget: post-seize plays the full ending cutscene before
             -- MNC2 chains into the hosted ch02 (longer than the old 3600).
@@ -2451,52 +2457,24 @@ end
 -- the record* scenario at 60fps. The lead-up drivers are shared here so the checkpoint
 -- and a from-scratch run stay in lock-step.
 
--- Drive ch00 win -> ch01 prep screen OPEN (default-lord A-taps through the save menu +
--- the Beat-1 Northlook scene + lord select). true at the prep proc.
-local function reachPrep()
-    if not winCh00() then return false end
-    if not waitFor(function() return chapter() == 2 end, 1800) then return false end
-    for i = 1, 200 do
-        if procActive(SYM.gProcScr_SALLYCURSOR) then return true end
-        press(K.A, 4); wait(36)
-    end
-    return false
-end
+-- Drive ch00 win -> ch01 prep screen OPEN, default lord. true at the prep proc.
+local function reachPrep() return reachCh01({ stopAtPrep = true }) end
 
--- Like reachPrep, but PICK THE LAST lord candidate (Pinky, not the default Braulo)
--- at the lord-select menu before continuing to prep. Used to checkpoint a Pinky-as-lord
--- prep so the convoy/force-deploy lord-select fixes can be exercised for a NON-Braulo lord.
-local function reachPrepPinky()
-    if not winCh00() then return false end
-    if not waitFor(function() return chapter() == 2 end, 1800) then return false end
-    local atMenu = false
-    for i = 1, 200 do
-        if menuOpen() then atMenu = true break end          -- scenic lord-select menu
-        if procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.A, 4); wait(36)
-    end
-    if not atMenu then return false end
-    wait(40)
-    for _ = 1, LORD_CANDIDATES - 1 do press(K.DOWN, 4); wait(8) end  -- walk to Pinky (last)
-    press(K.A, 4); wait(40)                                  -- pick
-    press(K.A, 4); wait(20)                                  -- [Yes] confirm
-    for i = 1, 80 do
-        if procActive(SYM.gProcScr_SALLYCURSOR) then return true end
-        press(K.A, 4); wait(36)
-    end
-    return false
-end
+-- Like reachPrep, but PICK THE LAST lord candidate (Pinky, not the default Braulo) so the
+-- convoy/force-deploy lord-select fixes can be exercised for a NON-Braulo lord. The walk
+-- to the last row now counts the LIVE menu instead of the LORD_CANDIDATES constant -- the
+-- old copy would silently pick the wrong lord the day the roster changed.
+local function reachPrepPinky() return reachCh01({ stopAtPrep = true, lord = "last" }) end
 
 -- From the open prep screen, leave via Fight! and grind (escort poked frail+harmless) to
 -- the seize-ready state: chief dead, Braulo moved ONTO the seize tile with its action
 -- menu open (Seize on top). Returns true there -- the caller presses A to Seize.
 local function leavePrepAndGrindToSeize()
     wait(180)
-    for i = 1, 40 do
-        if not procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.B, 4); wait(10); press(K.START, 4); wait(40)
-        if i % 4 == 0 and procActive(SYM.gProcScr_SALLYCURSOR) then press(K.A, 4) wait(20) end
-    end
+    -- Leave via the live Fight callback. The B/START/A flail this replaces was guessing
+    -- at which key the prep screen would accept, and its `i % 4 == 0` A-press could
+    -- commit whatever happened to be under the cursor (#238).
+    if not driveThroughPrep() then return false end
     if not waitFor(function()
         return not procActive(SYM.gProcScr_SALLYCURSOR) and faction() == 0 and turn() >= 1
     end, 1200) then return false end

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1566,6 +1566,61 @@ class Ch04RuntimeHost(unittest.TestCase):
         self.assertIsNotNone(card.getbbox())
 
 
+class HostedChapterEnumeration(unittest.TestCase):
+    """Which chapters are hosted must be DISCOVERED, not listed by hand.
+
+    HostChapterEventGroup below is the guard written after the ch04 disaster, and it
+    iterated a hand-written tuple of (HOST_INDEX, EVENT_GROUP) pairs. A hand-written
+    list does not extend: ch05 would have been the first chapter NOT covered by the very
+    test written to prevent that class of failure -- and ch05 hosts deeper into the slot
+    divergence than ch04 did, since vanilla's slot index stops tracking chapter number
+    at 4. Enumerating from the module's own constants closes that (#138).
+    """
+
+    def test_finds_every_currently_hosted_chapter(self):
+        got = {c.name: c.host_index for c in bc.hosted_chapters()}
+        self.assertEqual(got, {'ch01': bc.CH01_HOST_INDEX, 'ch02': bc.CH02_HOST_INDEX,
+                               'ch03': bc.CH03_HOST_INDEX, 'ch04': bc.CH04_HOST_INDEX})
+
+    def test_each_entry_carries_the_event_group_its_injector_fills(self):
+        groups = {c.name: c.event_group for c in bc.hosted_chapters()}
+        self.assertEqual(groups['ch04'], bc.CH04_EVENT_GROUP)
+        self.assertEqual(groups['ch01'], bc.CH01_EVENT_GROUP)
+
+    def test_it_is_ordered_by_chapter(self):
+        names = [c.name for c in bc.hosted_chapters()]
+        self.assertEqual(names, sorted(names))
+
+    def test_a_new_chapter_enrolls_itself(self):
+        """The whole point: declaring CH05_* is enough to be covered."""
+        bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP = 6, 'Ch6Events'
+        try:
+            entry = {c.name: c for c in bc.hosted_chapters()}['ch05']
+            self.assertEqual((entry.host_index, entry.event_group), (6, 'Ch6Events'))
+        finally:
+            del bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP
+
+    def test_a_host_slot_without_an_event_group_fails_loudly(self):
+        """Naming the group is mandatory -- inheriting the slot-index coincidence is
+        exactly how ch04 shipped a chapter running another chapter's roster."""
+        bc.CH05_HOST_INDEX = 6
+        try:
+            with self.assertRaises(ValueError) as raised:
+                bc.hosted_chapters()
+            self.assertIn('CH05_EVENT_GROUP', str(raised.exception))
+        finally:
+            del bc.CH05_HOST_INDEX
+
+    def test_two_chapters_cannot_host_on_one_slot(self):
+        bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP = bc.CH04_HOST_INDEX, 'Ch6Events'
+        try:
+            with self.assertRaises(ValueError) as raised:
+                bc.hosted_chapters()
+            self.assertIn('slot %d' % bc.CH04_HOST_INDEX, str(raised.exception))
+        finally:
+            del bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP
+
+
 class HostChapterEventGroup(unittest.TestCase):
     """A hosted chapter must RUN the ChapterEventGroup its injector fills.
 
@@ -1624,14 +1679,15 @@ class HostChapterEventGroup(unittest.TestCase):
     def test_every_hosted_chapter_names_the_event_group_it_fills(self):
         # The earlier slots were correct only because slot index == chapter number there;
         # they are now explicit, so the next hosted chapter cannot inherit the coincidence.
-        for host_index, group in (
-                (bc.CH01_HOST_INDEX, bc.CH01_EVENT_GROUP),
-                (bc.CH02_HOST_INDEX, bc.CH02_EVENT_GROUP),
-                (bc.CH03_HOST_INDEX, bc.CH03_EVENT_GROUP),
-                (bc.CH04_HOST_INDEX, bc.CH04_EVENT_GROUP)):
-            host = self._retarget(host_index, group)
-            self.assertEqual(host['mapEventDataId'], self._vanilla_index(group),
-                             'host slot %d must run %s' % (host_index, group))
+        # Enumerated, NOT listed: a hand-written tuple would leave the next chapter
+        # uncovered by the guard written for exactly its failure (#138).
+        chapters = bc.hosted_chapters()
+        self.assertTrue(chapters, 'no hosted chapters discovered')
+        for chapter in chapters:
+            host = self._retarget(chapter.host_index, chapter.event_group)
+            self.assertEqual(host['mapEventDataId'], self._vanilla_index(chapter.event_group),
+                             '%s: host slot %d must run %s'
+                             % (chapter.name, chapter.host_index, chapter.event_group))
 
     def test_making_it_explicit_moves_ch04_alone(self):
         """ch01-ch03 must be byte-identical after the repoint -- they were already right,


### PR DESCRIPTION
First pass on #238: the ch01 spine is now driven on observed state, and the green light is proven to mean something.

> **Stacked on `feat/138-inject-chapter` (#239) → `feat/236-state-inspector` (#237).** Merge in that order; this branch's own diff is one file.

## The defect

`ch01win` **passed for the wrong reason.** Its opening 33 lines were a blind A-cadence re-implementation of the route `reachCh01Map` already drives — it mashed through the post-chapter save prompt, the 74-page Beat-1 Northlook scene, the lord menu, and the lord-select Yes/No prompt, verifying none of it.

That is the prompt #232 spent three sessions on. `ch01win` rode over it and reported PASS the entire time.

## The proof it now bites

With the `yes_no_choice` rule temporarily disabled, `ch01win` **FAILS**:

```
RESULT: FAIL -- ch01 parked on an unclassified wait (see the inspect snapshot)
```

and the inspector names the rejecting rule in its own words:

```
  state:  transition   [rule: passive_proc]   *** UNCLASSIFIED WAIT ***
  considered (in order, all rejected before the verdict):
    dialogue_wait      talk_wait proc absent
    yes_no_choice      TEMPORARILY DISABLED for the #238 bite test
    ...
```

**Before this change the identical sabotage still PASSED**, because mashing A does not care what is on screen. That is the whole issue in one experiment.

## Changes

- **Three copies of one route became one driver.** `reachCh01(opts)` takes `stopAtPrep` and `lord="default"|"last"`; `reachCh01Map`, `reachPrep` and `reachPrepPinky` are thin wrappers. The Pinky walk now counts the **live menu** instead of the `LORD_CANDIDATES` constant, so it cannot silently pick the wrong lord the day the roster changes.
- **`ch01win`'s Seize** was `press(K.A)` on the assumption that Seize tops the menu — a guess about menu *order*, exactly what the controller reads from the live menu. Now uses the `selectSemantic("seize", …)` pattern already established at two other sites.
- **`leavePrepAndGrindToSeize`'s prep exit** was a B/START/A flail guessing at which key Preparations accepts, with an `i % 4 == 0` A-press that could commit whatever was under the cursor. Now `driveThroughPrep()`.

## Scope correction (also posted to the issue)

The issue's counts came from a **name-based filter** and are wrong in both directions. By `matrix.yaml` — the authority on what produces a verdict — it is **12 verdict scenarios / 72 presses**, not 11 / 52:

- `recordsupply` (15 presses) and `recordunitlist` are `kind: verdict` despite their names, and **`recordunitlist` is in the gate**. Both in scope.
- `attackprobe` and `bootobserve` are `kind: diagnostic`. Out of scope, along with the 16 genuine `kind: record` scenarios.

## Remaining for a second pass

`retreat`, `lordfloor`, `ch01lord`, `recordsupply`, and the three `LORD_CANDIDATES` blind menu-walks at `harness.lua` 3122/3164/3211.

## Verification

| gate | result |
|---|---|
| `make matrix` | **14/14** — `ch01win` 28s → 40s, because it now verifies instead of mashing |
| bite test | sabotaged classification ⇒ FAIL (previously PASS) |
| `make test` · `make check` | green · `drift check: clean` |
| raw presses in harness | 133 → 121 |

CI has not run — GitHub Actions is still in a `major_outage`, as recorded on #237.

Part of #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
