### PR TITLE
gate: add ch05village, and fix the dependency bug that was blocking the gate (#245, #25)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3827,6 +3827,14 @@ whether the file survived an earlier build. `_write_chapter_title_card` now conv
 **The general rule: if an injector generates art, it owns the conversion.** Deleting an
 intermediate is not a way to ask make for anything on this toolchain.
 
+Both title-card sites are fixed — `inject_prologue` had an inline copy of
+`_write_chapter_title_card` carrying the same bug, and now calls the helper. **Three more sites
+have the same delete-and-hope shape and are NOT verified**, all in the montage path, which is why
+they are named here rather than quietly assumed fine: the opening subtitle cards
+(`.feimg2`/`.fetsa2`), `MontageMural.4bpp{,.lz}`, and the drawn world-map `.lz` copies. They may be
+harmless if their consuming `.s` changes on every build (which would force the reassemble this bug
+needs) — that is exactly what someone should check before trusting them.
+
 ### Vanilla prose is a legitimate PLACEHOLDER; vanilla wiring is not (2026-08-07, #25)
 
 **A chapter is wired end-to-end first, and only its PROSE waits for the dialogue pass** (Nicolas).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3801,6 +3801,32 @@ for the safest errand in a chapter whose structure *is* the race for the reward-
 Sibling of `validate_terrain_matches_vanilla` (a retile inherits vanilla's terrain), one layer up:
 the rewards standing on that terrain.
 
+### Generated art is CONVERTED by the injector, never left for make (2026-08-07, #245)
+
+**GNU Make 3.81 — what Apple ships and what this repo builds with — drops the incbin
+dependency**, so an injector must run the `gbagfx` conversions itself and drop the consuming
+`.o`. It must not delete the intermediates and trust make to re-derive them.
+
+The chain that fails: `data/data_chap_title.o` reaches its `.4bpp.lz` files through
+`$$(data_dep)`, a `$(shell scaninc …)` target-specific variable resolved by `.SECONDEXPANSION`,
+which 3.81 does not handle. Verified directly — with the `.lz` deleted, `make -n fireemblem8.gba`
+plans **no** rule that rebuilds it.
+
+Two consequences, and the quiet one is worse:
+
+1. When `data_chap_title.o` needs reassembling, the build dies on `Error: file not found:
+   graphics/chap_title/chap_title_N.4bpp.lz`.
+2. When it does not — the common case, since its `.s` never changes — **the build succeeds and
+   the ROM silently keeps the previous card.** A retitled chapter simply never lands.
+
+This is the real root cause of **#245**, which was filed as "the `TESTCH` build race". It is not a
+race and it is not `TESTCH`'s: it looked intermittent only because whether it fires depends on
+whether the file survived an earlier build. `_write_chapter_title_card` now converts and drops the
+`.o`, and the gate went from a standing `BLOCKED` to 15/15.
+
+**The general rule: if an injector generates art, it owns the conversion.** Deleting an
+intermediate is not a way to ask make for anything on this toolchain.
+
 ### Vanilla prose is a legitimate PLACEHOLDER; vanilla wiring is not (2026-08-07, #25)
 
 **A chapter is wired end-to-end first, and only its PROSE waits for the dialogue pass** (Nicolas).

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -4966,12 +4966,10 @@ def inject_prologue(campaign, verbose=True, montage=False):
     # short; the YAML's full objective.description is for docs/banners).
     set_message_body(lines, host['goal']['statusObjectiveTextId'],
                      name_message_body('Defeat ' + display_name(by_id['sephek-kaltro'])))
-    title_png = os.path.join(DECOMP, 'graphics', 'chap_title',
-                             'chap_title_%d.png' % host['chapTitleId'])
-    gen_chapter_title.compose_title('Prologue: ' + chap['title']).save(title_png)
-    for stale in (title_png[:-4] + '.4bpp', title_png[:-4] + '.4bpp.lz'):
-        if os.path.exists(stale):
-            os.remove(stale)
+    # Was an inline copy of _write_chapter_title_card, carrying the same delete-and-hope bug
+    # (#245): make does not re-derive a deleted .4bpp.lz, so the prologue's card either broke
+    # the build or silently never landed. One helper now, which owns the conversion.
+    _write_chapter_title_card(host, 'Prologue: ' + chap['title'])
 
     # 4c. Dialogue (ch00 dialogue pass, 2026-06-10): message bodies are GENERATED from
     #     the chapter YAML's locked `script:` blocks + quote fields -- the YAML stays
@@ -5966,6 +5964,11 @@ def _write_chapter_title_card(host, title):
                              'chap_title_%d.png' % host['chapTitleId'])
     gen_chapter_title.compose_title(title).save(title_png)
     gbagfx = os.path.join(DECOMP, 'tools', 'gbagfx', 'gbagfx')
+    if not os.path.exists(gbagfx):
+        # A fresh checkout has no helper tools -- tools/setup-toolchain.sh omits upstream's
+        # build_tools.sh (HANDOFF). Say so, rather than raising FileNotFoundError on a path.
+        sys.exit('ERROR: %s is missing -- a fresh checkout needs the decomp helper tools:\n'
+                 '  (cd fireemblem8u && ./build_tools.sh)' % gbagfx)
     four_bpp, lz = title_png[:-4] + '.4bpp', title_png[:-4] + '.4bpp.lz'
     for src, dst in ((title_png, four_bpp), (four_bpp, lz)):
         subprocess.run([gbagfx, src, dst], cwd=DECOMP, check=True)

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5943,14 +5943,36 @@ def _prepend_defeat_quote(quote):
 
 
 def _write_chapter_title_card(host, title):
-    """Compose the chapter's title-card banner (the intro/status banner is a 4bpp
-    image, not text) and drop stale converted intermediates so make re-converts."""
+    """Compose the chapter's title-card banner (the intro/status banner is a 4bpp image, not
+    text) and CONVERT it ourselves, rather than deleting the intermediates and trusting make.
+
+    This used to delete `chap_title_N.4bpp{,.lz}` "so make re-converts". make does not: the
+    incbin dependency reaches `data/data_chap_title.o` through `$$(data_dep)` -- a
+    `$(shell scaninc ...)` target-specific variable resolved by `.SECONDEXPANSION` -- and GNU
+    Make **3.81**, which is what Apple ships and what this repo builds with, drops it. Verified
+    directly: with the .lz deleted, `make -n fireemblem8.gba` plans no rule that rebuilds it.
+
+    That has two consequences and neither announces itself (this is #245's actual root cause,
+    which was filed as a "TESTCH build race" -- it is not a race, and it is not TESTCH's):
+      1. When `data_chap_title.o` DOES need reassembling, the build dies on
+         `Error: file not found: graphics/chap_title/chap_title_N.4bpp.lz`.
+      2. When it does NOT -- the common case, since its .s never changes -- the build succeeds
+         and the ROM silently keeps the PREVIOUS card. A retitled chapter just never lands.
+
+    So: run the same two gbagfx conversions the Makefile would have, then drop the .o so the
+    new bytes are actually assembled in. Deterministic, and independent of the make version.
+    """
     title_png = os.path.join(DECOMP, 'graphics', 'chap_title',
                              'chap_title_%d.png' % host['chapTitleId'])
     gen_chapter_title.compose_title(title).save(title_png)
-    for stale in (title_png[:-4] + '.4bpp', title_png[:-4] + '.4bpp.lz'):
-        if os.path.exists(stale):
-            os.remove(stale)
+    gbagfx = os.path.join(DECOMP, 'tools', 'gbagfx', 'gbagfx')
+    four_bpp, lz = title_png[:-4] + '.4bpp', title_png[:-4] + '.4bpp.lz'
+    for src, dst in ((title_png, four_bpp), (four_bpp, lz)):
+        subprocess.run([gbagfx, src, dst], cwd=DECOMP, check=True)
+    # The incbin dependency is dropped, so a fresh .lz alone would sit there unread.
+    chap_title_o = os.path.join(DECOMP, 'data', 'data_chap_title.o')
+    if os.path.exists(chap_title_o):
+        os.remove(chap_title_o)
 
 
 def inject_ch01(campaign, verbose=True):

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -310,6 +310,7 @@ suites:
     - ch04cottage
     - ch04snag
     - clear_ch04_parley
+    - ch05village
 
   ch01:
     - controller_turn


### PR DESCRIPTION
Two things, and the second was found by doing the first.

## The gate decision

**`ch05village` joins the gate. ch04's six stay.**

The gate carries the *active* chapter's scenarios — six ch04 rows, no ch03 — and ch05 is now the active chapter, so it belongs there on the established pattern.

**Not trimming ch04 is the deliberate half.** Those six aren't "ch04 coverage", they're coverage of *mechanisms* that ch05 and the queued convergence PR are about to reuse or rewire:

| scenario | mechanism | why it matters now |
|---|---|---|
| `ch04village` | village visit + item payout | rides `village_script`/`location_events`, made shared this session |
| `ch04snag` | tile changes | `_inject_tile_changes` is what ch03 is about to migrate onto |
| `ch04packmath` | parley / CUSN recruit | the flow Sahnar's recruit will reuse |
| `ch04cottage` | village with no item + door closure | the other half of the Location path |

Cutting the safety net immediately before rewiring what it hangs under is backwards. Cost is one additional ROM build; every further ch05 scenario is ~10s now that `ch05boot` is in the matrix.

## #245 is not a race, and not TESTCH's

Adding a fourth build made the "TESTCH build race" fire on **every** run instead of occasionally, which was enough to go look properly.

**GNU Make 3.81** — what Apple ships and what this repo builds with — **drops the incbin dependency**. `data/data_chap_title.o` reaches its `.4bpp.lz` files through `$$(data_dep)`, a `$(shell scaninc …)` target-specific variable resolved by `.SECONDEXPANSION`, which 3.81 doesn't handle. Verified directly:

```
$ rm graphics/chap_title/chap_title_2.4bpp.lz
$ make -n fireemblem8.gba | grep -c chap_title_2.4bpp
0        # make plans nothing that rebuilds it
```

`_write_chapter_title_card` deleted those intermediates *"so make re-converts"*. It doesn't. Two consequences, and the quiet one is worse:

1. When `data_chap_title.o` needs reassembling → build dies on `Error: file not found: …chap_title_N.4bpp.lz`.
2. When it doesn't — **the common case**, since its `.s` never changes → the build succeeds and **the ROM silently keeps the previous card**. A retitled chapter simply never lands.

Cards **2–6 had no `.lz` on disk at all** when this was found. It looked intermittent only because whether it fires depends on whether the file survived an earlier build.

**Fix:** the injector runs the same two `gbagfx` conversions the Makefile would have, and drops the `.o` so the new bytes are actually assembled in. Deterministic, independent of the make version. The general rule is now an ADR: *if an injector generates art, it owns the conversion* — deleting an intermediate is not a way to ask make for anything on this toolchain.

## Verification

- `make matrix` **15/15, all four builds green** — the `testch` row had been `BLOCKED` on every prior run today
- `make test` exit 0 · `make check` = `drift check: clean`
- ch05's title card now genuinely reaches the ROM (`data_chap_title.o` reassembled, confirmed in the build log)
- submodule pointer not staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
