### PR TITLE
ch05: wire the reliquaries and the elven store, borrowing vanilla's prose (#25)

### DIFF
--- a/docs/adding-a-chapter.md
+++ b/docs/adding-a-chapter.md
@@ -144,6 +144,14 @@ geometry regardless of which slot hosts it (ch03 repaints vanilla Ch3 "Borgo" bu
      keeps the item set, the total and the parity verdict identical while inverting which site is
      worth defending. Deliberate moves declare `vanilla_gift_divergence: <why>` on the village.
 
+   **Do not wait for the dialogue pass to wire this.** Point the visits at the vanilla message ids
+   that already hold the host-chapter's village lines and do NOT write them — the ROM keeps
+   vanilla's prose, the ids stay unclaimed, and the dialogue pass later writes our body at the same
+   id. The give-item half is real wiring, not a placeholder, and shops need no script or text at
+   all. Build with `location_events(villages, slots, shops)` + `village_script`, and declare one
+   `MS_ChNNVisit*` per site with `declare_event_script` — **after** the block-replacement pass, or
+   the appends are discarded (`assert_event_scripts_defined` pins it).
+
 8. **Title + names** — `set_message_body(lines, host['chapTitleTextId'], name_message_body(title))`;
    rename any vanilla boss slot's nameplate (`vanilla_name_text_id`) so it doesn't leak; compose the
    title-card image with `_write_chapter_title_card` (add `graphics/chap_title/chap_title_N.png` to

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3801,6 +3801,38 @@ for the safest errand in a chapter whose structure *is* the race for the reward-
 Sibling of `validate_terrain_matches_vanilla` (a retile inherits vanilla's terrain), one layer up:
 the rewards standing on that terrain.
 
+### Vanilla prose is a legitimate PLACEHOLDER; vanilla wiring is not (2026-08-07, #25)
+
+**A chapter is wired end-to-end first, and only its PROSE waits for the dialogue pass** (Nicolas).
+ch05's four reliquary visits point at vanilla Ch5's own message ids (`0x9CD`–`0x9D0`) and we never
+*write* them, so the ROM keeps vanilla's text, the ids stay unclaimed in
+`HOSTED_CHAPTER_MESSAGE_IDS`, and the dialogue pass later writes our body **at the same id** — one
+line per site, not a rewire. ch05's authored dialogue skips that range exactly (`0x9BE`–`0x9CC`,
+then `0x9D5`), so nothing collides.
+
+What is *not* placeholder is everything else, and that is the point: the `SVAL(EVT_SLOT_3, <item>)`
++ `GIVEITEMTO` half is the real wiring, already gated by `assert_village_gifts_match_vanilla`, so
+the rewards are obtainable and correct now rather than twice. **Shops are not placeholders at all**
+— `Armory`/`Vendor` take their stock directly and run no script and show no text, so listing the
+tile finishes them.
+
+The alternative — leaving the `Location` list empty until the prose lands — is what shipped ch04's
+unreachable Iron Axe and left ch05 with four villages, an armory and a vendor sitting on intact
+tiles that nothing pointed at. A finished-looking map with unobtainable rewards is the failure
+mode; borrowed prose is not.
+
+### Campaign-owned EVENT SCRIPTS, same as tables (2026-08-07, #25)
+
+`declare_event_script` is the script twin of `declare_unit_table`, for the same reason: a host slot
+frees only the scripts its stripped cutscenes stop referencing (slot 6 leaves five; ch05 needs
+three waves plus one per village), and `MS_Ch05VisitSouth` says what it runs where
+`EventScr_089F2AE4` says nothing.
+
+**It APPENDS, so it must run AFTER the injector's block-replacement pass**, which rewrites the same
+file wholesale from a copy read earlier. Declaring first silently discards every appended script —
+the Location list still names them and the externs still exist, so the only symptom is a link error
+pointing at the reference rather than at the loss. `assert_event_scripts_defined` pins the ordering.
+
 ### Campaign rosters live in campaign-named symbols (2026-08-07, #25)
 
 **A chapter's unit tables are ours and are named `MS_ChNN*`** (`declare_unit_table`), appended to

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5748,6 +5748,69 @@ def assert_event_group_roster(info_path, group, symbol):
                      % (group, field, match.group(1), symbol))
 
 
+def declare_event_script(path, symbol, body, comment):
+    """DEFINE a campaign-owned EventListScr in `path` (a chN-eventscript.h), and return its symbol.
+
+    The script twin of declare_unit_table, for the same reason and with the same payoff. A host
+    slot frees only the scripts its stripped cutscenes stop referencing -- slot 6 leaves five, and
+    ch05 needs three reinforcement waves plus one per village, which is more than it has. Naming
+    our own removes the budget entirely, and `MS_Ch05Village2` says what it runs where
+    `EventScr_089F2AE4` says nothing at all.
+    """
+    with open(path, encoding='utf-8') as f:
+        script = f.read()
+    if ('EventListScr %s[]' % symbol) in script:
+        sys.exit('ERROR: event script %s is already defined this build -- two injectors are '
+                 'claiming one symbol name' % symbol)
+    _assert_ms_symbol(symbol)
+    with open(path, 'a', encoding='utf-8') as f:
+        f.write('\n/* %s */\nCONST_DATA EventListScr %s[] = %s;\n' % (comment, symbol, body))
+    with open(EVENTCALL_H, encoding='utf-8') as f:
+        header = f.read()
+    with open(EVENTCALL_H, 'w', encoding='utf-8') as f:
+        f.write(event_script_extern(header, symbol, comment))
+    return symbol
+
+
+def assert_event_scripts_defined(path, symbols):
+    """Fail the BUILD if a declared event script is missing from `path`.
+
+    `declare_event_script` APPENDS, while the injectors' block-replacements rewrite the same file
+    wholesale from a copy read earlier -- so declaring before the bulk write silently discards
+    every appended script. The Location list still names them and the externs still exist, so the
+    only symptom is a link error pointing at the reference rather than at the loss. Cheap to
+    assert, and it pins the ordering against a future reshuffle of the injector.
+    """
+    with open(path, encoding='utf-8') as f:
+        script = f.read()
+    missing = [s for s in symbols if ('EventListScr %s[]' % s) not in script]
+    if missing:
+        sys.exit('ERROR: %s declared but not defined in %s -- declare_event_script APPENDS, so it '
+                 'must run AFTER the block-replacement pass rewrites the file, never before'
+                 % (', '.join(missing), os.path.basename(path)))
+
+
+# Anchored on the first EventListScr extern, like the UnitDefinition block above it.
+_SCRIPT_EXTERN_ANCHOR = 'extern CONST_DATA EventListScr EventScr_9EEA58[];'
+
+
+def event_script_extern(header, symbol, comment):
+    """Pure: `header` (eventcall.h) with an extern for event script `symbol`. Idempotent.
+
+    The Location list that names these lives in a DIFFERENT file from their definitions, so
+    without the declaration agbcc sees an implicit int and the build dies a long way from here.
+    """
+    _assert_ms_symbol(symbol)
+    decl = 'extern CONST_DATA EventListScr %s[];' % symbol
+    if decl in header:
+        return header
+    if _SCRIPT_EXTERN_ANCHOR not in header:
+        sys.exit('ERROR: eventcall.h has no EventListScr extern block to extend (looked for %r)'
+                 % _SCRIPT_EXTERN_ANCHOR)
+    return header.replace(_SCRIPT_EXTERN_ANCHOR,
+                          '%s\n%s /* %s */' % (_SCRIPT_EXTERN_ANCHOR, decl, comment), 1)
+
+
 def unit_table_definition(udefs, symbol, rows, comment):
     """Pure: `udefs` with a campaign-owned UnitDefinition table appended.
 
@@ -7422,6 +7485,29 @@ CH05_LINE_TABLE = 'MS_Ch05Line'                  # the 16 turn-1 tomb-guardians
 CH05_SAHNAR_TABLE = 'MS_Ch05Sahnar'              # the turn-2 convertible (rises hostile)
 CH05_WAVE_TABLES = {2: 'MS_Ch05Wave2', 3: 'MS_Ch05Wave3', 5: 'MS_Ch05Wave5'}
 
+# The four reliquary visits. Each rides OUR OWN script (declare_event_script) but shows VANILLA
+# Ch5's own village line, by pointing at the message id that already holds it -- we never WRITE
+# 0x9CD..0x9D0, so the ROM keeps vanilla's text verbatim and the id stays unclaimed
+# (HOSTED_CHAPTER_MESSAGE_IDS). ch05's authored dialogue skips this range exactly (it runs
+# 0x9BE..0x9CC then jumps to 0x9D5), so nothing collides.
+#
+# TEMPORARY, and only the PROSE is (Nicolas, 2026-08-07): the give-item half is the real wiring
+# and is already gated by assert_village_gifts_match_vanilla, so the rewards are obtainable and
+# correct now. The dialogue pass replaces each body AT THE SAME ID -- one line per site, not a
+# rewire -- and claims the ids in HOSTED_CHAPTER_MESSAGE_IDS when it does.
+CH05_VILLAGE_SLOTS = {
+    'reliquary-east':  ('MS_Ch05VisitEast',  0x9CD),   # vanilla's (12,10) line
+    'reliquary-south': ('MS_Ch05VisitSouth', 0x9CE),   # vanilla's (12,19) line
+    'reliquary-west':  ('MS_Ch05VisitWest',  0x9CF),   # vanilla's (5,6) line
+    'reliquary-north': ('MS_Ch05VisitNorth', 0x9D0),   # vanilla's (5,1) line
+}
+CH05_VISIT_BG = 'BG_HOUSE'          # vanilla's own village interior, as its village scripts use
+# The elven store (`economy.elven_store`). Armory/Vendor take their stock DIRECTLY -- no script,
+# no text -- so these are wired PERMANENTLY, not as placeholders. Stock is vanilla Ch5's own,
+# which is what `make difficulty CH=ch05` prices the shop tier against.
+CH05_SHOPS = (('Armory', 'ShopList_Event_Ch5Armory', 2, 1),
+              ('Vendor', 'ShopList_Event_Ch5Vendor', 6, 10))
+
 CH05_LAYOUT = ('Ch05ElvenTombMap', 'ch05-the-elven-tomb')   # (asset label, maps/ stem)
 CH05_CHAPTER_YAML = 'ch05-the-elven-tomb.yaml'
 CH05_TILESET = 'port-or-town-winter'             # stem 'PortTown'; ch05 is the first chapter to
@@ -7601,7 +7687,7 @@ def convert_survivors_green(pids, label_base, what):
         for i, pid in enumerate(pids))
 
 
-def ch04_village_script(msg, item, bg):
+def village_script(msg, item, bg):
     """A village visit, in vanilla Ch4's own shape (EventScr_089F1BD8): one text box over the
     village BG, then the reward into the visitor's hands.
 
@@ -7627,10 +7713,21 @@ def ch04_village_script(msg, item, bg):
             '    ENDA\n}' % (bg, msg, give))
 
 
-def village_reward_item(village):
-    """The FE item a village hands over, or None when its reward is the line alone."""
+def village_reward_id(village):
+    """The YAML id of what a village hands over, or None when its reward is the line alone."""
     reward = village.get('visit_reward')
-    return CH04_ITEM_IDS[reward[0]['id']] if reward else None
+    return reward[0]['id'] if reward else None
+
+
+def village_reward_item(village, item_ids):
+    """The FE item enum a village hands over, or None when its reward is the line alone.
+
+    `item_ids` is the CHAPTER's id->enum map. It used to close over CH04_ITEM_IDS, which made a
+    shared helper silently ch04-only: ch05's gifts (the two stat boosters) are not in that dict,
+    so the first chapter to reuse it would have died on a KeyError naming ch04.
+    """
+    reward = village_reward_id(village)
+    return item_ids[reward] if reward else None
 
 
 def village_boxes(village):
@@ -7652,19 +7749,36 @@ def village_boxes(village):
     return [' '.join(box.split()) for box in text]
 
 
-def ch04_location_events(chap):
-    """ch04's Location list: one `Village` per authored village, at the tile the chapter YAML
-    names, each running its OWN script (CH04_VILLAGE_SLOTS) -- two doors sharing one script show
-    the same line at both. Vanilla Ch4 wires two and so do we (#24).
+def location_events(villages, village_slots, shops=()):
+    """The host slot's Location list: everything the player can VISIT.
+
+    One `Village` per authored village, at the tile the chapter YAML names, each running its OWN
+    script (`village_slots[id]`) -- two doors sharing one script show the same line at both.
 
     `Village(eid, scr, x, y)` expands to VILL + a LOCA on the tile ABOVE (EAstdlib), which is how
     FE8 lets a unit standing north of the door trigger it -- so the door tile is the anchor, not
-    the whole building."""
-    return ('{\n' + ''.join(
+    the whole building.
+
+    `shops` are `(macro, shoplist_symbol, x, y)` -- `Armory`/`Vendor` take their stock DIRECTLY
+    and run no script and show no text, so a shop is fully wired the moment its tile is listed.
+
+    **An empty Location list makes every reward on the map unobtainable while the map still draws
+    it.** That is how ch04 shipped an unreachable Iron Axe (#205), and it is why this returns a
+    list built from the YAML rather than something a chapter has to remember to fill in.
+    """
+    rows = ''.join(
         '    Village(0, %s, %d, %d) /* %s -- %s */\n'
-        % (CH04_VILLAGE_SLOTS[v['id']][0], v['tile'][0], v['tile'][1], v['id'],
-           village_reward_item(v) or 'the line is the reward')
-        for v in chap.get('villages', [])) + '    END_MAIN\n}')
+        % (village_slots[v['id']], v['tile'][0], v['tile'][1], v['id'],
+           village_reward_id(v) or 'the line is the reward')
+        for v in villages)
+    rows += ''.join('    %s(%s, %d, %d)\n' % shop for shop in shops)
+    return '{\n' + rows + '    END_MAIN\n}'
+
+
+def ch04_location_events(chap):
+    """ch04's Location list. Vanilla Ch4 wires two villages and so do we (#24); no shops."""
+    return location_events(chap.get('villages', []),
+                           {vid: slot[0] for vid, slot in CH04_VILLAGE_SLOTS.items()})
 
 
 def assert_village_tiles_visitable(chap, maps_dir, stem):
@@ -8875,7 +8989,8 @@ def inject_ch04(campaign, boot=False, verbose=True):
         symbol, msg, _fid, bg = CH04_VILLAGE_SLOTS[village['id']]
         script = _replace_brace_block(
             script, symbol + '[] =',
-            ch04_village_script(msg, village_reward_item(village), bg), CH5_EVENTSCRIPT_H)
+            village_script(msg, village_reward_item(village, CH04_ITEM_IDS), bg),
+            CH5_EVENTSCRIPT_H)
     # The moose-flees beat (Stage 4): fired by the Misc AREA when a unit reaches the tomb-side
     # clearing. Loads the moose, holds on it, RBG's one line, then it bolts NE and is gone.
     script = _replace_brace_block(
@@ -9132,11 +9247,14 @@ def inject_ch05(campaign, boot=False, verbose=True):
         info, CH05_EVENT_LISTS['misc'] + '[] =',
         '{\n    DefeatBoss(%s)\n    CauseGameOverIfLordDies\n    END_MAIN\n}'
         % CH05_ENDING_SCRIPT, CH05_EVENTINFO_H)
-    # The four reliquary visits are authored but their visit_text is still owed (#25), so the
-    # Location list stays empty for now. Blanking it is what made ch04's Iron Axe unobtainable,
-    # so this is a KNOWN gap tracked on the issue, not an oversight -- the village TILES are
-    # intact on the map either way (assert_village_tiles_visitable has something true to check).
-    for key in ('character', 'location', 'select_unit', 'select_dest', 'unit_move', 'tutorial'):
+    # Location = the four reliquary visits + the elven store. The shops are wired for good (a
+    # shop needs no script and no text); the visits borrow vanilla's prose and own their rewards.
+    info = _replace_brace_block(
+        info, CH05_EVENT_LISTS['location'] + '[] =',
+        location_events(chap.get('villages', []),
+                        {vid: slot[0] for vid, slot in CH05_VILLAGE_SLOTS.items()},
+                        CH05_SHOPS), CH05_EVENTINFO_H)
+    for key in ('character', 'select_unit', 'select_dest', 'unit_move', 'tutorial'):
         info = _replace_brace_block(info, CH05_EVENT_LISTS[key] + '[] =',
                                     '{\n    END_MAIN\n}', CH05_EVENTINFO_H)
     # Point the group at OUR roster table. Declaring it is not enough -- the engine reads the
@@ -9187,6 +9305,25 @@ def inject_ch05(campaign, boot=False, verbose=True):
         CH05_EVENTSCRIPT_H)
     with open(CH05_EVENTSCRIPT_H, 'w', encoding='utf-8') as f:
         f.write(script)
+
+    # 4b. The four reliquary visits, one script each so a site can get its own line later without
+    #     disturbing the others. Vanilla's own village shape (village_script, shared with ch04):
+    #     one text box over the interior BG, then the gift into the visitor's hands.
+    #
+    #     AFTER the bulk write, and that ordering is load-bearing: declare_event_script APPENDS to
+    #     this file, while the block-replacement above rewrites it wholesale from a copy read
+    #     earlier. Declaring first silently discards every appended script -- the Location list
+    #     still names them, the externs still exist, and the build dies at link time pointing at
+    #     the reference rather than the loss. assert_event_scripts_defined catches the reorder.
+    for village in chap.get('villages', []):
+        symbol, msg = CH05_VILLAGE_SLOTS[village['id']]
+        declare_event_script(
+            CH05_EVENTSCRIPT_H, symbol,
+            village_script(msg, village_reward_item(village, CH05_ITEM_IDS), CH05_VISIT_BG),
+            'ch05 %s -- gift is ours, prose is vanilla 0x%X until the dialogue pass (#25)'
+            % (village['id'], msg))
+    assert_event_scripts_defined(
+        CH05_EVENTSCRIPT_H, [slot[0] for slot in CH05_VILLAGE_SLOTS.values()])
 
     # 5. Texts + the flagged defeat quote that IS the win trigger.
     with open(TEXTS_TXT, encoding='utf-8') as f:

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6355,6 +6355,42 @@ scenarios.ch04village = function()
         "the Lonelywood village handed over its Iron Axe: %d -> %d in the party", before, after))
 end
 
+-- ch05village (#25): does the SOUTH reliquary at (12,19) actually hand over its Dracoshield?
+-- Two things this pins, both of which shipped wrong once. First the same failure ch04village
+-- exists for: ch05's Location list was EMPTY, so four villages plus an armory and a vendor sat on
+-- intact tiles that nothing pointed at -- a finished-looking map with unreachable rewards.
+-- Second, WHICH gift: (12,19) is the south-east site and the turn-2 eruption pair spawns beside
+-- it, so vanilla puts its richest gift here and its cheapest at (5,1); ours had them swapped,
+-- which no other gate can see (same item set, same total, parity still reads PARITY). Checking
+-- the Dracoshield specifically -- not "some item" -- is what makes that visible here too.
+-- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05village (needs a CH05BOOT=1 ROM).
+scenarios.ch05village = function()
+    local VILLAGE_X, VILLAGE_Y, DRACOSHIELD = 12, 19, 0x60
+    if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
+    pokeFastConfig()
+    waitFor(function() return faction() == 0 and not menuOpen()
+        and not procActive(SYM.ProcScr_StdEventEngine) end, 6000, true)
+    local function shields()
+        local n = 0
+        for _, id in ipairs(collectedItems()) do if id == DRACOSHIELD then n = n + 1 end end
+        return n
+    end
+    local before = shields()
+    log(string.format("ch05village: %d Dracoshield(s) in the party before visiting", before))
+    local ok, why = visitVillage(VILLAGE_X, VILLAGE_Y, function() return shields() > before end)
+    if not ok then return result("FAIL", why) end
+    shot("ch05village")
+    local after = shields()
+    if after <= before then
+        return result("FAIL", string.format(
+            "visited (%d,%d) but the party still holds %d Dracoshield(s) -- the reliquary handed "
+            .. "over nothing (check the tile's terrain AND the Village() entry)",
+            VILLAGE_X, VILLAGE_Y, after))
+    end
+    return result("PASS", string.format(
+        "the south reliquary handed over its Dracoshield: %d -> %d in the party", before, after))
+end
+
 -- ch04cottage (#24): the SECOND village at (1,11), whose reward is its line.
 -- The shipped bug was not a bad reward, it was NO VISIT: the tile was visitable-capable but had
 -- no Location entry, and FE8 runs the village off that event -- so the player saw a cottage they

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -242,6 +242,9 @@ scenarios:
     rom: ch04boot
     host_chapter: 5
     kind: record
+  ch05village:
+    rom: ch05boot
+    host_chapter: 6
   ch04snag:
     rom: ch04boot
     host_chapter: 5
@@ -351,6 +354,9 @@ suites:
     - smoke_ch04
     - clear_ch04
     - clear_ch04_parley
+
+  ch05:
+    - ch05village
 
   sandbox:
     - recordunitlist

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1340,7 +1340,7 @@ class Ch04RuntimeHost(unittest.TestCase):
     def test_the_village_hands_the_visitor_the_authored_reward(self):
         # vanilla's own shape (EventScr_089F1BD8): one text box over the village BG, then
         # SVAL the item into slot 3 and GIVEITEMTO the unit that visited.
-        s = bc.ch04_village_script(0x9C3, 'ITEM_AXE_IRON', bc.CH04_OPENING_FOREST_BG)
+        s = bc.village_script(0x9C3, 'ITEM_AXE_IRON', bc.CH04_OPENING_FOREST_BG)
         self.assertIn('Text_BG(%s, 0x9C3)' % bc.CH04_OPENING_FOREST_BG, s)
         self.assertLess(s.index('Text_BG'), s.index('SVAL(EVT_SLOT_3, ITEM_AXE_IRON)'))
         self.assertLess(s.index('SVAL(EVT_SLOT_3, ITEM_AXE_IRON)'),
@@ -1459,14 +1459,14 @@ class Ch04RuntimeHost(unittest.TestCase):
                              '%s should stand outside its cabin, in the fog' % name)
 
     def test_a_village_script_plays_over_the_backdrop_it_is_given(self):
-        s = bc.ch04_village_script(0x9C6, None, 'BG_MS_LONELYWOOD_FOG')
+        s = bc.village_script(0x9C6, None, 'BG_MS_LONELYWOOD_FOG')
         self.assertIn('Text_BG(BG_MS_LONELYWOOD_FOG, 0x9C6)', s)
 
     def test_a_village_with_no_reward_hands_over_nothing(self):
         """ch04's economy is deliberately Ch4-lean (decisions.md): the Iron Axe is the whole
         material gift, so the cottage's reward IS its line. The script must drop the give-item
         tail rather than quietly hand over some default."""
-        s = bc.ch04_village_script(0x9C6, None, bc.CH04_OPENING_FOREST_BG)
+        s = bc.village_script(0x9C6, None, bc.CH04_OPENING_FOREST_BG)
         self.assertIn('Text_BG(%s, 0x9C6)' % bc.CH04_OPENING_FOREST_BG, s)
         self.assertNotIn('SVAL(EVT_SLOT_3', s)
         self.assertNotIn('GIVEITEMTO', s)
@@ -2625,3 +2625,73 @@ class VillageGiftsInheritVanilla(unittest.TestCase):
     def test_the_live_ch05_villages_inherit_vanilla(self):
         chap = bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.CH05_CHAPTER_YAML)
         bc.assert_village_gifts_match_vanilla(chap, bc.CH05_ITEM_IDS)
+
+
+class CampaignOwnedEventScripts(unittest.TestCase):
+    """The script twin of campaign-owned unit tables. A host slot frees only the scripts its
+    stripped cutscenes stop referencing -- slot 6 leaves five, and ch05 needs three waves plus
+    one per village. Naming our own removes the budget, and MS_Ch05VisitSouth says what it runs
+    where EventScr_089F2AE4 says nothing."""
+
+    HEADER = 'extern CONST_DATA EventListScr EventScr_9EEA58[];\n'
+
+    def test_extern_is_added_once_and_is_idempotent(self):
+        once = bc.event_script_extern(self.HEADER, 'MS_Ch05VisitSouth', 'south reliquary')
+        twice = bc.event_script_extern(once, 'MS_Ch05VisitSouth', 'south reliquary')
+        self.assertEqual(once, twice)
+        self.assertEqual(twice.count('MS_Ch05VisitSouth[];'), 1)
+
+    def test_an_unprefixed_symbol_is_refused(self):
+        with self.assertRaises(SystemExit):
+            bc.event_script_extern(self.HEADER, 'EventScr_089F2AE4', 'squatting')
+
+    def test_a_declared_but_undefined_script_fails_the_build(self):
+        """declare_event_script APPENDS, while the injector rewrites the same file wholesale from
+        a copy read earlier -- so declaring before the bulk write silently discards every script.
+        It happened, and the only symptom was a link error naming the reference, not the loss."""
+        tmp = tempfile.mkdtemp()
+        try:
+            path = os.path.join(tmp, 'ch6-eventscript.h')
+            with open(path, 'w') as f:
+                f.write('CONST_DATA EventListScr MS_Ch05VisitNorth[] = {\n    ENDA\n};\n')
+            bc.assert_event_scripts_defined(path, ['MS_Ch05VisitNorth'])   # present -> quiet
+            with self.assertRaises(SystemExit) as caught:
+                bc.assert_event_scripts_defined(
+                    path, ['MS_Ch05VisitNorth', 'MS_Ch05VisitSouth'])
+            self.assertIn('MS_Ch05VisitSouth', str(caught.exception))
+            self.assertIn('AFTER', str(caught.exception), 'the error must name the ordering')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+class LocationEventsAreBuiltFromTheYaml(unittest.TestCase):
+    """An empty Location list makes every reward on the map unobtainable while the map still
+    draws it -- ch04's unreachable Iron Axe, and ch05's four villages plus an armory and vendor."""
+
+    VILLAGES = [{'id': 'a', 'tile': [12, 19], 'visit_reward': [{'id': 'booster-def'}]},
+                {'id': 'b', 'tile': [5, 1]}]
+    SLOTS = {'a': 'MS_Ch05VisitSouth', 'b': 'MS_Ch05VisitNorth'}
+
+    def test_each_village_rides_its_own_script_at_its_own_tile(self):
+        body = bc.location_events(self.VILLAGES, self.SLOTS)
+        self.assertIn('Village(0, MS_Ch05VisitSouth, 12, 19)', body)
+        self.assertIn('Village(0, MS_Ch05VisitNorth, 5, 1)', body)
+        self.assertTrue(body.rstrip().endswith('END_MAIN\n}'))
+
+    def test_a_village_with_no_reward_says_so_rather_than_naming_an_item(self):
+        body = bc.location_events(self.VILLAGES, self.SLOTS)
+        self.assertIn('the line is the reward', body)
+
+    def test_shops_need_no_script_and_no_text(self):
+        body = bc.location_events([], {}, (('Armory', 'ShopList_Event_Ch5Armory', 2, 1),
+                                          ('Vendor', 'ShopList_Event_Ch5Vendor', 6, 10)))
+        self.assertIn('Armory(ShopList_Event_Ch5Armory, 2, 1)', body)
+        self.assertIn('Vendor(ShopList_Event_Ch5Vendor, 6, 10)', body)
+
+    def test_village_reward_item_uses_the_chapters_own_map(self):
+        """It used to close over CH04_ITEM_IDS, which made a shared helper silently ch04-only:
+        ch05's stat boosters are not in that dict, so the first reuser would die on a KeyError."""
+        village = {'id': 'a', 'visit_reward': [{'id': 'booster-def'}]}
+        self.assertEqual(bc.village_reward_item(village, {'booster-def': 'ITEM_BOOSTER_DEF'}),
+                         'ITEM_BOOSTER_DEF')
+        self.assertIsNone(bc.village_reward_item({'id': 'b'}, {}))


### PR DESCRIPTION
ch05's `Location` list was **empty**, so its four reliquary villages plus the armory `(2,1)` and vendor `(6,10)` sat on intact tiles that nothing pointed at — a finished-looking map with unreachable rewards, which is exactly how ch04 shipped its unobtainable Iron Axe. It was blocked on `visit_text`, so this unblocks it the cheap way: take vanilla's prose temporarily, wire the chapter fully, replace the words in the dialogue pass.

## Only the prose is temporary

| | status |
|---|---|
| Village **prose** | vanilla Ch5's, borrowed — placeholder |
| Village **rewards** | real wiring, gated by `assert_village_gifts_match_vanilla` |
| **Shops** | permanent — no script, no text, nothing to replace |

The visits point at vanilla Ch5's message ids `0x9CD`–`0x9D0` and **never write them**, so the ROM keeps vanilla's text, the ids stay unclaimed in `HOSTED_CHAPTER_MESSAGE_IDS`, and the dialogue pass later writes our body *at the same id* — one line per site, not a rewire. ch05's authored dialogue skips that range exactly (`0x9BE`–`0x9CC`, then `0x9D5`), so nothing collides with ch04 or with ch05's own plan.

`Armory`/`Vendor` take their stock directly, so the elven store is finished, not stubbed. Stock is vanilla Ch5's own — which is what `make difficulty CH=ch05` prices the shop tier against.

## Proven in-engine, not by inspection

New `ch05village` scenario walks a unit onto the south reliquary:

```
ch05village: 0 Dracoshield(s) in the party before visiting
RESULT: PASS -- the south reliquary handed over its Dracoshield: 0 -> 1 in the party
```

It checks *that item specifically* rather than "some item", because which gift sits on which tile is the one thing no other gate can see.

## A hazard this created, and its guard

Four visit scripts were needed where slot 6 frees two, so `declare_event_script` extends campaign-owned symbols from tables to scripts. **It appends, and the injector rewrites the same file wholesale from a copy read earlier** — so declaring before the bulk write silently discards every script. The Location list still names them and the externs still exist, so the only symptom is a link error pointing at the reference rather than at the loss. That happened here; `assert_event_scripts_defined` now pins the ordering.

## Helpers that stopped being ch04-only

- `ch04_village_script` → `village_script`
- `ch04_location_events` → `location_events(villages, slots, shops)`
- `village_reward_item` closed over `CH04_ITEM_IDS`, which would have killed the first reuser on a `KeyError` — ch05's stat boosters aren't in that dict. Now takes the chapter's own map.

## Verification

- `ch05village` **PASS** (0 → 1 Dracoshield) · `mapshot` **PASS**
- `make test` exit 0 · `make check` = `drift check: clean` · `verify_text` 3404 msgs, 0 runaway
- 7 new unit tests · submodule pointer not staged

## Still owed on #25

Basil→Sahnar Talk recruit (she has no `PORTRAIT_MAP` slot yet), the opening/ending cutscenes, the arena tutorial, title-card and boss art, and **the dialogue pass that replaces these four borrowed lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
