### PR TITLE
Fix the code-review findings on the #237/#239/#240 stack (#241)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -58,11 +58,13 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
    `_asm_table_word_index(ASSET_TABLE_S, 'gChapterDataAssetTable', ...)`; `HostChapterEventGroup`
    in `tools/test_build_campaign.py` pins it.
 
-   **You get this guard for free — but only if you declare both constants.** `hosted_chapters()`
-   discovers chapters from `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP`, so writing the pair is what
-   enrols your chapter in the event-group check; there is no list to update. Declaring a host slot
-   without naming its event group fails `make check` in 0s, and so does two chapters claiming one
-   slot (#138).
+   **You get this guard for free, and you cannot forget to opt in.** Declare `CHNN_HOST_INDEX` +
+   `CHNN_EVENT_GROUP` in **`tools/inject/hosts.py`** (the registry — stdlib-only so CI can lint it
+   without Pillow; `build_campaign` re-exports both). `hosted_chapters()` discovers chapters from
+   that pair, so writing it is what enrols your chapter in the event-group check; there is no list
+   to update. `make check` fails in 0s on a host slot with no event group, on two chapters claiming
+   one slot (the prologue's slot 1 included), and — since #241 — on an `inject_chNN` that declares
+   nothing at all, which used to be silently unhosted (#138).
 
    Pick a donor slot whose goal type matches and that our injectors don't overwrite:
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -468,6 +468,69 @@ _Decided: 2026-08-06 (Nicolas — merge commits for the stack; the retarget-befo
 
 ---
 
+**A lint may not import `build_campaign`, and a limit may not be written down.** Two rules with one
+root, both from the code review of the #237/#239/#240 stack (#241).
+
+**(a) `tools/check.py` runs in CI's `checks` job, which installs pyyaml and nothing else.**
+`check_hosted_chapters_declared` imported `build_campaign` to reach the host-slot constants, and
+`build_campaign` imports Pillow at module scope — so the gate would have failed *every* push with
+`build_campaign does not import: No module named 'PIL'`: a red check that names the wrong problem
+and teaches everyone to ignore it. The fix is structural, not a `pip install`: the host-slot
+registry moved to **`tools/inject/hosts.py`**, stdlib-only like `inject/decomp.py` beside it, and
+`build_campaign` re-exports it so every call site still reads `bc.CH04_HOST_INDEX`. The rule
+generalises — **a lint imports the smallest module that owns the fact, or reads the source with
+`ast`; it never imports the build.** `check_purple_bank_blankers_known` already said so for its own
+constants; this makes it the standing rule.
+
+Two more defects fell out of moving it. Discovery matched `CH(\d+)_HOST_INDEX`, so the **prologue
+was invisible** — `PROLOGUE_HOST_INDEX = 1` was not in the collision map, and a later
+`CH05_HOST_INDEX = 1` would have passed the guard and quietly overwritten the prologue's events.
+And enrolment was a *convention*: `inject_ch05` with a typo'd constant is simply not discovered, and
+every guard built on the registry then passes with one chapter fewer and no complaint — the exact
+ch04 failure class #138 set out to close. `undeclared_injectors()` now reads `build_campaign`'s
+source with `ast` and fails the build on an injector that enrols nothing.
+
+**(b) A limit that kills everything at once must be MEASURED, not documented.** `harness.lua` sits
+at Lua's 200-local ceiling, and the remaining margin was written as prose — "two free slots" — in
+`harness.lua`, `check.py` and `HANDOFF.md` simultaneously. It was wrong in all three within one PR
+of being written: #240 spent a slot and updated no comment. Measured, the margin was **one**.
+`check_lua_local_headroom` now appends probe locals until the chunk stops compiling, prints the real
+number on every `make check`, and fails at zero. Same reasoning retired the hand-written
+`LUA_CHUNKS` tuple, which listed 4 of the 9 chunks `harness.lua` loads — a syntax error in
+`recorder.lua` or `liveness.lua` killed every scenario with the gate green. **If a number about our
+own code can be computed, compute it; a hand-maintained one is a comment that lies eventually.**
+_Decided: 2026-08-06 (code review of #237/#239/#240; #241)_
+
+---
+
+**The controller's rule order is load-bearing, and its stall detector belongs where it can be
+tested.** Three corrections to the #236/#238 contract, all from the same review (#241).
+
+**Order: the more SPECIFIC state outranks the more general one.** `yes_no_choice` was placed above
+the passive `std_event` rule (that was #232's fix) but *below* `dialogue_wait` — and that pairing is
+the same bug wearing a disguise: `dialogue_wait` answers "press A", `YesNoChoice_Loop_KeyHandler`
+CONSUMES that A, and the prompt is answered by accident with the run green. A live `YesNoChoice` in
+its key handler owns the A button whatever else is on screen. The order is now pinned by tests
+(`talk_wait`+`yes_no`, `menu`+`std_event`, `map_fade`+`std_event`), because rule order is the one
+property of this design that no single rule's tests can protect.
+
+**Liveness: `PROC_REPEAT` is how every long-running FE8 proc works, so a constant `scrCur`/`idleCb`/
+`lockCnt` is not evidence of a stall.** `ProcScr_StdEventEngine`, `gProcScr_TalkWaitForInput`,
+`sProcScr_BMXFADE` and `gProcScr_YesNoChoice` are all `PROC_REPEAT`, holding those three fields
+constant for an entire scene; the signature can only see churn. It now includes `sleepTime` (a proc
+counting down a timed wait IS progressing — and `INSPECT.snapshot`'s own `frozen` field already
+compared it, so the feature held two contradictory definitions of "not moving") and the pool count.
+
+**Placement: the thing that decides FAIL cannot live where nothing can load it.** `INSPECT.watch`
+was in `harness.lua`, which only runs inside mGBA, so the most flake-prone component in the stack
+had zero tests. The decision moved to `controller.lua` as `stallWatch()`/`procSignature()` — pure,
+unit-tested — and the harness kept only the logging. As a bonus it calls `explain()` once per hold
+instead of once per frame of a 36000-iteration loop. **General rule: pure decisions live in
+controller.lua (unit-tested, no ceiling); harness.lua drives the emulator.**
+_Decided: 2026-08-06 (code review of #237/#238/#240; #241)_
+
+---
+
 ## Combat System
 
 > **2026-05-28 — Combat resolution reverted to vanilla FE.** The earlier "Hybrid

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -51,6 +51,14 @@ from inject.decomp import (  # noqa: E402  shared decomp paths + patch primitive
     BATTLEQUOTES_C, BMUNIT_C, LORDSEL_FLAG_BASE,
     WEAPON_ITEM_ENUM, fe_item_enum)  # shared weapon<->ITEM map (used by inject_prologue)
 from inject import engine_hooks  # noqa: E402  campaign-agnostic engine C-source hooks
+# The host-slot registry. Stdlib-only and OWNED there so tools/check.py can lint it in the
+# CI job that has no Pillow; re-exported here so the constants read the same at every call
+# site below (#241).
+from inject.hosts import (  # noqa: E402,F401
+    PROLOGUE_CHAPTER_INDEX, PROLOGUE_HOST_INDEX, PROLOGUE_EVENT_GROUP,
+    CH01_HOST_INDEX, CH01_EVENT_GROUP, CH02_HOST_INDEX, CH02_EVENT_GROUP,
+    CH03_HOST_INDEX, CH03_EVENT_GROUP, CH04_HOST_INDEX, CH04_EVENT_GROUP,
+    HostedChapter, hosted_chapters, injector_chapters, undeclared_injectors)
 
 PORTRAIT_DIR = os.path.join(DECOMP, 'graphics', 'portrait')
 CHARACTERS_C = os.path.join(DECOMP, 'src', 'data_characters.c')
@@ -136,10 +144,7 @@ TEST_CHAPTER_INDEX = 1
 PROLOGUE_UDEFS_H = os.path.join(DECOMP, 'src', 'events', 'prologue-eventudefs.h')
 PROLOGUE_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'prologue-eventinfo.h')
 PROLOGUE_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'prologue-eventscript.h')
-PROLOGUE_CHAPTER_INDEX = 0   # CHAPTER_L_PROLOGUE -- the vanilla slot we configure then clone
-PROLOGUE_HOST_INDEX = 1      # CHAPTER_L_1 -- normal chapter slot we actually load (New Game
-                             # redirects 0 -> 1). The prologue slot has special engine paths
-                             # that break our stripped chapter; a normal slot does not.
+# PROLOGUE_CHAPTER_INDEX / PROLOGUE_HOST_INDEX / PROLOGUE_EVENT_GROUP: inject/hosts.py.
 # Cold-open guests ride vanilla character slots that are NOT in PORTRAIT_MAP, so their
 # names/portraits are free placeholders until custom art (see [[feedback_nicolas_not_an_artist]]).
 # Sephek rides the vanilla prologue boss slot (ONEILL) so he inherits its CA_BOSS
@@ -174,8 +179,7 @@ CH2_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch2-eventscript.h')
 CH3_EVENTINFO_H = os.path.join(DECOMP, 'src', 'events', 'ch3-eventinfo.h')
 CH3_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch3-eventscript.h')
 EVENTS_UDEFS_C = os.path.join(DECOMP, 'src', 'events_udefs.c')
-CH01_HOST_INDEX = 2          # CHAPTER_L_2 -- the prologue ending's MNC2(0x2) target
-CH01_EVENT_GROUP = 'Ch2Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
+# CH01_HOST_INDEX / CH01_EVENT_GROUP: inject/hosts.py.
 # The goal WINDOW + status-objective strings are message ids, and hosted chapters used to inherit
 # them from whatever donor slot `_retarget_host_chapter` copied -- which silently shared them
 # between chapters (#207). Every hosted chapter now DECLARES its pair, so `assert_message_ids_unique`
@@ -313,8 +317,7 @@ CH01_LORDSEL_BG = 'BG_DARKLING_WOODS'
 # host goal is swapped to vanilla slot-4's defeat_all template and the vanilla Ch3
 # Seize(14,1) is dropped, so CountRedUnits() drives the rout win; CauseGameOverIfLordDies
 # already sits in EventListScr_Ch3_Misc.
-CH02_HOST_INDEX = 3          # CHAPTER_L_3 -- ch01's ending MNC2(0x3) target
-CH02_EVENT_GROUP = 'Ch3Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
+# CH02_HOST_INDEX / CH02_EVENT_GROUP: inject/hosts.py.
 CH02_GOAL_WINDOW_MSG = 0x19E     # vanilla slot 4's defeat_all window
 CH02_GOAL_STATUS_MSG = 0x1A6
 CH02_LAYOUT = ('Ch02ColdWelcomeMap', 'ch02-cold-welcome')  # (asset label, maps/ stem)
@@ -6867,8 +6870,7 @@ def inject_ch02(campaign, verbose=True):
 # ── Ch3 "The Termalaine Mine" (#23): hosted on chapter slot 4 (repaint of vanilla Ch3
 #    "Bandits of Borgo", so the roster/positions mirror vanilla Ch3 1:1). Uses the vanilla
 #    "Ch4" decomp symbol set (host index N -> ChN symbols, cf. ch02 on slot 3 = Ch3 symbols).
-CH03_HOST_INDEX = 4
-CH03_EVENT_GROUP = 'Ch4Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
+# CH03_HOST_INDEX / CH03_EVENT_GROUP: inject/hosts.py.
 CH03_GOAL_WINDOW_MSG = 0x19D     # vanilla slot 6's defeat_boss window
 CH03_GOAL_STATUS_MSG = 0x1A7
 CH03_LAYOUT = ('Ch03TermalaineMineMap', 'ch03-the-termalaine-mine')  # (asset label, maps/ stem)
@@ -6983,13 +6985,8 @@ CH4_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'ch4-eventscript.h')
 # preserves vanilla Ch4's 15x15 geometry, and the force preserves its 16 line + 7
 # reinforcement pressure shape. The D&D creatures ground the encounter fiction, but
 # player-facing units deliberately keep their vanilla FE8 monster identities/names.
-CH04_HOST_INDEX = 5
-# The ChapterEventGroup this injector fills. NOT derivable from the slot index: vanilla's
-# slot index tracks the chapter number only up to 4, because FE8 inserts chapter 5X at
-# slot 5. So slot 5 ships pointing at Ch5XEvents, and every ch04 event below is written
-# into the Ch5* symbols -- _retarget_host_chapter repoints the slot or the chapter runs
-# 5X's roster and scripts underneath our map.
-CH04_EVENT_GROUP = 'Ch5EventData'
+# CH04_HOST_INDEX / CH04_EVENT_GROUP: inject/hosts.py. The group is NOT derivable from the
+# slot index -- vanilla inserts chapter 5X at slot 5 -- and the registry says why.
 CH04_LAYOUT = ('Ch04LonelywoodForestMap', 'ch04-lonelywood-forest')
 CH04_CHAPTER_YAML = 'ch04-the-white-moose.yaml'
 CH04_GOAL_DONOR = CH02_HOST_INDEX  # ch02 is already hosted with the stable DefeatAll/Rout goal.
@@ -8239,48 +8236,6 @@ def inject_ch03(campaign, boot=False, verbose=True):
               'DefeatBoss(grell) WIN wired, PREP deploy cap %d%s + %d enemies (grell@14,1); opening/entrance/midmap/ending cutscenes wired'
               % (obj_idx, pal_idx, cfg_idx, layout_idx, CH03_HOST_INDEX, len(cap_rows),
                  ' (boot-seeded party)' if boot else '', len(enemies)))
-
-
-HostedChapter = collections.namedtuple(
-    'HostedChapter', 'name number host_index event_group')
-
-
-def hosted_chapters():
-    """Every chapter this build hosts, DISCOVERED from the module's own constants.
-
-    Declaring `CHNN_HOST_INDEX` + `CHNN_EVENT_GROUP` is what enrols a chapter -- there is
-    no list to remember to update. That is the whole point: the guard written after the
-    ch04 disaster (HostChapterEventGroup in tools/test_build_campaign.py) iterated a
-    hand-written tuple, so ch05 would have been the first chapter NOT covered by the very
-    test written to prevent that failure -- and ch05 hosts deeper into the divergence than
-    ch04 did, since vanilla's slot index stops tracking chapter number at 4 (#138).
-
-    Raises ValueError rather than sys.exit: the lints and tests that consume this need to
-    assert on the failure, not die inside it.
-    """
-    found, by_slot = [], {}
-    scope = globals()
-    for name in sorted(scope):
-        match = re.match(r'^(CH(\d+))_HOST_INDEX$', name)
-        if not match:
-            continue
-        prefix, number = match.group(1), int(match.group(2))
-        group = scope.get('%s_EVENT_GROUP' % prefix)
-        if group is None:
-            raise ValueError(
-                '%s_HOST_INDEX is declared with no %s_EVENT_GROUP. A hosted slot must NAME '
-                'the ChapterEventGroup its injector fills -- never assume the slot already '
-                'points there. Retargeting the map ids alone still makes the chapter LOOK '
-                'right while it runs the host slot\'s roster and scripts (see '
-                'docs/adding-a-chapter.md step 4).' % (prefix, prefix))
-        slot = scope[name]
-        if slot in by_slot:
-            raise ValueError(
-                'host slot %d is claimed by both %s and %s -- one chapter would overwrite '
-                'the other\'s events' % (slot, by_slot[slot], prefix))
-        by_slot[slot] = prefix
-        found.append(HostedChapter(prefix.lower(), number, slot, group))
-    return found
 
 
 def inject_ch04(campaign, boot=False, verbose=True):

--- a/tools/check.py
+++ b/tools/check.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -135,8 +136,18 @@ def check_tests_pass(fail):
                 os.path.relpath(t, REPO), tail[-1] if tail else 'see output'))
 
 
-LUA_CHUNKS = ('tools/playtest/harness.lua', 'tools/playtest/controller.lua',
-              'tools/playtest/clearbot.lua', 'tools/playtest/json.lua')
+# gen_symbols.py outputs, gitignored and absent in CI -- a gate that fails on a missing
+# generated file is a gate nobody can keep green.
+GENERATED_LUA = ('tools/playtest/symbols.lua', 'tools/playtest/procscr.lua')
+
+# DISCOVERED, not listed: harness.lua dofiles nine chunks and the hand-written tuple named
+# four, so a syntax error in recorder.lua or liveness.lua killed every scenario with this
+# gate green (#241). Same defect #138 closed for chapters -- a list you must remember to
+# update is not a gate.
+LUA_CHUNKS = tuple(sorted(
+    os.path.relpath(p, REPO)
+    for p in glob.glob(os.path.join(REPO, 'tools', 'playtest', '*.lua'))
+    if os.path.relpath(p, REPO) not in GENERATED_LUA))
 
 
 def lua_compile_error(path):
@@ -166,10 +177,10 @@ def check_lua_chunks_load(fail):
     invisible until mGBA loads it minutes later.
 
     The specific hazard is Lua's ceiling of 200 local variables per function. harness.lua
-    is one ~6,700-line main chunk with only TWO free slots (measured 2026-08-06: +2
-    top-level locals still compiles, +3 does not), so a routine edit can cross it -- and
-    crossing it kills every scenario simultaneously, a total outage rather than a single
-    red row. #236 crossed it and caught it only by hand.
+    is one ~6,700-line main chunk sitting AT that ceiling, so a routine edit can cross it
+    -- and crossing it kills every scenario simultaneously, a total outage rather than a
+    single red row. #236 crossed it and caught it only by hand. How much room is actually
+    left is MEASURED by check_lua_local_headroom below, never written down.
 
     loadfile COMPILES without executing, so the emulator globals the chunk needs at
     runtime (emu, SYM, PLAYTEST_*) are irrelevant here."""
@@ -183,29 +194,98 @@ def check_lua_chunks_load(fail):
             fail.append('%s does not compile: %s' % (rel, err))
 
 
+def lua_local_headroom(path, probe_max=8):
+    """How many more top-level `local`s `path` can take before it stops compiling.
+
+    Measured by appending them, because there is no way to ask Lua: the limit counts
+    what the compiler allocates, not what a regex can see (upvalues, `for` control
+    variables, locals inside the chunk's own blocks).
+    """
+    with open(path, encoding='utf-8') as f:
+        body = f.read()
+    for extra in range(probe_max + 1):
+        probe = body + '\n' + ''.join(
+            'local __headroom_probe%d = %d\n' % (i, i) for i in range(extra + 1))
+        fd, tmp = tempfile.mkstemp(suffix='.lua')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(probe)
+            if lua_compile_error(tmp) is not None:
+                return extra
+        finally:
+            os.unlink(tmp)
+    return probe_max
+
+
+def check_lua_local_headroom(fail, paths=None):
+    """Report the REMAINING local slots in the playtest chunks, and fail at zero.
+
+    The margin used to be prose -- "two free slots", repeated in harness.lua, in this
+    file and in HANDOFF.md -- and it was wrong in all three places within one PR of being
+    written, because #240 spent a slot and updated no comment. A hand-maintained number
+    about a limit whose breach kills every scenario at once is the wrong shape, so it is
+    computed here and printed on every run (#241).
+
+    Zero is a build failure rather than a warning: at zero the next helper anyone adds
+    takes the whole harness down, and the fix (hang it off INSPECT/TUNE, or move logic to
+    controller.lua) is cheap only while it is still a choice."""
+    if shutil.which('lua') is None:
+        print('check_lua_local_headroom: skipping (no lua on PATH; brew install lua)')
+        return
+    for path in (paths or (os.path.join(REPO, 'tools/playtest/harness.lua'),)):
+        free = lua_local_headroom(path)
+        rel = os.path.relpath(path, REPO)
+        print('%s: %d top-level local slot(s) free of Lua\'s 200-local ceiling' % (rel, free))
+        if free == 0:
+            fail.append(
+                '%s has NO room under the 200-local ceiling -- the next top-level local '
+                'stops the whole chunk loading and every scenario dies at once. Hang the '
+                'new helper off an existing table (INSPECT, TUNE) or move it to '
+                'controller.lua.' % rel)
+
+
 def check_hosted_chapters_declared(fail):
     """Every hosted chapter must declare the ChapterEventGroup its injector fills, and no
     two may claim one host slot.
 
-    `build_campaign.hosted_chapters()` enforces both while DISCOVERING chapters from the
-    module's constants; this runs it early, without the decomp submodule, so a bad
+    `inject.hosts.hosted_chapters()` enforces both while DISCOVERING chapters from the
+    registry's constants; this runs it early, without the decomp submodule, so a bad
     declaration fails in 0s rather than at ROM-build time. The deeper check -- that the
     retargeted slot actually resolves to that group in the vanilla asset table -- lives in
     HostChapterEventGroup (tools/test_build_campaign.py), which needs the submodule.
 
     Why it is worth a rule at all: retargeting a host slot's MAP ids alone is enough to
     make a chapter look right while it runs the host slot's roster and scripts, so this
-    class of mistake is silent and total (docs/adding-a-chapter.md step 4)."""
+    class of mistake is silent and total (docs/adding-a-chapter.md step 4).
+
+    Imports inject.hosts, NEVER build_campaign: this job installs pyyaml and nothing else,
+    and build_campaign pulls in Pillow at module scope -- the first version of this lint
+    failed every push with "No module named 'PIL'", a red check naming the wrong problem.
+    Same rule check_purple_bank_blankers_known states for its own constants (#241)."""
     sys.path.insert(0, os.path.join(REPO, 'tools'))
     try:
-        import build_campaign
+        from inject import hosts
     except Exception as exc:                      # pragma: no cover - import guard
-        fail.append('build_campaign does not import: %s' % exc)
+        fail.append('inject.hosts does not import: %s' % exc)
         return
+    finally:
+        sys.path.remove(os.path.join(REPO, 'tools'))
     try:
-        build_campaign.hosted_chapters()
+        hosts.hosted_chapters()
     except ValueError as exc:
         fail.append('hosted chapters: %s' % exc)
+        return
+    try:
+        stranded = hosts.undeclared_injectors()
+    except (OSError, SyntaxError) as exc:         # pragma: no cover - source-read guard
+        fail.append('hosted chapters: cannot read build_campaign.py: %s' % exc)
+        return
+    if stranded:
+        fail.append(
+            'inject_%s exists but enrols nothing -- declare %s_HOST_INDEX + '
+            '%s_EVENT_GROUP in tools/inject/hosts.py, or every guard built on the registry '
+            'passes with one chapter fewer and no complaint'
+            % (stranded[0], stranded[0].upper(), stranded[0].upper()))
 
 
 def check_yaml_parses(fail):
@@ -957,7 +1037,7 @@ def check_lane_ownership(fail):
 def main():
     fail = []
     for check in (check_python_compiles, check_lua_chunks_load,
-                  check_hosted_chapters_declared,
+                  check_lua_local_headroom, check_hosted_chapters_declared,
                   check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
                   check_injection_order, check_playtest_matrix,

--- a/tools/inject/hosts.py
+++ b/tools/inject/hosts.py
@@ -1,0 +1,135 @@
+"""The host-slot registry: which vanilla chapter slot each of our chapters occupies,
+and which ChapterEventGroup its injector fills.
+
+Kept STDLIB-ONLY on purpose, like decomp.py next to it. `tools/check.py` lints this in
+CI's lightweight `checks` job, which installs pyyaml and nothing else; the first version
+of that lint imported build_campaign, which imports Pillow at module scope, so the job
+would have failed every push with `build_campaign does not import: No module named 'PIL'`
+-- a red check that names the wrong problem (#241). build_campaign re-exports everything
+here, so the constants still read as `bc.CH04_HOST_INDEX` at their call sites.
+
+Why a registry at all: retargeting a host slot's MAP ids alone is enough to make a chapter
+LOOK right while it runs the host slot's roster and scripts. That is silent and total, and
+it is how ch04 shipped once (docs/adding-a-chapter.md step 4).
+"""
+import ast
+import collections
+import os
+import re
+
+_TOOLS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BUILD_CAMPAIGN_PY = os.path.join(_TOOLS, 'build_campaign.py')
+
+# --- the declarations themselves -------------------------------------------------------
+# Declaring CHNN_HOST_INDEX + CHNN_EVENT_GROUP here is what ENROLS a chapter. There is no
+# list to remember to update, and undeclared_injectors() below fails the build if an
+# inject_chNN exists without them.
+
+PROLOGUE_CHAPTER_INDEX = 0   # CHAPTER_L_PROLOGUE -- the vanilla slot we configure then clone
+PROLOGUE_HOST_INDEX = 1      # CHAPTER_L_1 -- normal chapter slot we actually load (New Game
+                             # redirects 0 -> 1). The prologue slot has special engine paths
+                             # that break our stripped chapter; a normal slot does not.
+PROLOGUE_EVENT_GROUP = 'Ch1Events'   # the group slot 1 already points at; the prologue is the
+                                     # one chapter that does NOT retarget (inject_prologue
+                                     # step 1: asset[7] garbles the HUD, asset[10] loads clean)
+
+CH01_HOST_INDEX = 2          # CHAPTER_L_2 -- the prologue ending's MNC2(0x2) target
+CH01_EVENT_GROUP = 'Ch2Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
+
+CH02_HOST_INDEX = 3          # CHAPTER_L_3 -- ch01's ending MNC2(0x3) target
+CH02_EVENT_GROUP = 'Ch3Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
+
+CH03_HOST_INDEX = 4
+CH03_EVENT_GROUP = 'Ch4Events'   # the ChapterEventGroup this injector fills (see _retarget_host_chapter)
+
+CH04_HOST_INDEX = 5
+# The ChapterEventGroup this injector fills. NOT derivable from the slot index: vanilla's
+# slot index tracks the chapter number only up to 4, because FE8 inserts chapter 5X at
+# slot 5. So slot 5 ships pointing at Ch5XEvents, and every ch04 event is written into the
+# Ch5* symbols -- _retarget_host_chapter repoints the slot or the chapter runs 5X's roster
+# and scripts underneath our map.
+CH04_EVENT_GROUP = 'Ch5EventData'
+
+# --- discovery -------------------------------------------------------------------------
+
+HostedChapter = collections.namedtuple(
+    'HostedChapter', 'name number host_index event_group')
+
+_HOST_INDEX_RE = re.compile(r'^(CH(\d+))_HOST_INDEX$')
+_INJECTOR_RE = re.compile(r'^inject_(prologue|ch(\d+))$')
+
+
+def hosted_chapters(scope=None):
+    """Every chapter this build hosts, DISCOVERED from the constants above.
+
+    The prologue is enrolled like any other chapter even though its constants are not
+    CHNN_-shaped. It was invisible to the first version of this function, which left slot 1
+    out of the collision map -- so a later CH05_HOST_INDEX = 1 would have passed the guard
+    and quietly overwritten the prologue's events (#241).
+
+    Ordered by chapter NUMBER, not name: the prologue is 0 and must lead, and a name sort
+    against a sorted() scan is a test that cannot fail.
+
+    Raises ValueError rather than sys.exit: the lints and tests that consume this need to
+    assert on the failure, not die inside it.
+    """
+    scope = globals() if scope is None else scope
+    found, by_slot = [], {}
+
+    def enrol(name, number, prefix, slot, group):
+        if slot in by_slot:
+            raise ValueError(
+                'host slot %d is claimed by both %s and %s -- one chapter would overwrite '
+                'the other\'s events' % (slot, by_slot[slot], name))
+        by_slot[slot] = name
+        found.append(HostedChapter(name, number, slot, group))
+
+    enrol('prologue', 0, 'PROLOGUE', scope['PROLOGUE_HOST_INDEX'],
+          scope['PROLOGUE_EVENT_GROUP'])
+    for name in sorted(scope):
+        match = _HOST_INDEX_RE.match(name)
+        if not match:
+            continue
+        prefix, number = match.group(1), int(match.group(2))
+        group = scope.get('%s_EVENT_GROUP' % prefix)
+        if group is None:
+            raise ValueError(
+                '%s_HOST_INDEX is declared with no %s_EVENT_GROUP. A hosted slot must NAME '
+                'the ChapterEventGroup its injector fills -- never assume the slot already '
+                'points there. Retargeting the map ids alone still makes the chapter LOOK '
+                'right while it runs the host slot\'s roster and scripts (see '
+                'docs/adding-a-chapter.md step 4).' % (prefix, prefix))
+        enrol(prefix.lower(), number, prefix, scope[name], group)
+    return sorted(found, key=lambda c: c.number)
+
+
+def injector_chapters(path=BUILD_CAMPAIGN_PY, source=None):
+    """The chapters build_campaign actually has an injector for, read from its SOURCE.
+
+    ast.parse rather than import, for the same reason this module is stdlib-only: the lint
+    that consumes it runs in a CI job with no Pillow.
+    """
+    if source is None:
+        with open(path, encoding='utf-8') as f:
+            source = f.read()
+    found = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        match = _INJECTOR_RE.match(node.name)
+        if match:
+            found.append(('prologue', 0) if match.group(1) == 'prologue'
+                         else (match.group(1), int(match.group(2))))
+    return [name for name, _ in sorted(set(found), key=lambda pair: pair[1])]
+
+
+def undeclared_injectors(path=BUILD_CAMPAIGN_PY, source=None, scope=None):
+    """Injectors that exist but enrol nothing -- discovery's blind spot.
+
+    Discovery covers a chapter that spells its constants right. `inject_ch05` with a typo'd
+    or missing CH05_HOST_INDEX is simply not found, and every guard built on the registry
+    passes with one chapter fewer and no complaint. That is the ch04 failure class #138 set
+    out to close, so it is a gate, not a convention (#241).
+    """
+    enrolled = {c.name for c in hosted_chapters(scope)}
+    return [name for name in injector_chapters(path, source) if name not in enrolled]

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -131,18 +131,15 @@ local RULES = {
         end,
     },
     {
-        name = "dialogue_wait",
-        check = function(observation)
-            if idleIs(observation, "talk_wait", "talk_wait_input") then
-                return matched("dialogue_wait", "talk_wait in talk_wait_input")
-            end
-            return rejected(missIs(observation, "talk_wait", "talk_wait_input"))
-        end,
-    },
-    {
-        -- Ordered ABOVE the passive rules on purpose: this prompt runs INSIDE a live
-        -- event scene, so `std_event` would otherwise swallow it as a transition -- which
-        -- is exactly how ch01's lord-select prompt stayed invisible through #232.
+        -- Ordered ABOVE `dialogue_wait` and the passive rules on purpose, and that order is
+        -- pinned by tests. The prompt runs INSIDE a live event scene, so `std_event` would
+        -- swallow it as a transition -- which is how ch01's lord-select prompt stayed
+        -- invisible through #232. `dialogue_wait` is the subtler version of the same trap:
+        -- it would answer "press A", the choice's key handler would CONSUME that A, and the
+        -- prompt would be answered by accident with the run still green (#241 review).
+        -- General rule for this table: the more SPECIFIC state outranks the more general
+        -- one -- a live YesNoChoice in its key handler owns the A button, whatever else is
+        -- on screen.
         name = "yes_no_choice",
         check = function(observation)
             if not proc(observation, "yes_no") then return rejected("yes_no proc absent") end
@@ -154,6 +151,15 @@ local RULES = {
                 return matched("transition", "yes_no live with no observed choice")
             end
             return matched("yes_no_choice", "yes_no in its key handler")
+        end,
+    },
+    {
+        name = "dialogue_wait",
+        check = function(observation)
+            if idleIs(observation, "talk_wait", "talk_wait_input") then
+                return matched("dialogue_wait", "talk_wait in talk_wait_input")
+            end
+            return rejected(missIs(observation, "talk_wait", "talk_wait_input"))
         end,
     },
     {
@@ -344,6 +350,56 @@ function M.explain(observation)
         live_procs = live,
         unclassified_wait = state == "transition" and unclassified or false,
     }
+end
+
+-- The liveness proxy behind the stall detector. Every long-running FE8 proc is
+-- PROC_REPEAT -- ProcScr_StdEventEngine (event.c), gProcScr_TalkWaitForInput (scene.c),
+-- sProcScr_BMXFADE (bmxfade.c), gProcScr_YesNoChoice (cgtext.c) -- so scrCur/idleCb/
+-- lockCnt are constant for an ENTIRE scene and cannot show progress inside a callback.
+-- What the signature can see is churn: a proc entering or leaving the pool, and a
+-- sleepTime counting down (a timed wait IS progress, and excluding it made a proc mid-STAL
+-- look frozen -- INSPECT.snapshot's own `frozen` field already compared it, so the feature
+-- held two different definitions of "not moving"). #241.
+function M.procSignature(observation)
+    local raw = (observation or {}).raw_procs or {}
+    local parts = { tostring(#raw) }
+    for _, p in ipairs(raw) do
+        parts[#parts + 1] = string.format("%d:%08X:%08X:%08X:%d:%d",
+            p.slot, p.script, p.scr_cur, p.idle, p.lock, p.sleep or 0)
+    end
+    return table.concat(parts, ",")
+end
+
+-- A `transition` the classifier has no NAME for, holding a byte-identical proc pool, is
+-- not a slow scene -- it is an input wait nothing will ever send. #232's ch01 burned a
+-- 12000-iteration loop and then reported a timeout that named nothing.
+--
+-- Returns a per-loop closure: call it with each observation and its state, and act on the
+-- first non-nil return (the explanation, ready to snapshot). Pure and unit-tested here;
+-- the harness only wraps it with logging, because this is now the thing that decides FAIL
+-- for a whole suite and it lived where nothing could test it (#241).
+--
+-- `samples` counts CALLS, not frames. The harness drives one call per frame on the
+-- transition path, which is what makes TUNE.stallFrames read as frames -- add a wait to
+-- that branch and the tunable stops meaning what it says.
+function M.stallWatch(samples)
+    local signature, held = nil, 0
+    return function(observation, state)
+        if state ~= "transition" then signature, held = nil, 0 return nil end
+        local now = M.procSignature(observation)
+        if now ~= signature then signature, held = now, 1 return nil end
+        held = held + 1
+        if held < samples then return nil end
+        -- explain() sorts the live-proc list, so it is called ONCE per hold rather than on
+        -- every frame of a 36000-iteration loop.
+        local explanation = M.explain(observation)
+        signature, held = nil, 0
+        -- Only an UNCLASSIFIED transition can stall this way. A named one (a map fade, a
+        -- menu animating in) is a state we can already wait out, and arming on those would
+        -- trade a silent hang for a noisy false positive.
+        if not explanation.unclassified_wait then return nil end
+        return explanation
+    end
 end
 
 local function add(actions, intention, key, source, target)

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -14,7 +14,7 @@ Three outputs, one nm pass:
                 PROC_NAME("E_FACE"), and reuses "bmenu" and "E_config" three times
                 each -- which is why freeze reports could not say which proc was
                 waiting (#236, blocking #232).
-  symbols.json  every ROM code symbol, for inspect.py. Idle callbacks are ordinary
+  symbols.json  every ROM code symbol, for inspect_state.py. Idle callbacks are ordinary
                 functions (~35k of them): too many for a Lua table, so the Lua side
                 dumps raw addresses and the Python renderer names them.
 
@@ -38,10 +38,15 @@ OUT_JSON = os.path.join(HERE, 'symbols.json')
 ROM_START = 0x08000000
 ROM_END = 0x0A000000
 
-# Proc scripts are `struct ProcCmd[]` in ROM: gProcScr_*/ProcScr_*/sProcScr_* plus the
-# handful named sProc_*/gProc_*. Keying by address makes a stray non-script match inert
-# (nothing ever looks up its address), while a missed one degrades to an honest unknown.
-PROC_SCRIPT_RE = re.compile(r'ProcScr|^[a-z]?Proc_')
+# Proc scripts are `struct ProcCmd[]` in ROM: `ProcScr_X`, `gProcScr_X`, `sProcScr_X`, plus
+# the handful named `gProc_X` / `sProc_X`. Keying by address makes a stray match inert
+# (nothing looks up its address) while a missed one degrades to an honest unknown -- but
+# the table is also what a human reads to learn which proc is live, so it is ANCHORED:
+# unanchored, it also swept in proc.c's API (Proc_Init, Proc_Start, Proc_ForEach, ...) and
+# two getters whose names merely END in ProcScript -- 30 functions that are not proc
+# scripts (#241). A bare `Proc_` prefix is always a function; a script carries the g/s
+# storage-class letter.
+PROC_SCRIPT_RE = re.compile(r'^(?:[a-z]Proc_|[a-z]?ProcScr)')
 
 Symbol = namedtuple('Symbol', 'name type addr')
 
@@ -235,7 +240,7 @@ def _by_address(symbols):
 
 def proc_scripts(symbols):
     """Proc-script address -> exact symbol name."""
-    return _by_address([s for s in _rom_code(symbols) if PROC_SCRIPT_RE.search(s.name)])
+    return _by_address([s for s in _rom_code(symbols) if PROC_SCRIPT_RE.match(s.name)])
 
 
 def code_symbols(symbols):

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -21,6 +21,10 @@ dofile(PLAYTEST_DIR .. "/symbols.lua")
 -- PROC_NAME string at proc+0x10 -- the decomp reuses those (E_FACE twice, bmenu three
 -- times), which is why freeze reports could not say which proc was waiting (#236).
 dofile(PLAYTEST_DIR .. "/procscr.lua")
+-- It is generated (gitignored, written by gen_symbols.py from the ELF), so a stale or
+-- half-written table is a total outage with a confusing error much later. Say so here.
+assert(type(PROCSCR) == "table" and next(PROCSCR) ~= nil,
+    "procscr.lua defined no PROCSCR table -- regenerate it: tools/playtest/gen_symbols.py")
 local Controller = dofile(PLAYTEST_DIR .. "/controller.lua")
 local Recorder = dofile(PLAYTEST_DIR .. "/recorder.lua")
 
@@ -272,9 +276,12 @@ end
 local controllerState, guardedInput, freezeReport
 -- The #236 state inspector, as ONE table rather than three top-level locals: this file
 -- is against Lua's 200-local ceiling for a main chunk, and crossing it stops the whole
--- harness loading (every scenario dies at once). Consolidating here bought back 2 slots,
--- and 2 is all the headroom there is -- measured 2026-08-06, +2 top-level locals still
--- compiles and +3 does not. `check_lua_chunks_load` now fails the build on it in 0s.
+-- harness loading (every scenario dies at once). Hang new helpers off an existing table
+-- (INSPECT, TUNE) or put the logic in controller.lua, which has a unit suite and no such
+-- ceiling. HOW MUCH ROOM IS LEFT IS NEVER WRITTEN DOWN HERE: `check.py
+-- check_lua_local_headroom` measures it and prints it on every `make check`, because the
+-- hand-maintained number said "two free slots" in three files at once and was wrong in
+-- all three within one PR (#241). `check_lua_chunks_load` fails the build on a crossing.
 -- Fields are assigned further down, next to the proc-pool reader they build on.
 local INSPECT = {}
 local function recordCutscene(o)
@@ -504,8 +511,11 @@ local function observeController()
                 -- liveness signal the stall detector keys on: a pool whose every proc holds
                 -- the same command, idle and lock for TUNE.stallFrames is not slow, it is
                 -- waiting for an input nothing will send (#236).
+                -- sleepTime (+0x24) is in there because those three fields are CONSTANT
+                -- under PROC_REPEAT -- which is how every long-running FE8 proc is written
+                -- -- so without it a proc counting down a timed wait reads as frozen (#241).
                 slot = i, script = script, scr_cur = ru32(addr + 0x04),
-                idle = ru32(addr + 0x0C), lock = ru8(addr + 0x28),
+                idle = ru32(addr + 0x0C), sleep = rs16(addr + 0x24), lock = ru8(addr + 0x28),
             }
         end
     end
@@ -693,18 +703,36 @@ local function selectSemantic(intention, expected, predicate, frames)
             return false
         end
         if wanted.key == "A" then return guardedInput(intention, "A", expected, predicate, frames) end
-        local count = observation.menu and #observation.menu.items or 0
-        if not wanted.target or count < 2 then
-            traceInput(observation, actions, intention, "none", expected, "fail:no-live-target", observation)
-            return false
+        -- A yes/no answer that is not highlighted moves with LEFT/RIGHT, not menu rows.
+        -- Without this, `answer_no` was advertised as legal-but-select-it-first and NO
+        -- driver could act on it -- the first scenario needing "No" would have failed on
+        -- fail:no-live-target with the contract technically correct (#241).
+        if intention == "answer_yes" or intention == "answer_no" then
+            local move = Controller.findAction(
+                actions, intention == "answer_no" and "select_no" or "select_yes")
+            if not (move and move.key) then
+                traceInput(observation, actions, intention, "none", expected,
+                    "fail:no-choice-navigation", observation)
+                return false
+            end
+            if not guardedInput(move.intention, move.key, "the live choice moves",
+                function(after)
+                    return after.choice ~= nil and after.choice.current ~= observation.choice.current
+                end, 30) then return false end
+        else
+            local count = observation.menu and #observation.menu.items or 0
+            if not wanted.target or count < 2 then
+                traceInput(observation, actions, intention, "none", expected, "fail:no-live-target", observation)
+                return false
+            end
+            local current = observation.menu.current
+            local down = (wanted.target - current) % count
+            local nav = down <= count - down and "menu_next" or "menu_previous"
+            local key = nav == "menu_next" and "DOWN" or "UP"
+            if not guardedInput(nav, key, "live menu selection changes", function(after)
+                return after.menu ~= nil and after.menu.current ~= current
+            end, 30) then return false end
         end
-        local current = observation.menu.current
-        local down = (wanted.target - current) % count
-        local nav = down <= count - down and "menu_next" or "menu_previous"
-        local key = nav == "menu_next" and "DOWN" or "UP"
-        if not guardedInput(nav, key, "live menu selection changes", function(after)
-            return after.menu ~= nil and after.menu.current ~= current
-        end, 30) then return false end
     end
     traceFailure(intention, expected, "fail:menu-navigation-budget", nil,
         "controller-menu-navigation")
@@ -1025,31 +1053,15 @@ local function driveSaveSlot()
     return false
 end
 
--- A `transition` the classifier has no name for, holding a byte-identical proc pool, is
--- not a slow scene -- it is an input wait nothing will ever send. #232's ch01 burned a
--- 12000-iteration loop and then reported a timeout that named nothing; this dumps the
--- inspector snapshot the moment the stall is provable, so the NEXT question is which
--- proc to classify rather than which hypothesis to rebuild for. Returns a per-loop
--- closure: call it with each observation, and act on the first true.
+-- The stall oracle: the DECISION lives in controller.lua (pure, unit-tested in
+-- test_controller.lua -- it decides FAIL for whole suites, so it may not live where
+-- nothing can load it), and this only reports it. Returns a per-loop closure: call it
+-- with each observation, and act on the first true.
 INSPECT.watch = function(what)
-    local signature, held = nil, 0
+    local stalled = Controller.stallWatch(TUNE.stallFrames)
     return function(observation, state)
-        if state ~= "transition" then signature, held = nil, 0 return false end
-        local explanation = Controller.explain(observation)
-        -- Only an UNCLASSIFIED transition can stall this way. A named one (a map fade, a
-        -- menu animating in) is a state we can already wait out, and arming on those
-        -- would trade a silent hang for a noisy false positive.
-        if not explanation.unclassified_wait then signature, held = nil, 0 return false end
-        local parts = {}
-        for _, p in ipairs(observation.raw_procs or {}) do
-            parts[#parts + 1] = string.format("%d:%08X:%08X:%08X:%d",
-                p.slot, p.script, p.scr_cur, p.idle, p.lock)
-        end
-        local now = table.concat(parts, ",")
-        if now ~= signature then signature, held = now, 0 return false end
-        held = held + 1
-        if held < TUNE.stallFrames then return false end
-        held = 0
+        local explanation = stalled(observation, state)
+        if not explanation then return false end
         log(string.format("STALL: %s held an unclassified wait for %d frames -- %s",
             what, TUNE.stallFrames, tostring(explanation.detail)))
         INSPECT.snapshot(what .. "-stall", explanation)
@@ -1094,7 +1106,10 @@ end
 local function bootToMap(stopAtPrep)
     log("booting to map with observed FE8 states")
     local stalled = INSPECT.watch("boot")
-    for _ = 1, 12000 do
+    -- TUNE.bootSteps, never a literal: a cap that expires mid-scene reports a timeout that
+    -- names nothing, which is how #232 stayed misdiagnosed for three sessions. The cap is
+    -- sized above any real scene and INSPECT.watch is what decides failure.
+    for _ = 1, TUNE.bootSteps do
         local observation = observeController()
         local state, why = controllerState(observation)
         if stalled(observation, state) then
@@ -1280,7 +1295,9 @@ freezeReport = function(tag, gap)
     for i = 0, 63 do
         if after[i] then log(procLine(i, after[i], before[i])) end
     end
-    INSPECT.snapshot(tag)
+    -- Hand over the pair sampled above: the report and the snapshot then describe the same
+    -- two moments, and the freeze costs one gap instead of two.
+    INSPECT.snapshot(tag, nil, { before = before, after = after })
 end
 
 -- ---- state inspector (#236): one machine-readable snapshot of what FE8 is doing.
@@ -1288,12 +1305,18 @@ end
 -- reasoning behind the classification, and pairs it with the raw proc inventory named by
 -- exact symbol. Rendered by tools/playtest/inspect_state.py, which resolves the idle-callback
 -- addresses (ordinary functions -- ~35k of them, too many for a Lua table) out of the ELF.
-INSPECT.snapshot = function(tag, explanation)
+-- `sampled` lets a caller that has ALREADY sampled the pool twice hand its pair over
+-- (freezeReport does): re-sampling costs another TUNE.inspectGap frames and reports a
+-- different moment than the report around it (#241).
+INSPECT.snapshot = function(tag, explanation, sampled)
     local observation = observeController()
     explanation = explanation or Controller.explain(observation)
-    local before = procPool()
-    wait(TUNE.inspectGap)
-    local after = procPool()
+    local before, after = (sampled or {}).before, (sampled or {}).after
+    if not (before and after) then
+        before = procPool()
+        wait(TUNE.inspectGap)
+        after = procPool()
+    end
     local procs = {}
     for i = 0, 63 do
         local p = after[i]
@@ -1674,8 +1697,12 @@ local function reachCh01(opts)
     -- The Beat-1 Northlook scene is 29 script lines -> 67 text pages, and at normal speed
     -- it costs ~170 frames a page. Nothing here is looked at, so set gameSpeed (gPlaySt
     -- +0x40 bit 7) and type it fast. Written inline, not as a helper: harness.lua is at
-    -- the 200-local ceiling, and one more top-level `local` stops the whole file loading.
-    -- Only gameSpeed -- animationType is left alone so winCh00's combat is unaffected.
+    -- the 200-local ceiling (check_lua_local_headroom prints what is actually left -- never
+    -- write that number down, it went stale in three places at once). Only gameSpeed --
+    -- animationType is left alone so winCh00's combat is unaffected.
+    -- DELIBERATELY NOT RESTORED: ckpt_prep/ckpt_lordpinky save AFTER this, so every record*
+    -- scenario loading them inherits fast text. That is what we want for capture runs, but
+    -- it IS a property of those checkpoints rather than an accident (#241).
     emu:write32(SYM.gPlaySt + 0x40, ru32(SYM.gPlaySt + 0x40) | (1 << 7))
     local stalled = INSPECT.watch("reach_ch01")
     for _ = 1, TUNE.bootSteps do
@@ -1691,10 +1718,17 @@ local function reachCh01(opts)
             if not driveThroughPrep() then
                 result("FAIL", "could not leave preparations via semantic Fight"); return false
             end
-        elseif state == "player_map_idle" and faction() == 0 and turn() >= 1 then
-            wait(120)
-            shot("ch01-map")
-            return true
+        elseif state == "player_map_idle" then
+            -- The map is up but the chapter has not handed the player turn 1 yet (opening
+            -- events still running). That is a WAIT, not an unsupported state -- bootToMap
+            -- yields on the same case, and falling through to advanceBootState here would
+            -- hard-FAIL a healthy run (#241).
+            if faction() == 0 and turn() >= 1 then
+                wait(120)
+                shot("ch01-map")
+                return true
+            end
+            yield()
         elseif state == "generic_menu" then
             -- Scenario policy: which lead to take. The controller owns the live menu
             -- callback and the guarded input either way; no row is guessed and no
@@ -1710,6 +1744,19 @@ local function reachCh01(opts)
                         result("FAIL", "could not walk the lead menu to the last candidate")
                         return false
                     end
+                end
+                -- Assert WHERE the walk landed. rows-1 presses reach the last candidate
+                -- only if the menu opened on row 0, which nothing guarantees, and FE8 menus
+                -- WRAP -- so being wrong picks a different lord and passes anyway. Nothing
+                -- downstream checks which lead was taken (ckpt_lordpinky just saves), so
+                -- without this the scenario's whole premise is unverified (#241).
+                local landed = observeController()
+                if not (landed.menu and landed.menu.current == rows - 1) then
+                    result("FAIL", string.format(
+                        "lead menu walk landed on row %s of %d, not the last candidate",
+                        tostring(landed.menu and landed.menu.current), rows))
+                    shot("ch01-lord-walk-lost")
+                    return false
                 end
             end
             if not guardedInput("select_current_menu_item", "A", "lead menu selection closes", function(after)

--- a/tools/playtest/inspect_state.py
+++ b/tools/playtest/inspect_state.py
@@ -5,8 +5,12 @@ that way, and where two runs first diverge (#236).
     tools/playtest/inspect_state.py render /tmp/playtest-ch01/playtest.log
     tools/playtest/inspect_state.py diff /tmp/accepted.log /tmp/playtest-ch01/playtest.log
 
+run.sh renders a failing run through this automatically; the commands above are for
+re-reading a log later, or diffing two runs.
+
 The harness emits the state; this names and formats it. Addresses resolve against
-symbols.json (written by gen_symbols.py after every make) by EXACT match -- idle callbacks
+symbols.json (written by gen_symbols.py, which run.sh invokes before every run -- `make`
+does NOT) by EXACT match -- idle callbacks
 are ordinary functions, ~35k of them, which is why the Lua side dumps raw addresses and
 the naming happens here. An address that matches no symbol is reported as unknown; a
 nearest-preceding guess is what made #232's freeze reports untrustworthy.
@@ -49,7 +53,16 @@ def parse_records(text):
 
 
 def load_symbols(path=SYMBOLS_JSON):
+    """The address -> symbol map, or {} with a WARNING.
+
+    Degrading silently is the one thing this must not do: every idle callback then renders
+    `unknown@0x...`, which is exactly what a genuinely unresolvable address looks like, and
+    the tool's whole contract is that an unknown is honest. gen_symbols.py runs from
+    run.sh, so anyone rendering an archived log on a fresh checkout hits this (#241)."""
     if not os.path.exists(path):
+        sys.stderr.write(
+            'WARNING: %s not found -- idle callbacks will render as unknown@0x... rather '
+            'than being named. Regenerate it: tools/playtest/gen_symbols.py\n' % path)
         return {}
     with open(path, encoding='utf-8') as f:
         raw = json.load(f)
@@ -60,7 +73,15 @@ def resolve(symbols, addr):
     """An address (hex string or int) as `Symbol(0x...)`, `none`, or an honest unknown."""
     if addr is None:
         return 'none'
-    value = addr if isinstance(addr, int) else int(str(addr), 16)
+    try:
+        value = addr if isinstance(addr, int) else int(str(addr), 16)
+    except ValueError:
+        # One malformed field must not kill the render: parse_records already treats a
+        # truncated log as ordinary input, and this is the same log (#241).
+        return 'unknown@%s' % addr
+    # ARM/THUMB function pointers carry bit 0. The Lua side masks it before logging, so
+    # this is belt-and-braces for any other caller handing us a raw pointer.
+    value &= ~1
     if value == 0:
         return 'none'
     name = symbols.get(value)
@@ -91,7 +112,7 @@ def _menu_line(menu):
         return '  menu:   -'
     items = ' '.join('0x%02X%s' % (i.get('override_id') or 0,
                                    '' if i.get('availability') == 1 else '(disabled)')
-                     for i in menu.get('items', []))
+                     for i in (menu.get('items') or []))
     return '  menu:   current=%s [%s] on_b=%s' % (
         menu.get('current'), items, menu.get('on_b') or '-')
 
@@ -212,15 +233,27 @@ def _read(path):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
-    parser.add_argument('--symbols', default=SYMBOLS_JSON,
+    # On BOTH the top-level parser and each subcommand: `render log --symbols X` is the
+    # order anyone types, and only the top-level form used to be accepted (#241).
+    symbols_flag = dict(default=SYMBOLS_JSON,
                         help='symbols.json from gen_symbols.py (default: alongside this tool)')
+    parser.add_argument('--symbols', **symbols_flag)
     sub = parser.add_subparsers(dest='command', required=True)
     render = sub.add_parser('render', help='human-readable state snapshots from a log')
     render.add_argument('log')
+    render.add_argument('--symbols', **symbols_flag)
     diff = sub.add_parser('diff', help='first semantic divergence between two runs')
     diff.add_argument('baseline')
     diff.add_argument('candidate')
+    diff.add_argument('--symbols', **symbols_flag)
     args = parser.parse_args(argv)
+
+    for path in [p for p in (getattr(args, 'log', None), getattr(args, 'baseline', None),
+                             getattr(args, 'candidate', None)) if p]:
+        if not os.path.exists(path):
+            # A diagnostic tool must not answer a typo with a traceback.
+            sys.stderr.write('no such log: %s\n' % path)
+            return 2
 
     if args.command == 'render':
         print(render_log(_read(args.log), load_symbols(args.symbols)))

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -219,6 +219,17 @@ EOF
     cat "$log" 2>/dev/null || echo "(no log produced)"
     echo "----------------------------------------"
     echo "$VERDICT"
+    # A failing run renders its OWN diagnosis. The snapshot was already in the log as
+    # JSON, but reading it meant knowing to run inspect_state.py by hand -- and the point
+    # of #236 was that the next question after a FAIL should be "which proc do I classify",
+    # not "which hypothesis do I rebuild" (#241).
+    case "$VERDICT" in
+        *PASS*) ;;
+        *) if grep -q '"event":"inspect"\|"event": "inspect"' "$log" 2>/dev/null; then
+               echo "---------------- inspector ----------------"
+               python3 "$HERE/inspect_state.py" render "$log" || true
+           fi ;;
+    esac
     echo "artifacts: $out"
 }
 

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -398,6 +398,32 @@ classify({
     choice = { current = "yes" },
 }, "yes_no_choice", "the yes/no prompt outranks the passive event engine")
 
+-- RULE ORDER IS THE LOAD-BEARING PROPERTY of the table, and only one pairing was pinned.
+-- The dangerous one is talk_wait + yes_no: `dialogue_wait` says "press A", the choice
+-- handler CONSUMES that A, and the prompt is answered by accident with the run green --
+-- exactly #232, restored silently. The specific state outranks the general one.
+classify({
+    procs = { talk_wait = { idle = "talk_wait_input" }, yes_no = { idle = "yes_no_input" } },
+    choice = { current = "yes" },
+}, "yes_no_choice", "the yes/no prompt outranks a waiting text box")
+check(action({
+    procs = { talk_wait = { idle = "talk_wait_input" }, yes_no = { idle = "yes_no_input" } },
+    choice = { current = "yes" },
+}, "advance_dialogue"), nil, "a live choice withdraws the blind dialogue A")
+
+classify({
+    procs = { std_event = { idle = "event_engine" }, menu = { idle = "menu_input" } },
+    menu = { current = 0, items = {
+        { slot = 0, override_id = 0x7F, availability = 1, on_selected = 0x0800B1C0 } } },
+}, "generic_menu", "an open menu outranks the passive event engine")
+
+classify({
+    procs = { std_event = { idle = "event_engine" }, map_fade = { idle = "map_fade_loop" } },
+}, "transition", "map_fade and std_event agree it is a transition")
+check(C.explain({
+    procs = { std_event = { idle = "event_engine" }, map_fade = { idle = "map_fade_loop" } },
+}).matched, "map_fade", "the named fade owns the transition, not the catch-all passive rule")
+
 -- explain(): the same verdict, plus WHY. Every #232 defect but one was an input wait
 -- nothing had a name for; each read as a passive `transition` and cost a full
 -- build-and-run cycle to identify. An unclassified wait has to say what it rejected.
@@ -448,6 +474,83 @@ check(fadingMenu.unclassified_wait, false,
 local broken = C.explain({ error = "malformed live menu", procs = proc("menu", "menu_input") })
 check(broken.state, nil, "explain fails closed on a malformed observation")
 check(broken.error, "malformed live menu", "explain preserves the observer rejection")
+
+-- The other two rules that flag an unclassified wait. Both feed the stall detector, and
+-- only passive_proc was covered -- so a change that stopped flagging either would have
+-- disarmed the failure oracle on those states silently (#241).
+local bootGap = C.explain({ procs = proc("game_control", "game_control_root") })
+check(bootGap.matched, "boot_proc", "an unnamed boot owner is the boot_proc rule's transition")
+check(bootGap.unclassified_wait, true, "and it is flagged as an unclassified wait")
+
+local strangePhase = C.explain({ procs = proc("player_phase", "player_unknown_idle") })
+check(strangePhase.matched, "player_phase", "an unknown player_phase callback stays with its rule")
+check(strangePhase.unclassified_wait, true, "and is flagged -- it is a wait with no name yet")
+check(strangePhase.detail:find("player_unknown_idle", 1, true) ~= nil, true,
+    "the detail names the callback nobody has classified")
+
+-- ---------------------------------------------------------------- stall detection
+-- The failure ORACLE: it is what turns "the run ended" into "the run ended HERE, waiting
+-- on this". It lived in harness.lua, which cannot be loaded outside mGBA, so the most
+-- flake-prone component in the playtest stack had no tests at all (#241).
+local function rawProc(fields)
+    return {
+        slot = fields.slot or 3, script = fields.script or 0x085A7EF4,
+        scr_cur = fields.scr_cur or 0x085A7F00, idle = fields.idle or 0x08007CA0,
+        lock = fields.lock or 1, sleep = fields.sleep or 0,
+    }
+end
+
+local sceneObs = {
+    procs = { std_event = { idle = "event_engine" } },
+    raw_procs = { rawProc({}) },
+}
+
+local function feed(watch, observation, times)
+    local fired = nil
+    for _ = 1, times do fired = watch(observation, C.classify(observation)) end
+    return fired
+end
+
+local watch = C.stallWatch(3)
+check(feed(watch, sceneObs, 2), nil, "an unclassified wait under the hold is not a stall")
+check(feed(watch, sceneObs, 1) ~= nil, true, "an unclassified wait held long enough is a stall")
+check(C.stallWatch(3)(sceneObs, "player_map_idle"), nil, "a classified STATE never arms the watch")
+
+-- The PROC_REPEAT blindness this was written for: every long-running FE8 proc
+-- (ProcScr_StdEventEngine, TalkWaitForInput, BMXFADE, YesNoChoice) is PROC_REPEAT, so
+-- scrCur/idleCb/lockCnt are constant for a whole scene. A proc counting DOWN a timed
+-- wait is progress, and the old signature could not see it.
+local sleeping = C.stallWatch(3)
+check(feed(sleeping, sceneObs, 2), nil, "two identical samples")
+check(sleeping({ procs = sceneObs.procs, raw_procs = { rawProc({ sleep = 30 }) } },
+    "transition"), nil, "a proc counting down its sleep resets the hold")
+
+local growing = C.stallWatch(3)
+check(feed(growing, sceneObs, 2), nil, "two identical samples")
+check(growing({ procs = sceneObs.procs,
+    raw_procs = { rawProc({}), rawProc({ slot = 4 }) } }, "transition"), nil,
+    "a proc entering the pool resets the hold")
+
+local shrinking = C.stallWatch(2)
+check(shrinking({ procs = sceneObs.procs, raw_procs = { rawProc({}), rawProc({ slot = 4 }) } },
+    "transition"), nil, "first sample of a two-proc pool")
+check(shrinking(sceneObs, "transition"), nil, "a proc LEAVING the pool resets the hold too")
+
+-- A named transition is a state we can wait out; arming on it trades a silent hang for a
+-- noisy false FAIL, which is worse.
+local fade = { procs = proc("map_fade", "map_fade_loop"), raw_procs = { rawProc({}) } }
+check(feed(C.stallWatch(2), fade, 6), nil, "a CLASSIFIED transition (map_fade) never arms")
+
+local leaving = C.stallWatch(2)
+check(feed(leaving, sceneObs, 1), nil, "one sample")
+check(leaving({ procs = proc("talk_wait", "talk_wait_input") }, "dialogue_wait"), nil,
+    "leaving the transition state resets the hold")
+check(feed(leaving, sceneObs, 1), nil, "and the count starts over rather than firing early")
+
+local fired = feed(C.stallWatch(2), sceneObs, 2)
+check(fired ~= nil and fired.state, "transition", "the stall carries the explanation with it")
+check(fired ~= nil and fired.unclassified_wait, true,
+    "and that explanation is the one that says nothing has a name for this")
 
 -- Fallthrough: no rule matched at all.
 local unknown = C.explain({ procs = { mystery = { idle = "mystery_idle" } } })

--- a/tools/playtest/test_gen_symbols.py
+++ b/tools/playtest/test_gen_symbols.py
@@ -62,6 +62,18 @@ class ProcScripts(unittest.TestCase):
     def test_excludes_ordinary_functions(self):
         self.assertNotIn(0x0801C9E0, gs.proc_scripts(gs.parse_nm(NM)))
 
+    def test_excludes_functions_that_merely_mention_proc(self):
+        """The unanchored pattern pulled ~51 non-scripts into the table (Proc_Init,
+        Proc_Start, GetSpellAssocMapAnimProcScript...). Inert, but a proc-script table
+        whose entries are not proc scripts makes every reader check twice (#241)."""
+        nm = NM + ('08002c08 T Proc_Init\n'
+                   '08002d10 T Proc_Start\n'
+                   '0808f120 T GetSpellAssocMapAnimProcScript\n')
+        got = gs.proc_scripts(gs.parse_nm(nm))
+        for addr in (0x08002C08, 0x08002D10, 0x0808F120):
+            self.assertNotIn(addr, got)
+        self.assertEqual(got[0x085B1890], 'gProcScr_PlayerPhase')
+
     def test_excludes_ram_symbols(self):
         self.assertNotIn(0x0202BCF0, gs.proc_scripts(gs.parse_nm(NM)))
 

--- a/tools/playtest/test_inspect.py
+++ b/tools/playtest/test_inspect.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Tests for tools/playtest/inspect.py -- the #236 state inspector's pure formatting and
-first-divergence logic. No emulator, no ROM, no ELF: the renderer is handed the symbol
+"""Tests for tools/playtest/inspect_state.py -- the #236 state inspector's pure formatting
+and first-divergence logic. No emulator, no ROM, no ELF: the renderer is handed the symbol
 table it resolves against. Run: python3 tools/playtest/test_inspect.py
 """
+import io
 import os
 import sys
+import tempfile
 import unittest
+import contextlib
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import inspect_state as ins
@@ -78,6 +81,67 @@ class ResolveSymbol(unittest.TestCase):
 
     def test_null_is_not_an_unknown_symbol(self):
         self.assertEqual(ins.resolve(SYMBOLS, '0x00000000'), 'none')
+
+    def test_a_thumb_pointer_resolves_to_its_function(self):
+        """ARM/THUMB pointers carry bit 0 set. The Lua side masks it today, so this is
+        correct only by convention -- and a raw pointer from any other caller would report
+        a confident `unknown` for a symbol we have (#241)."""
+        self.assertEqual(ins.resolve(SYMBOLS, '0x08007CA1'),
+                         'TalkWaitForInput_OnIdle(0x08007CA0)')
+
+    def test_a_malformed_address_is_reported_not_raised(self):
+        """parse_records tolerates a truncated log; the renderer must be equally tolerant
+        of one bad field, or a diagnostic tool dies on the run it exists to diagnose."""
+        self.assertEqual(ins.resolve(SYMBOLS, '0xZZZZ'), 'unknown@0xZZZZ')
+
+
+class SymbolTableIsMissing(unittest.TestCase):
+    """An unknown must mean "this address matches no symbol", never "nobody loaded the
+    symbols". Silently returning {} made every callback in the report read unknown@0x...,
+    indistinguishable from a real one (#241)."""
+
+    def test_it_says_so_on_stderr(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            symbols = ins.load_symbols('/nonexistent/symbols.json')
+        self.assertEqual(symbols, {})
+        self.assertIn('gen_symbols.py', err.getvalue())
+
+    def test_a_present_table_warns_about_nothing(self):
+        fd, path = tempfile.mkstemp(suffix='.json')
+        self.addCleanup(os.unlink, path)
+        with os.fdopen(fd, 'w') as f:
+            f.write('{"code": {"0x08007CA0": "TalkWaitForInput_OnIdle"}}')
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            symbols = ins.load_symbols(path)
+        self.assertEqual(symbols, {0x08007CA0: 'TalkWaitForInput_OnIdle'})
+        self.assertEqual(err.getvalue(), '')
+
+
+class MenuWithoutItems(unittest.TestCase):
+    def test_a_null_items_list_renders(self):
+        """`items` present-but-null is what a truncated or in-between observation looks
+        like; `.get('items', [])` returns None there and the renderer blows up."""
+        self.assertIn('current=2', ins._menu_line({'current': 2, 'items': None}))
+
+
+class Cli(unittest.TestCase):
+    def test_symbols_may_follow_the_subcommand(self):
+        """`render log --symbols X` is the order anyone types; it was rejected because
+        --symbols only existed on the top-level parser."""
+        fd, log = tempfile.mkstemp(suffix='.log')
+        self.addCleanup(os.unlink, log)
+        with os.fdopen(fd, 'w') as f:
+            f.write('[f000001] {"event": "inspect", "tag": "t", "state": "transition"}\n')
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(ins.main(['render', log, '--symbols', '/nonexistent.json']), 0)
+
+    def test_a_missing_log_is_an_error_not_a_traceback(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(ins.main(['render', '/nonexistent/playtest.log']), 2)
+        self.assertIn('/nonexistent/playtest.log', err.getvalue())
 
 
 class RenderInspect(unittest.TestCase):

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1574,51 +1574,37 @@ class HostedChapterEnumeration(unittest.TestCase):
     list does not extend: ch05 would have been the first chapter NOT covered by the very
     test written to prevent that class of failure -- and ch05 hosts deeper into the slot
     divergence than ch04 did, since vanilla's slot index stops tracking chapter number
-    at 4. Enumerating from the module's own constants closes that (#138).
+    at 4. Enumerating from the registry's constants closes that (#138).
+
+    The registry itself moved to inject/hosts.py so a CI job without Pillow can lint it;
+    its behaviour (collisions, missing groups, self-enrolment) is tested in tools/
+    test_hosts.py. What is asserted HERE is the seam: build_campaign re-exports it, and
+    every chapter this module injects is enrolled in it (#241).
     """
 
     def test_finds_every_currently_hosted_chapter(self):
         got = {c.name: c.host_index for c in bc.hosted_chapters()}
-        self.assertEqual(got, {'ch01': bc.CH01_HOST_INDEX, 'ch02': bc.CH02_HOST_INDEX,
+        self.assertEqual(got, {'prologue': bc.PROLOGUE_HOST_INDEX,
+                               'ch01': bc.CH01_HOST_INDEX, 'ch02': bc.CH02_HOST_INDEX,
                                'ch03': bc.CH03_HOST_INDEX, 'ch04': bc.CH04_HOST_INDEX})
 
     def test_each_entry_carries_the_event_group_its_injector_fills(self):
         groups = {c.name: c.event_group for c in bc.hosted_chapters()}
         self.assertEqual(groups['ch04'], bc.CH04_EVENT_GROUP)
         self.assertEqual(groups['ch01'], bc.CH01_EVENT_GROUP)
+        self.assertEqual(groups['prologue'], bc.PROLOGUE_EVENT_GROUP)
 
-    def test_it_is_ordered_by_chapter(self):
-        names = [c.name for c in bc.hosted_chapters()]
-        self.assertEqual(names, sorted(names))
+    def test_it_is_ordered_by_chapter_number(self):
+        """Not by name -- 'ch01' sorts before 'prologue', and a name sort against a
+        sorted() scan is a test that cannot fail."""
+        self.assertEqual([c.name for c in bc.hosted_chapters()],
+                         ['prologue', 'ch01', 'ch02', 'ch03', 'ch04'])
 
-    def test_a_new_chapter_enrolls_itself(self):
-        """The whole point: declaring CH05_* is enough to be covered."""
-        bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP = 6, 'Ch6Events'
-        try:
-            entry = {c.name: c for c in bc.hosted_chapters()}['ch05']
-            self.assertEqual((entry.host_index, entry.event_group), (6, 'Ch6Events'))
-        finally:
-            del bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP
-
-    def test_a_host_slot_without_an_event_group_fails_loudly(self):
-        """Naming the group is mandatory -- inheriting the slot-index coincidence is
-        exactly how ch04 shipped a chapter running another chapter's roster."""
-        bc.CH05_HOST_INDEX = 6
-        try:
-            with self.assertRaises(ValueError) as raised:
-                bc.hosted_chapters()
-            self.assertIn('CH05_EVENT_GROUP', str(raised.exception))
-        finally:
-            del bc.CH05_HOST_INDEX
-
-    def test_two_chapters_cannot_host_on_one_slot(self):
-        bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP = bc.CH04_HOST_INDEX, 'Ch6Events'
-        try:
-            with self.assertRaises(ValueError) as raised:
-                bc.hosted_chapters()
-            self.assertIn('slot %d' % bc.CH04_HOST_INDEX, str(raised.exception))
-        finally:
-            del bc.CH05_HOST_INDEX, bc.CH05_EVENT_GROUP
+    def test_every_injector_in_this_module_is_enrolled(self):
+        """Discovery only covers a chapter that spells its constants right. An
+        inject_ch05 with a typo'd CH05_HOST_INDEX is silently unhosted, and every guard
+        built on the registry passes with one chapter fewer."""
+        self.assertEqual(bc.undeclared_injectors(), [])
 
 
 class HostChapterEventGroup(unittest.TestCase):

--- a/tools/test_check_lua_loads.py
+++ b/tools/test_check_lua_loads.py
@@ -8,6 +8,7 @@ catches it: check_playtest_matrix only parses the file textually for scenario na
 
 Run: python3 tools/test_check_lua_loads.py
 """
+import glob
 import os
 import shutil
 import subprocess
@@ -57,6 +58,44 @@ class LuaCompileError(unittest.TestCase):
         self.assertIsNone(check.lua_compile_error(path))
 
 
+@unittest.skipUnless(HAVE_LUA, 'no lua on PATH')
+class LocalHeadroom(unittest.TestCase):
+    """The 200-local margin must be MEASURED, never written down.
+
+    It was documented as "two free slots" in three places at once (harness.lua, check.py,
+    HANDOFF.md) and was wrong in all three within one PR of being written -- #240 spent a
+    slot and updated no comment. A number a human maintains by hand about a limit that
+    kills every scenario at once is the wrong shape (#241).
+    """
+
+    def _write(self, locals_count):
+        fd, path = tempfile.mkstemp(suffix='.lua')
+        with os.fdopen(fd, 'w') as f:
+            f.write(''.join('local v%d = %d\n' % (i, i) for i in range(locals_count)))
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_an_empty_chunk_reports_the_probe_cap(self):
+        self.assertEqual(check.lua_local_headroom(self._write(0), probe_max=4), 4)
+
+    def test_a_chunk_one_short_of_the_ceiling_reports_one(self):
+        self.assertEqual(check.lua_local_headroom(self._write(199)), 1)
+
+    def test_a_chunk_at_the_ceiling_reports_zero(self):
+        self.assertEqual(check.lua_local_headroom(self._write(200)), 0)
+
+    def test_the_gate_fails_when_nothing_is_left(self):
+        fail = []
+        check.check_lua_local_headroom(fail, paths=(self._write(200),))
+        self.assertTrue(fail, 'a chunk with no slots left must fail the build')
+        self.assertIn('200-local', fail[0])
+
+    def test_the_live_harness_still_has_room(self):
+        fail = []
+        check.check_lua_local_headroom(fail)
+        self.assertEqual(fail, [])
+
+
 class LiveRepo(unittest.TestCase):
     def test_every_declared_chunk_exists(self):
         for rel in check.LUA_CHUNKS:
@@ -65,6 +104,20 @@ class LiveRepo(unittest.TestCase):
 
     def test_harness_is_covered(self):
         self.assertIn('tools/playtest/harness.lua', check.LUA_CHUNKS)
+
+    def test_every_playtest_chunk_is_covered(self):
+        """A hand-written list covered 4 of the 9 chunks harness.lua dofiles, so a syntax
+        error in recorder.lua or liveness.lua killed every scenario with the gate green --
+        the same "list you must remember to update" defect #138 closed for chapters."""
+        on_disk = {os.path.relpath(p, check.REPO)
+                   for p in glob.glob(os.path.join(check.REPO, 'tools/playtest/*.lua'))}
+        self.assertEqual(on_disk - set(check.LUA_CHUNKS) - set(check.GENERATED_LUA), set())
+
+    def test_generated_tables_are_excluded(self):
+        """symbols.lua/procscr.lua are gitignored build outputs -- absent in CI, and a
+        gate that fails on a missing generated file is a gate nobody can keep green."""
+        for name in check.GENERATED_LUA:
+            self.assertNotIn(name, check.LUA_CHUNKS)
 
     def test_the_live_repo_compiles(self):
         fail = []

--- a/tools/test_hosts.py
+++ b/tools/test_hosts.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Tests for the host-slot registry (inject/hosts.py, #241).
+
+Two properties are load-bearing here, and both were review findings on #239:
+
+  * The registry must import with NOTHING but the stdlib. `check.py` lints it in CI's
+    lightweight `checks` job, which installs pyyaml and nothing else -- the first version
+    imported build_campaign, which imports Pillow, so the job would have failed every push
+    with "build_campaign does not import: No module named 'PIL'".
+  * Enrolment must be a GATE, not a convention. Discovery from `CHNN_HOST_INDEX` only
+    covers a chapter that spells its constants right; an injector with a typo'd or missing
+    declaration is silently unhosted, which is the exact ch04 class of failure #138 set out
+    to close.
+
+Run: python3 tools/test_hosts.py
+"""
+import importlib
+import importlib.abc
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from inject import hosts
+
+
+class _BlockImports(importlib.abc.MetaPathFinder):
+    """Simulates CI's `pip install pyyaml` environment."""
+
+    def __init__(self, *names):
+        self.blocked = set(names)
+
+    def find_spec(self, name, path=None, target=None):
+        if name.split('.')[0] in self.blocked:
+            raise ImportError('No module named %r' % name.split('.')[0])
+
+
+class DependencyFree(unittest.TestCase):
+    def test_it_imports_without_pillow_or_yaml(self):
+        """The CRITICAL finding: this is what CI actually runs the lint in."""
+        blocker = _BlockImports('PIL', 'yaml', 'numpy')
+        sys.meta_path.insert(0, blocker)
+        try:
+            for name in [m for m in sys.modules if m.startswith('inject.hosts')]:
+                del sys.modules[name]
+            module = importlib.import_module('inject.hosts')
+            self.assertTrue(module.hosted_chapters())
+        finally:
+            sys.meta_path.remove(blocker)
+            importlib.import_module('inject.hosts')
+
+
+class Discovery(unittest.TestCase):
+    def test_finds_every_currently_hosted_chapter(self):
+        got = {c.name: c.host_index for c in hosts.hosted_chapters()}
+        self.assertEqual(got, {'prologue': hosts.PROLOGUE_HOST_INDEX,
+                               'ch01': hosts.CH01_HOST_INDEX,
+                               'ch02': hosts.CH02_HOST_INDEX,
+                               'ch03': hosts.CH03_HOST_INDEX,
+                               'ch04': hosts.CH04_HOST_INDEX})
+
+    def test_the_prologue_is_enrolled_like_any_other_chapter(self):
+        """It was invisible to discovery because PROLOGUE_HOST_INDEX does not match
+        CH(\\d+)_HOST_INDEX -- so slot 1 was unguarded and a later CH05_HOST_INDEX = 1
+        would have collided with it in silence."""
+        entry = {c.name: c for c in hosts.hosted_chapters()}['prologue']
+        self.assertEqual(entry.host_index, 1)
+        self.assertEqual(entry.event_group, 'Ch1Events')
+        self.assertEqual(entry.number, 0)
+
+    def test_a_chapter_claiming_the_prologue_slot_fails_loudly(self):
+        scope = dict(vars(hosts), CH05_HOST_INDEX=hosts.PROLOGUE_HOST_INDEX,
+                     CH05_EVENT_GROUP='Ch6Events')
+        with self.assertRaises(ValueError) as caught:
+            hosts.hosted_chapters(scope)
+        self.assertIn('prologue', str(caught.exception))
+
+    def test_it_is_ordered_by_chapter_NUMBER_not_name(self):
+        """Ordering by name is tautological against a sorted() implementation, and wrong
+        once the prologue joins: 'ch01' sorts before 'prologue'."""
+        scope = dict(vars(hosts), CH10_HOST_INDEX=11, CH10_EVENT_GROUP='Ch11Events')
+        names = [c.name for c in hosts.hosted_chapters(scope)]
+        self.assertEqual(names, ['prologue', 'ch01', 'ch02', 'ch03', 'ch04', 'ch10'])
+
+    def test_a_new_chapter_enrolls_itself(self):
+        scope = dict(vars(hosts), CH05_HOST_INDEX=6, CH05_EVENT_GROUP='Ch6EventData')
+        entry = {c.name: c for c in hosts.hosted_chapters(scope)}['ch05']
+        self.assertEqual((entry.host_index, entry.event_group), (6, 'Ch6EventData'))
+
+    def test_a_host_slot_without_an_event_group_fails_loudly(self):
+        scope = dict(vars(hosts), CH05_HOST_INDEX=6)
+        with self.assertRaises(ValueError) as caught:
+            hosts.hosted_chapters(scope)
+        self.assertIn('CH05_EVENT_GROUP', str(caught.exception))
+
+    def test_two_chapters_may_not_share_a_host_slot(self):
+        scope = dict(vars(hosts), CH05_HOST_INDEX=hosts.CH04_HOST_INDEX,
+                     CH05_EVENT_GROUP='Ch6Events')
+        with self.assertRaises(ValueError) as caught:
+            hosts.hosted_chapters(scope)
+        self.assertIn('CH04', str(caught.exception).upper())
+
+
+class EnrolmentIsAGate(unittest.TestCase):
+    """An injector that exists but declares nothing must be caught -- reading the SOURCE,
+    so the lint never imports build_campaign (and its Pillow dependency)."""
+
+    def test_it_finds_the_injectors_in_the_source(self):
+        found = hosts.injector_chapters()
+        self.assertEqual(found, ['prologue', 'ch01', 'ch02', 'ch03', 'ch04'])
+
+    def test_it_reads_source_rather_than_importing(self):
+        blocker = _BlockImports('PIL', 'yaml', 'numpy')
+        sys.meta_path.insert(0, blocker)
+        try:
+            self.assertIn('ch04', hosts.injector_chapters())
+        finally:
+            sys.meta_path.remove(blocker)
+
+    def test_an_injector_with_no_declaration_is_reported(self, ):
+        src = 'def inject_ch05(campaign):\n    pass\n'
+        self.assertEqual(hosts.undeclared_injectors(source=src), ['ch05'])
+
+    def test_a_declared_injector_is_not_reported(self):
+        src = 'def inject_ch05(campaign):\n    pass\n'
+        scope = dict(vars(hosts), CH05_HOST_INDEX=6, CH05_EVENT_GROUP='Ch6Events')
+        self.assertEqual(hosts.undeclared_injectors(source=src, scope=scope), [])
+
+    def test_the_live_build_has_no_undeclared_injectors(self):
+        self.assertEqual(hosts.undeclared_injectors(), [])
+
+
+class TheLintRunsInTheCiEnvironment(unittest.TestCase):
+    def test_check_hosted_chapters_declared_passes_without_pillow(self):
+        """The regression this whole module exists for: `checks` runs `python3
+        tools/check.py` with pyyaml and nothing else installed."""
+        blocker = _BlockImports('PIL', 'numpy')
+        sys.meta_path.insert(0, blocker)
+        try:
+            for name in [m for m in sys.modules if m == 'check']:
+                del sys.modules[name]
+            check = importlib.import_module('check')
+            fail = []
+            check.check_hosted_chapters_declared(fail)
+            self.assertEqual(fail, [])
+        finally:
+            sys.meta_path.remove(blocker)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #241. Two reviewer passes over the merged `71b37de..c489c56` stack; this fixes every finding.

## The Critical one is live on `main` right now

The Actions outage lifted at ~22:05 UTC and the first real run on `main` failed in 3m29s with exactly the predicted error:

```
DRIFT (1):
  - build_campaign does not import: No module named 'PIL'
```

`check_hosted_chapters_declared` imported `build_campaign` to reach the host-slot constants, and the `checks` job installs pyyaml and nothing else. **The fix is structural, not `pip install pillow`:** the host-slot registry moves to **`tools/inject/hosts.py`** — stdlib-only, like `inject/decomp.py` beside it — and `build_campaign` re-exports it, so every call site still reads `bc.CH04_HOST_INDEX`. A lint imports the smallest module that owns the fact, or reads the source with `ast`; it never imports the build. That was already `check_purple_bank_blankers_known`'s rule; it is now the standing one.

Moving it surfaced two more defects in the same discovery code:

- **The prologue was invisible.** `PROLOGUE_HOST_INDEX = 1` does not match `CH(\d+)_HOST_INDEX`, so slot 1 was not in the collision map and a later `CH05_HOST_INDEX = 1` would have passed the guard and quietly overwritten the prologue's events.
- **Enrolment was a convention, not a gate.** `inject_ch05` with a typo'd constant is simply not discovered, and every guard built on the registry then passes with one chapter fewer and no complaint — the ch04 failure class #138 exists to close. `undeclared_injectors()` parses `build_campaign`'s source with `ast` and fails the build.

## Numbers we maintained by hand, now computed

- **Local headroom said "two free slots" in `harness.lua`, `check.py` and `HANDOFF.md` at once. Measured, it was one** — #240 spent a slot and updated no comment. `check_lua_local_headroom` appends probe locals until the chunk stops compiling, prints the real number on every `make check`, and fails at zero.
- **`LUA_CHUNKS` listed 4 of the 9 chunks `harness.lua` loads**, so a syntax error in `recorder.lua` or `liveness.lua` killed every scenario with the gate green. Globbed, with the generated tables excluded.

## The controller contract

- **`yes_no_choice` now outranks `dialogue_wait`.** It already outranked `std_event` (#232's fix), but `dialogue_wait` is the same bug in disguise: it answers "press A", `YesNoChoice_Loop_KeyHandler` consumes that A, and the prompt is answered by accident with the run green. Three ordering pairs are now pinned by tests — rule order is the load-bearing property no single rule's tests can protect.
- **The stall signature was blind to `PROC_REPEAT`**, which is how every long-running FE8 proc is written (`ProcScr_StdEventEngine`, `TalkWaitForInput`, `BMXFADE`, `YesNoChoice`): `scrCur`/`idleCb`/`lockCnt` are constant for an entire scene. It now includes `sleepTime` — `observeController` had to start reading it, or the fix would have been inert — and the pool count.
- **`INSPECT.watch` decided FAIL for whole suites from inside `harness.lua`, where nothing could load it.** The decision is `Controller.stallWatch()` now — pure, unit-tested, 15 new assertions — and the harness kept only the logging. It also calls `explain()` once per hold instead of once per frame of a 36000-iteration loop.

## Minors

A missing `symbols.json` warns instead of rendering every callback as a fake `unknown@…`; `resolve()` masks the THUMB bit and tolerates a malformed field; `--symbols` works after the subcommand; a missing log is an error, not a traceback; `PROC_SCRIPT_RE` stops sweeping 30 proc.c functions into the proc-script table; `answer_no` has a driver that can reach it; the ch01 lord walk asserts where it landed (it assumed the menu opens on row 0, and FE8 menus wrap, so being wrong picked a different lord silently); `bootToMap` uses `TUNE.bootSteps` instead of a literal 12000; a `player_map_idle` before turn 1 yields instead of hard-failing; `freezeReport` hands its samples to the snapshot instead of taking two more; the harness asserts `PROCSCR` actually loaded; `run.sh` renders a failing run's own diagnosis automatically.

## Verification

- `make test` exit 0 (41 suites) · `make check` clean · `git diff --check` clean
- **`check.py` run with `PIL`/`numpy` blocked — CI's dependency set — is clean.** That regression is now a test (`tools/test_hosts.py`), so the next lint that reaches for `build_campaign` fails locally instead of on CI.
- `make matrix` re-run green on the final tree (see the comment below).
