### PR TITLE
Drive every verdict scenario on observed state, and gate it (#238)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -127,6 +127,11 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
     SUITE=chNN` runs the lot off one build. `check.py check_playtest_matrix` fails the build if a
     scenario in `harness.lua` has no row, so this is not optional bookkeeping — it is how
     `run.sh chNNsomething` knows the flag and the host slot without you typing either.
+    The row's `kind` is load-bearing beyond timing: `check.py
+    check_verdict_scenarios_are_guarded` requires every `kind: verdict` scenario to drive the UI
+    through `guardedInput`/`selectSemantic`, never a raw `press` (#238). Capture scenarios are
+    `kind: record` and stay exempt — so set `kind` by what the scenario **asserts**, never by its
+    name prefix (`recordsupply` and `recordunitlist` are verdict scenarios).
 
 ## Load-test it (see the map with units)
 
@@ -166,13 +171,26 @@ the proc + its input callback to `gen_symbols.py`, `CALLBACK_NAMES`, `observeCon
 `classify` rule, and let the *scenario* decide the answer. That is the whole fix for a wait, and it
 is how ch01's lord-select Yes/No prompt was closed (#232).
 
-Two traps this replaces, both of which cost real sessions:
+**Naming a new state is not finished until the drivers know about it (#238).** A state that used to
+fall through to `generic_menu` was cancellable by `cancelToPlayerMap` and recoverable by
+`awaitControllerState`; giving it its own name silently takes that away. Wire its cancel in the same
+change. And enumerate a movement action only where the engine would actually move — the bounds
+belong in `controller.lua`, read off the same field the engine checks, not hand-rolled in the
+scenario.
+
+Three traps this replaces, all of which cost real sessions:
 
 - **Do not re-run a scenario to re-test a hypothesis the evidence already killed.** A budget-bounded
   loop exits at the same frame no matter what is on screen, so an identical frame number proves
   nothing. Instrument for the answer instead.
 - **A `transition` is not "nothing is happening".** It is the classifier saying it has no name for
   this. The snapshot's `considered` list tells you what it looked for.
+- **A scenario that fails before it presses anything is accusing the harness, not the chapter.**
+  ch03's doors and chests read as broken for as long as `baseTile` held a hard-coded address the
+  engine had grown past: both scenarios died on the tile READ, before any input, and said
+  "placement or gBmMapBaseTiles addr wrong". Check where in the scenario the verdict came from
+  before you go looking at the map data. `check_no_hardcoded_symbol_addresses` now makes that
+  particular version impossible — every address comes from `SYM` (#238).
 
 ## Gotchas (learned the hard way)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1562,6 +1562,28 @@ found them.** Removing a cadence is not a no-op, and neither was worth a guess:
   The assertion caught the comment, not a defect. Contrast assertions have to be written
   against the engine's rule, not the prose around them.
 
+**Naming a new state is not finished until the DRIVERS know about it.** Code review caught two
+instances on this branch. `item_list` and `send_to_convoy` had classified as `generic_menu`
+before they were named, so `cancelToPlayerMap` could back out of both; giving them their own
+states silently removed that — and that function is the recovery path #238 had just put behind
+`ch01win`'s post-seize menu surprise. `awaitControllerState`'s recovery had the same gap for
+`supply_screen`/`unit_list_screen`. **A classification change is a change to what the harness
+can escape from**, so a new state ships with its cancel wired in the same commit.
+
+**Enumerate a movement action only where the engine would actually move.** The Character
+screen's UP at row 0 is not a no-op: `sub_809144C` sets `unk_29 = 3`, routing into
+`sub_80917D8`, the sort-column mode — a persistent input state the observer reports as
+`scrolling`, i.e. as a transition offering nothing. Advertising UP there hands a driver an
+action that walks it somewhere it has no enumerated way out of, to sit until the stall watch
+fires on a wait the controller itself caused. Both ends of that walk are now bounded off
+`gUnknown_0200F158`, the same field the engine bounds against — the rule `prep_pick_units`
+already followed.
+
+**An absence assertion must assert the state first.** `legalActions` returns `nil` when
+`classify` finds no state, and `findAction(nil, …)` is `nil` — so "the command was not offered"
+and "we could not tell what was on screen" were indistinguishable. `recordsupply`'s contrast
+check now requires a live `unit_command_menu` before concluding Supply is absent.
+
 Also: **a budget must not count the frames a screen spends TEARING DOWN.** `cancelToPlayerMap`
 looped eight times total, and the convoy's fade-out held a `transition` for far longer than
 that, so the cap decided the failure — the trap `docs/decisions.md` already records from #232.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1519,6 +1519,47 @@ inspection, and external policies—those products are follow-ups, not controlle
 _Decided: 2026-08-03 (#220; supersedes timing/row-driven common harness mechanics and #63 M2's blind Attack
 executor limitation)_
 
+**A scenario that produces a VERDICT may not drive the UI with a raw `press` — enforced, not
+reviewed (#238).** #220 set the contract but migrated only the shared paths; the historical
+verdict scenarios kept their blind cadences, and a blind cadence makes a green run worthless as
+evidence. `ch01win` was the proof: it rode straight through the lord-select Yes/No prompt that
+cost #232 three sessions, mashing A at a prompt it never saw, and passed. `check.py
+check_verdict_scenarios_are_guarded` now fails the build on one, scoping from **`matrix.yaml`'s
+`kind`** and following harness.lua's call graph, with a small named allowlist
+(`BLIND_PRESS_ALLOWED`) carrying each exception's reason. `record`/`diagnostic` scenarios stay
+blind by design — nothing is asserted there, so nothing can pass for the wrong reason.
+
+Three lessons from the migration, all of which cost real evidence:
+
+- **Count presses by ENCLOSING FUNCTION, never by distance to the next `scenarios.X`.** Splitting
+  harness.lua on scenario definitions charges every intervening `local function` helper to
+  whichever scenario sits above it. #238's own scope list was built that way and was wrong in both
+  directions: it named `retreat` (which has none of its own) and missed `reachRbgCh01` (8) — a
+  fifth hand-rolled copy of the ch01 lead route nobody knew was there.
+- **A fixed press count is not a walk to a row.** FE8 menus WRAP, so `rows - 1` DOWNs land on the
+  last candidate only if the menu opened on row 0. Walk off the LIVE cursor, stop when it arrives,
+  and ASSERT where it landed — otherwise picking a different lord than the one the scenario names
+  passes silently.
+- **Watch the field the engine's key handler actually moves.** `recordunitlist` stopped its roster
+  walk on `unk_2c` (the on-screen row, which CLAMPS as the list scrolls under it) and `+0x38`
+  (untouched by the D-pad) instead of `unk_30`, so it could capture a fraction of the roster and
+  still report PASS.
+
+Newly classified for it, by the usual four-edit recipe (`gen_symbols.py` WANTED → `CALLBACK_NAMES`
+→ `observeController` → a `classify` rule): unit commands Chest `0x5D`, Door `0x5E`, Item `0x67`
+and Supply `0x69`; the map-menu **Character screen** (`ProcScr_UnitListScreen_Field`); the **Pick
+Units** deploy grid; and the in-map **convoy** (`ProcScr_BmSupplyScreen`). Two ordering rules came
+with them. The Character screen and the convoy sit **above `player_phase`** — the map is still in
+the proc pool underneath, and `player_map_idle` would offer cursor moves that go nowhere. And each
+of the three screens reports a **transition while its own scroll animates** (`unk_29` on the
+Character screen, `list_num_pre != list_num_cur` on Pick Units): FE8's key handler does not run in
+that window, so an input sent then is lost outright, and calling it an input state is how a press
+goes missing. Pick Units' legal moves mirror `ProcPrepUnit_Idle`'s TWO-COLUMN bounds exactly (LEFT
+only from an odd index, RIGHT only from an even one short of the end, UP/DOWN by two) — a press
+outside them moves nothing, and a driver that assumed a straight list would go on to act on
+whoever it was still parked on.
+_Decided: 2026-08-06 (#238; extends #220's contract from the shared paths to every verdict scenario)_
+
 **Recording a cutscene as a review GIF (the standard way to show Nicolas motion).**
 The harness fast-forwards non-recorded lead-up, so an assert scenario's screenshots can land
 on fades — to SEE a scene play, use a `record*` scenario: it drives the game to the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1545,10 +1545,39 @@ Three lessons from the migration, all of which cost real evidence:
   (untouched by the D-pad) instead of `unk_30`, so it could capture a fraction of the roster and
   still report PASS.
 
+**Two of these blind presses turned out to be LOAD-BEARING, and only running the scenarios
+found them.** Removing a cadence is not a no-op, and neither was worth a guess:
+
+- **`clear_ch02`'s A-mash was answering a prompt the scenario never knew existed.** The ch02
+  ending's third charm-gift lands on a full inventory, so FE8 raises
+  `gSendToConvoyMenuItems` — "which item goes to the convoy" — and the entire MNC2 chain
+  stops until it is answered. The mash resolved it by accident; drive the ending on observed
+  state without naming that prompt and the run sits behind it for its whole budget and reports
+  "2/3 charms" on a chapter that never left slot 3. That verdict's green had been resting on a
+  stray press. The chooser is now a classified `send_to_convoy` state.
+- **A scenario's own comment is not evidence.** `recordsupply` claimed "a NON-lord deployed
+  unit's action menu has NO Supply row". `SupplyUsability` (bmmenu.c) returns `MENU_ENABLED`
+  for the lead **or** for anyone `IsAdjacentForSupply` finds orthogonally beside them — so the
+  claim is false for a neighbour, and the first deployed non-lord spawns right next to Pinky.
+  The assertion caught the comment, not a defect. Contrast assertions have to be written
+  against the engine's rule, not the prose around them.
+
+Also: **a budget must not count the frames a screen spends TEARING DOWN.** `cancelToPlayerMap`
+looped eight times total, and the convoy's fade-out held a `transition` for far longer than
+that, so the cap decided the failure — the trap `docs/decisions.md` already records from #232.
+It now counts CANCELS, with a separate `TUNE.cancelFrames` ceiling for transitions.
+
 Newly classified for it, by the usual four-edit recipe (`gen_symbols.py` WANTED → `CALLBACK_NAMES`
 → `observeController` → a `classify` rule): unit commands Chest `0x5D`, Door `0x5E`, Item `0x67`
-and Supply `0x69`; the map-menu **Character screen** (`ProcScr_UnitListScreen_Field`); the **Pick
-Units** deploy grid; and the in-map **convoy** (`ProcScr_BmSupplyScreen`). Two ordering rules came
+and Supply `0x69`; the **inventory list** a unit's Item command opens (`gItemSelectMenuItems`,
+`0x43`–`0x47`); the **send-to-convoy chooser** (`gSendToConvoyMenuItems`, `0x2A`–`0x2F`); the
+map-menu **Character screen** (`ProcScr_UnitListScreen_Field`); the **Pick Units** deploy grid;
+and the in-map **convoy** (`ProcScr_BmSupplyScreen`). The inventory list needed its own state
+because `MENU_DISABLED` means something different there: `ItemSelectMenu_Usability` greys any
+item the unit cannot *use* — a weapon, a vulnerary at full HP — but `Menu_OnIdle`'s A path never
+consults availability and `ItemSelectMenu_Effect` opens the submenu regardless. A greyed row is
+still a live row; reading it as a command menu reported "unsupported standard menu" the moment
+every item happened to be unusable, which is Hlin's whole inventory at ch00 turn 1. Two ordering rules came
 with them. The Character screen and the convoy sit **above `player_phase`** — the map is still in
 the proc pool underneath, and `player_map_idle` would offer cursor moves that go nowhere. And each
 of the three screens reports a **transition while its own scroll animates** (`unk_29` on the

--- a/tools/check.py
+++ b/tools/check.py
@@ -546,6 +546,105 @@ def check_playtest_matrix(fail):
                             % (suite, name))
 
 
+# Functions in harness.lua that may hold a raw press() even though a verdict scenario can
+# reach them. Each is a deliberate exception with its own reason -- NOT a backlog.
+BLIND_PRESS_ALLOWED = {
+    # press() itself, and the two places the contract is IMPLEMENTED. guardedInput is the
+    # thing that re-observes, re-authorises and verifies; it has to press eventually.
+    'press': 'the emulator primitive every guarded input is built on',
+    'guardedInput': 'the guarded input itself -- this is where the contract presses',
+    'awaitControllerState': 'traced, enumerated cancel while backing out of an unwanted state',
+    # A save slot takes TWO confirms and SaveMenu_SaveSlotSelectLoop stays the idle callback
+    # across both, so the first press has no state change to be verified against. Legality is
+    # re-checked before every press and the loop stops on the OUTCOME (the prompt closing).
+    'driveSaveSlot': 'two confirms with no distinguishing postcondition; verified on the outcome',
+    # The fuzzer's whole purpose is unguarded, weighted-random input. Driving it through the
+    # controller would mean it could only ever send inputs the controller already calls legal,
+    # which is precisely the space a fuzzer exists to leave.
+    'fuzzDrive': 'random input IS the scenario -- guarding it would defeat the fuzzer',
+}
+
+_LUA_FUNC_DEF = re.compile(
+    r'^(?:local function (\w+)|scenarios\.(\w+) = function|(\w+) = function)', re.M)
+
+
+def _harness_functions(source):
+    """{name: (body, kind)} for every top-level function in harness.lua.
+
+    Attribution is by ENCLOSING FUNCTION, not by distance to the next `scenarios.X`.
+    Splitting on scenario definitions charges every intervening `local function` helper to
+    whichever scenario happens to sit above it -- which is how #238's own scope list came to
+    name `retreat` (0 presses of its own) and miss `reachRbgCh01` (8)."""
+    lines = source.split('\n')
+    marks = []
+    for i, line in enumerate(lines):
+        m = _LUA_FUNC_DEF.match(line)
+        if m:
+            name = m.group(1) or m.group(2) or m.group(3)
+            marks.append((i, name, 'scenario' if m.group(2) else 'helper'))
+    marks.append((len(lines), None, None))
+    out = {}
+    for (start, name, kind), (end, _, _) in zip(marks, marks[1:]):
+        body = '\n'.join(l for l in lines[start:end] if not l.strip().startswith('--'))
+        out[name] = (body, kind)
+    return out
+
+
+def _reaches(name, funcs, seen=None):
+    """Every harness function reachable from `name`, including itself."""
+    seen = seen if seen is not None else set()
+    if name in seen or name not in funcs:
+        return seen
+    seen.add(name)
+    body = funcs[name][0]
+    for callee in set(re.findall(r'\b(\w+)\s*\(', body)):
+        if callee in funcs and callee != name:
+            _reaches(callee, funcs, seen)
+    return seen
+
+
+def check_verdict_scenarios_are_guarded(fail):
+    """A scenario that produces a VERDICT may not drive the UI with a raw press().
+
+    A blind press cannot tell "the scene advanced" from "FE8 swallowed that input", so a
+    green run from one is not evidence -- ch01win rode straight through the very Yes/No
+    prompt that cost #232 three sessions, and passed. Every input a verdict scenario sends
+    now goes through guardedInput: observed state -> enumerated legal action -> verified
+    postcondition (#238).
+
+    Scope comes from matrix.yaml's `kind`, never from the scenario NAME: recordsupply and
+    recordunitlist are verdict scenarios despite the prefix, and recordunitlist is in the
+    gate suite. Capture (`record`) and `diagnostic` scenarios are out -- blind input is
+    harmless where nothing is asserted."""
+    sys.path.insert(0, os.path.join(REPO, 'tools', 'playtest'))
+    try:
+        import matrix as mx
+        m = mx.Manifest.load()
+    except Exception as exc:                      # noqa: BLE001 -- check_playtest_matrix reports it
+        return
+    with open(os.path.join(REPO, 'tools/playtest/harness.lua'), encoding='utf-8') as fh:
+        funcs = _harness_functions(fh.read())
+
+    for name in sorted(m.scenarios):
+        try:
+            if m.resolve(name).kind != 'verdict':
+                continue
+        except mx.ManifestError:
+            continue
+        if name not in funcs:
+            continue
+        for reached in sorted(_reaches(name, funcs)):
+            if reached in BLIND_PRESS_ALLOWED:
+                continue
+            count = len(re.findall(r'\bpress\(', funcs[reached][0]))
+            if count:
+                where = reached if reached == name else '%s (via %s)' % (reached, name)
+                fail.append(
+                    'verdict scenario %s drives the UI with %d raw press() call(s) in %s -- '
+                    'use guardedInput/selectSemantic, or classify the state it needs (#238)'
+                    % (name, count, where))
+
+
 def check_tool_refs_exist(fail):
     """A doc or code comment naming tools/<x>.py|rb, or a docs/<x>.md path, must
     point at a file that exists -- dangling pointers are the cheapest-to-catch form
@@ -1041,6 +1140,7 @@ def main():
                   check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
                   check_injection_order, check_playtest_matrix,
+                  check_verdict_scenarios_are_guarded,
                   check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
                   check_purple_bank_blankers_known,

--- a/tools/check.py
+++ b/tools/check.py
@@ -588,7 +588,10 @@ def _harness_functions(source):
     marks.append((len(lines), None, None))
     out = {}
     for (start, name, kind), (end, _, _) in zip(marks, marks[1:]):
-        body = '\n'.join(l for l in lines[start:end] if not l.strip().startswith('--'))
+        # Strip trailing comments too, not just whole comment lines: `local x = 1 -- press(A)`
+        # otherwise trips the gate on prose. Lua has no string type that survives this
+        # naively, but no line in these files puts `--` inside a literal.
+        body = '\n'.join(l.split('--')[0] for l in lines[start:end])
         out[name] = (body, kind)
     return out
 
@@ -623,7 +626,7 @@ def check_verdict_scenarios_are_guarded(fail):
     try:
         import matrix as mx
         m = mx.Manifest.load()
-    except Exception as exc:                      # noqa: BLE001 -- check_playtest_matrix reports it
+    except Exception:                             # noqa: BLE001 -- check_playtest_matrix reports it
         return
     with open(os.path.join(REPO, 'tools/playtest/harness.lua'), encoding='utf-8') as fh:
         funcs = _harness_functions(fh.read())
@@ -634,7 +637,13 @@ def check_verdict_scenarios_are_guarded(fail):
                 continue
         except mx.ManifestError:
             continue
+        # A verdict scenario the harness no longer defines would otherwise drop out of this
+        # gate in silence -- renamed in Lua, still listed in the manifest, and never checked
+        # again. check_playtest_matrix reports the pairing separately; this refuses to pretend
+        # it reviewed something it could not find.
         if name not in funcs:
+            fail.append('verdict scenario %s has no function in harness.lua, so the '
+                        'blind-press gate cannot review it (#238)' % name)
             continue
         for reached in sorted(_reaches(name, funcs)):
             if reached in BLIND_PRESS_ALLOWED:
@@ -651,7 +660,10 @@ def check_verdict_scenarios_are_guarded(fail):
 # GBA address space. 0x04-0x07 are ARCHITECTURAL (MMIO, palette, VRAM, OAM) -- fixed by the
 # hardware, so a literal there is a constant, not a symbol. 0x02/0x03 (EWRAM/IWRAM) and
 # 0x08/0x09 (ROM) are where OUR symbols live, and those move on every engine change.
-_DRIFTING_ADDR = re.compile(r'0x0[2389][0-9A-Fa-f]{6}')
+# The leading zero is OPTIONAL: 0x8091AEC is the usual GBA shorthand, and it is literally the
+# form the decomp's own symbol names encode (sub_8091AEC). Requiring `0x0` would miss exactly
+# the spelling the next stale literal is most likely to be written in.
+_DRIFTING_ADDR = re.compile(r'0x0?[2389][0-9A-Fa-f]{6}\b')
 
 
 def check_no_hardcoded_symbol_addresses(fail):
@@ -666,8 +678,9 @@ def check_no_hardcoded_symbol_addresses(fail):
     A wrong address is the worst failure shape available here: it does not crash, it reads
     plausible garbage, and it indicts the feature instead of the harness.
 
-    symbols.lua is generated (it is nothing BUT addresses) and test_* files use fake ones as
-    fixtures, so both are exempt -- the same carve-outs the other scans use."""
+    symbols.lua and procscr.lua are GENERATED (they are nothing but addresses) and test_* files
+    use fake ones as fixtures, so all three are exempt -- the same carve-outs the other scans
+    use."""
     for path in sorted(glob.glob(os.path.join(REPO, 'tools/playtest/*.lua'))):
         name = os.path.basename(path)
         if name.startswith('test_') or name in ('symbols.lua', 'procscr.lua'):

--- a/tools/check.py
+++ b/tools/check.py
@@ -66,6 +66,9 @@ DEAD_CONCEPTS = [
     # retired by #220 (2026-08-03): common playtest mechanics are state-driven.
     r'bootToMap.{0,40}alternat(?:e|es|ing).{0,12}(?:A.{0,3}START|START.{0,3}A)',
     r'chooseAttack.{0,50}row 0 blind',
+    # retired by #238 (2026-08-06): the base-tiles grid comes from SYM like every other
+    # symbol. The literal it held drifted and made ch03's doors and chests read as broken.
+    r'GBMMAPBASETILES_ADDR',
     # NOT registered here: `hasPrepScreen`. It IS a dead field (FE7 leftover, chapterdata.h:37 --
     # false for every chapter, including ones that plainly have prep) and citing it as evidence is
     # exactly the mistake that produced a bogus "our prep is a divergence" claim on 2026-07-29.
@@ -645,6 +648,41 @@ def check_verdict_scenarios_are_guarded(fail):
                     % (name, count, where))
 
 
+# GBA address space. 0x04-0x07 are ARCHITECTURAL (MMIO, palette, VRAM, OAM) -- fixed by the
+# hardware, so a literal there is a constant, not a symbol. 0x02/0x03 (EWRAM/IWRAM) and
+# 0x08/0x09 (ROM) are where OUR symbols live, and those move on every engine change.
+_DRIFTING_ADDR = re.compile(r'0x0[2389][0-9A-Fa-f]{6}')
+
+
+def check_no_hardcoded_symbol_addresses(fail):
+    """The playtest Lua may not hard-code a ROM/EWRAM address. gen_symbols.py exists for
+    exactly this -- "BSS/EWRAM addresses shift when engine code changes, so the Lua harness
+    must never hard-code them" -- and one literal that slipped through proved the point: the
+    base-tiles grid was pinned at 0x085AF5DC, the engine grew, and that address came to hold
+    0x000004AB. ch03door and ch03chest then failed on their PRECONDITION, before driving a
+    single input, and read for months like broken doors and chests. Nothing was wrong with
+    the tile-change wiring (#238).
+
+    A wrong address is the worst failure shape available here: it does not crash, it reads
+    plausible garbage, and it indicts the feature instead of the harness.
+
+    symbols.lua is generated (it is nothing BUT addresses) and test_* files use fake ones as
+    fixtures, so both are exempt -- the same carve-outs the other scans use."""
+    for path in sorted(glob.glob(os.path.join(REPO, 'tools/playtest/*.lua'))):
+        name = os.path.basename(path)
+        if name.startswith('test_') or name in ('symbols.lua', 'procscr.lua'):
+            continue
+        with open(path, encoding='utf-8') as fh:
+            for n, line in enumerate(fh, 1):
+                if line.strip().startswith('--'):
+                    continue
+                for hit in _DRIFTING_ADDR.findall(line):
+                    fail.append('%s:%d hard-codes the ROM/EWRAM address %s -- read it from '
+                                'SYM (add it to gen_symbols.py WANTED); those addresses move '
+                                'on every engine change (#238)'
+                                % (os.path.relpath(path, REPO), n, hit))
+
+
 def check_tool_refs_exist(fail):
     """A doc or code comment naming tools/<x>.py|rb, or a docs/<x>.md path, must
     point at a file that exists -- dangling pointers are the cheapest-to-catch form
@@ -1141,6 +1179,7 @@ def main():
                   check_chapter_status, check_chapter_deployment_schema,
                   check_injection_order, check_playtest_matrix,
                   check_verdict_scenarios_are_guarded,
+                  check_no_hardcoded_symbol_addresses,
                   check_tool_refs_exist, check_no_dead_concepts,
                   check_generated_indexes_fresh, check_engine_guards_present,
                   check_purple_bank_blankers_known,

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -20,6 +20,12 @@ local MENU_DOOR = 0x5E
 local MENU_ITEM = 0x67
 local MENU_SUPPLY = 0x69
 local MENU_WAIT = 0x6B
+-- gSendToConvoyMenuItems: the inventory-full "which item goes to the convoy" chooser.
+local MENU_CONVOY_SEND_FIRST = 0x2A
+local MENU_CONVOY_SEND_LAST = 0x2F
+-- gItemSelectMenuItems: one row per inventory slot (menu_def.c).
+local MENU_ITEM_SLOT_FIRST = 0x43
+local MENU_ITEM_SLOT_LAST = 0x47
 local MENU_UNIT_LIST = 0x6E
 local MENU_STATUS = 0x6F
 local MENU_END_PHASE = 0x78
@@ -213,6 +219,25 @@ local RULES = {
             end
             if unit and map then
                 return unsupported("ambiguous standard menu contains unit and map commands")
+            end
+            -- Raised by ConvoyMenuProc_StarMenu when a unit is given an item with no free
+            -- slot. Nothing in the game advances until it is answered, so a driver that reads
+            -- it as an ordinary menu and waits for the scene to end waits forever.
+            for _, item in ipairs(observation.menu.items) do
+                if item.override_id >= MENU_CONVOY_SEND_FIRST
+                    and item.override_id <= MENU_CONVOY_SEND_LAST then
+                    return matched("send_to_convoy", "menu rows are convoy-send choices")
+                end
+            end
+            -- Checked against EVERY observed row, not just the enabled ones. uimenu.c builds a
+            -- MenuItemProc for anything that is not MENU_NOTSHOWN, so a row we can see is a
+            -- slot that holds an item -- and MENU_DISABLED here only means the unit cannot USE
+            -- it, not that A does nothing (Menu_OnIdle's A path never consults availability).
+            for _, item in ipairs(observation.menu.items) do
+                if item.override_id >= MENU_ITEM_SLOT_FIRST
+                    and item.override_id <= MENU_ITEM_SLOT_LAST then
+                    return matched("item_list", "menu rows are inventory slots")
+                end
             end
             if weapon then return matched("weapon_menu", "menu offers weapon items") end
             if unit then return matched("unit_command_menu", "menu offers unit commands") end
@@ -603,6 +628,20 @@ function M.legalActions(observation)
             if item.override_id >= MENU_WEAPON_FIRST and item.override_id <= MENU_WEAPON_LAST then
                 add(actions, "select_weapon", observation.menu.current == item.slot and "A" or nil,
                     string.format("menu.override_id=0x%02X", item.override_id), item.slot)
+            end
+        end
+    elseif state == "send_to_convoy" then
+        addMenuNavigation(actions, observation)
+        for _, item in ipairs(observation.menu.items) do
+            if observation.menu.current == item.slot then
+                add(actions, "send_item", "A", "menu.convoy_send_slot", item.slot)
+            end
+        end
+    elseif state == "item_list" then
+        addMenuNavigation(actions, observation)
+        for _, item in ipairs(observation.menu.items) do
+            if observation.menu.current == item.slot then
+                add(actions, "select_item", "A", "menu.item_slot", item.slot)
             end
         end
     elseif state == "generic_menu" then

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -15,6 +15,10 @@ local MENU_ATTACK = 0x4F
 local MENU_BALLISTA_ATTACK = 0x50
 local MENU_TALK = 0x5A
 local MENU_VISIT = 0x5C
+local MENU_CHEST = 0x5D
+local MENU_DOOR = 0x5E
+local MENU_ITEM = 0x67
+local MENU_SUPPLY = 0x69
 local MENU_WAIT = 0x6B
 local MENU_UNIT_LIST = 0x6E
 local MENU_STATUS = 0x6F
@@ -46,7 +50,9 @@ local function menuKinds(observation)
         end
         if item.override_id == MENU_SEIZE or item.override_id == MENU_ATTACK
             or item.override_id == MENU_BALLISTA_ATTACK
-            or item.override_id == MENU_TALK or item.override_id == MENU_WAIT then unit = true end
+            or item.override_id == MENU_TALK or item.override_id == MENU_CHEST
+            or item.override_id == MENU_DOOR or item.override_id == MENU_ITEM
+            or item.override_id == MENU_SUPPLY or item.override_id == MENU_WAIT then unit = true end
         if item.override_id == MENU_END_PHASE then map = true end
     end
     return unit, map, weapon
@@ -218,6 +224,33 @@ local RULES = {
             end
             if callbacks then return matched("generic_menu", "every enabled item has a callback") end
             return unsupported("unsupported standard menu has no recognized semantic commands")
+        end,
+    },
+    {
+        -- Ordered ABOVE player_phase, and that order is load-bearing. The Character screen is
+        -- opened from the map menu DURING the player phase, so gProcScr_PlayerPhase is still
+        -- in the pool underneath it -- and the player_phase rule would answer
+        -- `player_map_idle`, advertising cursor moves for a map nothing can reach. It is not
+        -- a MenuProc either, so the menu rule never sees it: this is a whole screen with its
+        -- own key handler, and until it was named a scenario walking the roster was pressing
+        -- DOWN into a state the controller had no word for (#238).
+        name = "unit_list",
+        check = function(observation)
+            if not proc(observation, "unit_list") then return rejected("unit_list proc absent") end
+            if not idleIs(observation, "unit_list", "unit_list_input") then
+                return matched("transition", string.format("unit_list idle=%s, not its key handler",
+                    tostring(idleOf(observation, "unit_list"))))
+            end
+            if not observation.unit_list then
+                return matched("transition", "unit_list live with no observed list structure")
+            end
+            -- unk_29 selects which branch sub_8091AEC runs: 0 is the key handler, 1 and 2 are
+            -- the row/page scroll animating. FE8 reads no D-pad in that window, so a press
+            -- sent then is simply LOST -- the exact shape of failure #232 spent sessions on.
+            if observation.unit_list.scrolling then
+                return matched("transition", "the unit list is mid-scroll")
+            end
+            return matched("unit_list_screen", "unit_list in its key handler")
         end,
     },
     {
@@ -485,6 +518,16 @@ function M.legalActions(observation)
                     "prep.command.index=0", item.slot)
             end
         end
+    elseif state == "unit_list_screen" then
+        -- sub_809144C (unitlistscreen.c): DOWN/UP walk the roster, LEFT/RIGHT change page, A
+        -- opens the highlighted unit's stat screen, B leaves. The roster index it moves is
+        -- unk_30 -- NOT the on-screen row, which clamps while the list scrolls under it, so a
+        -- driver that watched the row would stop believing it had reached the end of a list
+        -- it was still halfway down.
+        add(actions, "list_next", "DOWN", "unit_list.row")
+        add(actions, "list_previous", "UP", "unit_list.row")
+        add(actions, "select_list_entry", "A", "unit_list.row")
+        add(actions, "close_list", "B", "unit_list.on_b")
     elseif state == "unit_command_menu" then
         addMenuNavigation(actions, observation)
         addMenuCommand(actions, observation, MENU_SEIZE, "seize")
@@ -492,6 +535,15 @@ function M.legalActions(observation)
         addMenuCommand(actions, observation, MENU_BALLISTA_ATTACK, "attack")
         addMenuCommand(actions, observation, MENU_TALK, "talk")
         addMenuCommand(actions, observation, MENU_VISIT, "visit")
+        -- The map-interaction and inventory commands. Each of these used to be reached by
+        -- pressing A on a row the scenario ASSUMED was top ("Door (row 0)"), which holds only
+        -- while the command's neighbours happen to be unavailable -- give the unit a talkable
+        -- ally or a chest on the same tile and the blind press fires the wrong command and
+        -- the run stays green (#238).
+        addMenuCommand(actions, observation, MENU_CHEST, "open_chest")
+        addMenuCommand(actions, observation, MENU_DOOR, "open_door")
+        addMenuCommand(actions, observation, MENU_ITEM, "open_items")
+        addMenuCommand(actions, observation, MENU_SUPPLY, "open_supply")
         addMenuCommand(actions, observation, MENU_WAIT, "wait")
     elseif state == "map_command_menu" then
         addMenuNavigation(actions, observation)

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -254,14 +254,40 @@ local RULES = {
         end,
     },
     {
+        -- The in-map convoy (ProcScr_BmSupplyScreen), opened by the unit menu's Supply
+        -- command. Above player_phase for the same reason as the unit list: the map is still
+        -- underneath it, and answering `player_map_idle` here offers cursor moves that go
+        -- nowhere.
+        name = "supply_screen",
+        check = function(observation)
+            if not proc(observation, "supply_screen") then
+                return rejected("supply_screen proc absent")
+            end
+            if not idleIs(observation, "supply_screen", "supply_input") then
+                return matched("transition", string.format("supply_screen idle=%s, not its key handler",
+                    tostring(idleOf(observation, "supply_screen"))))
+            end
+            return matched("supply_screen", "supply_screen in its key handler")
+        end,
+    },
+    {
         name = "prep_units",
         check = function(observation)
             if not proc(observation, "prep_units") then return rejected("prep_units proc absent") end
-            if idleIs(observation, "prep_units", "prep_units_input") then
-                return matched("prep_pick_units", "prep_units in its input loop")
+            if not idleIs(observation, "prep_units", "prep_units_input") then
+                return matched("transition", string.format("prep_units idle=%s, not prep_units_input",
+                    tostring(idleOf(observation, "prep_units"))))
             end
-            return matched("transition", string.format("prep_units idle=%s, not prep_units_input",
-                tostring(idleOf(observation, "prep_units"))))
+            if not observation.prep_units then
+                return matched("transition", "prep_units live with no observed list structure")
+            end
+            -- ProcPrepUnit_Idle gates its ENTIRE key handler on list_num_pre == list_num_cur:
+            -- while the list scrolls to a new row it reads nothing, so an input sent in that
+            -- window is lost and the driver goes on believing it landed.
+            if not observation.prep_units.settled then
+                return matched("transition", "the deploy list is scrolling to a new row")
+            end
+            return matched("prep_pick_units", "prep_units in its input loop")
         end,
     },
     {
@@ -518,6 +544,27 @@ function M.legalActions(observation)
                     "prep.command.index=0", item.slot)
             end
         end
+    elseif state == "prep_pick_units" then
+        -- ProcPrepUnit_Idle (prep_unitselect.c) walks a TWO-COLUMN list, and its bounds are
+        -- reproduced here rather than approximated: LEFT only from an odd index, RIGHT only
+        -- from an even one short of the end, UP/DOWN by two. A press outside those bounds
+        -- moves nothing at all -- so a driver that assumed a straight list would act on
+        -- whoever it was still parked on and report success.
+        local pick = observation.prep_units
+        if (pick.cursor & 1) == 1 then add(actions, "pick_left", "LEFT", "prep_units.column") end
+        if (pick.cursor & 1) == 0 and pick.cursor < pick.count - 1 then
+            add(actions, "pick_right", "RIGHT", "prep_units.column")
+        end
+        if pick.cursor - 2 >= 0 then add(actions, "pick_previous", "UP", "prep_units.row") end
+        if pick.cursor + 2 <= pick.count - 1 then
+            add(actions, "pick_next", "DOWN", "prep_units.row")
+        end
+        add(actions, "toggle_deploy", "A", "prep_units.cursor")
+        -- START only launches with someone deployed; on an empty field FE8 just buzzes.
+        if pick.deployed > 0 then add(actions, "fight", "START", "prep_units.deployed") end
+        add(actions, "cancel_pick", "B", "prep_units.on_b")
+    elseif state == "supply_screen" then
+        add(actions, "close_supply", "B", "supply_screen.on_b")
     elseif state == "unit_list_screen" then
         -- sub_809144C (unitlistscreen.c): DOWN/UP walk the roster, LEFT/RIGHT change page, A
         -- opens the highlighted unit's stat screen, B leaves. The roster index it moves is

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -20,8 +20,11 @@ local MENU_DOOR = 0x5E
 local MENU_ITEM = 0x67
 local MENU_SUPPLY = 0x69
 local MENU_WAIT = 0x6B
--- gSendToConvoyMenuItems: the inventory-full "which item goes to the convoy" chooser.
-local MENU_CONVOY_SEND_FIRST = 0x2A
+-- The two arms of ConvoyMenuProc_StarMenu (convoymenu.c), which is raised whenever a unit is
+-- handed an item it has no room for: gConvoyMenuItems (0x24-0x29) when the convoy is FULL,
+-- gSendToConvoyMenuItems (0x2A-0x2F) when it has room. Contiguous in menu_def.c, and they
+-- block the chapter identically, so they are one state.
+local MENU_CONVOY_SEND_FIRST = 0x24
 local MENU_CONVOY_SEND_LAST = 0x2F
 -- gItemSelectMenuItems: one row per inventory slot (menu_def.c).
 local MENU_ITEM_SLOT_FIRST = 0x43
@@ -270,8 +273,11 @@ local RULES = {
                 return matched("transition", "unit_list live with no observed list structure")
             end
             -- unk_29 selects which branch sub_8091AEC runs: 0 is the key handler, 1 and 2 are
-            -- the row/page scroll animating. FE8 reads no D-pad in that window, so a press
-            -- sent then is simply LOST -- the exact shape of failure #232 spent sessions on.
+            -- the row/page scroll animating, and 3 is sub_80917D8, the sort-column mode. Only
+            -- 0 reads the D-pad, so a press sent in 1 or 2 is simply LOST -- the exact shape of
+            -- failure #232 spent sessions on. 3 is a persistent INPUT state we deliberately do
+            -- not drive: nothing needs it, and legalActions refuses to offer the UP that opens
+            -- it, so a run should never arrive here (see unit_list_screen below).
             if observation.unit_list.scrolling then
                 return matched("transition", "the unit list is mid-scroll")
             end
@@ -596,8 +602,15 @@ function M.legalActions(observation)
         -- unk_30 -- NOT the on-screen row, which clamps while the list scrolls under it, so a
         -- driver that watched the row would stop believing it had reached the end of a list
         -- it was still halfway down.
-        add(actions, "list_next", "DOWN", "unit_list.row")
-        add(actions, "list_previous", "UP", "unit_list.row")
+        -- Bounded at BOTH ends off gUnknown_0200F158, the same field sub_809144C bounds
+        -- against -- and UP at row 0 is not merely a no-op: it sets unk_29 = 3, routing
+        -- sub_8091AEC into sub_80917D8 (the sort-column mode). The observer reports that as
+        -- `scrolling`, i.e. as a transition offering nothing, so advertising UP there hands a
+        -- driver an action that walks it into a screen with no enumerated way out, to sit
+        -- until the stall watch fires on a wait the controller itself caused.
+        local list = observation.unit_list
+        if list.row > 0 then add(actions, "list_previous", "UP", "unit_list.row") end
+        if list.row < list.count - 1 then add(actions, "list_next", "DOWN", "unit_list.row") end
         add(actions, "select_list_entry", "A", "unit_list.row")
         add(actions, "close_list", "B", "unit_list.on_b")
     elseif state == "unit_command_menu" then

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -159,6 +159,12 @@ WANTED = [
                                 # screen (src/unitlistscreen.c, started by StartUnitListScreenField
                                 # off gMapMenuItems[0], overrideId 0x6E). A live instance == the
                                 # unit list is actually on screen -> the #218 capture point.
+    'sub_8091AEC',              # the Character screen's PROC_REPEAT input loop
+                                # (src/unitlistscreen.c). Unnamed in the decomp, but it is the
+                                # exact callback that makes the list an INPUT state rather than
+                                # a screen that happens to be up -- and its unk_29 branch says
+                                # whether the row/page scroll is still animating, i.e. whether
+                                # a D-pad press would be read at all (#238).
     'unit_icon_wait_table',     # UnitIconWait[] (include/unit_icon_data.h): {pattern, size, sheet}
                                 # per SMS id. `size` is the UNIT_ICON_SIZE_* PutUnitSprite switches
                                 # on, so reading it in-engine proves what the ROM believes about a

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -77,6 +77,16 @@ WANTED = [
     'gBmMapUnit',               # u8** tile->unit grid (include/bmmap.h): gBmMapUnit[y][x] is the
                                 # on-tile unit id the engine uses for cursor selection. Relocating
                                 # a unit must update THIS, not just its xPos/yPos.
+    'gBmMapBaseTiles',          # u16** metatile grid a chest/door tile-change writes
+                                # (ApplyMapChangesById, bmtrick.c). Unlike the other gBmMap*
+                                # grids this one lives in ROM .data and is never reassigned:
+                                # it holds a constant pointer to the sBmBaseTilesPool row
+                                # array in EWRAM. It was HARD-CODED in harness.lua and the
+                                # engine grew out from under it -- 0x085AF5DC held 0x000004AB
+                                # rather than the pool -- so ch03door/ch03chest failed on
+                                # their PRECONDITION, before pressing anything, and read as
+                                # broken doors and chests for as long as that lasted. Which
+                                # is the entire reason this file exists (#238).
     'gBmMapTerrain',            # u8** terrain-id grid (include/bmmap.h): gBmMapTerrain[y][x] is the
                                 # TERRAIN_* id, used to build a passability map for the clear-bot's
                                 # BFS march-to-boss (#60).

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -155,6 +155,11 @@ WANTED = [
                                 # In a --montage build this carries the #43 lore crawl, so a
                                 # live instance == the montage opener actually played.
     'ProcScr_PrepUnitScreen',   # proc script: the prep "Pick Units" screen (deploy/bench).
+    'gPrepUnitList',            # struct PrepUnitList (include/prepscreen.h): units[0x40] then
+                                # max_num at +0x100 -- PrepGetUnitAmount(). It is what
+                                # ProcPrepUnit_Idle bounds its RIGHT/DOWN moves against, so
+                                # the controller reads the LIVE roster length instead of
+                                # assuming the deploy list's shape (#238).
     'ProcScr_UnitListScreen_Field', # proc script: the map-menu "Unit" list, i.e. the Character
                                 # screen (src/unitlistscreen.c, started by StartUnitListScreenField
                                 # off gMapMenuItems[0], overrideId 0x6E). A live instance == the
@@ -172,6 +177,11 @@ WANTED = [
     'ProcScr_BmSupplyScreen',   # proc script: the in-map Supply (convoy) screen, opened by
                                 # the unit-menu Supply command (src/prep_itemsupply.c). A live
                                 # instance == a unit actually opened the convoy on the field.
+    'PrepItemSupply_Loop_GiveTakeKeyHandler', # exact convoy input callback. B leaves it
+                                # (Proc_Goto 8); nothing else is ever wanted there, but it has
+                                # to be a NAMED state -- blind B's into an unclassified screen
+                                # cannot tell "the convoy closed" from "that also cancelled
+                                # the unit's move" (#238).
     'ProcScr_BattleEventEngine',# proc script: in-battle event engine (src/event.c). Runs
                                 # CallBattleQuoteEventInBattle -> the brief in-combat quotes
                                 # (per-PC DEATH quotes, boss taunts). A live instance == a

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -164,6 +164,12 @@ WANTED = [
                                 # screen (src/unitlistscreen.c, started by StartUnitListScreenField
                                 # off gMapMenuItems[0], overrideId 0x6E). A live instance == the
                                 # unit list is actually on screen -> the #218 capture point.
+    'gUnknown_0200F158',        # u8: how many units the Character screen actually sorted into
+                                # its roster (src/unitlistscreen.c). This -- NOT the proc's own
+                                # allyCount -- is what sub_809144C bounds DOWN against, and it
+                                # is the only one of the two that a FIELD-mode list ever writes:
+                                # StartUnitListScreenField sets `mode` and nothing else, so
+                                # allyCount is left holding whatever was in the proc slot (#238).
     'sub_8091AEC',              # the Character screen's PROC_REPEAT input loop
                                 # (src/unitlistscreen.c). Unnamed in the decomp, but it is the
                                 # exact callback that makes the list an INPUT state rather than

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -67,6 +67,10 @@ local TUNE = {
     -- Frames between the two proc-pool samples an inspector snapshot takes. One sample
     -- cannot tell a frozen proc from a live one; two, a gap apart, can.
     inspectGap = 90,
+    -- Frames cancelToPlayerMap may spend watching a screen TEAR DOWN before it gives up.
+    -- Separate from the cancel count on purpose: a fading screen is progress, and a cap that
+    -- counts it is a cap that decides failure.
+    cancelFrames = 900,
     -- How long an UNCLASSIFIED transition may hold a byte-identical proc pool before the
     -- inspector calls it a stalled input wait. 600 frames is 10s of wall clock at 60fps --
     -- longer than any fade or animation, and far cheaper than the 12000-iteration boot
@@ -1702,7 +1706,7 @@ scenarios.goodberry = function()
     -- goblin and the blind press opens Attack and the capture silently shoots the wrong
     -- screen.
     if not selectSemantic("open_items", "the Item command opens Hlin's inventory", function(after)
-        return controllerState(after) == "generic_menu"
+        return controllerState(after) == "item_list"
     end, 120) then
         return result("FAIL", "Hlin's command menu offered no live Item command")
     end
@@ -1723,10 +1727,13 @@ scenarios.goodberry = function()
     wait(20)
     shot("goodberry-highlighted")
     -- Open the Use/Equip/Trade/Discard submenu on the HIGHLIGHTED item -- which also shows
-    -- its description. gItemSubMenuItems carry override ids 0x34-0x37 against the list's
-    -- 0x38+, so "a different menu is up" is a fact we can read rather than a wait to guess.
+    -- its description. gItemSubMenuItems carry override ids 0x34-0x37 against the inventory
+    -- rows' 0x43-0x47, so "a different menu is up" is a fact we can read rather than a wait
+    -- to guess. Note the Goodberry is GREYED at full HP (ItemSelectMenu_Usability returns
+    -- MENU_DISABLED for an item that cannot be used) -- and still opens its submenu, because
+    -- Menu_OnIdle's A path does not consult availability.
     local before = observeController().menu.items[1].override_id
-    if not selectSemantic("select_current_menu_item", "the Goodberry's item submenu opens",
+    if not guardedInput("select_item", "A", "the Goodberry's item submenu opens",
         function(after)
             return after.menu ~= nil and after.menu.items[1].override_id ~= before
         end, 120) then
@@ -1975,10 +1982,17 @@ local function cancelUnitActionMenu()
 end
 
 local function cancelToPlayerMap()
-    for _ = 1, 8 do
+    -- The budget counts CANCELS, not iterations. A transition here is a screen tearing itself
+    -- down -- the convoy's fade-out runs for hundreds of frames after its key handler lets go
+    -- -- and charging those to an 8-step loop made the CAP the thing that decided failure,
+    -- which is the trap #232 spent three sessions in. Transitions get their own frame ceiling
+    -- so a genuinely wedged screen still fails closed (#238).
+    local cancels, frames = 0, 0
+    while cancels < 8 and frames < TUNE.cancelFrames do
         local observation = observeController()
         local state = controllerState(observation)
         if state == "player_map_idle" then return true end
+        if state ~= "transition" then cancels = cancels + 1 end
         if state == "unit_selected" then
             if not guardedInput("cancel_selection", "B", "movement selection returns to player map",
                 function(after) return controllerState(after) == "player_map_idle" end, 120) then
@@ -1990,6 +2004,7 @@ local function cancelToPlayerMap()
                 return false
             end
         elseif state == "transition" then
+            frames = frames + 1
             yield()
         else
             traceFailure("cancel_to_map", "player map after semantic cancellation",
@@ -2839,7 +2854,10 @@ scenarios.recordsupply = function()
     -- Launch straight from Pick Units. START is a legal action here only because someone is
     -- deployed -- on an empty field FE8 just buzzes, and the old blind START could not tell
     -- that apart from a launch, so it went on to A-mash at a screen that had not moved.
-    if not selectSemantic("fight", "Pick Units launches the chapter", function(after)
+    -- guardedInput, not selectSemantic: selectSemantic navigates a menu to reach a row and
+    -- then presses A, and Fight is a START action with no row to walk to (it reported
+    -- fail:no-live-target). driveThroughPrep drives the main prep menu's Fight the same way.
+    if not guardedInput("fight", "START", "Pick Units launches the chapter", function(after)
         return after.procs.prep_units == nil
     end, 600) then
         shot("supply-no-launch")
@@ -2889,24 +2907,35 @@ scenarios.recordsupply = function()
         shot("supply")                                    -- the convoy screen -> Pinky USING Supply
         log("pinky opened convoy=" .. tostring(usedSupply))
         if usedSupply then
-            -- Leave the convoy, then the unit menu, each on its own enumerated cancel. Two
-            -- blind B's could not tell those two levels apart: one too few left the run in
-            -- the convoy, one too many cancelled Pinky's move as well.
+            -- Leave the convoy on its own enumerated cancel. Two blind B's stood in for this,
+            -- and the second had nothing to close: SupplyCommandEffect returns MENU_ACT_END,
+            -- so the unit menu is already gone by the time the convoy is up -- that press went
+            -- into the map. The postcondition is the convoy PROC being gone, not merely the
+            -- state changing: its key handler lets go while the screen is still fading out.
             if not guardedInput("close_supply", "B", "the convoy screen closes", function(after)
-                return controllerState(after) ~= "supply_screen"
-            end, 300) then return result("FAIL", "could not leave the convoy screen") end
-            if not cancelToPlayerMap() then
-                return result("FAIL", "could not return to the map after the convoy")
+                return after.procs.supply_screen == nil
+            end, 600) then return result("FAIL", "could not leave the convoy screen") end
+            if not awaitControllerState("player_map_idle", 600) then
+                return result("FAIL", "the map never came back after the convoy")
             end
         end
     else
         shot("supply-no-menu")
     end
-    -- Contrast: a NON-lord deployed unit's action menu has NO Supply row.
+    -- Contrast: a deployed unit that is neither the lead nor STANDING NEXT TO them has no
+    -- Supply row. The adjacency clause is not a detail -- SupplyUsability (bmmenu.c) returns
+    -- MENU_ENABLED for the lead OR for anyone IsAdjacentForSupply finds orthogonally beside
+    -- them, so "a non-lord has no Supply" is simply false for a neighbour, and asserting it
+    -- fails on a correct engine. This scenario's own comment claimed the stronger rule; the
+    -- first deployed non-lord turned out to spawn right next to Pinky, and the assertion
+    -- caught the CLAIM rather than a defect (#238).
     waitFor(function() return faction() == 0 and not menuOpen() end, 1500, true)
+    pinky = blue(CHAR_PINKY_LORD)
     for i = 0, 50 do
         local u = unitAt(SYM.gUnitArrayBlue, i)
-        if u and u.charId ~= CHAR_PINKY_LORD and (u.state & 0x9) == 0 and u.x ~= 0xFF then
+        local beside = pinky and u and math.abs(u.x - pinky.x) + math.abs(u.y - pinky.y) == 1
+        if u and u.charId ~= CHAR_PINKY_LORD and not beside
+            and (u.state & 0x9) == 0 and u.x ~= 0xFF then
             if moveUnit(u.x, u.y, u.x, u.y) then
                 wait(40); shot("supply")
                 -- The CONTRAST is the point of this half, so assert it rather than leaving
@@ -2915,7 +2944,8 @@ scenarios.recordsupply = function()
                 if Controller.findAction(
                     Controller.legalActions(observeController()), "open_supply") then
                     return result("FAIL", string.format(
-                        "a non-lord (char 0x%02X) was offered the Supply command", u.charId))
+                        "char 0x%02X is neither the lead nor beside them, but was offered Supply",
+                        u.charId))
                 end
                 if not cancelToPlayerMap() then
                     return result("FAIL", "could not back out of the non-lord's command menu")
@@ -5056,7 +5086,7 @@ scenarios.ch03tourmaline = function()
     -- observation rather than a staging assumption; the isolation stays, because the SHOT
     -- wants a clean two-item menu.
     if not selectSemantic("open_items", "the Item command opens the inventory list", function(after)
-        return controllerState(after) == "generic_menu"
+        return controllerState(after) == "item_list"
     end, 120) then
         return result("FAIL", "the command menu offered no live Item command to the holder")
     end
@@ -5551,25 +5581,39 @@ scenarios.clear_ch02 = function()
         snapCharms()
         if chapter() == CH03_CHAPTER then reachedCh03 = true; snapCharms(); break end
         if procActive(SYM.gProcScr_TitleScreen) then snapCharms(); break end  -- fallback: chain broken -> old landing
-        -- Advance the ending on the CLASSIFIED dialogue wait rather than on an A cadence
-        -- (#238). The cadence pressed A every 10 frames whatever was on screen, so it could
-        -- not tell "this page is waiting for me" from "this input is being swallowed" -- and
-        -- a scene that wedged just ran the cap out and reported a timeout naming nothing.
-        -- The charm poll rides the postcondition closure, so the sampling stays as
-        -- fine-grained as the charm window (CHECK_ALIVE -> GIVEITEMTO) needs it.
+        -- Drive the ending on OBSERVED state rather than an A cadence (#238). The cadence
+        -- pressed A every 10 frames whatever was on screen, so it could not tell "this page
+        -- is waiting for me" from "this input is being swallowed", and a scene that wedged
+        -- just ran the cap out and reported a timeout naming nothing.
+        --
+        -- advanceBootState, NOT a dialogue-only check: the ch02 -> ch03 chain is not one long
+        -- conversation. MNC2(0x4) runs the ending, then the post-chapter SAVE prompt, then
+        -- ch03's chapter-intro card -- three different classified input waits. Advancing only
+        -- dialogue_wait yielded forever at the save prompt, burned the whole step budget and
+        -- reported 2/3 charms on a chapter that had never left slot 3. This is the same
+        -- driver reachCh01 uses for the identical hand-off one chapter earlier.
         local observation = observeController()
         local state = controllerState(observation)
         if watchEnding(observation, state) then
             return result("FAIL", "the ch02 ending parked on an unclassified wait (see the snapshot)")
         end
-        if state == "dialogue_wait" then
-            if not guardedInput("advance_dialogue", "A", "the ending's dialogue wait clears",
-                function(after)
-                    snapCharms()
-                    return controllerState(after) ~= "dialogue_wait"
-                end, 120) then break end
+        snapCharms()
+        -- The third charm-gift lands on a FULL inventory, so FE8 raises its "which item goes
+        -- to the convoy" chooser and the whole chain stops until it is answered. Answering it
+        -- is scenario policy -- send whatever is highlighted; the charm reaching the leader OR
+        -- the convoy is what this scenario asserts either way. The old A-mash answered this
+        -- prompt by ACCIDENT, which is the only reason its "3/3 charms delivered" verdict was
+        -- reachable: a blind press was doing load-bearing work nothing had named (#238).
+        if state == "send_to_convoy" then
+            if not guardedInput("send_item", "A", "the convoy chooser closes", function(after)
+                return after.menu == nil or controllerState(after) ~= "send_to_convoy"
+            end, 300) then break end
         else
-            yield()
+            local advanced = advanceBootState(observation, state)
+            if advanced == false then break end
+            -- nil = a state it has no input for (the map is up mid-scene). Wait it out; the
+            -- step budget and the stall watch above bound this, never a tight spin.
+            if advanced == nil then yield() end
         end
     end
     shot("clear-ch02-ending")

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -372,6 +372,7 @@ local CALLBACK_NAMES = {
     [SYM.PlayerPhase_WaitForUnitMovement] = "player_move_wait",
     [SYM.TargetSelection_Loop] = "target_selection_input",
     [SYM.BattleForecast_LoopDisplay] = "battle_forecast_display",
+    [SYM.sub_8091AEC] = "unit_list_input",
 }
 local PREP_CALLBACK_NAMES = {
     [SYM.PrepScreenMenu_OnStartPress] = "prep_main_fight",
@@ -556,6 +557,19 @@ local function observeController()
     put("prep_menu", observedProc(SYM.ProcScr_PrepMenu))
     put("sally", observedProc(SYM.gProcScr_SALLYCURSOR, "sally_idle"))
     put("prep_units", observedProc(SYM.ProcScr_PrepUnitScreen))
+    local unitList = observedProc(SYM.ProcScr_UnitListScreen_Field)
+    put("unit_list", unitList)
+    if unitList then
+        -- struct UnitListScreenProc (include/unitlistscreen.h). unk_30 is the ROSTER index
+        -- the key handler moves; unk_2c is only where that lands on screen, and it clamps
+        -- while the list scrolls under it. unk_29 != 0 means a scroll is animating and
+        -- sub_809144C is not running, so no D-pad press would be read.
+        observation.unit_list = {
+            row = ru8(unitList.addr + 0x30), screen_row = ru8(unitList.addr + 0x2C),
+            page = ru8(unitList.addr + 0x2F), allies = ru8(unitList.addr + 0x3A),
+            deployed = ru8(unitList.addr + 0x3B), scrolling = ru8(unitList.addr + 0x29) ~= 0,
+        }
+    end
     put("map_fade", observedProc(SYM.sProcScr_BMXFADE, "map_fade"))
     put("player_phase", observedProc(SYM.gProcScr_PlayerPhase))
     put("target_selection", observedProc(SYM.gProcScr_TargetSelection))
@@ -1658,19 +1672,43 @@ scenarios.goodberry = function()
         return result("FAIL", "action menu never opened for Hlin")
     end
     shot("action-menu")
-    -- No enemy is in handaxe range at turn 1, so the command menu is [Item, Wait];
-    -- A picks Item (top). Screenshot shows both items with icons + names.
-    press(K.A)
-    wait(40)
+    -- Resolve the live Item command rather than pressing the row it is expected to occupy
+    -- (#238). "No enemy is in handaxe range at turn 1, so the menu is [Item, Wait] and A
+    -- picks the top" was true, but it is a claim about turn 1's enemy placement -- move a
+    -- goblin and the blind press opens Attack and the capture silently shoots the wrong
+    -- screen.
+    if not selectSemantic("open_items", "the Item command opens Hlin's inventory", function(after)
+        return controllerState(after) == "generic_menu"
+    end, 120) then
+        return result("FAIL", "Hlin's command menu offered no live Item command")
+    end
+    wait(20)
     shot("item-list")
-    -- inventory order is Hand Axe (slot 1) then Goodberry (slot 2): DOWN highlights
-    -- the Goodberry, refreshing the name/description panel.
-    press(K.DOWN)
-    wait(30)
+    -- Inventory order is Hand Axe then Goodberry: one row down highlights the Goodberry and
+    -- refreshes the name/description panel. The postcondition is the live highlight moving.
+    local list = observeController().menu
+    if not (list and #list.items >= 2) then
+        return result("FAIL", "the inventory list did not come up with both of Hlin's items")
+    end
+    if not guardedInput("menu_next", "DOWN", "the inventory highlight moves to the Goodberry",
+        function(after)
+            return after.menu ~= nil and after.menu.current ~= list.current
+        end, 60) then
+        return result("FAIL", "could not move the inventory highlight onto the Goodberry")
+    end
+    wait(20)
     shot("goodberry-highlighted")
-    -- open the item submenu (Use/Trade/Discard) -> shows the item description too.
-    press(K.A)
-    wait(40)
+    -- Open the Use/Equip/Trade/Discard submenu on the HIGHLIGHTED item -- which also shows
+    -- its description. gItemSubMenuItems carry override ids 0x34-0x37 against the list's
+    -- 0x38+, so "a different menu is up" is a fact we can read rather than a wait to guess.
+    local before = observeController().menu.items[1].override_id
+    if not selectSemantic("select_current_menu_item", "the Goodberry's item submenu opens",
+        function(after)
+            return after.menu ~= nil and after.menu.items[1].override_id ~= before
+        end, 120) then
+        return result("FAIL", "the Goodberry row did not open its item submenu")
+    end
+    wait(20)
     shot("goodberry-detail")
     result("PASS", "Goodberry item menu captured (see screenshots)")
 end
@@ -1680,13 +1718,16 @@ end
 -- destination; false with its own FAIL logged otherwise.
 --
 -- opts.stopAtPrep  stop with Preparations open instead of driving through it
--- opts.lord        "default" (accept the highlighted lead) | "last" (walk to the final
---                  candidate -- Pinky -- so a NON-Braulo lord can be exercised)
+-- opts.lord        "default" (accept the highlighted lead) | "last" (the final candidate --
+--                  Pinky) | a NUMBER (that row of the live lead menu, 0-based)
+-- opts.picked      OUT: the row the lead menu was actually committed on. Read it instead of
+--                  recomputing a row from LORD_CANDIDATES -- a scenario that assumes a roster
+--                  size asserts against a constant rather than against what it did (#241).
 --
--- One driver, three destinations (#238). reachPrep and reachPrepPinky used to be separate
--- copies of this route on a blind A-cadence; a copy that mashes A cannot tell "the scene
--- advanced" from "the input was swallowed", which is how ch01win rode straight through the
--- lord-select Yes/No prompt that cost #232 three sessions.
+-- One driver, every destination (#238). reachPrep, reachPrepPinky, lordfloor, ch01lord and
+-- reachRbgCh01 were five copies of this route on a blind A-cadence; a copy that mashes A
+-- cannot tell "the scene advanced" from "the input was swallowed", which is how ch01win rode
+-- straight through the lord-select Yes/No prompt that cost #232 three sessions.
 local function reachCh01(opts)
     opts = opts or {}
     if not winCh00() then return false end
@@ -1732,38 +1773,51 @@ local function reachCh01(opts)
         elseif state == "generic_menu" then
             -- Scenario policy: which lead to take. The controller owns the live menu
             -- callback and the guarded input either way; no row is guessed and no
-            -- candidate count is assumed -- "last" walks the LIVE item list.
-            if opts.lord == "last" then
-                local rows = observation.menu and #observation.menu.items or 0
-                for _ = 1, rows - 1 do
+            -- candidate count is assumed -- the walk counts the LIVE item list.
+            local rows = observation.menu and #observation.menu.items or 0
+            local want = opts.lord
+            if want == "last" then want = rows - 1 end
+            if type(want) == "number" then
+                if want < 0 or want >= rows then
+                    result("FAIL", string.format(
+                        "lead row %d is not in the live menu of %d candidates", want, rows))
+                    return false
+                end
+                -- Walk off the LIVE cursor and stop when it ARRIVES, rather than pressing a
+                -- fixed count: a fixed count reaches the wanted row only if the menu opened
+                -- on row 0, which nothing guarantees, and FE8 menus WRAP -- so being wrong
+                -- picks a different lead and passes anyway. The landing is asserted below
+                -- either way, because nothing downstream re-checks which lead was taken
+                -- (ckpt_lordpinky just saves the state) (#241).
+                for _ = 1, rows do
+                    local at = observeController()
+                    if at.menu and at.menu.current == want then break end
                     if not guardedInput("menu_next", "DOWN", "the lead menu selection moves",
                         function(after, before)
                             return after.menu ~= nil and before.menu ~= nil
                                 and after.menu.current ~= before.menu.current
                         end, 60) then
-                        result("FAIL", "could not walk the lead menu to the last candidate")
+                        result("FAIL", "could not walk the lead menu to the chosen candidate")
                         return false
                     end
                 end
-                -- Assert WHERE the walk landed. rows-1 presses reach the last candidate
-                -- only if the menu opened on row 0, which nothing guarantees, and FE8 menus
-                -- WRAP -- so being wrong picks a different lord and passes anyway. Nothing
-                -- downstream checks which lead was taken (ckpt_lordpinky just saves), so
-                -- without this the scenario's whole premise is unverified (#241).
                 local landed = observeController()
-                if not (landed.menu and landed.menu.current == rows - 1) then
+                if not (landed.menu and landed.menu.current == want) then
                     result("FAIL", string.format(
-                        "lead menu walk landed on row %s of %d, not the last candidate",
-                        tostring(landed.menu and landed.menu.current), rows))
+                        "lead menu walk landed on row %s of %d, not row %d",
+                        tostring(landed.menu and landed.menu.current), rows, want))
                     shot("ch01-lord-walk-lost")
                     return false
                 end
             end
+            local committing = observeController().menu
+            opts.picked = committing and committing.current or want
             if not guardedInput("select_current_menu_item", "A", "lead menu selection closes", function(after)
                 return after.menu == nil
             end, 300) then
                 result("FAIL", "could not choose the highlighted lead"); return false
             end
+            log(string.format("lead committed on menu row %s of %d", tostring(opts.picked), rows))
         elseif state == "yes_no_choice" then
             -- Lord select confirms the pick with "Will <lead> lead the party?". Same
             -- scenario policy as the menu above -- accept the default -- and Yes is the
@@ -2487,7 +2541,13 @@ scenarios.ch01win = function()
                 return result("PASS",
                     "Braulo seized the camp; ending + dev placeholder played -> title")
             end
-            press(K.B); press(K.B) -- menu surprise: back out, retry next turn
+            -- The seize did not end the chapter, so back out to the map on ENUMERATED
+            -- cancels and retry next turn (#238). Two blind B's used to stand in for this:
+            -- they could not tell how many levels deep the surprise was, so one too few left
+            -- the run parked on a menu and one too many cancelled the unit selection as well.
+            if not cancelToPlayerMap() then
+                return result("FAIL", "could not back out of the post-seize screen")
+            end
         end
         local phase = runEnemyPhase(CH01_PARK)
         if phase == "gameover" then
@@ -2553,7 +2613,9 @@ local function leavePrepAndGrindToSeize()
                 wait(20)
                 return true
             end
-            press(K.B); press(K.B)
+            -- The move onto the seize tile did not open the menu; back out on enumerated
+            -- cancels rather than two blind B's and retry on the next phase (#238).
+            if not cancelToPlayerMap() then return false end
         end
         local phase = runEnemyPhase(CH01_PARK)
         if phase == "gameover" then return false end
@@ -2586,41 +2648,22 @@ end
 -- double-apply": both ride the identical BmMain_StartPhase -> LordFloor_ApplyOnce
 -- early-return once the flag is set. make-green can't prove this -- only a real run can.
 scenarios.lordfloor = function()
-    local MARTY = 0x02                 -- marty rides CHARACTER_SETH (lord-select menu index 1)
+    local MARTY = 0x02                 -- marty rides CHARACTER_SETH
+    local MARTY_ROW = 1                -- ...at row 1 of the lead menu (row 0 is Braulo)
     local BASE_HP, FLOOR_HP = 18, 25   -- base maxHP 18, floor +7 (difficulty --lord-floor oracle)
     local BASE_DEF, FLOOR_DEF = 2, 6   -- base def 2, floor +4
     local APPLIED = 0xFA               -- LORDFLOOR_APPLIED_FLAG (permanent)
 
-    if not winCh00() then return result("FAIL", "never won ch00") end
-    if not waitFor(function() return chapter() == 2 end, 1800) then
-        return result("FAIL", "ch01 never started") end
-
-    -- ride the save menu + Northlook scene to the scenic lord-select menu, then pick MARTY.
-    local atMenu = false
-    for _ = 1, 200 do
-        if menuOpen() then atMenu = true break end
-        if procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.A, 4); wait(36)
-    end
-    if not atMenu then return result("FAIL", "lord-select menu never opened") end
-    wait(40)
-    press(K.DOWN, 4); wait(8)          -- index 0 (Braulo) -> index 1 (Marty)
-    press(K.A, 4); wait(40)            -- pick
-    press(K.A, 4); wait(20)            -- [Yes] confirm
-
-    -- through prep -> Fight! -> interactive turn 1.
-    for _ = 1, 80 do
-        if procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.A, 4); wait(36)
-    end
-    for i = 1, 40 do
-        if not procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.B, 4); wait(10); press(K.START, 4); wait(40)
-        if i % 4 == 0 and procActive(SYM.gProcScr_SALLYCURSOR) then press(K.A, 4); wait(20) end
-    end
-    if not waitFor(function()
-        return not procActive(SYM.gProcScr_SALLYCURSOR) and faction() == 0 and turn() >= 1
-    end, 1200) then return result("FAIL", "ch01 turn 1 never reached") end
+    -- Ride the shared, migrated ch01 route and take MARTY as the lead: the save menu, the
+    -- Northlook scene, the lead menu, its Yes/No confirm and Preparations are all driven on
+    -- observed state (#238). This scenario used to carry its own blind-A copy of that route,
+    -- which could not tell a swallowed input from an advanced scene -- and which would have
+    -- ridden straight through the lord-select prompt exactly as ch01win did.
+    local route = { lord = MARTY_ROW }
+    if not reachCh01(route) then return end
+    if route.picked ~= MARTY_ROW then
+        return result("FAIL", string.format("lead committed on row %s, not Marty's row %d",
+            tostring(route.picked), MARTY_ROW)) end
     wait(60)
 
     -- marty must be force-deployed (the chosen lord) and floored at turn 1.
@@ -3229,71 +3272,22 @@ end
 -- set, the pick is force-deployed onto the field (cap intact), and their death
 -- ends in the game-over screen (UnitKill hook -> EVFLAG_GAMEOVER -> AFEV).
 scenarios.ch01lord = function()
-    if not winCh00() then return end
-    if not waitFor(function() return chapter() == 2 end, 1800) then
-        return result("FAIL", "chapter slot 2 never loaded after the ch00 win")
-    end
-    log("in ch01; riding the save menu to the lord-select menu")
-    -- The lord menu is the first generic menu while the beginning scene's
-    -- goblins are on the map (the post-chapter save screen runs before any
-    -- LOAD; the prep screen comes after the menu).
-    -- A-taps ride the save menu + the ~22-page Beat-1 Northlook scene to the lord
-    -- prompt+menu (cf. ch01win's 200-iter budget; the old 60 ran out mid-scene).
-    -- The lord-select menu is a StartMenu(MenuDef_LordSelect) over a scenic BG
-    -- (BG_DARKLING_WOODS) BEFORE the battle map loads -- so the chief is NOT in the
-    -- red array during it. Detect it by menuOpen() alone (sProc_Menu); the earlier
-    -- post-chapter save screen is a different proc and does not trip menuOpen().
-    local atMenu = false
-    for i = 1, 200 do
-        if menuOpen() then atMenu = true break end
-        if procActive(SYM.gProcScr_SALLYCURSOR) then break end -- overshot it
-        press(K.A, 4)
-        wait(36)
-    end
-    if not atMenu then
-        shot("ch01lord-no-menu")
-        return result("FAIL", "lord-select menu never opened before preps")
-    end
-    shot("lord-menu")
-    for _ = 1, LORD_CANDIDATES - 1 do press(K.DOWN, 4) wait(8) end
-    shot("lord-menu-last")
-    press(K.A, 4)
-    wait(40)
-    shot("lord-confirm")
-    -- A answers the [Yes] confirm; then A-tap to the prep screen.
-    local prep = false
-    for i = 1, 40 do
-        if procActive(SYM.gProcScr_SALLYCURSOR) then prep = true break end
-        press(K.A, 4)
-        wait(36)
-    end
-    if not prep then
-        shot("ch01lord-no-prep")
-        return result("FAIL", "prep screen never opened after the lord pick")
-    end
-    if not eventFlag(LORDSEL_FLAG_BASE + LORD_CANDIDATES - 1) then
-        return result("FAIL", "lord-choice permanent flag not set after confirm")
-    end
-    wait(180)
-    shot("ch01lord-prep")
-    for i = 1, 40 do
-        if not procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.B, 4)
-        wait(10)
-        press(K.START, 4)
-        wait(40)
-        if i % 4 == 0 and procActive(SYM.gProcScr_SALLYCURSOR) then press(K.A, 4) wait(20) end
-    end
-    local fighting = waitFor(function()
-        return not procActive(SYM.gProcScr_SALLYCURSOR)
-            and faction() == 0 and turn() >= 1
-    end, 1200)
-    if not fighting then
-        shot("ch01lord-prep-stuck")
-        return result("FAIL", "could not leave preparations via Fight!")
-    end
-    wait(120)
+    -- The shared migrated route takes the LAST lead candidate and asserts where the walk
+    -- landed, so "which lead did we actually pick" is verified rather than assumed (#238).
+    -- The lead menu is a StartMenu(MenuDef_LordSelect) over a scenic BG (BG_DARKLING_WOODS)
+    -- BEFORE the battle map loads -- so the chief is NOT in the red array during it, and the
+    -- classifier sees it as a generic_menu (every enabled row carries an on_selected).
+    local route = { lord = "last" }
+    if not reachCh01(route) then return end
     shot("ch01lord-map")
+    -- The permanent flag is indexed off the row the route REPORTS committing on, not off
+    -- LORD_CANDIDATES: a constant that outlives a roster change asserts the wrong flag and
+    -- the scenario's whole premise goes unchecked.
+    if not eventFlag(LORDSEL_FLAG_BASE + route.picked) then
+        return result("FAIL", string.format(
+            "lord-choice permanent flag 0x%X (row %d) not set after confirm",
+            LORDSEL_FLAG_BASE + route.picked, route.picked))
+    end
     local lord = blue(CHAR_PINKY)
     if not lord or (lord.state & 0x9) ~= 0 or lord.x == 0xFF then
         return result("FAIL", "chosen lord (char 0x08) is not force-deployed")
@@ -3326,7 +3320,7 @@ scenarios.ch01lord = function()
     shot("ch01lord-no-gameover")
     log(string.format("debug: EVFLAG_GAMEOVER=%s lordflag=%s dead=%s",
         tostring(eventFlag(0x65)),
-        tostring(eventFlag(LORDSEL_FLAG_BASE + LORD_CANDIDATES - 1)),
+        tostring(eventFlag(LORDSEL_FLAG_BASE + route.picked)),
         tostring(isDead(blue(CHAR_PINKY)))))
     if isDead(blue(CHAR_PINKY)) then
         return result("FAIL", "chosen lord died but NO game over followed")
@@ -3768,32 +3762,18 @@ local CAST = {
 -- Built ONCE at 240fps into the "rbgch01" checkpoint (ckpt_rbgch01); recordrbg LOADS it
 -- so the slow prologue+lord-select grind isn't replayed every capture (#65).
 local function reachRbgCh01()
-    if not winCh00() then return false, "never won ch00" end
-    if not waitFor(function() return chapter() == 2 end, 1800) then
-        return false, "ch01 never started" end
-    local atMenu = false
-    for _ = 1, 200 do
-        if menuOpen() then atMenu = true break end
-        if procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.A, 4); wait(36)
-    end
-    if not atMenu then return false, "lord-select menu never opened" end
-    wait(40)
-    for _ = 1, 4 do press(K.DOWN, 4); wait(8) end  -- index 0 (Braulo) -> index 4 (RBG)
-    press(K.A, 4); wait(40)   -- pick
-    press(K.A, 4); wait(20)   -- [Yes]
-    for _ = 1, 80 do
-        if procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.A, 4); wait(36)
-    end
-    for i = 1, 40 do
-        if not procActive(SYM.gProcScr_SALLYCURSOR) then break end
-        press(K.B, 4); wait(10); press(K.START, 4); wait(40)
-        if i % 4 == 0 and procActive(SYM.gProcScr_SALLYCURSOR) then press(K.A, 4); wait(20) end
-    end
-    if not waitFor(function()
-        return not procActive(SYM.gProcScr_SALLYCURSOR) and faction() == 0 and turn() >= 1
-    end, 1200) then return false, "ch01 turn 1 never reached" end
+    -- The shared migrated route again (#238), taking RBG's row as the lead. This was the
+    -- fifth hand-rolled copy of the same save-menu/Northlook/lead-menu/prep walk; the blind
+    -- version could not tell an input that landed from one FE8 swallowed, and its four
+    -- literal DOWN presses assumed both the roster order and that the menu opened on row 0.
+    -- Function-scoped, not a new top-level `local`: harness.lua is AT Lua's 200-local
+    -- ceiling for the main chunk, and crossing it stops the whole file loading (#236).
+    local RBG_ROW = 4
+    local route = { lord = RBG_ROW }
+    if not reachCh01(route) then return false, "could not reach ch01 with RBG as the lead" end
+    if route.picked ~= RBG_ROW then
+        return false, string.format("lead committed on row %s, not RBG's row %d",
+            tostring(route.picked), RBG_ROW) end
     local rbg = blue(RBG_PID)
     if not rbg then return false, "RBG not on the field after lord-select" end
     return rbg
@@ -4279,18 +4259,34 @@ scenarios.recordunitlist = function()
     shot("unitlist-page1")
     local listC32, listC16 = dumpSmsBudget("with the unit list open")
 
-    -- Walk the roster. Each DOWN is one input with a real postcondition (the highlighted row or
-    -- the scroll offset must move); when neither moves we are at the end of the list, not stuck.
-    local proc = findProc(SYM.ProcScr_UnitListScreen_Field)
-    if not proc then return result("FAIL", "the unit list proc vanished after it started") end
-    local allies = ru8(proc + 0x3A)
+    -- Walk the roster on the classified Character screen (#238). Each DOWN is a guarded input
+    -- whose postcondition is the ROSTER index moving; arriving at the last entry is the one
+    -- case where it legitimately does not, so that is checked FIRST and ends the walk.
+    --
+    -- The old loop pressed DOWN blind and stopped when the on-screen row AND `proc+0x38` both
+    -- held. Neither is the roster position: sub_809144C moves unk_30 (+0x30), while unk_2c
+    -- (+0x2C) CLAMPS as the list scrolls beneath it, and +0x38 is not touched by the D-pad at
+    -- all. So the walk could stop a few rows in, capture a fraction of the roster, and still
+    -- report PASS -- a green light that did not mean what it said, which is the whole defect
+    -- #238 exists for.
+    if not awaitControllerState("unit_list_screen", 300) then
+        return result("FAIL", "the unit list never reached its key handler")
+    end
+    local listed = observeController().unit_list
     log(string.format("unit list: %d allies on the roster, %d visible rows per page",
-        allies, UNITLIST_ROWS))
+        listed.allies, UNITLIST_ROWS))
     local shots = 1
-    for _ = 1, allies + UNITLIST_ROWS do
-        local row, scroll = ru8(proc + 0x2C), ru8(proc + 0x38)
-        press(K.DOWN, 4); wait(10)
-        if ru8(proc + 0x2C) == row and ru8(proc + 0x38) == scroll then break end
+    for _ = 1, listed.allies + UNITLIST_ROWS do
+        local at = observeController()
+        if not at.unit_list then break end
+        local row = at.unit_list.row
+        if row >= listed.allies - 1 then break end        -- the end of the roster, not a stall
+        if not guardedInput("list_next", "DOWN", "the roster selection advances", function(after)
+            return after.unit_list ~= nil and after.unit_list.row ~= row
+        end, 60) then
+            return result("FAIL", string.format(
+                "the roster walk stalled on entry %d of %d", row, listed.allies))
+        end
         shots = shots + 1
         shot(string.format("unitlist-row%02d", shots))
     end
@@ -4810,15 +4806,22 @@ scenarios.ch03door = function()
     if not parked then return result("FAIL", "no free tile adjacent to the (2,3) door to park a unit") end
     log(string.format("parked opener at (%d,%d), adjacent to the door", parked[1], parked[2]))
     shot("ch03door-before")
-    -- Select (no move) -> command menu; Door is row 0. A picks Door, A confirms the sole target.
+    -- Select (no move) -> command menu, then resolve the live Door command (#238). This used
+    -- to press A on "Door (row 0)" and then a SECOND A to "confirm the door target" -- but
+    -- DoorCommandEffect (bmmenu.c) returns MENU_ACT_END: it sets gActionData and the menu is
+    -- gone, there is no target step. So the first press depended on Door happening to be the
+    -- top row, and the second went into whatever the map put up next.
     waitFor(function() return faction() == 0 and not menuOpen() end, 300, true)
     if not moveUnit(parked[1], parked[2], parked[1], parked[2]) then
         shot("ch03door-no-menu")
         return result("FAIL", "could not open the opener's command menu")
     end
     wait(20); shot("ch03door-menu")
-    press(K.A, 4); wait(30)   -- Door (row 0)
-    press(K.A, 4)             -- confirm the door target
+    if not selectSemantic("open_door", "the Door command closes the unit menu", function(after)
+        return after.menu == nil
+    end, 120) then
+        return result("FAIL", "the command menu offered no live Door command to the key-holder")
+    end
     local flipped = waitFor(function() return baseTile(DX, DY) == OPEN_T end, 400, true)
     wait(20); shot("ch03door-after")
     local post = baseTile(DX, DY)
@@ -4871,8 +4874,18 @@ scenarios.ch03chest = function()
         return result("FAIL", "could not open the opener's command menu on the chest tile")
     end
     wait(20); shot("ch03chest-menu")
-    press(K.A, 4); wait(40)   -- Chest (row 0); the open animation + item pop-up plays
-    for _ = 1, 8 do press(K.A, 3); wait(20) end   -- clear the "got Iron Lance" fanfare/textbox
+    -- Resolve the live Chest command instead of pressing an assumed row 0 (#238).
+    -- ChestCommandEffect returns MENU_ACT_END, so the postcondition is the menu going away;
+    -- the open animation and the "got Iron Lance" fanfare follow on their own. That fanfare
+    -- was being cleared by eight blind A's -- which is a text box, i.e. a CLASSIFIED
+    -- dialogue_wait, so the waitFor below already advances it through the guarded input and
+    -- stops the instant the tile flips. Eight unconditional presses could not tell the two
+    -- apart, and any that overran the box went into the map.
+    if not selectSemantic("open_chest", "the Chest command closes the unit menu", function(after)
+        return after.menu == nil
+    end, 120) then
+        return result("FAIL", "the command menu offered no live Chest command on the chest tile")
+    end
     local flipped = waitFor(function() return baseTile(CX, CY) == OPEN_T end, 400, true)
     wait(20); shot("ch03chest-after")
     local post = baseTile(CX, CY)
@@ -4939,7 +4952,17 @@ scenarios.ch03tourmaline = function()
         return result("FAIL", "could not open the command menu")
     end
     wait(20); shot("ch03tourmaline-cmdmenu")
-    press(K.A, 4); wait(40)            -- Item (row 0, no weapon) -> inventory list with icons
+    -- Resolve the live Item command (#238). The isolation trick above exists precisely
+    -- because the old blind A assumed Item sat at row 0 -- a neighbouring ally added Rescue
+    -- above it and the press opened the wrong submenu. Naming the command makes that an
+    -- observation rather than a staging assumption; the isolation stays, because the SHOT
+    -- wants a clean two-item menu.
+    if not selectSemantic("open_items", "the Item command opens the inventory list", function(after)
+        return controllerState(after) == "generic_menu"
+    end, 120) then
+        return result("FAIL", "the command menu offered no live Item command to the holder")
+    end
+    wait(20)
     shot("ch03tourmaline-inventory")   -- the money shot: Tourmaline (pink) above two pal-0 items
     -- Diagnostic for the custom-bank reservation: inventory remains over the battle map, so inspect
     -- every enabled BG tilemap's palette nibbles before selecting a dedicated icon bank.
@@ -5425,11 +5448,31 @@ scenarios.clear_ch02 = function()
     -- MNC2s straight into ch03, so we A-mash through it until chapter() == 4 (ch03), not the title.
     if routed and not advanced() then endTurn() end
     local reachedCh03 = false
-    for _ = 1, 1200 do
+    local watchEnding = INSPECT.watch("clear_ch02_ending")
+    for _ = 1, TUNE.bootSteps do
         snapCharms()
         if chapter() == CH03_CHAPTER then reachedCh03 = true; snapCharms(); break end
         if procActive(SYM.gProcScr_TitleScreen) then snapCharms(); break end  -- fallback: chain broken -> old landing
-        press(K.A, 2); wait(8)
+        -- Advance the ending on the CLASSIFIED dialogue wait rather than on an A cadence
+        -- (#238). The cadence pressed A every 10 frames whatever was on screen, so it could
+        -- not tell "this page is waiting for me" from "this input is being swallowed" -- and
+        -- a scene that wedged just ran the cap out and reported a timeout naming nothing.
+        -- The charm poll rides the postcondition closure, so the sampling stays as
+        -- fine-grained as the charm window (CHECK_ALIVE -> GIVEITEMTO) needs it.
+        local observation = observeController()
+        local state = controllerState(observation)
+        if watchEnding(observation, state) then
+            return result("FAIL", "the ch02 ending parked on an unclassified wait (see the snapshot)")
+        end
+        if state == "dialogue_wait" then
+            if not guardedInput("advance_dialogue", "A", "the ending's dialogue wait clears",
+                function(after)
+                    snapCharms()
+                    return controllerState(after) ~= "dialogue_wait"
+                end, 120) then break end
+        else
+            yield()
+        end
     end
     shot("clear-ch02-ending")
     log(string.format("charms delivered: %d/3; reached ch03=%s (chapter=%d)",
@@ -6412,8 +6455,19 @@ local function clearCh04(parley)
     for f = 1, 5400 do
         if f % 4 == 0 then shot(tag) end
         if won() then ended = true break end
-        if f % 90 == 0 then press(K.A, 3) end
-        yield()
+        -- Advance the ending only where FE8 is CLASSIFIED as waiting for it (#238). The
+        -- every-90-frames A this replaces was the "stray press on Press START" hazard the
+        -- comment above worries about, made structural: a cadence cannot see what is on
+        -- screen, so the guard against it was a frame count chosen to be slow enough. A
+        -- guarded input on dialogue_wait cannot fire on the title at all.
+        if controllerState() == "dialogue_wait" then
+            if not guardedInput("advance_dialogue", "A", "the ending's dialogue wait clears",
+                function(after) return controllerState(after) ~= "dialogue_wait" end, 120) then
+                break
+            end
+        else
+            yield()
+        end
     end
     log(string.format("%s: liveEnemies=%d chapter=%d (host=%d)",
         tag, #liveEnemies(), chapter(), HOST_CHAPTER))

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -373,6 +373,7 @@ local CALLBACK_NAMES = {
     [SYM.TargetSelection_Loop] = "target_selection_input",
     [SYM.BattleForecast_LoopDisplay] = "battle_forecast_display",
     [SYM.sub_8091AEC] = "unit_list_input",
+    [SYM.PrepItemSupply_Loop_GiveTakeKeyHandler] = "supply_input",
 }
 local PREP_CALLBACK_NAMES = {
     [SYM.PrepScreenMenu_OnStartPress] = "prep_main_fight",
@@ -556,7 +557,21 @@ local function observeController()
     put("at_menu", observedProc(SYM.ProcScr_AtMenu, "at_menu_idle"))
     put("prep_menu", observedProc(SYM.ProcScr_PrepMenu))
     put("sally", observedProc(SYM.gProcScr_SALLYCURSOR, "sally_idle"))
-    put("prep_units", observedProc(SYM.ProcScr_PrepUnitScreen))
+    local pickUnits = observedProc(SYM.ProcScr_PrepUnitScreen)
+    put("prep_units", pickUnits)
+    if pickUnits then
+        -- struct ProcPrepUnit (include/prepscreen.h). list_num_cur is where the cursor IS,
+        -- list_num_pre where it has settled -- ProcPrepUnit_Idle reads no keys at all while
+        -- they differ. count is the live roster length (gPrepUnitList.max_num, what
+        -- PrepGetUnitAmount returns), which is what bounds a RIGHT or DOWN off the end.
+        observation.prep_units = {
+            cursor = ru16(pickUnits.addr + 0x2E),
+            settled = ru16(pickUnits.addr + 0x2C) == ru16(pickUnits.addr + 0x2E),
+            deployed = ru8(pickUnits.addr + 0x29), cap = ru8(pickUnits.addr + 0x2A),
+            count = ru32(SYM.gPrepUnitList + 0x100),
+        }
+    end
+    put("supply_screen", observedProc(SYM.ProcScr_BmSupplyScreen))
     local unitList = observedProc(SYM.ProcScr_UnitListScreen_Field)
     put("unit_list", unitList)
     if unitList then
@@ -2759,41 +2774,78 @@ scenarios.recordsupply = function()
     if not loadState("lordpinky") then return result("FAIL", "no lordpinky checkpoint (run.sh builds it)") end
     wait(60)
     shot("supply")                                        -- prep main, Pinky as lord
-    press(K.A, 4); wait(60)                               -- enter Pick Units (single A from prep)
-    if not procActive(SYM.ProcScr_PrepUnitScreen) then
+    -- Enter Pick Units through the live prep command, not a bare A on the top row (#238).
+    if not awaitControllerState("prep_main", 600) then
+        shot("supply-no-prep"); return result("FAIL", "the prep main menu never took input") end
+    if not selectSemantic("pick_units", "the Pick Units deploy screen opens", function(after)
+        return after.procs.prep_units ~= nil
+    end, 300) then
         shot("supply-no-pickunits")
         return result("FAIL", "Pick Units screen never opened")
     end
+    if not awaitControllerState("prep_pick_units", 600) then
+        return result("FAIL", "the deploy list never reached its key handler") end
     shot("supply")
-    -- Pick Units 2-col list, cursor starts on Pinky (pos 0):
+    -- The deploy list is a TWO-COLUMN grid and the cursor starts on the lead (index 0):
     --   0 Pinky | 1 Braulo / 2 Marty | 3 Wolfram / 4 Mees | 5 RBG / 6 Rootis | 7 Sclorbo
-    -- Bench Braulo (pos 1): RIGHT to him, A only if he is currently deployed.
-    press(K.RIGHT, 4); wait(20)
-    if isDeployedInPrep(CHAR_BRAULO) then press(K.A, 4); wait(20) end
+    -- Bench Braulo (index 1): step RIGHT to him, then toggle only if he is deployed.
+    --
+    -- Every one of these moves used to be a blind press against that map of the roster. The
+    -- moves are now enumerated from the LIVE list -- the controller mirrors
+    -- ProcPrepUnit_Idle's own bounds -- so a RIGHT or DOWN that FE8 would refuse is not
+    -- offered at all, instead of silently leaving the cursor where it was and toggling
+    -- whoever happened to be under it.
+    local function pickStep(intention, key, where)
+        local at = observeController().prep_units
+        if not at then return false end
+        return guardedInput(intention, key, "the deploy cursor moves " .. where, function(after)
+            return after.prep_units ~= nil and after.prep_units.cursor ~= at.cursor
+        end, 60)
+    end
+    if not pickStep("pick_right", "RIGHT", "onto the second column") then
+        return result("FAIL", "could not step the deploy cursor onto Braulo's column") end
+    if isDeployedInPrep(CHAR_BRAULO) then
+        local before = countDeployedPrep()
+        if not guardedInput("toggle_deploy", "A", "Braulo leaves the deployed count", function()
+            return not isDeployedInPrep(CHAR_BRAULO) and countDeployedPrep() < before
+        end, 120) then return result("FAIL", "could not bench Braulo") end
+    end
     shot("supply")
-    -- Top up to 4 with non-Braulo units: walk down col 1 (RBG pos5, Sclorbo pos7) and
-    -- deploy benched ones until the cap is full. (Cursor is on Braulo/pos1.)
-    for _, downs in ipairs({2, 2}) do          -- pos1 -> pos5 (RBG); pos5 -> pos7 (Sclorbo)
+    -- Top up to 4 with non-Braulo units: walk down the second column (RBG at 5, Sclorbo at 7)
+    -- and deploy the benched ones until the cap is full.
+    for _ = 1, 2 do
         if countDeployedPrep() >= 4 then break end
-        for _ = 1, downs do press(K.DOWN, 4); wait(12) end
-        press(K.A, 4); wait(20)                -- deploy the (benched) unit here
+        for _ = 1, 2 do
+            if not pickStep("pick_next", "DOWN", "down a row") then
+                return result("FAIL", "could not walk the deploy list down a row") end
+        end
+        local before = countDeployedPrep()
+        if not guardedInput("toggle_deploy", "A", "the deployed count rises", function()
+            return countDeployedPrep() > before
+        end, 120) then return result("FAIL", "could not deploy the benched unit under the cursor") end
         shot("supply")
     end
     log(string.format("prep: brauloDeployed=%s deployedCount=%d",
         tostring(isDeployedInPrep(CHAR_BRAULO)), countDeployedPrep()))
-    -- Launch the chapter straight from Pick Units (START = Fight!).
-    press(K.START, 4); wait(40)
-    for i = 1, 30 do
-        if not procActive(SYM.gProcScr_SALLYCURSOR) and not procActive(SYM.ProcScr_PrepUnitScreen)
-           and faction() == 0 and turn() >= 1 then break end
-        press(K.A, 4); wait(30)
+    -- Launch straight from Pick Units. START is a legal action here only because someone is
+    -- deployed -- on an empty field FE8 just buzzes, and the old blind START could not tell
+    -- that apart from a launch, so it went on to A-mash at a screen that had not moved.
+    if not selectSemantic("fight", "Pick Units launches the chapter", function(after)
+        return after.procs.prep_units == nil
+    end, 600) then
+        shot("supply-no-launch")
+        return result("FAIL", "START did not launch the chapter from Pick Units")
+    end
+    if not awaitControllerState("player_map_idle", 900) then
+        shot("supply-no-map")
+        return result("FAIL", "never reached the player-phase map")
     end
     if not waitFor(function()
         return faction() == 0 and turn() >= 1
             and not procActive(SYM.gProcScr_SALLYCURSOR)
     end, 1200) then
         shot("supply-no-map")
-        return result("FAIL", "never reached the player-phase map")
+        return result("FAIL", "the map came up but turn 1 never began")
     end
     wait(120); shot("supply")                             -- the deployed field
     -- Map-side assertions: Braulo benched (not on field), Pinky deployed, exactly 4 out.
@@ -2817,15 +2869,27 @@ scenarios.recordsupply = function()
     pinky = blue(CHAR_PINKY_LORD)
     if moveUnit(pinky.x, pinky.y, pinky.x, pinky.y) then
         wait(40); shot("supply")                          -- Pinky's menu: Rescue/Item/Trade/Supply/Wait
-        -- Supply is row 3 (Rescue0 Item1 Trade2 Supply3 Wait4); cursor starts at row 0.
-        press(K.DOWN, 4); wait(12)
-        press(K.DOWN, 4); wait(12)
-        press(K.DOWN, 4); wait(12); shot("supply")        -- cursor on Supply
-        press(K.A, 4); wait(60)
-        usedSupply = procActive(SYM.ProcScr_BmSupplyScreen)
+        -- Resolve the live Supply command. Three blind DOWNs used to walk to "row 3 (Rescue0
+        -- Item1 Trade2 Supply3 Wait4)" -- a claim about which of Rescue and Trade happen to
+        -- be available, both of which depend on who is standing next to Pinky. Park an ally
+        -- beside her and the walk lands on Wait, the run opens no convoy, and the failure
+        -- reads as "Supply is broken" (#238).
+        usedSupply = selectSemantic("open_supply", "Supply opens the convoy screen", function(after)
+            return controllerState(after) == "supply_screen"
+        end, 300)
         shot("supply")                                    -- the convoy screen -> Pinky USING Supply
         log("pinky opened convoy=" .. tostring(usedSupply))
-        press(K.B, 4); wait(20); press(K.B, 4); wait(20)  -- back out of convoy + menu
+        if usedSupply then
+            -- Leave the convoy, then the unit menu, each on its own enumerated cancel. Two
+            -- blind B's could not tell those two levels apart: one too few left the run in
+            -- the convoy, one too many cancelled Pinky's move as well.
+            if not guardedInput("close_supply", "B", "the convoy screen closes", function(after)
+                return controllerState(after) ~= "supply_screen"
+            end, 300) then return result("FAIL", "could not leave the convoy screen") end
+            if not cancelToPlayerMap() then
+                return result("FAIL", "could not return to the map after the convoy")
+            end
+        end
     else
         shot("supply-no-menu")
     end
@@ -2834,8 +2898,20 @@ scenarios.recordsupply = function()
     for i = 0, 50 do
         local u = unitAt(SYM.gUnitArrayBlue, i)
         if u and u.charId ~= CHAR_PINKY_LORD and (u.state & 0x9) == 0 and u.x ~= 0xFF then
-            if moveUnit(u.x, u.y, u.x, u.y) then wait(40); shot("supply") end  -- no Supply row
-            press(K.B, 4); wait(20); press(K.B, 4); wait(20)
+            if moveUnit(u.x, u.y, u.x, u.y) then
+                wait(40); shot("supply")
+                -- The CONTRAST is the point of this half, so assert it rather than leaving
+                -- it to the screenshot: a non-lord's live command menu must offer no Supply
+                -- at all. The old code just backed out on two blind B's and asserted nothing.
+                if Controller.findAction(
+                    Controller.legalActions(observeController()), "open_supply") then
+                    return result("FAIL", string.format(
+                        "a non-lord (char 0x%02X) was offered the Supply command", u.charId))
+                end
+                if not cancelToPlayerMap() then
+                    return result("FAIL", "could not back out of the non-lord's command menu")
+                end
+            end
             break
         end
     end

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -579,11 +579,20 @@ local function observeController()
         -- the key handler moves; unk_2c is only where that lands on screen, and it clamps
         -- while the list scrolls under it. unk_29 != 0 means a scroll is animating and
         -- sub_809144C is not running, so no D-pad press would be read.
+        -- `count` is gUnknown_0200F158, the number of units the screen actually sorted, and
+        -- it is what sub_809144C bounds DOWN against. The proc's OWN allyCount (+0x3A) is
+        -- deliberately not used: StartUnitListScreenField writes only `mode`, so on the
+        -- map-menu list that field holds whatever was in the proc slot -- it read 0 in the
+        -- TESTCH sandbox, and a roster walk sized off it stops before it starts (#238).
         observation.unit_list = {
             row = ru8(unitList.addr + 0x30), screen_row = ru8(unitList.addr + 0x2C),
-            page = ru8(unitList.addr + 0x2F), allies = ru8(unitList.addr + 0x3A),
-            deployed = ru8(unitList.addr + 0x3B), scrolling = ru8(unitList.addr + 0x29) ~= 0,
+            page = ru8(unitList.addr + 0x2F), count = ru8(SYM.gUnknown_0200F158),
+            scrolling = ru8(unitList.addr + 0x29) ~= 0,
         }
+        -- allyCount (+0x3A) and deployedCount (+0x3B) are deliberately NOT observed. They are
+        -- written by StartUnitListScreenPrepMenu only, so on this list they are whatever the
+        -- proc slot held -- and an untrustworthy field in the observation is how the walk
+        -- above came to be sized off a roster of "0".
     end
     put("map_fade", observedProc(SYM.sProcScr_BMXFADE, "map_fade"))
     put("player_phase", observedProc(SYM.gProcScr_PlayerPhase))
@@ -4349,22 +4358,35 @@ scenarios.recordunitlist = function()
         return result("FAIL", "the unit list never reached its key handler")
     end
     local listed = observeController().unit_list
-    log(string.format("unit list: %d allies on the roster, %d visible rows per page",
-        listed.allies, UNITLIST_ROWS))
+    log(string.format("unit list: %d units sorted onto the roster, %d visible rows per page",
+        listed.count, UNITLIST_ROWS))
+    -- A roster the screen reports as empty means the count is not being read from where the
+    -- engine keeps it. Fail rather than "walk" a zero-length list and report a green capture
+    -- of one frame -- which is exactly what the old allyCount read did.
+    if listed.count < 1 then
+        return result("FAIL", "the Character screen reports an empty roster")
+    end
     local shots = 1
-    for _ = 1, listed.allies + UNITLIST_ROWS do
+    for _ = 1, listed.count do
         local at = observeController()
         if not at.unit_list then break end
         local row = at.unit_list.row
-        if row >= listed.allies - 1 then break end        -- the end of the roster, not a stall
+        if row >= listed.count - 1 then break end         -- the end of the roster, not a stall
         if not guardedInput("list_next", "DOWN", "the roster selection advances", function(after)
             return after.unit_list ~= nil and after.unit_list.row ~= row
         end, 60) then
             return result("FAIL", string.format(
-                "the roster walk stalled on entry %d of %d", row, listed.allies))
+                "the roster walk stalled on entry %d of %d", row, listed.count))
         end
         shots = shots + 1
         shot(string.format("unitlist-row%02d", shots))
+    end
+    -- The capture is only worth anything if the walk actually reached the last entry.
+    local ended = observeController().unit_list
+    if not (ended and ended.row == listed.count - 1) then
+        return result("FAIL", string.format(
+            "the roster walk stopped on entry %s of %d without reaching the end",
+            tostring(ended and ended.row), listed.count))
     end
     wait(20); shot("unitlist-end")
     dumpSmsBudget("after scrolling the whole roster")
@@ -4386,7 +4408,7 @@ scenarios.recordunitlist = function()
             listC32, listC16, mapC32, mapC16))
     end
     return result("PASS", string.format(
-        "unit list captured in %d frames; SMS budget held (32x=%d < 16x=%d, %d slots spare); "
+        "walked the whole %d-entry roster; SMS budget held (32x=%d < 16x=%d, %d slots spare); "
         .. "%d custom id(s) draw 32x32 into a 16px row pitch",
         shots, listC32, listC16, listC16 - listC32, #oversize))
 end

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -4879,13 +4879,16 @@ scenarios.ch03prep = function()
 end
 
 -- gBmMapBaseTiles (u16**): the metatile grid a chest/door tile-change writes (ApplyMapChangesById,
--- bmtrick.c). Unlike the gBmMap* grids, this variable lives in FE8's ROM .data (objdump: `g O ROM`
--- at 0x085AF5DC) -- it's never reassigned, holding a constant pointer to the sBmBaseTilesPool row-
--- pointer array in EWRAM. So: read the pointer from ROM, index the row array, read the tile. The
--- scenario asserts the closed door reads 812<<2 first, validating this chain before the flip check.
-local GBMMAPBASETILES_ADDR = 0x085AF5DC
+-- bmtrick.c). Unlike the other gBmMap* grids this one lives in FE8's ROM .data and is never
+-- reassigned, holding a constant pointer to the sBmBaseTilesPool row-pointer array in EWRAM.
+-- So: read the pointer from ROM, index the row array, read the tile.
+--
+-- The address comes from SYM, never a literal. It WAS a literal (0x085AF5DC), the engine grew
+-- out from under it, and that address came to hold 0x000004AB -- so ch03door and ch03chest
+-- failed on their PRECONDITION, before driving any input, and read for all the world like
+-- broken doors and chests. Nothing about the tile-change wiring was wrong (#238).
 local function baseTile(x, y)
-    local grid = ru32(GBMMAPBASETILES_ADDR)   -- u16** value = &sBmBaseTilesPool
+    local grid = ru32(SYM.gBmMapBaseTiles)   -- u16** value = &sBmBaseTilesPool
     return ru16(ru32(grid + y * 4) + x * 2)
 end
 
@@ -5015,11 +5018,22 @@ scenarios.ch03chest = function()
         return result("FAIL", "the command menu offered no live Chest command on the chest tile")
     end
     local flipped = waitFor(function() return baseTile(CX, CY) == OPEN_T end, 400, true)
+    -- The two halves of "the chest opened" do NOT land on the same frame: the tile flips
+    -- first, and the Iron Lance arrives at the end of the grant sequence with its own fanfare
+    -- in between. So WAIT for the loot rather than reading the inventory the instant the tile
+    -- moves -- that raced, and reported a chest that had in fact opened as one that granted
+    -- nothing. (tapA advances the "got Iron Lance" box through the guarded dialogue input;
+    -- the eight blind A's this replaces papered over the race by taking ~160 frames.)
+    -- Re-find the opener (its array index is stable; read items[0..4] for the loot).
+    local function hasLance()
+        for s = 0, 4 do
+            if (ru16(u.addr + 0x1E + s * 2) & 0xFF) == IRON_LANCE then return true end
+        end
+        return false
+    end
+    local got = waitFor(hasLance, 400, true)
     wait(20); shot("ch03chest-after")
     local post = baseTile(CX, CY)
-    -- Re-find the opener (its array index is stable; read items[0..4] for the loot).
-    local got = false
-    for s = 0, 4 do if (ru16(u.addr + 0x1E + s * 2) & 0xFF) == IRON_LANCE then got = true break end end
     log(string.format("chest (%d,%d) tile after = %d (want %d); iron-lance in inventory = %s",
         CX, CY, post, OPEN_T, tostring(got)))
     if not flipped then

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -593,6 +593,10 @@ local function observeController()
             page = ru8(unitList.addr + 0x2F), count = ru8(SYM.gUnknown_0200F158),
             scrolling = ru8(unitList.addr + 0x29) ~= 0,
         }
+        -- screen_row and page are not read by controller.lua. They are kept because every
+        -- observation is written into the trace record, so they are what a failed roster walk
+        -- is diagnosed FROM -- "row moved but screen_row clamped" is the whole story of the
+        -- bug this replaced. Unused-by-the-classifier is not unused.
         -- allyCount (+0x3A) and deployedCount (+0x3B) are deliberately NOT observed. They are
         -- written by StartUnitListScreenPrepMenu only, so on this list they are whatever the
         -- proc slot held -- and an untrustworthy field in the observation is how the walk
@@ -853,9 +857,16 @@ local function awaitControllerState(want, frames)
             -- cannot hide behind it, and the allowance is small so a genuinely stuck screen
             -- still fails closed. (A silent version of this is precisely what let five
             -- defects sit unnoticed behind the old blind cadence.)
-            local cancel = Controller.findAction(Controller.legalActions(last), "cancel_menu")
-                or Controller.findAction(Controller.legalActions(last), "cancel_target")
-                or Controller.findAction(Controller.legalActions(last), "cancel_selection")
+            -- Every enumerated way OUT of a screen, including the ones #238 named. Leaving
+            -- close_supply/close_list off this list would mean a run that wandered into the
+            -- convoy or the Character screen could not recover from it, even though the
+            -- controller offers the exit.
+            local legal = Controller.legalActions(last)
+            local cancel = Controller.findAction(legal, "cancel_menu")
+                or Controller.findAction(legal, "cancel_target")
+                or Controller.findAction(legal, "cancel_selection")
+                or Controller.findAction(legal, "close_supply")
+                or Controller.findAction(legal, "close_list")
             if cancel and recoveries < TUNE.stuckRecoveries then
                 recoveries = recoveries + 1
                 traceInput(last, Controller.legalActions(last), cancel.intention, cancel.key,
@@ -1732,7 +1743,11 @@ scenarios.goodberry = function()
     -- to guess. Note the Goodberry is GREYED at full HP (ItemSelectMenu_Usability returns
     -- MENU_DISABLED for an item that cannot be used) -- and still opens its submenu, because
     -- Menu_OnIdle's A path does not consult availability.
-    local before = observeController().menu.items[1].override_id
+    local open = observeController().menu
+    if not (open and open.items[1]) then
+        return result("FAIL", "the inventory list closed before the Goodberry could be opened")
+    end
+    local before = open.items[1].override_id
     if not guardedInput("select_item", "A", "the Goodberry's item submenu opens",
         function(after)
             return after.menu ~= nil and after.menu.items[1].override_id ~= before
@@ -1998,9 +2013,22 @@ local function cancelToPlayerMap()
                 function(after) return controllerState(after) == "player_map_idle" end, 120) then
                 return false
             end
-        elseif state == "unit_command_menu" or state == "weapon_menu" or state == "generic_menu" then
+        elseif state == "unit_command_menu" or state == "weapon_menu" or state == "generic_menu"
+            or state == "item_list" or state == "send_to_convoy" then
+            -- item_list and send_to_convoy USED to classify as generic_menu, so naming them
+            -- would have quietly cost this function the ability to back out of either -- and
+            -- this is the recovery path #238 put behind ch01win's post-seize "menu surprise".
+            -- A new classified screen has to teach the drivers about itself in the same
+            -- change, or it narrows what the harness can escape from.
             if not guardedInput("cancel_menu", "B", "live menu closes one semantic level",
                 function(after) return after.menu == nil or controllerState(after) ~= state end, 120) then
+                return false
+            end
+        elseif state == "supply_screen" or state == "unit_list_screen" then
+            -- Full-screen states with their own B intention rather than a MenuProc cancel.
+            local leave = state == "supply_screen" and "close_supply" or "close_list"
+            if not guardedInput(leave, "B", "the full-screen state closes",
+                function(after) return controllerState(after) ~= state end, 300) then
                 return false
             end
         elseif state == "transition" then
@@ -2822,8 +2850,14 @@ scenarios.recordsupply = function()
     local function pickStep(intention, key, where)
         local at = observeController().prep_units
         if not at then return false end
+        -- SETTLED, not merely moved: ProcPrepUnit_Idle reads no keys while the list scrolls,
+        -- so returning on the cursor alone leaves the next guarded input to race the scroll
+        -- and fail its own legality pre-check. That it works today rests on press() costing
+        -- more frames than a 16px scroll at scroll_val=4 -- which holding L (8) or a roster
+        -- long enough to make ShouldPrepUnitMenuScroll true would take away.
         return guardedInput(intention, key, "the deploy cursor moves " .. where, function(after)
             return after.prep_units ~= nil and after.prep_units.cursor ~= at.cursor
+                and after.prep_units.settled
         end, 60)
     end
     if not pickStep("pick_right", "RIGHT", "onto the second column") then
@@ -2941,8 +2975,18 @@ scenarios.recordsupply = function()
                 -- The CONTRAST is the point of this half, so assert it rather than leaving
                 -- it to the screenshot: a non-lord's live command menu must offer no Supply
                 -- at all. The old code just backed out on two blind B's and asserted nothing.
-                if Controller.findAction(
-                    Controller.legalActions(observeController()), "open_supply") then
+                -- Assert the STATE first. legalActions returns nil when classify finds no
+                -- state, and findAction(nil, ...) is nil -- so without this, a fade, a menu
+                -- that never opened, or any state we cannot name reads as "Supply correctly
+                -- absent" and the scenario passes. That is green-for-the-wrong-reason inside
+                -- the assertion added to stop green-for-the-wrong-reason.
+                local menu = observeController()
+                if controllerState(menu) ~= "unit_command_menu" then
+                    return result("FAIL", string.format(
+                        "expected a live command menu for char 0x%02X, got %s",
+                        u.charId, tostring(controllerState(menu))))
+                end
+                if Controller.findAction(Controller.legalActions(menu), "open_supply") then
                     return result("FAIL", string.format(
                         "char 0x%02X is neither the lead nor beside them, but was offered Supply",
                         u.charId))
@@ -4403,7 +4447,10 @@ scenarios.recordunitlist = function()
         local row = at.unit_list.row
         if row >= listed.count - 1 then break end         -- the end of the roster, not a stall
         if not guardedInput("list_next", "DOWN", "the roster selection advances", function(after)
+            -- Settled for the same reason as the deploy walk: sub_809144C reads no D-pad
+            -- while unk_29 says the rows are still scrolling under the cursor.
             return after.unit_list ~= nil and after.unit_list.row ~= row
+                and not after.unit_list.scrolling
         end, 60) then
             return result("FAIL", string.format(
                 "the roster walk stalled on entry %d of %d", row, listed.count))
@@ -5623,11 +5670,14 @@ scenarios.clear_ch02 = function()
                 return after.menu == nil or controllerState(after) ~= "send_to_convoy"
             end, 300) then break end
         else
-            local advanced = advanceBootState(observation, state)
-            if advanced == false then break end
+            -- Named `drove`, not `advanced`: this scope already has an advanced() predicate
+            -- for "the chapter moved on", and shadowing it with a boolean would make a later
+            -- `if advanced() then` read as the check it looks like while calling a boolean.
+            local drove = advanceBootState(observation, state)
+            if drove == false then break end
             -- nil = a state it has no input for (the map is up mid-scene). Wait it out; the
             -- step budget and the stall watch above bound this, never a tight spin.
-            if advanced == nil then yield() end
+            if drove == nil then yield() end
         end
     end
     shot("clear-ch02-ending")
@@ -6607,6 +6657,11 @@ local function clearCh04(parley)
     -- the end -- a stray press on "Press START" starts a spurious New Game (the clear_ch03
     -- lesson), and the run then films ch04's OPENING under the ending's name. So stop pressing
     -- the moment the title is up, and stop the loop with it. Shoot densely: motion is the point.
+    -- NOTE: `f` counts ITERATIONS, not frames. It did before too, but every iteration was one
+    -- yield, so the two matched; an iteration can now carry a whole guarded input. The cap and
+    -- the screenshot cadence are therefore both looser than they read. That is fine for a
+    -- bounded recording -- won() is what ends this, never the cap -- but do not read 5400 as
+    -- a frame budget (#238).
     local ended = false
     for f = 1, 5400 do
         if f % 4 == 0 then shot(tag) end

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -228,8 +228,13 @@ check(a and a.target, 2, "Item resolves from semantic id 0x67")
 a = action(fieldMenu, "open_supply")
 check(a and a.target, 3, "Supply resolves from semantic id 0x69")
 
--- Availability is read, never assumed: a locked door with no key is drawn but disabled, and
--- a driver that pressed its row anyway would sit on a command the engine ignores.
+-- Availability is read, never assumed. This pins a DELIBERATELY conservative choice rather
+-- than an engine behaviour: addMenuCommand filters on enabledMenuItems, so a MENU_DISABLED row
+-- is never offered as a command -- even though Menu_OnIdle would in fact fire its onSelected
+-- (it never consults availability; see the inventory list below, which relies on exactly that).
+-- No unit command actually greys today: DoorCommandUsability and its neighbours return only
+-- MENU_ENABLED or MENU_NOTSHOWN, and a NOTSHOWN row is not built at all (uimenu.c). So this
+-- guards the day one of them starts greying, and the fixture is synthetic on purpose.
 local shutMenu = {
     procs = proc("menu", "menu_input"),
     menu = {
@@ -289,6 +294,25 @@ local sendToConvoy = {
     },
 }
 classify(sendToConvoy, "send_to_convoy", "the inventory-full convoy chooser is its own state")
+
+-- ConvoyMenuProc_StarMenu has TWO arms off one call site: gSendToConvoyMenuItems (0x2A-0x2F)
+-- when the convoy has room, gConvoyMenuItems (0x24-0x29) when it is FULL. Both block the same
+-- way, so classifying only the first leaves the identical hang one branch over -- and it would
+-- not even trip the stall watch, which arms on UNCLASSIFIED transitions and this would read as
+-- a tidy generic_menu.
+local convoyFull = {
+    procs = { menu = { idle = "menu_input" }, std_event = { idle = "event_engine" } },
+    menu = {
+        current = 0,
+        items = {
+            { slot = 0, override_id = 0x24, availability = 1, on_selected = "0x08022B00" },
+            { slot = 5, override_id = 0x29, availability = 1, on_selected = "0x08022B40" },
+        },
+    },
+}
+classify(convoyFull, "send_to_convoy", "...and so is the convoy-FULL arm of the same call site")
+a = action(convoyFull, "send_item")
+check(a and a.key, "A", "which blocks the chapter identically and so is answered identically")
 a = action(sendToConvoy, "send_item")
 check(a and a.key, "A", "A sends the highlighted item to the convoy")
 check(a and a.target, 0, "...the HIGHLIGHTED one, not an assumed row")
@@ -315,10 +339,28 @@ local unitList = {
 classify(unitList, "unit_list_screen", "the Character screen outranks the map underneath it")
 check(action(unitList, "list_next") ~= nil, true, "the roster can be walked forward")
 check(action(unitList, "cursor_down"), nil, "and the map cursor is NOT offered while it is up")
-a = action(unitList, "list_previous")
-check(a and a.key, "UP", "...and backward")
 a = action(unitList, "close_list")
 check(a and a.key, "B", "B leaves the Character screen (sub_809144C)")
+
+-- The walk is bounded at BOTH ends, from the same field sub_809144C bounds against. UP at
+-- row 0 is not a no-op: it sets unk_29 = 3, which routes sub_8091AEC into sub_80917D8, the
+-- sort-column mode -- a persistent input state the observer reports as `scrolling`, i.e. as a
+-- transition offering nothing. Advertising UP there hands the driver an action that walks it
+-- into a screen it has no enumerated way out of, and it burns its budget until the stall
+-- watch fires on a wait the controller itself caused.
+check(action(unitList, "list_previous"), nil, "UP at row 0 is NOT offered -- it opens sort mode")
+local midList = {
+    procs = { unit_list = { idle = "unit_list_input" } },
+    unit_list = { row = 4, screen_row = 4, page = 0, count = 9, scrolling = false },
+}
+a = action(midList, "list_previous")
+check(a and a.key, "UP", "...but it is offered anywhere the row can actually move up")
+local lastList = {
+    procs = { unit_list = { idle = "unit_list_input" } },
+    unit_list = { row = 8, screen_row = 5, page = 0, count = 9, scrolling = false },
+}
+check(action(lastList, "list_next"), nil,
+    "and DOWN is not offered on the last entry (unk_30 < count-1 is the engine's own bound)")
 
 -- unk_29 != 0 is the page/row scroll animating, and its key handler does not run then. FE8
 -- DROPS input in that window, so calling it an input state is how a press goes missing.

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -112,7 +112,62 @@ local prepView = {
 }
 classify(prepView, "prep_map_menu", "View Map preparations menu is distinct")
 check(action(prepView, "fight"), nil, "controller never exits prep through View Map")
-classify({ procs = proc("prep_units", "prep_units_input") }, "prep_pick_units", "Pick Units screen")
+-- The Pick Units deploy screen. Its legal moves are exactly the bounds ProcPrepUnit_Idle
+-- enforces on a TWO-COLUMN list (prep_unitselect.c): LEFT only from an odd index, RIGHT only
+-- from an even one that is not the last, and UP/DOWN by two. A scenario that pressed RIGHT or
+-- DOWN off the end of that grid moved nothing and then acted on whoever it was still sitting
+-- on -- which is how a bench/deploy walk can pick the wrong unit and stay green (#238).
+local pickUnits = {
+    procs = proc("prep_units", "prep_units_input"),
+    prep_units = { cursor = 0, settled = true, deployed = 1, count = 8 },
+}
+classify(pickUnits, "prep_pick_units", "Pick Units screen")
+a = action(pickUnits, "pick_right")
+check(a and a.key, "RIGHT", "an even index can cross to the second column")
+check(action(pickUnits, "pick_left"), nil, "...but the first column has nothing to its left")
+check(action(pickUnits, "pick_previous"), nil, "and the top row has nothing above it")
+a = action(pickUnits, "pick_next")
+check(a and a.key, "DOWN", "the row below is two indices on")
+a = action(pickUnits, "toggle_deploy")
+check(a and a.key, "A", "A benches or deploys whoever the cursor holds")
+a = action(pickUnits, "fight")
+check(a and a.key, "START", "START launches once at least one unit is deployed")
+
+local lastPick = {
+    procs = proc("prep_units", "prep_units_input"),
+    prep_units = { cursor = 7, settled = true, deployed = 4, count = 8 },
+}
+check(action(lastPick, "pick_right"), nil, "the last entry has nothing to its right")
+check(action(lastPick, "pick_next"), nil, "...and nothing below it")
+a = action(lastPick, "pick_left")
+check(a and a.key, "LEFT", "but an odd index can always step back a column")
+
+local emptyPick = {
+    procs = proc("prep_units", "prep_units_input"),
+    prep_units = { cursor = 0, settled = true, deployed = 0, count = 8 },
+}
+check(action(emptyPick, "fight"), nil, "START does not launch with an empty field")
+
+-- The whole key handler is gated on list_num_pre == list_num_cur: while the list scrolls to a
+-- new row FE8 reads no keys at all, so a press sent then is lost outright.
+local scrollingPick = {
+    procs = proc("prep_units", "prep_units_input"),
+    prep_units = { cursor = 4, settled = false, deployed = 2, count = 8 },
+}
+classify(scrollingPick, "transition", "a scrolling deploy list takes no input")
+check(action(scrollingPick, "toggle_deploy"), nil, "and offers none")
+
+-- The in-map convoy, opened by the unit menu's Supply command. Only ever entered to look and
+-- leave, so B is the whole contract -- but it has to be a NAMED state, because two blind B's
+-- into an unclassified screen cannot tell "the convoy closed" from "the second B also
+-- cancelled the unit's move".
+local supply = {
+    procs = { supply_screen = { idle = "supply_input" }, player_phase = { idle = "player_main_idle" } },
+}
+classify(supply, "supply_screen", "the map convoy outranks the map underneath it")
+a = action(supply, "close_supply")
+check(a and a.key, "B", "B leaves the convoy (PrepItemSupply_Loop_GiveTakeKeyHandler)")
+check(action(supply, "cursor_down"), nil, "and the map cursor is not offered while it is up")
 
 -- Standard menus expose semantic command IDs and enabled availability, never guessed rows.
 local unitMenu = {

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -268,7 +268,7 @@ check(action(itemList, "menu_next") ~= nil, true, "and the list can be walked to
 local unitList = {
     procs = { player_phase = { idle = "player_main_idle" },
               unit_list = { idle = "unit_list_input" } },
-    unit_list = { row = 0, screen_row = 0, page = 0, allies = 9, scrolling = false },
+    unit_list = { row = 0, screen_row = 0, page = 0, count = 9, scrolling = false },
 }
 classify(unitList, "unit_list_screen", "the Character screen outranks the map underneath it")
 check(action(unitList, "list_next") ~= nil, true, "the roster can be walked forward")
@@ -282,7 +282,7 @@ check(a and a.key, "B", "B leaves the Character screen (sub_809144C)")
 -- DROPS input in that window, so calling it an input state is how a press goes missing.
 local scrollingList = {
     procs = { unit_list = { idle = "unit_list_input" } },
-    unit_list = { row = 3, screen_row = 1, page = 0, allies = 9, scrolling = true },
+    unit_list = { row = 3, screen_row = 1, page = 0, count = 9, scrolling = true },
 }
 classify(scrollingList, "transition", "a scrolling Character screen takes no input")
 check(action(scrollingList, "list_next"), nil, "and offers none")

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -144,6 +144,94 @@ a = action(unitMenu, "cancel_menu")
 check(a and a.key, "B", "standard menu cancellation comes from its live B callback")
 check(a and a.source, "menu.on_b=0x0804F000", "menu cancel records the live callback")
 
+-- The rest of gUnitActionMenuItems that our scenarios actually drive (menu_def.c). Each was
+-- being reached by pressing A on an assumed ROW -- "Door (row 0)", "Chest (row 0)", "Item
+-- (row 0, no weapon)" -- which is only true while the command's neighbours happen to be
+-- unavailable. Naming them makes the row an observation instead of an assumption (#238).
+local fieldMenu = {
+    procs = proc("menu", "menu_input"),
+    menu = {
+        current = 0,
+        items = {
+            { slot = 0, override_id = 0x5D, availability = 1 },  -- Chest
+            { slot = 1, override_id = 0x5E, availability = 1 },  -- Door
+            { slot = 2, override_id = 0x67, availability = 1 },  -- Item
+            { slot = 3, override_id = 0x69, availability = 1 },  -- Supply
+            { slot = 4, override_id = 0x6B, availability = 1 },  -- Wait
+        },
+    },
+}
+classify(fieldMenu, "unit_command_menu", "Chest/Door/Item/Supply are unit commands")
+a = action(fieldMenu, "open_chest")
+check(a and a.target, 0, "Chest resolves from semantic id 0x5D")
+check(a and a.key, "A", "the highlighted command carries its key")
+a = action(fieldMenu, "open_door")
+check(a and a.target, 1, "Door resolves from semantic id 0x5E")
+check(a and a.key, nil, "a command that is not highlighted must be selected first")
+a = action(fieldMenu, "open_items")
+check(a and a.target, 2, "Item resolves from semantic id 0x67")
+a = action(fieldMenu, "open_supply")
+check(a and a.target, 3, "Supply resolves from semantic id 0x69")
+
+-- Availability is read, never assumed: a locked door with no key is drawn but disabled, and
+-- a driver that pressed its row anyway would sit on a command the engine ignores.
+local shutMenu = {
+    procs = proc("menu", "menu_input"),
+    menu = {
+        current = 0,
+        items = {
+            { slot = 0, override_id = 0x5E, availability = 2 },  -- Door, greyed out
+            { slot = 1, override_id = 0x6B, availability = 1 },
+        },
+    },
+}
+check(action(shutMenu, "open_door"), nil, "a disabled Door is not a legal action")
+
+-- The item LIST and its Use/Equip/Trade/Discard submenu carry no command ids at all
+-- (gItemMenuItems / gItemSubMenuItems, override 0x38+/0x34+), so they land on the generic
+-- rule -- which is exactly right: the row is chosen by scenario policy, and the controller
+-- only certifies that the highlighted row has a live on_selected callback to fire.
+local itemList = {
+    procs = proc("menu", "menu_input"),
+    menu = {
+        current = 1,
+        items = {
+            { slot = 0, override_id = 0x38, availability = 1, on_selected = "0x08016A00" },
+            { slot = 1, override_id = 0x39, availability = 1, on_selected = "0x08016A40" },
+        },
+    },
+}
+classify(itemList, "generic_menu", "the inventory list is a generic callback menu")
+a = action(itemList, "select_current_menu_item")
+check(a and a.target, 1, "the inventory list commits the HIGHLIGHTED row, never an assumed one")
+check(action(itemList, "menu_next") ~= nil, true, "and the list can be walked to another row")
+
+-- The map-menu Character screen (ProcScr_UnitListScreen_Field). It is not a MenuProc at all
+-- -- it owns the whole screen and runs its own key handler -- so before it was named, a
+-- scenario walking the roster pressed DOWN into a state the controller could not see, and
+-- the player_phase rule underneath was calling the same frames `player_map_idle` (#238).
+local unitList = {
+    procs = { player_phase = { idle = "player_main_idle" },
+              unit_list = { idle = "unit_list_input" } },
+    unit_list = { row = 0, screen_row = 0, page = 0, allies = 9, scrolling = false },
+}
+classify(unitList, "unit_list_screen", "the Character screen outranks the map underneath it")
+check(action(unitList, "list_next") ~= nil, true, "the roster can be walked forward")
+check(action(unitList, "cursor_down"), nil, "and the map cursor is NOT offered while it is up")
+a = action(unitList, "list_previous")
+check(a and a.key, "UP", "...and backward")
+a = action(unitList, "close_list")
+check(a and a.key, "B", "B leaves the Character screen (sub_809144C)")
+
+-- unk_29 != 0 is the page/row scroll animating, and its key handler does not run then. FE8
+-- DROPS input in that window, so calling it an input state is how a press goes missing.
+local scrollingList = {
+    procs = { unit_list = { idle = "unit_list_input" } },
+    unit_list = { row = 3, screen_row = 1, page = 0, allies = 9, scrolling = true },
+}
+classify(scrollingList, "transition", "a scrolling Character screen takes no input")
+check(action(scrollingList, "list_next"), nil, "and offers none")
+
 local lockedMenu = {
     procs = { menu = { idle = "menu_input", locked = true, frozen = false } },
     menu = unitMenu.menu,

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -242,24 +242,66 @@ local shutMenu = {
 }
 check(action(shutMenu, "open_door"), nil, "a disabled Door is not a legal action")
 
--- The item LIST and its Use/Equip/Trade/Discard submenu carry no command ids at all
--- (gItemMenuItems / gItemSubMenuItems, override 0x38+/0x34+), so they land on the generic
--- rule -- which is exactly right: the row is chosen by scenario policy, and the controller
--- only certifies that the highlighted row has a live on_selected callback to fire.
+-- The inventory list a unit's Item command opens (gItemSelectMenuItems, override 0x43-0x47).
+-- It needs its own state because MENU_DISABLED means something different here than it does
+-- on a command menu: ItemSelectMenu_Usability greys any item the unit cannot USE -- a weapon,
+-- a healing item at full HP -- but Menu_OnIdle's A path calls onSelected WITHOUT consulting
+-- availability, and ItemSelectMenu_Effect opens the Use/Equip/Trade/Discard submenu
+-- unconditionally. A greyed row is still a live row. Reading it as a command menu instead
+-- reported "unsupported standard menu has no recognized semantic commands" the moment every
+-- item happened to be unusable, which is Hlin's whole inventory at ch00 turn 1 (#238).
 local itemList = {
     procs = proc("menu", "menu_input"),
     menu = {
         current = 1,
+        on_b = "0x0802291C",
         items = {
-            { slot = 0, override_id = 0x38, availability = 1, on_selected = "0x08016A00" },
-            { slot = 1, override_id = 0x39, availability = 1, on_selected = "0x08016A40" },
+            { slot = 0, override_id = 0x43, availability = 2, on_selected = "0x080234E4" },
+            { slot = 1, override_id = 0x44, availability = 2, on_selected = "0x080234E4" },
         },
     },
 }
-classify(itemList, "generic_menu", "the inventory list is a generic callback menu")
-a = action(itemList, "select_current_menu_item")
-check(a and a.target, 1, "the inventory list commits the HIGHLIGHTED row, never an assumed one")
+classify(itemList, "item_list", "an inventory of unusable items is still an inventory")
+a = action(itemList, "select_item")
+check(a and a.target, 1, "the inventory commits the HIGHLIGHTED row, never an assumed one")
+check(a and a.key, "A", "a greyed row is selectable -- grey means unusable, not unreachable")
 check(action(itemList, "menu_next") ~= nil, true, "and the list can be walked to another row")
+a = action(itemList, "cancel_menu")
+check(a and a.key, "B", "B backs out of the inventory")
+
+-- FE8's "your inventory is full -- which item goes to the convoy" chooser
+-- (gSendToConvoyMenuItems, override 0x2A-0x2F; raised by ConvoyMenuProc_StarMenu whenever a
+-- unit is handed an item with no free slot). It is a MenuProc with no semantic command on it,
+-- so it fell through to generic_menu -- and a driver waiting for a scene to finish would sit
+-- behind it forever, because nothing advances until it is answered. The ch02 ending's third
+-- charm-gift raises exactly this, which is why clear_ch02's blind A-mash was load-bearing:
+-- the run's "3/3 charms delivered" verdict depended on a stray press resolving a prompt the
+-- scenario never knew was there (#238).
+local sendToConvoy = {
+    procs = { menu = { idle = "menu_input" }, std_event = { idle = "event_engine" } },
+    menu = {
+        current = 0,
+        items = {
+            { slot = 0, override_id = 0x2A, availability = 1, on_selected = "0x08022BEC" },
+            { slot = 1, override_id = 0x2B, availability = 1, on_selected = "0x08022BEC" },
+            { slot = 5, override_id = 0x2F, availability = 1, on_selected = "0x08022C40" },
+        },
+    },
+}
+classify(sendToConvoy, "send_to_convoy", "the inventory-full convoy chooser is its own state")
+a = action(sendToConvoy, "send_item")
+check(a and a.key, "A", "A sends the highlighted item to the convoy")
+check(a and a.target, 0, "...the HIGHLIGHTED one, not an assumed row")
+check(action(sendToConvoy, "menu_next") ~= nil, true, "and another slot can be chosen first")
+
+local usableItems = {
+    procs = proc("menu", "menu_input"),
+    menu = {
+        current = 0,
+        items = { { slot = 0, override_id = 0x43, availability = 1, on_selected = "0x080234E4" } },
+    },
+}
+classify(usableItems, "item_list", "...and so is an inventory of usable ones")
 
 -- The map-menu Character screen (ProcScr_UnitListScreen_Field). It is not a MenuProc at all
 -- -- it owns the whole screen and runs its own key handler -- so before it was named, a


### PR DESCRIPTION
Finishes #238: every `kind: verdict` scenario now drives the UI on observed state, and a build gate keeps it that way.

## The scope in the issue was wrong in both directions

The issue's list (and the HANDOFF note built from it) came from counting `press(` between `scenarios.X = function` markers. That charges every intervening `local function` helper to whichever scenario happens to sit above it. Re-counted by **enclosing function**:

- **`retreat` was already clean** — 0 presses of its own. The 13 charged to it belong to `shootCombatFrames`, `captureAttack` and `reachRbgCh01`, which sit between it and the next scenario.
- **`reachRbgCh01` was missed** — 8 presses, a *fifth* hand-rolled copy of the ch01 lead route.
- The two `LORD_CANDIDATES` walks the note flagged are in `recordlord`/`recordlordfast`, both `kind: record` and explicitly out of scope.

## What landed

**One route, not five.** `lordfloor`, `ch01lord` and `reachRbgCh01` were separate blind-A copies of the ch01 save-menu → Northlook → lead-menu → Preparations walk. They ride `reachCh01` now: `opts.lord` takes a row index, the walk stops when the **live** cursor arrives rather than after a fixed press count (FE8 menus wrap, so a fixed count silently picks a different lead and passes anyway), and the route reports back the row it committed on — so `ch01lord` asserts its permanent flag against what it *did*, not against the `LORD_CANDIDATES` constant.

**Newly classified**, by the four-edit recipe: unit commands Chest `0x5D` / Door `0x5E` / Item `0x67` / Supply `0x69`; the inventory list (`gItemSelectMenuItems`); the send-to-convoy chooser (`gSendToConvoyMenuItems`); the map-menu Character screen; the Pick Units deploy grid; and the in-map convoy.

Two ordering rules came with them. The Character screen and the convoy sit **above `player_phase`** — the map is still in the proc pool underneath, and `player_map_idle` would offer cursor moves that go nowhere. And each screen reports a **transition while its own scroll animates**: FE8's key handler doesn't run in that window, so an input sent then is lost outright.

**`check.py check_verdict_scenarios_are_guarded`** makes the rule a gate. Scopes from `matrix.yaml`'s `kind` (never the name — `recordsupply` and `recordunitlist` are verdict scenarios despite the prefix) and follows the call graph. Four exceptions are named with reasons in `BLIND_PRESS_ALLOWED`; the load-bearing one is `fuzzDrive`, where guarding the input would confine the fuzzer to states the controller already calls legal.

## Defects this surfaced

Running the scenarios — not reading them — found four things worth more than the cleanup:

1. **`clear_ch02`'s A-mash was answering a prompt the scenario never knew existed.** The ch02 ending's third charm-gift lands on a full inventory, so FE8 raises `gSendToConvoyMenuItems` and the whole `MNC2` chain stops until it's answered. The mash resolved it by accident; without naming it the run sits behind it for its entire budget and reports "2/3 charms" on a chapter that never left slot 3. That green had been resting on a stray press.
2. **`recordunitlist` was walking 6 of 11 roster entries and passing.** It sized the walk off the proc's `allyCount`, which only `StartUnitListScreenPrepMenu` writes — the map-menu list leaves it holding whatever was in the proc slot (it reads 0). The real bound is `gUnknown_0200F158`, what `sub_809144C` itself checks DOWN against.
3. **`ch03door` pressed A twice** — "Door", then "confirm the door target". `DoorCommandEffect` returns `MENU_ACT_END`; there is no target step, so the second press went into whatever came next.
4. **`recordsupply`'s non-lord half asserted nothing.** It opened a menu, screenshotted and backed out. The contrast is the whole point of that half.

And one correction to my own work: my first contrast assertion said "a non-lord has no Supply row", copying the scenario's comment. `SupplyUsability` returns `MENU_ENABLED` for the lead **or** anyone `IsAdjacentForSupply` finds orthogonally beside them — the assertion caught the comment, not a defect.

Also fixed: `cancelToPlayerMap` looped eight times *total*, counting transition frames, so the convoy's fade-out made the cap decide the failure — the trap `decisions.md` already records from #232. It counts cancels now, with a separate `TUNE.cancelFrames` ceiling.

## Verification

- `make matrix` **14/14** (6m11s)
- `make test` 41/41 · `make check` clean · `git diff --check` clean
- controller suite 209 → **244** assertions
- Individually in-engine: `recordsupply`, `goodberry`, `ch01lord`, `clear_ch02`, `ch03tourmaline`, `recordunitlist` all PASS

**Bite tests** (the issue's acceptance criterion), both confirmed to FAIL where they had passed:
- `unit_list` classified as a bare transition — as if the screen had never been named → `the unit list never reached its key handler`, `fail:state-timeout`. The old code consulted no classification here at all, so this sabotage could not have touched it.
- the lead-menu walk stopped one row short → `lead menu walk landed on row 0 of 8, not row 1`.

The guard itself was sabotage-verified in both shapes: a press in `ch03door`'s own body, and one hidden in `cancelToPlayerMap` (correctly reported against `ch01win` and `recordsupply`).

## Not in scope, and not mine

`ch03door`, `ch03chest`, `ch03win`, `clear_ch03` and `clear_ch01` fail on this branch — and fail **identically on `main`'s harness against the same ROM**, which I checked rather than assumed. `ch03door`/`ch03chest` die on a `gBmMapBaseTiles` read before any input; the other three time out in the untouched `chooseAttack`. Pre-existing, outside #238, left alone. Worth their own issue.

Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
