### PR TITLE
guard: a retile inherits vanilla's gift PLACEMENT, not just its terrain (#25)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -132,6 +132,18 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
    - Lord-death loss is always `CauseGameOverIfLordDies` (fires on `EVFLAG_GAMEOVER`, set by the
      lord's flagged defeat quote / the `_inject_lord_select_engine` hook).
 
+7b. **Location events (villages, shops, chests, doors)** — anything the player *visits* lives in the
+   host slot's `Location` list. **Leaving that list empty makes every reward on the map
+   unobtainable while the map still draws it** — that is how ch04 shipped an unreachable Iron Axe,
+   and ch05 currently has four reliquary villages plus an armory and a vendor sitting on intact
+   tiles that nothing points at. Two guards, both cheap:
+   - `assert_village_tiles_visitable` — FE8 offers Visit only on house/inn/village terrain
+     (`bmmenu.c`), so a `Village()` on scenery is a reward that silently does not exist.
+   - `assert_village_gifts_match_vanilla` — on a retile, **which gift sits on which tile is
+     vanilla's** (`decisions.md` → "A retile inherits vanilla's GIFT PLACEMENT"). Swapping two
+     keeps the item set, the total and the parity verdict identical while inverting which site is
+     worth defending. Deliberate moves declare `vanilla_gift_divergence: <why>` on the village.
+
 8. **Title + names** — `set_message_body(lines, host['chapTitleTextId'], name_message_body(title))`;
    rename any vanilla boss slot's nameplate (`vanilla_name_text_id`) so it doesn't leak; compose the
    title-card image with `_write_chapter_title_card` (add `graphics/chap_title/chap_title_N.png` to

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3781,6 +3781,26 @@ session state. `HANDOFF.md` points here._
 &page=The%20Empire%27s%20Reach&prop=wikitext&format=json&formatversion=2"
   ```
 
+### A retile inherits vanilla's GIFT PLACEMENT, not just its terrain (2026-08-07, #25)
+
+**Which gift sits on which tile is vanilla's decision**, gated by
+`assert_village_gifts_match_vanilla` for any chapter whose `map:` names a `vanilla_layout:`.
+Deliberate divergence is one key on the village — `vanilla_gift_divergence: <why>` — and the error
+message names it. **The default is inheritance because exceptions are rarer than re-deriving four
+placements every time** (Nicolas, 2026-08-07); a from-scratch canvas is skipped, and so is a site
+vanilla does not have (one we added rather than moved).
+
+It earns a gate because nothing else can see it. Swap two gifts and the item set, the economy total
+and the parity verdict are all unchanged — `difficulty.py` counts the SET, not the tiles — so
+`make difficulty` still reads PARITY while the chapter's risk/reward is inverted. ch05 shipped that
+way: `(12,19)` is the south-east site and the turn-2 eruption pair spawns at `(14,16)/(14,15)` beside
+it, so vanilla puts its richest gift (Dracoshield, 8000g) on the site the first raiders reach and its
+cheapest (Torch, 500g) at `(5,1)`, behind the whole enemy line. We had them swapped, paying the most
+for the safest errand in a chapter whose structure *is* the race for the reward-sites.
+
+Sibling of `validate_terrain_matches_vanilla` (a retile inherits vanilla's terrain), one layer up:
+the rewards standing on that terrain.
+
 ### Campaign rosters live in campaign-named symbols (2026-08-07, #25)
 
 **A chapter's unit tables are ours and are named `MS_ChNN*`** (`declare_unit_table`), appended to

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -7693,6 +7693,84 @@ def assert_village_tiles_visitable(chap, maps_dir, stem):
                      % (village['id'], x, y, terrain[y][x]))
 
 
+def vanilla_village_gifts(layout, eventinfo=None, eventscript=None):
+    """{(x, y): ITEM_ enum} -- what vanilla hands out at each village on `layout`'s chapter.
+
+    Read from HEAD, like every other vanilla fact. The tile comes from the Location list's
+    `Village(flag, script, x, y)` entries; the ITEM is a RAW id inside that script's
+    `SVAL(EVT_SLOT_3, <id>)`, which is why it is easy to have and never look at.
+    """
+    stem = re.sub(r'Map$', '', layout).lower()          # Ch5Map -> ch5
+    if eventinfo is None:
+        eventinfo = _vanilla_decomp_text_at_head('src/events/%s-eventinfo.h' % stem)
+    if eventscript is None:
+        eventscript = _vanilla_decomp_text_at_head('src/events/%s-eventscript.h' % stem)
+    by_id = {int(v, 16): n for n, v in re.findall(
+        r'(ITEM_\w+)\s*=\s*(0x[0-9A-Fa-f]+)',
+        _vanilla_decomp_text_at_head('include/constants/items.h'))}
+    gifts = {}
+    for script, x, y in re.findall(
+            r'Village\(\s*[^,]+,\s*(\w+),\s*(\d+),\s*(\d+)\s*\)', eventinfo):
+        body = eventscript.split('EventListScr %s[] = {' % script, 1)
+        if len(body) < 2:
+            continue                                    # script lives elsewhere; nothing to read
+        match = re.search(r'SVAL\(EVT_SLOT_3,\s*(0x[0-9A-Fa-f]+|\d+)\)', body[1].split('};', 1)[0])
+        if match:
+            gifts[(int(x), int(y))] = by_id.get(int(match.group(1), 0))
+    return gifts
+
+
+def assert_village_gifts_match_vanilla(chap, item_ids, gifts=None):
+    """Guard (#25): on a RETILE, which gift sits on which tile is vanilla's decision.
+
+    A retile inherits vanilla's terrain (`validate_terrain_matches_vanilla`); this is the same
+    rule one layer up, for the rewards standing on that terrain. It is worth a gate because the
+    failure is invisible to every other one: swap two gifts and the item set is identical, the
+    economy total is identical, and `difficulty.py` counts the SET, not the tiles -- so the
+    parity read still says PARITY while the chapter's risk/reward is inverted.
+
+    That is exactly what ch05 shipped. `(12,19)` is the south-east site and the turn-2 eruption
+    pair spawns at `(14,16)/(14,15)`, right beside it: vanilla puts its RICHEST gift there
+    (Dracoshield, 8000g) and its cheapest at `(5,1)` (Torch, 500g), which sits behind the whole
+    enemy line. Ours had them swapped, paying the most for the safest errand in a chapter whose
+    structure IS the race for the reward-sites.
+
+    Deliberate divergence stays cheap -- a village may carry `vanilla_gift_divergence: <why>` and
+    is then skipped by name. The default is inheritance because exceptions are rarer than
+    re-deriving four placements every time (Nicolas, 2026-08-07).
+
+    Only runs for a chapter whose `map:` block names a `vanilla_layout:`; a from-scratch canvas
+    has no vanilla to inherit from.
+    """
+    layout = (chap.get('map') or {}).get('vanilla_layout')
+    if not layout:
+        return
+    if gifts is None:
+        gifts = vanilla_village_gifts(layout)
+    for village in chap.get('villages', []):
+        why = village.get('vanilla_gift_divergence')
+        if why:
+            continue
+        tile = tuple(village['tile'])
+        want = gifts.get(tile)
+        if want is None:
+            continue        # vanilla has no village on that tile -- a site we ADDED, not moved
+        reward = (village.get('visit_reward') or [{}])[0].get('id')
+        got = item_ids.get(reward)
+        if got is None:
+            sys.exit('ERROR: village %r gives %r, which is not in this chapter\'s item map -- '
+                     'add it to CHNN_ITEM_IDS so the gift can be checked and injected'
+                     % (village['id'], reward))
+        if got != want:
+            sys.exit(
+                'ERROR: village %r at (%d, %d) gives %s, but vanilla %s hands out %s there. On a '
+                'retile the gift PLACEMENT is vanilla\'s -- swapping two gifts keeps the item set '
+                'and the economy total identical (so the parity read still says PARITY) while '
+                'inverting which site is worth defending. If the move is deliberate, say so with '
+                '`vanilla_gift_divergence: <why>` on that village.'
+                % (village['id'], tile[0], tile[1], got, layout, want))
+
+
 def _is_blank_metatile(tileset, metatile):
     """True if a metatile is a single flat colour -- i.e. DECLARED in the terrain table but never
     painted. snowy-bern has one of these on TERRAIN_BRIDGE_SNAG, and writing it into a map change
@@ -8700,6 +8778,10 @@ def inject_ch04(campaign, boot=False, verbose=True):
     # list is what made ch04's Iron Axe unobtainable -- and the map's door tile had ALSO lost its
     # village terrain in the reskin, so both halves had to come back.
     assert_village_tiles_visitable(chap, maps_dir, CH04_LAYOUT[1])
+    # No-op today -- ch04's forest is a from-scratch canvas, so its `map:` block names no
+    # `vanilla_layout:` and there is no vanilla gift placement to inherit. Wired anyway so the
+    # rule travels with the chapter rather than with whoever remembers it (#25).
+    assert_village_gifts_match_vanilla(chap, CH04_ITEM_IDS)
     info = _replace_brace_block(info, 'EventListScr_Ch5_Location[] =',
                                 ch04_location_events(chap), CH5_EVENTINFO_H)
     # Tile flips (#214): the snag falls into a crossing (the Iron Axe's whole purpose) and each
@@ -8963,6 +9045,11 @@ def inject_ch05(campaign, boot=False, verbose=True):
     """
     maps_dir = os.path.join(REPO, 'campaigns', campaign, 'maps')
     chap = _load_chapter_yaml(campaign, CH05_CHAPTER_YAML)
+    # A retile inherits vanilla's gift PLACEMENT, not just its terrain. Runs before anything is
+    # written: the failure it catches is invisible to the parity read (same items, same total,
+    # different tiles), so it has to be a gate rather than a review note.
+    assert_village_gifts_match_vanilla(chap, CH05_ITEM_IDS)
+    assert_village_tiles_visitable(chap, maps_dir, CH05_LAYOUT[1])
 
     # 1. Map: register the port-or-town-winter tileset (ch05 is its first user, so it
     #    self-registers -- the Cave/inject_ch03 idiom) and the painted layout, then point

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -2555,3 +2555,73 @@ class EventGroupRosterPointer(unittest.TestCase):
                 self.skipTest('host slot not injected in this tree')
         bc.assert_event_group_roster(bc.CH05_EVENTINFO_H, bc.CH05_EVENT_GROUP,
                                      bc.CH05_ALLY_TABLE)
+
+
+class VillageGiftsInheritVanilla(unittest.TestCase):
+    """On a retile, WHICH gift sits on WHICH tile is vanilla's decision.
+
+    Worth a gate because the failure is invisible to every other one: swap two gifts and the
+    item set, the economy total and the parity verdict are all unchanged, while the chapter's
+    risk/reward inverts. ch05 shipped with booster-def and torch swapped -- the richest gift
+    ended up on the safest site, and the cheapest on the one the turn-2 raiders reach first."""
+
+    INFO = ('CONST_DATA EventListScr EventListScr_Ch5_Location[] = {\n'
+            '    Armory(ShopList_Event_Ch5Armory, 2, 1)\n'
+            '    Village(EVFLAG_TMP(8),  EventScr_A, 12, 10)\n'
+            '    Village(EVFLAG_TMP(9),  EventScr_B, 12, 19)\n'
+            '    END_MAIN\n};\n')
+    SCRIPT = ('CONST_DATA EventListScr EventScr_A[] = {\n'
+              '    SVAL(EVT_SLOT_3, 0xe)\n    GIVEITEMTO(CHAR_EVT_ACTIVE_UNIT)\n};\n'
+              'CONST_DATA EventListScr EventScr_B[] = {\n'
+              '    SVAL(EVT_SLOT_3, 0x60)\n    GIVEITEMTO(CHAR_EVT_ACTIVE_UNIT)\n};\n')
+    ITEMS = {'armorslayer': 'ITEM_SWORD_ARMORSLAYER', 'booster-def': 'ITEM_BOOSTER_DEF',
+             'torch': 'ITEM_TORCH'}
+
+    def _gifts(self):
+        return bc.vanilla_village_gifts('Ch5Map', self.INFO, self.SCRIPT)
+
+    def _chap(self, tile, gift):
+        return {'map': {'vanilla_layout': 'Ch5Map'},
+                'villages': [{'id': 'v', 'tile': list(tile),
+                              'visit_reward': [{'id': gift, 'amount': 1}]}]}
+
+    def test_it_reads_the_gift_out_of_the_village_script(self):
+        # the tile is in the Location list, the ITEM is a raw id inside the script it names --
+        # which is why it is easy to have the data and never actually look at it
+        self.assertEqual(self._gifts(),
+                         {(12, 10): 'ITEM_SWORD_ARMORSLAYER', (12, 19): 'ITEM_BOOSTER_DEF'})
+
+    def test_a_matching_gift_passes(self):
+        bc.assert_village_gifts_match_vanilla(
+            self._chap((12, 19), 'booster-def'), self.ITEMS, self._gifts())
+
+    def test_a_swapped_gift_is_refused(self):
+        with self.assertRaises(SystemExit) as caught:
+            bc.assert_village_gifts_match_vanilla(
+                self._chap((12, 19), 'torch'), self.ITEMS, self._gifts())
+        self.assertIn('vanilla_gift_divergence', str(caught.exception),
+                      'the error must name the escape hatch')
+
+    def test_a_declared_divergence_is_allowed(self):
+        chap = self._chap((12, 19), 'torch')
+        chap['villages'][0]['vanilla_gift_divergence'] = 'the tomb has no armoury tier yet'
+        bc.assert_village_gifts_match_vanilla(chap, self.ITEMS, self._gifts())
+
+    def test_a_site_vanilla_does_not_have_is_left_alone(self):
+        # a village we ADDED, not moved -- nothing to inherit
+        bc.assert_village_gifts_match_vanilla(
+            self._chap((3, 3), 'torch'), self.ITEMS, self._gifts())
+
+    def test_a_from_scratch_canvas_is_skipped(self):
+        chap = self._chap((12, 19), 'torch')
+        chap['map'] = {}                      # no vanilla_layout -> no vanilla to inherit
+        bc.assert_village_gifts_match_vanilla(chap, self.ITEMS, self._gifts())
+
+    def test_an_unmapped_reward_id_is_refused(self):
+        with self.assertRaises(SystemExit):
+            bc.assert_village_gifts_match_vanilla(
+                self._chap((12, 19), 'nonesuch'), self.ITEMS, self._gifts())
+
+    def test_the_live_ch05_villages_inherit_vanilla(self):
+        chap = bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.CH05_CHAPTER_YAML)
+        bc.assert_village_gifts_match_vanilla(chap, bc.CH05_ITEM_IDS)


### PR DESCRIPTION
Makes "a retile inherits vanilla's gift placement" a build gate, instead of a thing someone has to remember. Sibling of `validate_terrain_matches_vanilla`, one layer up: the rewards standing on that terrain.

## Why it needs a gate

Nothing else can see this failure. Swap two gifts and the item set, the economy total and the parity verdict are **all unchanged** — `difficulty.py` counts the SET, not the tiles — so `make difficulty CH=ch05` happily reads `PARITY` while the chapter's risk/reward is inverted.

That is how ch05 shipped. `(12,19)` is the south-east site and the turn-2 eruption pair spawns at `(14,16)/(14,15)`, right beside it. Vanilla puts its **richest** gift there (Dracoshield, 8000g) and its cheapest at `(5,1)`, which sits behind the whole enemy line and is the safest tile on the map. Ours had them swapped — paying the most for the safest errand, in a chapter whose entire structure is the race for the reward-sites.

## The rule

Default is inheritance; exceptions are one key on the village:

```yaml
- id: reliquary-south
  tile: [12, 19]
  vanilla_gift_divergence: "the tomb has no armoury tier yet"
  visit_reward:
    - id: torch
```

and the error message names that key, so the escape hatch is discoverable at the moment you need it. Skipped for a from-scratch canvas (no `vanilla_layout:` to inherit from) and for a site vanilla does not have — one we *added* rather than moved.

Wired into `inject_ch04` as well, where it is a no-op today (its forest is from-scratch), so the rule travels with the chapter rather than with whoever remembers it.

## Also

`docs/adding-a-chapter.md` had **no step for Location events at all** — which is the gap behind both this and ch04's unobtainable Iron Axe. Added one, covering villages/shops/chests/doors and both guards. ch05's own `Location` list is still empty and its four villages plus the armory `(2,1)` and vendor `(6,10)` remain unreachable; that is tracked on #25 and blocked on `visit_text`.

## Verification

- The guard **passes** on ch05 as it now stands and **bites on the exact original swap** (asserted in the tests, not just by hand)
- 8 new tests · `make test` exit 0 · `make check` = `drift check: clean`
- Runs inside the real `--ch05-boot` injection
- submodule pointer not staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
