### PR TITLE
ch05: Basil becomes a Cleric, and the Basil→Sahnar recruit is wired (#25)

### DIFF
--- a/.claude/skills/dialogue-pass/references/natural-speech.md
+++ b/.claude/skills/dialogue-pass/references/natural-speech.md
@@ -63,7 +63,7 @@ in). Reserve is conveyed by **brevity and plainness**, never by trailing dots.
   line sounds quotable, check whether a person would actually say it out loud.
 - **Contractions and casual register** where the character allows ("wanna", "gotta", "a ton of").
 - **A character's own values should generate their turns**, not the other character teaching
-  them. Basil's doubt had to come from *his* horror at an unhealed animal, not from Sahnar
+  them. Basil's doubt had to come from *her* horror at an unhealed animal, not from Sahnar
   pronouncing a verdict on Ravisin.
 - **Villains condemn themselves in reported speech.** *"She said it would still run"* damns
   Ravisin harder than any character analysing her would.

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -39,7 +39,7 @@ narrative: >
   awake and watching for millennia — who comes willingly, believing the party are the
   intruders she was left to stop. She is MISLED, not puppeted. The party turn her by
   chaperoning the goodberry shrub, Basil, across to tell her the truth. They repot Basil
-  and take him along, and turn down the coast toward Bremen.
+  and take her along, and turn down the coast toward Bremen.
 
 # ── Map ────────────────────────────────────────────────────────────────────────
 map:
@@ -91,8 +91,8 @@ objective:
         a HOSTILE guardian — a fast, crit-threat Myrmidon mummy (killing-edge, Joshua's
         exact donor), WOKEN by Ravisin and fighting of her own will in the belief that she is
         finally doing her duty — and the only way to turn her is to walk fragile BASIL up to her
-        to Talk (Basil is our Natasha: her exact donor, a frail Priest). Only he can turn her,
-        because she does not weigh his argument — she RECOGNISES him (9C6: her purpose holds,
+        to Talk (Basil is our Natasha: her exact donor, a frail Cleric). Only Basil can turn her,
+        because Sahnar does not weigh the argument — she RECOGNISES the arguer (9C6: her purpose holds,
         her enemy resolves). So you must chaperone a weak healer across the depression to the
         deadly duelist, clearing a safe pocket first — the escort-recruit that defines how
         you play Ch5. Optional; free her and she fights the back half (recruit swing
@@ -154,7 +154,7 @@ deployment:
   note: >
     Deployable pool by Ch5: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin
     (beast-Cav, won in ch04 — a clean all-chapter combatant, +1.0 kills/round the static
-    party number omits). Basil (Priest) is present from the start as the fragile RECRUITER
+    party number omits). Basil (Cleric) is present from the start as the fragile RECRUITER
     (must be fielded and protected to Talk Sahnar — the Natasha role), NOT a fighter.
     Sahnar is NOT in the starting field — she rises mid-combat as a HOSTILE convertible
     (the Joshua flip) and joins only once Basil Talks her. With deploy_limit 9 and a pool
@@ -453,7 +453,7 @@ enemy_units:
     convertible: true           # #171 — the Joshua flip. Hostile crit-Myrmidon until fragile BASIL
                                 # chaperones across to Talk her; then a +~0.9 kills/round back-half ally.
     parley:
-      by: basil                 # the Natasha-donor Priest, walked up under escort to Talk her
+      by: basil                 # the Natasha-donor Cleric, walked up under escort to Talk her
       result: become_allied
       recruits_npc: sahnar      # joins as a playable Myrmidon (npcs/sahnar.yaml)
     skin:                       # the moon-elf mummy; already art-planned (#25 issue thread)
@@ -527,7 +527,7 @@ enemy_units:
 #                        0x9C8 = Saar DEATH quote (EVFLAG_DEFEAT_BOSS)
 # So "9C6" was a BAD label for our recruit: the real 0x9C6 is a death quote. Our recruit is
 # 0x9CC and is now labelled so. And 0x9C6 gives us a slot we had not accounted for at all --
-# Natasha is BASIL's donor, so Basil owes a chapter-specific death quote too (see his slot).
+# Natasha is BASIL's donor, so Basil owes a chapter-specific death quote too (see her slot).
 # `vanilla_scene.py` used to read TEXTSHOW only and so HID every Text_BG scene -- it reported
 # this opening as 8 messages / 71 boxes when it is 11 / 98, with 9BC and 9BD missing entirely.
 # Fixed 2026-07-29; the tool now prints each message's id and channel. If a mined beat looks
@@ -558,20 +558,20 @@ events:
     type: cutscene
     ea_file: events/ch05-basil-sahnar.ea
     description: >
-      Basil visits the sarcophagus, as he does. Sahnar has been AWAKE in there for millennia
+      Basil visits the sarcophagus, as she does. Sahnar has been AWAKE in there for millennia
       (never asleep — npcs/sahnar.yaml), so they talk through the stone: the gentle shrub and
       the imprisoned queen, the only two kind things in a frost druid's tomb. Establishes BOTH
       recruits before either is a unit — vanilla spends 10 A-presses on the Joshua/Natasha
       meet-cute for exactly this reason — and it is why Basil later begs the party to free her:
-      she is his friend, not a quest object. Their SECOND scene is the recruit (9C6), which is
+      Sahnar is her friend, not a quest object. Their SECOND scene is the recruit (9C6), which is
       where the weight lands, so this one stays a window rather than a thesis.
       Ravisin is damned entirely in REPORTED SPEECH ("she said it would still run") and never
-      diagnosed by Sahnar — Basil's doubt stays his own. Sahnar knows only what Basil tells her;
+      diagnosed by Sahnar — Basil's doubt stays her own. Sahnar knows only what Basil tells her;
       she has no other window on the world. LOCKED 2026-07-23 (dialogue-pass, co-written with
       Nicolas). 16 boxes; the closing aside is hand-matched to Joshua's 3-box / 5-line cadence.
     script:                           # LOCKED 2026-07-23 (dialogue-pass, co-written with Nicolas)
       # (The tomb's eastern berm, before the party arrives. A frost-furred sarcophagus half-sunk
-      #  in snow. A goodberry shrub hurries up on root-feet — he walks; he is not potted.)
+      #  in snow. A goodberry shrub hurries up on root-feet — she walks; she is not potted.)
       - basil: "Sahnar! Sahnar, the moose came back, the white one, it came back tonight--"
       - basil: "--and it's hurt. There are arrows in it. Three of them, in the shoulder. I counted."
       # (Sahnar's voice comes from inside the stone.)
@@ -597,7 +597,7 @@ events:
       - sahnar: "Don't worry about me, little one."
       - basil: "...All right."
       - sahnar: "Go on, now. She'll want you before dawn."
-      # (He goes. A few steps on root-feet. Then stops and looks back. The closing aside is
+      # (She goes. A few steps on root-feet. Then stops and looks back. The closing aside is
       #  Joshua's MSG_9BB shape beat for beat: observation -> wish -> resolve, 3 boxes/5 lines.)
       - basil: "...And there she stays."
       - basil: "I wish I could share my berries with her."
@@ -666,7 +666,7 @@ events:
     ea_file: events/ch05-basil-doubt.ea
     description: >
       Ravisin + Basil, alone after Sephek leaves. She appraises the warrior she has just been
-      given leave to use; Basil asks after her — his friend, though he never says so — and is
+      given leave to use; Basil asks after her — her friend, though she never says so — and is
       shut down and handed a chore.
       MINED SKELETON — vanilla MSG_9BD (Cormag + Glen, 7 boxes). NB the DOUBT there belongs to
       the SUPERIOR, not the subordinate: Glen reflects on the zeal he has just watched, lets a
@@ -680,17 +680,17 @@ events:
       deflection reveals there was never any feeling to read. She has always KNOWN Sahnar is
       under that stone (consistent with 9BC's "...The elf?"); what damns her is that she walked
       past a thousand times and only valued her once someone else pointed. Basil never reveals
-      that he knows Sahnar — that stays his secret for the recruit to spend.
+      that she knows Sahnar — that stays her secret for the recruit to spend.
       LOCKED 2026-07-23 (dialogue-pass, co-written with Nicolas).
     script:                           # LOCKED 2026-07-23 (dialogue-pass, co-written with Nicolas)
       # (The tomb, after Sephek has gone. Ravisin looking toward the sarcophagus on the berm.)
       - ravisin: "A queen's blade. I have walked past that stone a thousand times."
       - ravisin: "It never once occurred to me she might be of use."
-      # (Basil knows exactly who is under that stone. He cannot say so.)
+      # (Basil knows exactly who is under that stone. She cannot say so.)
       - basil: "...What will you do with her?"
       - ravisin: "It's not your concern."
       - ravisin: "Come. There is work before dawn."
-      # ("MY berries" — they were never his to give; cf. 9BB, where he hands them out freely.)
+      # ("MY berries" — they were never hers to give; cf. 9BB, where she hands them out freely.)
       - ravisin: "Prepare my berries."
       - basil: "...Yes."
   # ── 9BE — the party ARRIVES; the PLACE ────────────────────────────────────────
@@ -755,8 +755,8 @@ events:
   # ── 0x9BF + 0x9C0 — CUT 2026-07-29 (Nicolas). 16 boxes buying nothing. ────────
   #  Vanilla's pair is the party OVERHEARING an incident and deciding to investigate. Its three
   #  jobs, and why each is already done or unavailable here:
-  #    (1) introduce the recruit-to-be by showing her in danger -> Basil introduces HIMSELF in
-  #        0x9C2, which is better; watching him bullied first would turn "Oh! Tourists. ...We
+  #    (1) introduce the recruit-to-be by showing her in danger -> Basil introduces HERSELF in
+  #        0x9C2, which is better; watching her bullied first would turn "Oh! Tourists. ...We
   #        don't get many." from a surprise into surveillance and kill the joke;
   #    (2) establish the enemy as lethal in their own words -> we came here to fight, so there is
   #        nothing to establish;
@@ -782,7 +782,7 @@ events:
       Party deployed at the stair-foot; the moose at bay; Ravisin a SILENT frost-robed figure at
       center among the risen dead (shown on the map, never narrated). Basil — a GREEN ally shrub —
       trundles up, cracks the tourist joke, notices LUPIN (a fellow awoken creature, now free),
-      and the thought dawns → he asks to be brought to Sahnar and JOINS (green → player unit). His
+      and the thought dawns → she asks to be brought to Sahnar and JOINS (green → player unit). Her
       "she lost her way" line on Ravisin is DEFERRED to the eruption (once she's formally
       introduced). LOCKED 2026-07-23 (dialogue-pass, co-written with Nicolas). Hand-boxed to GBA
       width. Wiring: Basil enters green, converts to a player unit on the join.
@@ -801,7 +801,7 @@ events:
         ch04's Lupin recruit is gated on `parley: by: marty`, and the ch04 difficulty model
         explicitly prices a no-parley path — so a player can reach ch05 with no wolf on the field
         and box 2 has no referent. The fallback moves Basil's trigger from Lupin to the PARTY
-        ITSELF: everyone he has ever met belonged to her, so people who belong to nobody are the
+        ITSELF: everyone she has ever met belonged to Ravisin, so people who belong to nobody are the
         whole revelation. Arguably the purer version — it needs no other unit to exist.
         Boxes 1 and 3 are unchanged in both branches.
       script:
@@ -835,7 +835,7 @@ events:
       - sahnar: "...Well. Something has come now."
       - sahnar: "I will defend this tomb. It is my purpose."
   # ── 9C4 — CUT 2026-07-29 (Nicolas). Slot deliberately left empty. ─────────────
-  # Was: "Basil, mid-escort, steeling himself" — vanilla's 4-box Natasha prayer (MSG_9C4),
+  # Was: "Basil, mid-escort, steeling herself" — vanilla's 4-box Natasha prayer (MSG_9C4),
   # which she spends psyching herself up to walk into danger and talk somebody down.
   # CUT because its only real job was to plant the berry ahead of the recruit, and 9BB
   # ALREADY plants it: "One day I'll give her one." Re-planting it one slot before the
@@ -843,9 +843,9 @@ events:
   # slots of silence between 9BB and 9C6 are doing the work instead.
   # Drafted and rejected at the same sitting: three variants (berry / scared-going-anyway /
   # "little one"), all four boxes, all bubble-legal. Nothing salvageable is owed forward —
-  # Basil's fear now lives inside the recruit scene itself, where it costs him something.
+  # Basil's fear now lives inside the recruit scene itself, where it costs her something.
   # NB the old description here carried `basil.md`'s RETIRED "voice is spare (2-5 words)"
-  # spec (retired 2026-07-23: it made him read as slow — his corpus twin is Ewan). Do not
+  # spec (retired 2026-07-23: it made her read as slow — her corpus twin is Ewan). Do not
   # resurrect it if this slot is ever refilled.
   # ── 0x9C4 — the LAST beat before the map: the moose triggers the fight ────────
   - trigger: chapter_start       # opening event list, LAST message
@@ -870,8 +870,8 @@ events:
       RAVISIN STAYS SILENT through this. The fight begins on the quarry's terms, not hers; her
       first words on the map are the eruption (0x9C5).
       Basil's steeling-himself beat — the twin's actual content — is CUT (Nicolas, 2026-07-29).
-      Not deferred, not homeless: cut. His nerve is not a beat this chapter needs stated, and 0x9BB
-      already establishes what he is walking toward.
+      Not deferred, not homeless: cut. Her nerve is not a beat this chapter needs stated, and 0x9BB
+      already establishes what she is walking toward.
       LOCKED 2026-07-29 (dialogue-pass, co-written with Nicolas). 2 boxes.
     script:                           # LOCKED 2026-07-29 (dialogue-pass, co-written with Nicolas)
       # (The hollow. The moose stands at bay among the standing dead. Nothing has moved.)
@@ -1002,11 +1002,11 @@ events:
       NOT break — she keeps it, and her ENEMY resolves. She was misled, never bound.
       Written by Nicolas; boxed to GBA width here. Deliberate, do not "fix":
         · "...Basil?" is her exact first line from 9BB — the recognition IS the word. No
-          introduction, no explanation; he never has to say who he is.
+          introduction, no explanation; she never has to say who she is.
         · The wolf stays GENERIC ("a wolf", "his whole pack", "travelers") — Sahnar has no way
           to know Lupin, and 9BB established she knows only what Basil tells her.
         · "child" → "little one" is an ARC: cold while she is still the summoned guardian,
-          then 9BB's name for him the moment she comes back to herself.
+          then 9BB's name for her the moment she comes back to herself.
         · The scene ENDS on Basil's berry question, unanswered — 9BB's "One day I'll give her
           one" left open on purpose, going into the fight.
       LOCKED 2026-07-29 (dialogue-pass, co-written with Nicolas). 16 boxes, Sahnar 8 / Basil 8.
@@ -1039,8 +1039,8 @@ events:
         Box 8 is PROOF #1 — the evidence that turns Sahnar — and it is a wolf the player may never
         have recruited (ch04's parley is optional). Without him the proof changes SHAPE: it stops
         being evidence someone else already walked free and becomes Basil's argument that the two
-        of THEM could. `lore/sahnar.md` supports the swap — "she does not weigh his argument, she
-        recognises HIM" — so the scene still turns on Basil rather than on the wolf.
+        of THEM could. `lore/sahnar.md` supports the swap — she does not weigh the argument, she
+        recognises the ARGUER — so the scene still turns on Basil rather than on the wolf.
         Box 9 ("All it took was knowing they had a choice... That we have a choice...") is
         unchanged in both branches; its "we" already includes him.
         OPEN: box 6 is kept at v0 (Nicolas), but "SOME of her creatures broke free" asserts a
@@ -1058,20 +1058,20 @@ events:
       BASIL's chapter-specific death quote. Vanilla Ch5 gives one to NATASHA and to nobody else
       on the map except the boss — not even to Joshua — because she is the ESCORT the chapter is
       built around, and losing her is the failure the player must feel. Basil is her exact donor
-      and holds exactly that role here, so he inherits the slot.
+      and holds exactly that role here, so she inherits the slot.
       The twin: "I can't let myself die here..... Someone has to hear my tale....." — she dies
       still reaching for her one errand, which is what makes it land.
       Ours has a sharper version of the same available, and it is the whole reason 9BB exists:
       Basil dies with the berry still undelivered. ONE box. Do not spend it on pathos about
-      himself; spend it on Sahnar, whom the player now knows he was walking toward.
+      herself; spend it on Sahnar, whom the player now knows she was walking toward.
       TWO CONSTRAINTS the draft is built to satisfy, both easy to break by "improving" it:
-        · It must read the same whether he dies BEFORE or AFTER the recruit. "Sahnar's still
+        · It must read the same whether she dies BEFORE or AFTER the recruit. "Sahnar's still
           waiting" is wrong once she is a party member; the berry is undelivered either way.
-        · It must not duplicate his LAST WORDS in 0x9CA, which are also about the berry. The
-          quote is him still holding it; 0x9CA is him handing the errand to someone else
+        · It must not duplicate her LAST WORDS in 0x9CA, which are also about the berry. The
+          quote is her still holding it; 0x9CA is her handing the errand to someone else
           ("Tell her I had one for her"). Same object, two different failures.
-      Hurt Basil goes SHORT — basil.md: he runs on when he cares, and the short lines are for
-      when he's hurt. The self-interruption is the one piece of his register that survives.
+      Hurt Basil goes SHORT — basil.md: she runs on when she cares, and the short lines are for
+      when she's hurt. The self-interruption is the one piece of her register that survives.
       LOCKED 2026-07-30 (dialogue-pass, co-written with Nicolas) — Nicolas kept v0 on review:
       the 9BB thread carries the pronoun. 1 box. Two alternates recorded below.
     script:                           # LOCKED 2026-07-30 (dialogue-pass, co-written with Nicolas)
@@ -1122,7 +1122,7 @@ events:
     type: cutscene
     ea_file: events/ch05-ending.ea
     description: >
-      Ravisin falls. The party adopts Basil — they REPOT him (he is already called Basil and
+      Ravisin falls. The party adopts Basil — they REPOT her (she is already called Basil and
       joined on the map; there is no discovery and no naming beat, LOCKED 2026-07-23). They turn
       down the coast toward Bremen, where Ravisin woke something in the lake.
       MINED SKELETON — vanilla MSG_9C9 (34 boxes, `EventScr_Ch5_EndingScene`, ON-MAP so bubbles
@@ -1131,8 +1131,8 @@ events:
       and she TELLS THEM THE PLOT — the escort, not a party member, carries the chapter's forward
       information; (4) the party deliberates in front of her; (5) a closing box that turns the win
       into the next journey.
-      WHO SITS IN WHICH SEAT: Natasha → BASIL (he is her donor and holds her role all chapter, so
-      he inherits the information too — and that is WHY 0x9CA has to exist). Eirika → BRAULO (he
+      WHO SITS IN WHICH SEAT: Natasha → BASIL (Basil is her donor and holds her role all chapter,
+      so she inherits the information too — and that is WHY 0x9CA has to exist). Eirika → BRAULO (he
       speaks when a decision has to be made, then the party follows). Seth → split between
       PROF-RBG (who knows where Bremen is; he makes inquiries everywhere) and MARTY (the reason
       to go that isn't money). Meesmickle is DELIBERATELY ABSENT — he already spent his one line
@@ -1140,7 +1140,7 @@ events:
       role.
       BASIL CAN CARRY THIS AND SAHNAR CANNOT: Sahnar is optional (no recruit, no scene) and has
       been under a stone for four thousand years — she has no way to know about a lake. Basil is
-      Ravisin's own attendant and reports what he HEARD her say, which is also how 9BB damns her
+      Ravisin's own attendant and reports what she HEARD Ravisin say, which is also how 9BB damns her
       ("she said it would still run"). Villains condemn themselves in reported speech.
       NO MOOSE (Nicolas, 2026-07-30). The moose is a CONVERTIBLE miniboss — the player may simply
       kill it — so the ending cannot assume it survived, and an earlier draft opened on it running
@@ -1162,7 +1162,7 @@ events:
     status: locked
     script:                           # LOCKED 2026-07-30 (dialogue-pass, co-written with Nicolas)
       # (Aftermath. Ravisin is down. Basil says the smallest true thing -- and it pays off 9BD,
-      #  where her last order to him was "Prepare my berries.")
+      #  where her last order to her was "Prepare my berries.")
       - basil: "I don't have to make berries for her anymore..."
       - marty: "No. You don't. ...Come with us instead."
       # (The pot is WOLFRAM's, not RBG's (Nicolas, 2026-07-30): the metallurgist repairs one out of
@@ -1211,7 +1211,7 @@ events:
       replaces: "She woke it. Like she woke the wolves. ...She told it to sink the boats."
       reason: >-
         "Like she woke the wolves" names a recruit the player may never have made. The fallback
-        puts the comparison in Basil's own mouth about HIMSELF, which is the harder line and needs
+        puts the comparison in Basil's own mouth about HERSELF, which is the harder line and needs
         no other unit to exist. Worth revisiting whether this should simply be unbranched — it
         would delete a branch point and, on the page, it reads stronger in both worlds.
       script:
@@ -1238,10 +1238,10 @@ events:
       is 0x9C9's own, with Braulo's final box carrying the one changed clause.
       THE CONCEIT IS INHERITED WHOLESALE. Natasha's map death is deferred to the cutscene — she
       is mortally wounded there, whenever she actually fell. Basil is a broken shrub in the snow
-      still talking, whether he went down on turn 2 or turn 12. It reads better for a plant than
+      still talking, whether she went down on turn 2 or turn 12. It reads better for a plant than
       it does for a person.
       WHAT THE LOSS COSTS, deliberately: no repot, no pot, no berry. If Basil died before the
-      Talk, Sahnar was never recruited (he is the only one who can turn her); if he died after,
+      Talk, Sahnar was never recruited (Basil is the only one who can turn her); if she died after,
       she is a party member. Either way she does NOT speak here — see the note below.
       NOT NESTED (2026-07-30): no second conditional for a recruited Sahnar over the body. One
       box from her would be the strongest line in the chapter, and it is deliberately not taken,
@@ -1262,13 +1262,13 @@ events:
       10 boxes; twin is 24.
     status: locked                    # ADOPTED + LOCKED 2026-07-30 after two red-pen passes
     script:                           # LOCKED 2026-07-30 (dialogue-pass, co-written with Nicolas)
-      # (The hollow. Ravisin down. Basil is in the snow where he fell, root-feet turned up,
-      #  broken through. The party has gathered. He is still talking.)
+      # (The hollow. Ravisin down. Basil is in the snow where she fell, root-feet turned up,
+      #  broken through. The party has gathered. She is still talking.)
       - basil: "......"
       - marty: "Easy. Easy, friend. Don't--"
       # (Nicolas's line, 2026-07-30, split across two A-presses -- 84 chars runs to 4 lines on-map,
       #  and splitting it lets BRAULO interrupt mid-report, which is vanilla's own conceit here:
-      #  the facts arrive in fragments, through the party telling him to stop talking.
+      #  the facts arrive in fragments, through the party telling her to stop talking.
       #  LUPIN-GATED -- "the wolf" needs the fallback below. "The moose" does NOT: Basil is
       #  listing who she WOKE, not who survived, so a player who killed it loses nothing.)
       - basil: "The moose, the wolf.. they were not alone.."
@@ -1278,7 +1278,7 @@ events:
       #  DEGRADED INFORMATION is the branch's whole point -- in this ending the party never learns
       #  what the thing was ordered to do, only that it is there. That is the loss, priced in
       #  facts. Cutting Marty's name-call also leaves Braulo as the scene's ONLY interruption,
-      #  so Basil's last two boxes run without anyone reaching for him.)
+      #  so Basil's last two boxes run without anyone reaching for her.)
       # (Not the berry errand -- 0x9C6 still holds that. This is the healer's own failure, and it
       #  is universal rather than about Sahnar, so it does not collide with the death quote.)
       - basil: "...I couldn't make enough berries..."
@@ -1297,7 +1297,7 @@ events:
         Same gate as 0x9C9 box 14: "the wolf" names an optional recruit. Only that clause moves —
         "the moose" stays in BOTH branches, because Basil is listing who she WOKE, not who
         survived, so a player who killed the moose loses nothing here. Parallel to 0x9C9's
-        fallback, Basil substitutes himself.
+        fallback, Basil substitutes herself.
       script:
         - basil: "The moose, and me.. we were not alone.."
   # ── 0x9CB — vanilla's ending CODA. FOLDED INTO 0x9C9 (2026-07-30). No separate slot. ──
@@ -1310,7 +1310,7 @@ events:
   # and here is where each of the coda's three jobs actually landed, so nobody re-opens the slot
   # looking for them:
   #   (1) a RESIDENT says what the win meant  -> Basil's "...I don't have to prepare her berries."
-  #       The hollow is the only place he has ever been; that line is the whole coda in one box.
+  #       The hollow is the only place she has ever been; that line is the whole coda in one box.
   #   (2) the resident's own future           -> the repot. Vanilla's townsman apologises that he
   #       can do nothing and stays behind to wait; ours can do something, and comes along. The
   #       coda INVERTED is the strongest use of it available to us.
@@ -1389,17 +1389,17 @@ post_chapter:
   units_available_to_recruit:
     - id: sahnar                         # Myrmidon (sword duelist); see npcs/sahnar.yaml
       description: "Sahnar (she/her), the reawakened elven royal — a moon-elf mummy, recruited via Basil's Talk (the Joshua beat). Playable Myrmidon."
-    - id: basil                          # Priest — 2nd healer (LOCKED 2026-06-20); see npcs/basil.yaml
+    - id: basil                          # Cleric — 2nd healer (role LOCKED 2026-06-20, class 2026-08-08); see npcs/basil.yaml
       description: >
-        Basil, the sentient goodberry shrub — now a PLAYABLE healer (Priest). His
-        Goodberries are the cosmetic skin on a vanilla heal staff; he is also the
+        Basil, the sentient goodberry shrub — now a PLAYABLE healer (Cleric). Her
+        Goodberries are the cosmetic skin on a vanilla heal staff; she is also the
         in-fiction source of the party's reflavored Vulneraries in the shop.
   unlocks_chapter: ch06-the-maer-monster
 
 design_notes: >
   Our FE8 Ch5 (The Empire's Reach) 1:1 — DefeatBoss, retiling Ch5's open spread field as an
   elven-tomb depression and emulating its two memorable set-pieces (decisions.md 2026-07-15):
-    - The Natasha→Joshua escort → BASIL (Natasha-donor Priest) chaperoned to Talk SAHNAR
+    - The Natasha→Joshua escort → BASIL (Natasha-donor Cleric) chaperoned to Talk SAHNAR
       (Joshua-donor Myrmidon), who rises as a hostile crit-threat and flips on the Talk. The
       donors were chosen for exactly this; the escort defines how you play the map.
     - The village-raid race → the Phantom-Ship ERUPTION (injected EARTHQUAKE/TILECHANGE)
@@ -1408,7 +1408,7 @@ design_notes: >
   Ravisin is the canonical frost druid and the villain thread tying the white moose (ch04) →
   this tomb → Messie (ch06): she awakened them all. She still DROPS the LOCKED 'crest of cold
   iron' (the promotion Chekhov's gun for the Ch8→9 seam) — its narrative role; the save-all
-  bonus is the mechanical echo, not a replacement. Basil joins as our second healer (Priest) —
+  bonus is the mechanical echo, not a replacement. Basil joins as our second healer (Cleric) —
   the goodberry shrub as a literal heal-staff unit (LOCKED 2026-06-20). No fog: the tension is
   the escort + eruption race, not vision. Map + roster build at the slice; targets checked via
   `make difficulty` (economy #170 + convertible/reinforcement dynamics #171).

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -76,7 +76,7 @@ difficulty_note: >
 
 # ── Deployment ──────────────────────────────────────────────────────────────────
 deployment:
-  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Priest), capped by deploy_limit (TBD), split across the two boats — small units (Basil/Trex/Sahnar/casters) on the Burly Ram, Braulo/Wolfram on the Pronged Goat. Marty MUST be deployable (his Talk is the hidden resolution). The beast-cavalry (Baxby/Lupin) may bench on the boat map by terrain — authoring call. Only the pack direwolves stay non-combat dressing. Positions set in Tiled."
+  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit (TBD), split across the two boats — small units (Basil/Trex/Sahnar/casters) on the Burly Ram, Braulo/Wolfram on the Pronged Goat. Marty MUST be deployable (his Talk is the hidden resolution). The beast-cavalry (Baxby/Lupin) may bench on the boat map by terrain — authoring call. Only the pack direwolves stay non-combat dressing. Positions set in Tiled."
 
 # ── Enemy Units (vanilla FE) ─────────────────────────────────────────────────────
 enemy_units:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch07-blood-in-bremen.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch07-blood-in-bremen.yaml
@@ -55,7 +55,7 @@ difficulty_note: >
 
 # ── Deployment ──────────────────────────────────────────────────────────────────
 deployment:
-  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Priest), capped by deploy_limit (TBD). Only the pack direwolves stay non-combat dressing. Positions set in Tiled."
+  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit (TBD). Only the pack direwolves stay non-combat dressing. Positions set in Tiled."
 
 # ── Enemy Units (vanilla FE) ─────────────────────────────────────────────────────
 # Grounding: Bremen "can muster up to 25 soldiers (tribal warrior stat block) and 2

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch08-the-eastway-ambush.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch08-the-eastway-ambush.yaml
@@ -54,7 +54,7 @@ difficulty_note: >
 
 # ── Deployment ──────────────────────────────────────────────────────────────────
 deployment:
-  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Priest), capped by deploy_limit (TBD). Only the pack direwolves stay non-combat dressing. Positions set in Tiled. (Casual/Classic permadeath toggle still applies up to the scripted end.)"
+  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit (TBD). Only the pack direwolves stay non-combat dressing. Positions set in Tiled. (Casual/Classic permadeath toggle still applies up to the scripted end.)"
 
 # ── Enemy Units (vanilla FE) ─────────────────────────────────────────────────────
 enemy_units:

--- a/campaigns/rime-of-the-frostmaiden/lore/basil.md
+++ b/campaigns/rime-of-the-frostmaiden/lore/basil.md
@@ -4,89 +4,95 @@
 > Verbalness fork RESOLVED (Groot-flavored + self-sufficient); origin (Ravisin's shrub)
 > approved; calibration lines still await red-pen.** ch05 "The
 > Elven Tomb" recruit — the Natasha beat (fragile healer the party escorts). Mechanics in
-> [`chapters/ch05-the-elven-tomb.yaml`](../chapters/ch05-the-elven-tomb.yaml) (Priest;
+> [`chapters/ch05-the-elven-tomb.yaml`](../chapters/ch05-the-elven-tomb.yaml) (Cleric;
 > Goodberries = the cosmetic skin on a vanilla heal staff; the in-fiction source of the
 > party's reflavored Vulneraries) and [`npcs/basil.yaml`](../npcs/basil.yaml). Art landed
 > PR #179 (Oddish-sourced).
 
 ## Concept
 
+**She/her** (2026-08-08). RotFM's awakened shrub has no gender — the book gives it none — so
+this is a choice, not a correction of canon, and it follows the class: FE8 has no male Cleric,
+and Cleric is the class whose promotion tree matches what Basil's art already assumes
+(`decisions.md` → "Basil is a Cleric"). Nothing in the locked ch05 script genders her either
+way, so every written line stands unchanged.
+
 A small **sentient goodberry shrub** — and, in canon, **Ravisin's own**: her awakened
 companion, kept at the druid's side so she always has goodberries to hand (RotFM). So Basil
 is the **villain's gentle pet, made kind** — the one soft thing the cold woman keeps
 close. (Not "a grieving zealot": `ravisin.md` bans grief/pathos for her outright — she keeps
-him because a druid wants goodberries to hand, not because she is lonely.) **He is already
-called Basil** — he introduces himself, and nobody in the party ever calls him anything else
+her because a druid wants goodberries to hand, not because she is lonely.) **She is already
+called Basil** — she introduces herself, and nobody in the party ever calls her anything else
 (LOCKED 2026-07-23, Nicolas: no "unnamed shrub" phase, no naming ceremony — the party naming
-him would have contradicted the locked opening, where he speaks as `basil:` from his first
+her would have contradicted the locked opening, where she speaks as `basil:` from her first
 line). Where the name came from is deliberately unexplained. When Ravisin falls the party
-takes him in — they **repot him**, and he becomes their second healer, growing Goodberries
-and handing them out, which is every heal-staff and Vulnerary the party drinks. He is **guileless, gentle, and growing**
+takes her in — they **repot her**, and she becomes their second healer, growing Goodberries
+and handing them out, which is every heal-staff and Vulnerary the party drinks. She is **guileless, gentle, and growing**
 (literally, over the campaign): no guile, no agenda, just the urge to feed and mend the
-people around him. As the fragile recruiter he must be walked into danger to reach Sahnar —
+people around her. As the fragile recruiter she must be walked into danger to reach Sahnar —
 and it's *Basil*, not a blade, that turns the old duelist.
 
 - **The arc:** Ravisin's shrub → the party's heart. Made by the old druidcraft, kept by its
-  coldest servant; in the party's hands the same green magic just *feeds people*. He is living
+  coldest servant; in the party's hands the same green magic just *feeds people*. She is living
   proof it didn't have to serve the winter. (Approved flavor, 2026-07-23, Nicolas.)
 - **Wants:** sun, water, and for everyone to be fed and unhurt. That's the whole list.
 - **Love-language is feeding** (the campaign's "feed them" motif — cf. Lupin's pack, ch04):
-  a berry offered *is* Basil saying he cares. He heals by feeding.
-- **Why he turns Sahnar:** he isn't afraid of the sword; he offers the scary dead queen a
+  a berry offered *is* Basil saying she cares. She heals by feeding.
+- **Why she turns Sahnar:** she isn't afraid of the sword; she offers the scary dead queen a
   berry. A living green thing, tended and kind, is the proof the old craft still grows —
   and that reaches Sahnar where a blade never could, through her long, bound watch.
 
 ## Voice — **REVISED 2026-07-23 after the 9BB write. Corpus twin: EWAN (of Ewan/Saleh).**
 
 > The earlier spec here said "usually 2–5 words, no subordinate clauses." **It was wrong and it
-> is retired.** In practice it made Basil read as *slow* — jokes landed at his expense and the
+> is retired.** In practice it made Basil read as *slow* — jokes landed at her expense and the
 > scene read as haiku rather than talk. Nicolas: "it makes Basil sound unintelligent."
 
-**Warm, eager, and he TUMBLES.** When something matters to him he spills — several sentences in
-one turn, interrupting himself, doubling back, arguing with a "no" before it arrives. Read
+**Warm, eager, and she TUMBLES.** When something matters to her she spills — several sentences in
+one turn, interrupting herself, doubling back, arguing with a "no" before it arrives. Read
 **Ewan** in the Ewan/Saleh supports: *"No way. I wanna be just like you. Why would I go study
 somewhere else? Wait— you've gotta go out on a mission again, don't you! Take me with you!"*
-That's the register. He is **awakened, not simple-minded** — the plainness is a kind heart with
-no guile, never a small mind. He is **self-sufficient**: he carries his own beats, including the
-Sahnar recruit — **no translator crutch**. He is NOT Marty — where Marty *sells*, Basil *offers*.
+That's the register. She is **awakened, not simple-minded** — the plainness is a kind heart with
+no guile, never a small mind. She is **self-sufficient**: she carries her own beats, including the
+Sahnar recruit — **no translator crutch**. She is NOT Marty — where Marty *sells*, Basil *offers*.
 
 **Diction rules**
-- **Runs on when he cares.** Long turns, stacked short sentences, self-interruption ("—and
-  then—", "Wait—"). Answers a question and keeps going. Short lines are for when he's *hurt*.
-- **He says the feeling out loud.** No coy subtext: "I'm worried." "I counted them." "I wish I
-  could share my berries with her." Plain sincerity is his whole charm.
-- **Concrete and countable.** He notices numbers and specifics — three arrows, six days, which
-  stone the sun cleared. Attention is how he loves.
+- **Runs on when she cares.** Long turns, stacked short sentences, self-interruption ("—and
+  then—", "Wait—"). Answers a question and keeps going. Short lines are for when she's *hurt*.
+- **She says the feeling out loud.** No coy subtext: "I'm worried." "I counted them." "I wish I
+  could share my berries with her." Plain sincerity is her whole charm.
+- **Concrete and countable.** She notices numbers and specifics — three arrows, six days, which
+  stone the sun cleared. Attention is how she loves.
 - **Feeding = affection.** Offering food is comfort, greeting, and love.
-- **Plant-logic, lightly:** sun, rain, roots, frost, growing. He reads the world as *tending*.
-- **No guile, irony, or sarcasm.** He means every word.
-- **Never write his lines as epigrams.** If a line sounds quotable, it is probably wrong for
-  him — see `.claude/skills/dialogue-pass/references/natural-speech.md`.
+- **Plant-logic, lightly:** sun, rain, roots, frost, growing. She reads the world as *tending*.
+- **No guile, irony, or sarcasm.** She means every word.
+- **Never write her lines as epigrams.** If a line sounds quotable, it is probably wrong for
+  her — see `.claude/skills/dialogue-pass/references/natural-speech.md`.
 
 **Calibration lines (draft — for Nicolas's red-pen; not yet used in any beat)**
 - (adopted at the end — repotted, not renamed) "A pot. …Mine?" → "I will grow. For you."
 - (healing in battle) "Hurt. Here. Eat." / "Eat. Grow. Stay."
-- (refusing Ravisin as she rips Sahnar up — his breaking point) "No. Not her. …I won't."
+- (refusing Ravisin as she rips Sahnar up — her breaking point) "No. Not her. …I won't."
 - (the Sahnar turn — **carries the recruit alone**, offering the berry to the bound mummy)
   "She hurt you. You are not hers. …Wake up. I have you. Eat."
 - (to Marty, on their two ways of winning people) "You sell. I feed. …Same."
 
-**Banned:** needing a party-member to translate for him (rejected — he stands on his own);
-writing him **simple-minded** (spare speech, full soul — never dumb); long or winding sentences;
+**Banned:** needing a party-member to translate for her (rejected — she stands on her own);
+writing her **simple-minded** (spare speech, full soul — never dumb); long or winding sentences;
 subordinate clauses; cutesy baby-talk / "hehe" overload; modern slang; any edge (sarcasm,
-menace — he has none); a literal "I am Basil" Groot-quote gimmick unless Nicolas asks for it;
+menace — she has none); a literal "I am Basil" Groot-quote gimmick unless Nicolas asks for it;
 **grieving or mourning Ravisin** (`ravisin.md`: she is never mourned — see Q4 below).
 
 ## Open questions for Nicolas
 1. ~~**The verbalness fork (A vs B)**~~ — **RESOLVED 2026-07-23:** Groot-flavored + self-sufficient
    (see §Voice header).
-2. ~~**Does Basil name himself or accept the name?**~~ — **RESOLVED 2026-07-23 (Nicolas): neither.
-   He is simply Basil from his first line.** No unnamed phase, no naming beat; the origin of the
+2. ~~**Does Basil name herself or accept the name?**~~ — **RESOLVED 2026-07-23 (Nicolas): neither.
+   She is simply Basil from her first line.** No unnamed phase, no naming beat; the origin of the
    name is left unexplained. Simpler, and it matches the locked opening.
-3. ~~**When does he leave Ravisin?**~~ — **RESOLVED 2026-07-23 by the locked ch05 opening:** he is
+3. ~~**When does she leave Ravisin?**~~ — **RESOLVED 2026-07-23 by the locked ch05 opening:** she is
    a **GREEN ally** on the map from the start (not Ravisin's unit, not a starting player unit), and
-   **converts to a player unit on the `map_opening` join** when he asks to be taken to Sahnar. The
-   `chapter_end` beat is then the *adoption* (repotting him), not the discovery or a naming.
+   **converts to a player unit on the `map_opening` join** when she asks to be taken to Sahnar. The
+   `chapter_end` beat is then the *adoption* (repotting her), not the discovery or a naming.
 4. ~~**Does Basil grieve Ravisin?**~~ — **RESOLVED: no.** `ravisin.md`'s banned list settles it —
    she is never mourned or softened, and Basil's kindness must not read as the story pitying her.
-   Play him **relieved**, not bereaved.
+   Play her **relieved**, not bereaved.

--- a/campaigns/rime-of-the-frostmaiden/lore/sahnar.md
+++ b/campaigns/rime-of-the-frostmaiden/lore/sahnar.md
@@ -48,9 +48,10 @@ worse: Sahnar spends herself on the wrong enemy of her own free will. What turns
   witch. Sahnar keeps the purpose she was given and turns it around: *"Then my purpose has not
   changed. Only my true enemy has been revealed."* Her solo scene (9C3) is built to set this
   up — she ends it certain, so the recruit is a **revelation, not a rescue**.
-- **Why Basil and nobody else:** she does not weigh his argument, she recognises *him*. Seeing
-  the little berry bush she has only ever heard through stone is what buys him the hearing;
-  anyone else gets the killing edge. That is the whole reason 9BB exists.
+- **Why Basil and nobody else:** Sahnar does not weigh the argument, she recognises the
+  *arguer*. Seeing the little berry bush she has only ever heard through stone is what buys
+  Basil the hearing; anyone else gets the killing edge. That is the whole reason 9BB exists.
+  (Both are she/her — name them in prose here rather than leaning on pronouns.)
 
 ## Voice
 

--- a/campaigns/rime-of-the-frostmaiden/npcs/basil.yaml
+++ b/campaigns/rime-of-the-frostmaiden/npcs/basil.yaml
@@ -2,18 +2,18 @@
 # Class roster: docs/CLASSES.md (generated). Rationale: docs/decisions.md §Class Mapping.
 # Combat is vanilla FE (docs/decisions.md §Combat).
 #
-# STATUS: design record. Class + role LOCKED (Nicolas, 2026-06-20) — promoted from
-# "non-combat caravan NPC" to a playable recruit; bases/growths below are vanilla Priest CLASS
-# data (data_classes.c [CLASS_PRIEST - 1], verbatim) -- identical to Sclorbo's, since it's the
-# same class. The "differentiated by donor" call in decisions.md (Sclorbo->Moulder durable,
-# Basil->Natasha frail-but-potent) is implemented at BUILD time, not in this design record:
-# STAT_DONOR in build_campaign.py pulls each donor's actual personal growths from vanilla
-# data_characters.c at injection time (Moulder's for Sclorbo, Natasha's for Basil once wired),
-# so the two Priests won't be stat-twins in-ROM even though this file shows the same class
-# baseline Sclorbo's shipped YAML does.
-# NOT yet wired into build_campaign (inert until the recruit wiring lands: free slot + recruit
-# logic + injection wiring + a STAT_DONOR entry). The ART is shipped (portrait, map sprites,
-# battle-anim frames — see `art:` below); wiring it in is ch05-slice work (#25).
+# STATUS: design record. Role LOCKED (Nicolas, 2026-06-20) — promoted from "non-combat caravan
+# NPC" to a playable recruit. CLASS is CLERIC as of 2026-08-08 (was Priest); rationale is the ADR
+# in decisions.md, "Basil is a Cleric, because Priest promotes into the wrong weapon type".
+# Bases/growths below are vanilla Cleric CLASS data (data_classes.c [CLASS_CLERIC - 1], verbatim),
+# guarded by test_basil_bases_are_vanilla_cleric_class_data_verbatim.
+# The "differentiated by donor" call in decisions.md (Sclorbo->Moulder durable, Basil->Natasha
+# frail-but-potent) is implemented at BUILD time, not in this design record: STAT_DONOR in
+# build_campaign.py pulls each donor's actual personal growths from vanilla data_characters.c at
+# injection time (Moulder's for Sclorbo, Natasha's for Basil). The class split now reinforces the
+# donor split rather than fighting it — the two healers no longer share a class at all.
+# The ART is shipped and UNAFFECTED by the class (portrait, map sprites, battle anim are all
+# character-keyed, never class-keyed — see `art:` below); wiring is ch05-slice work (#25).
 
 id: basil
 name: Basil
@@ -23,7 +23,7 @@ name: Basil
 # cannot lean on ch05. It is deliberately NOT the ch05 escort quote (0x9C6, "But I haven't--
 # I still have her berry..."), which is locked and stays chapter-specific -- that one is the
 # undelivered berry; this one is the larder running out. basil.md: hurt Basil goes SHORT, and
-# the self-interruption is the piece of his register that survives being hurt.
+# the self-interruption is the piece of her register that survives being hurt.
 death_quote: "Oh-- I'm sorry. I had more berries... I was going to..."
 
 # D&D flavor: canonically the book's **Awakened Shrub** — an intelligent, speaking shrub
@@ -34,33 +34,45 @@ dnd:
   class: Awakened Shrub (goodberry)
   race: Plant
 
-# ── Role (LOCKED 2026-06-20) ─────────────────────────────────────────────────
-# PRIEST — our SECOND healer (we ran one-healer-thin on Sclorbo all game). A plant that
+# ── Role (LOCKED 2026-06-20; class revised 2026-08-08) ───────────────────────
+# CLERIC — our SECOND healer (we ran one-healer-thin on Sclorbo all game). A plant that
 # literally produces healing berries = a staff healer, flavor and function in one.
 # HEALER DIFFERENTIATION (Nicolas, 2026-06-20), mirroring the Marty/Meesmickle shaman split:
-#   - Sclorbo = MOULDER donor -> the durable "war-priest" (HP70/Def25, balanced, lord-viable).
-#   - Basil   = NATASHA donor -> the frail "mage-healer" (HP50/Def15 but Pow60/Res55/Lck60):
-#       a glass, dodgy, magically-potent nuke-healer. Frailty is fine HERE because Basil is
-#       NOT a lord candidate (lord-select is the Ch1 founding cast; Basil joins Ch5), so no
-#       survivability-floor burden — and "fragile but potent natural magic" suits a shrub.
+#   - Sclorbo = PRIEST, MOULDER donor -> the durable "war-priest" (HP70/Def25, lord-viable).
+#   - Basil   = CLERIC, NATASHA donor -> the frail "mage-healer" (HP50/Def15 but
+#       Pow60/Res55/Lck60): a glass, dodgy, magically-potent nuke-healer. Frailty is fine HERE
+#       because Basil is NOT a lord candidate (lord-select is the Ch1 founding cast; she joins
+#       Ch5), so no survivability-floor burden — and "fragile but potent natural magic" suits
+#       a shrub. Cleric's own bases lean the same way Natasha does (-2 HP, -1 Def, +1 Res/Skl
+#       against Priest), so class and donor now push together instead of against each other.
 fe_stats:
-  class: Priest
+  class: Cleric
   level: 1
-  # Vanilla FE8 Priest stats, verbatim from data_classes.c [CLASS_PRIEST - 1].
-  HP: 18
-  MAG: 1                    # FE Pow (Priest basePow) — magic attack stat
-  SKL: 1
+  # Vanilla FE8 Cleric stats, verbatim from data_classes.c [CLASS_CLERIC - 1].
+  HP: 16
+  MAG: 1                    # FE Pow (Cleric basePow) — magic attack stat
+  SKL: 2
   SPD: 2
-  DEF: 1
-  RES: 5
+  DEF: 0
+  RES: 6
   LCK: 0                    # ClassData has no base luck
-  MOV: 5                    # Priest baseMov
-  CON: 5
+  MOV: 5                    # Cleric baseMov
+  CON: 4                    # NOT flavor: CanUnitRescue is `aid >= target CON` (bmunit.c:905),
+                            # and a foot unit's aid is CON-1 — so Cleric's 4 (vs Priest's 5)
+                            # widens the set of units that can ferry the ch05 escort by one
+                            # Con tier. The chaperone mission is the chapter; this serves it.
 donor:
   character: Natasha        # vanilla Cleric — frail/high-magic line (distinct from Sclorbo's Moulder)
   why: glass mage-healer identity, opposite Sclorbo's durable Moulder line; Basil is no lord, so frailty costs nothing
 
-# ── Growth Rates (% per level) — vanilla Priest growths from data_classes.c ──
+# Vanilla FE8 has no male Cleric (the class carries the female promotion tree), and Basil is an
+# awakened PLANT — the book gives it no gender at all, so nothing in canon was overridden here.
+# Mechanically inert on a foot unit: both CA_FEMALE readers in the decomp (GetUnitAid, koido.c's
+# rescued-unit sprite) gate on CA_MOUNTEDAID first. It would start to matter only on Valkyrie.
+gender: female
+
+# ── Growth Rates (% per level) — from data_classes.c. Cleric's growths are BYTE-IDENTICAL
+#    to Priest's, so the class change moved her bases and her promotion tree, not her curve. ──
 growth_rates:
   HP: 50
   MAG: 30
@@ -71,8 +83,13 @@ growth_rates:
   LCK: 45
 
 promotion:
-  branch: [Bishop, Sage]    # vanilla FE8 Priest branch (classchg-data.c)
-  default: Bishop
+  branch: [Bishop, Valkyrie]  # vanilla FE8 Cleric branch, gPromoJidLut (classchg-data.c):
+                              # {CLASS_BISHOP_F, CLASS_VALKYRIE}. Bishop_F shares Bishop's
+                              # nameTextId (0x2d4), so the game shows both as "Bishop".
+  default: Bishop             # ClassData.promotion for CLASS_CLERIC — and it is LIGHT, which is
+                              # what `battle_anim.spell_palette_tint` below already assumes.
+                              # Priest's default was CLASS_SAGE (anima); that mismatch is why
+                              # the class changed. Guarded by the decomp-pinned test.
 
 recruited_via: "story — repotted from the Elven Tomb (Ch5)"
 recruit:
@@ -101,12 +118,12 @@ art:
     idle_frames: PMD Idle-Anim S row f0/f1/f3, bottom-anchored
     walk_frames: PMD Walk-Anim W/S/N rows, 8->5 downsample [0,2,3,5,6]; side faces left
     palette: shared cast palette; index map chosen in map_sprite_swapper (--idle-frame-h 32)
-    # ── Pre-recruit look: he stands GREEN until a party member Talks him (the chapter's first
-    # recruit), so he needs the same treatment Lupin's red does -- a charId-keyed cast override
-    # is unconditional, and it would pin his Oddish colours across a faction change nothing
+    # ── Pre-recruit look: she stands GREEN until a party member Talks her (the chapter's first
+    # recruit), so she needs the same treatment Lupin's red does -- a charId-keyed cast override
+    # is unconditional, and it would pin her Oddish colours across a faction change nothing
     # would flag. Derived at build time from the sheets above, so pixel edits flow through.
     # His BODY (idx10, the blue Oddish bulb) rides the faction ramp: green as an NPC, the
-    # standard blue once he joins. Leaves and eyes are his either way -- idx14 -> the neutral
+    # standard blue once she joins. Leaves and eyes are hers either way -- idx14 -> the neutral
     # grey-green, idx6 -> the standard red. idx1 is pure outline here (unlike Sahnar's), so it
     # goes to the dark neutral and stays black on both sides.
     pre_recruit_roles: {1: 15, 6: 11, 10: 9, 14: 13}
@@ -119,13 +136,16 @@ art:
     palette: one shared <=14-color quantize across all three frames
 
 # ── Battle anim (the block the injector reads) ───────────────────────────────
-# The 3-pose path, not an import: his three PMD poses ARE the animation (a shrub casting has no
+# The 3-pose path, not an import: her three PMD poses ARE the animation (a shrub casting has no
 # travel to transcribe, unlike Pinky's swoop or Lupin's pounce), and they shipped finished in
 # #179. NO new donor row is needed -- `clone_from: bishop` gives a STAFF slot (heal-cast, the
-# MVP) plus a LIGHT slot for after he promotes to Bishop, and call_spell_anim resolves which at
+# MVP) plus a LIGHT slot for after she promotes to Bishop, and call_spell_anim resolves which at
 # runtime off the equipped item. That row's own comment already named Basil as its reuser.
-# NOT shaman: Basil heals. Same donor as Sclorbo, which is correct -- they are the same class;
-# what separates them is the STAT_DONOR (Natasha vs Moulder), not the animation.
+# The donor survived the Cleric change untouched, and that is not luck: the injector registers a
+# PRIVATE per-CHARACTER AnimConf (gUnitSpecificBanimConfigs + _u25), so nothing here is keyed to
+# the class, and Bishop_F needs the same STAFF+LIGHT pair Bishop does.
+# NOT shaman: Basil heals. Same donor as Sclorbo -- correct, because the animation follows the
+# weapon types, not the class; what separates the two healers is the STAT_DONOR and now the class.
 battle_anim:
   clone_from: bishop
   abbr: basil
@@ -141,11 +161,13 @@ battle_anim:
     color: gold
     waveform: build
   # ...and the one thing that must NOT match. Basil rides the same Bishop donor as Sclorbo,
-  # so without a tint of his own both healers cast identical cyan -- the healer split
+  # so without a tint of her own both healers cast identical cyan -- the healer split
   # (decisions.md: Moulder war-priest vs Natasha mage-healer) would be invisible in the one
   # place the player actually watches. Gold is cyan's mirror in the engine (red+green pinned
   # high, blue suppressed) and reads as goodberry warmth against Sclorbo's cold flame.
-  # Both weapon types, same as his: STAFF is the heal now, LIGHT is after he promotes.
+  # Still earns its keep after the Cleric change: the class split shows up on the status
+  # screen, but the CASTING frame is the same donor for both, so the tint is what separates
+  # them mid-battle. Both weapon types: STAFF is the heal now, LIGHT is after she promotes.
   spell_palette_tint:
     weapon_types: [staff, light]
     color: gold

--- a/docs/CLASSES.md
+++ b/docs/CLASSES.md
@@ -27,7 +27,7 @@ roster derived from the unit YAML.
 
 | Unit | FE base | Promotion | Joins via |
 |---|---|---|---|
-| Basil | Priest | **Bishop** / Sage | story — repotted from the Elven Tomb (Ch5) |
+| Basil | Cleric | **Bishop** / Valkyrie | story — repotted from the Elven Tomb (Ch5) |
 | Baxby | Cavalier | **Paladin** / Great Knight | — |
 | Brie | TBD (post-MVP) | — | not a recruit — vanilla map ballista (RBG's siege), from ~Ch10 |
 | Lupin | Cavalier | **Paladin** / Great Knight | story — Marty talks the direwolf pack into the sled team (Ch4) |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -866,7 +866,7 @@ that force a two-front race. So we keep the twins' maps and layer the theme on t
 - **ch05 (The Empire's Reach twin)** — DefeatBoss (Ravisin); retile Ch5's spread-village field as an
   **open-air elven-tomb depression** (crypt tileset + crystal pillars — keep the open spread-site skeleton,
   dress it as a ruin); **no fog** (mood from art, not vision). Emulates Ch5's two set-pieces: (a) the
-  **Natasha→Joshua escort** becomes **Basil (Natasha-donor Priest) chaperoned to Talk Sahnar (Joshua-donor
+  **Natasha→Joshua escort** becomes **Basil (Natasha-donor Cleric) chaperoned to Talk Sahnar (Joshua-donor
   Myrmidon)** — a convertible crit-threat you neutralize by recruiting; (b) the **village-raid race**
   becomes the **Phantom-Ship eruption** (injected `EARTHQUAKE`/`TILECHANGE`) spawning undead that raid
   **spread reward-sites** (elven reliquaries), with the **crest-of-cold-iron** (promotion relic) as the
@@ -1049,15 +1049,45 @@ palette is an OBJ palette (bank 11), not a BG palette, so an item icon cannot po
 _Revised: 2026-07-14 (Nicolas — observed pink text; Codex — additive source bank, draw-time BG bank-15
 route, and active-tilemap regression check; supersedes the 2026-07-11 pal-1 assumption)._
 
-**Two healers, differentiated by donor (same move as the shamans).** Sclorbo and Basil are both
-Priests, so they get *distinct* vanilla donor lines to avoid stat-twins: **Sclorbo → Moulder** (the
-durable "war-priest": HP70/Def25, balanced, accurate) and **Basil → Natasha** (the frail "mage-healer":
-HP50/Def15 but Pow60/Res55/Lck60 — a glass, dodgy, magically-potent nuke-healer). The frail line sits
+**Two healers, differentiated by donor (same move as the shamans).** The army's two staff users get
+*distinct* vanilla donor lines to avoid stat-twins: **Sclorbo → Moulder** (the durable "war-priest":
+HP70/Def25, balanced, accurate) and **Basil → Natasha** (the frail "mage-healer": HP50/Def15 but
+Pow60/Res55/Lck60 — a glass, dodgy, magically-potent nuke-healer). The frail line sits
 on Basil deliberately: **Sclorbo is a lord candidate** (#42) and the per-lord floor would have to work
 harder on a frailer lord (he's already the weakest, staff-only lord pick), whereas **Basil is not a lord**
 (joins Ch5, after the Ch1 lord-select), so frailty there carries no survivability-floor cost — and "fragile
-but potent natural magic" suits an awakened shrub. Donor stats only; both stay Priest → Bishop/Sage.
-_Decided: 2026-06-20 (Nicolas)._
+but potent natural magic" suits an awakened shrub. Sclorbo is a **Priest → Bishop/Sage**; Basil is a
+**Cleric → Bishop/Valkyrie** (see the next entry), so since 2026-08-08 the two differ by class as well
+as by donor — but the donor is still what separates the stat lines, and it is the part that would matter
+even if they shared a class.
+_Decided: 2026-06-20 (Nicolas); Basil's class revised 2026-08-08._
+
+**Basil is a Cleric, because Priest promotes into the wrong weapon type.** Basil was a Priest from
+2026-06-20 until 2026-08-08, on the reasonable-looking grounds that she is the same class as Sclorbo
+and differs only by donor. That was the wrong class, and the decomp says why: `ClassData.promotion`
+for `CLASS_PRIEST` is **`CLASS_SAGE`** — an *anima* mage — while `CLASS_CLERIC`'s is **`CLASS_BISHOP_F`**,
+which is *light*. Basil's own `battle_anim.spell_palette_tint` has always declared `[staff, light]`, so
+Priest pointed her at the one promoted class whose weapon type contradicts her shipped art. Cleric's
+branch (`gPromoJidLut`: Bishop_F / Valkyrie) is the one her kit already assumed.
+Three things made this cheap enough to be worth doing, all verified rather than assumed:
+**(1) the art does not move** — bust, map sprite and battle anim are all keyed to the *character* slot
+(`GetUnitSMSId` override, a private `gUnitSpecificBanimConfigs` AnimConf), never to the class, and the
+`clone_from: bishop` donor supplies the STAFF+LIGHT pair Bishop_F needs anyway;
+**(2) the locked dialogue does not move** — not one locked Basil line in any chapter genders her, so the
+whole ch05 corpus ported unchanged;
+**(3) the slot does not move** — `gender:` in the unit YAML rewrites `.attributes` (`_set_gender`) on
+whatever character slot the unit wears, so a female Cleric rides the male Artur slot fine, and promotion
+is keyed by CLASS in `gPromoJidLut`, never by character.
+Two bonuses that were not the reason but are real: Cleric's bases (HP16/Def0/Res6/**Con4** vs Priest's
+18/1/5/**5**) lean the same way the Natasha donor does, and `CanUnitRescue` is `GetUnitAid(actor) >=
+UNIT_CON(target)` (`bmunit.c:905`) — so Con 4 widens the set of party members who can ferry the ch05
+escort, which is the chapter's whole set-piece. Growths are byte-identical between the two classes,
+so nothing about her level-up curve changed. `gender: female` is mechanically inert on a foot unit:
+both `CA_FEMALE` readers in the decomp (`GetUnitAid`, `koido.c`'s rescued-unit sprite) gate on
+`CA_MOUNTEDAID` first. Basil is an awakened *plant*, which RotFM gives no gender, so nothing in canon
+was overridden. Guarded by `test_basil_is_a_cleric_because_priest_promotes_into_the_wrong_weapon_type`
+and `test_basil_bases_are_vanilla_cleric_class_data_verbatim`, both pinned against the decomp.
+_Decided: 2026-08-08 (Nicolas, after an adversarial review that reversed CLAUDE's initial "not worth it")._
 
 **Lord floor, runtime mechanism (#45 3b/3c): a build-baked table applied once at the first player phase.**
 The build emits `gLordFloorDeltas[]` (`events_udefs.c`, parallel to `gLordSelectCandidates[]`): one
@@ -3130,7 +3160,7 @@ _Decided: 2026-06-09 (community research: FEU writing threads, DM voice guides, 
 
 **MINE THE CORPUS BEFORE WRITING A LINE — this is now step 0 of the drafting loop, not advice.**
 ch05's Basil/Sahnar scene burned a dozen rejected drafts written from instinct; **two Ewan/Saleh support conversations fixed it in a single pass.** FE8 ships ~40k lines and we were cherry-picking six quotes and then guessing. The method (`.claude/skills/dialogue-pass/references/natural-speech.md`, wired as SKILL.md drafting-loop step 0): read the twin chapter's scenes with `tools/vanilla_scene.py`, and for a two-hander find the **relationship twin** among FE8's ~217 two-character scenes — its **support conversations** are the game's intimate two-handers and the closest form to most of our scenes. Pick the pair whose *dynamic* matches (eager student + reserved mentor → Ewan/Saleh) and read all of them.
-The diagnosis it produced — **"epigram disease," our single most common dialogue failure**: every line polished into an artifact that lands one beat and hands off, which reads as poetry rather than talk. **Vanilla is redundant and inefficient and that is precisely why it sounds human** (Joshua and Natasha both apologise twice; she says four things that all mean "I'm leaving"). Four laws follow: turns are **lopsided** (two words answered by forty); the eager character **runs on and interrupts himself**; characters **say the feeling plainly** instead of burying it in subtext; reserve reads as **brevity and plain complete sentences**, never as an ellipsis on every line. Corollary applied to `basil.md`: the "2–5 words, no subordinate clauses" spec was retired — it made him read as slow rather than gentle.
+The diagnosis it produced — **"epigram disease," our single most common dialogue failure**: every line polished into an artifact that lands one beat and hands off, which reads as poetry rather than talk. **Vanilla is redundant and inefficient and that is precisely why it sounds human** (Joshua and Natasha both apologise twice; she says four things that all mean "I'm leaving"). Four laws follow: turns are **lopsided** (two words answered by forty); the eager character **runs on and interrupts himself**; characters **say the feeling plainly** instead of burying it in subtext; reserve reads as **brevity and plain complete sentences**, never as an ellipsis on every line. Corollary applied to `basil.md`: the "2–5 words, no subordinate clauses" spec was retired — it made her read as slow rather than gentle.
 _Decided: 2026-07-23 (Nicolas + CLAUDE; ch05 9BB — "you have the entire game's dialogue and you're not writing like it")_
 
 **Villain voice is grounded in FE8's own script, and contrasting clichés are banned.**

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4041,6 +4041,21 @@ from "finished and still red", because reporting one as the other is how a wirin
 invented and then hunted.
 _Decided: 2026-08-08 (#25; the scenario caught its own author first)._
 
+**DISPLAYING a vanilla message id you do not own is fine; displaying one another chapter WRITES
+is not (#25 review).** ch05's scene labels read `slot: "vanilla 0x9C2"`, and those labels name the
+chapter we **mine** (vanilla Ch5) — not the block we may write into. ch04 hosts on slot 5 and owns
+`0x9BA..0x9C6` outright, so `0x9C2` in the built ROM is ch04's own no-parley ending. Pointing
+Basil's join beat at it would have played Pinky and Marty discussing supper, in ch04's voice, with
+ch04's faces — a green build, a passing `ch05recruit` (it reads factions, not text), and the wrong
+scene on screen. The reliquary pattern is still correct and still in use: `0x9CC` and `0x9CD..0x9D0`
+are written by NO hosted chapter, so the ROM holds vanilla's prose and borrowing it is exactly the
+placeholder ADR. The two cases are indistinguishable at the call site — both are an int in a
+constant — so `assert_message_id_unclaimed` now checks it instead of asking anyone to remember.
+The join beat ships SILENT until the dialogue pass gives it an id from ch05's own block
+(vanilla Ch6, `0x9E4..0x9F5`); a silent beat also keeps the script in vanilla's safe shape, since
+one that continues with VISIBLE content after the prep prologue needs its own `FADU(16)` first.
+_Decided: 2026-08-08 (found by `/code-review high` on PR #252, not by the build or the gate)._
+
 ---
 
 ## Open Questions (not yet decided)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4011,6 +4011,36 @@ is therefore read off FE8's own `banim_myrm_sw1` (swing_short → hit → swing_
 with the `slash_air` lifted from its critical mode, the only place vanilla gives the blade an arc)
 rather than borrowed from the axe or lance rows.
 
+**A green recruit's TILE is load-bearing, and getting it wrong has no symptom (#25).**
+ch05's Basil is LOADed GREEN and CUSA'd blue by the opening's own join beat. The obvious tile for
+her is the one her vanilla twin stands on — this chapter lifts *everything* 1:1 from FE8 Ch5, so
+that is the habit — but Natasha is **BLUE** in `UnitDef_Event_Ch5Ally`, meaning her tile is now one
+of our **nine PREP deploy slots**. A green body parked there silently costs the player a
+deployment on a map whose difficulty is priced for the full cap, and nothing anywhere reports it.
+Two more failures in the same family: an impassable tile makes the recruit untalkable, and a tile
+walled off from the unit she must reach kills the set-piece with no symptom but a player who never
+manages the Talk. `assert_green_recruit_placement` gates all three at injection time (deploy-slot
+collision, passability, and a flood-fill to the target — the same fill
+`assert_scripted_move_reachable` runs). Basil sits at **(5,15)**, the row-15 corridor at the
+pocket's mouth, clear of all nine slots and of the four stairs.
+_Decided: 2026-08-08 (#25, the ch05 recruit wiring)._
+
+**Wiring a recruit and PROVING it are different jobs, and the passing scenario proved nothing.**
+`ch05village` was green across every version of ch05's opening, including ones where Basil never
+joined: it leaves Preparations with START and walks a *different* unit to a door, so a green shrub
+nobody can command is invisible to it. The recruit chain needed its own gate, and `ch05recruit` is
+it — three assertions in the order the player meets them: Basil is BLUE and commandable at turn 1
+(the opening CUSA landed, the step with no other witness), Sahnar rises RED on turn 2, and Basil's
+Talk flips her BLUE. It also gates the RECRUITER, not just the recruit: if the CHAR list named the
+wrong talker the command menu simply has no Talk, and the chapter looks fine until a player tries.
+**Its first run failed for the wrong reason, which is the lesson.** It reported "the CUSA did not
+fire" when the CUSA was fine — the scene shows vanilla's 32-box `0x9CC` and my advance-dialogue
+loop capped at 3600 frames, expiring 18 boxes in. *A loop cap must never be what decides failure.*
+The fix is both halves: a budget with real headroom, **and** a verdict that tells "still running"
+from "finished and still red", because reporting one as the other is how a wiring bug gets
+invented and then hunted.
+_Decided: 2026-08-08 (#25; the scenario caught its own author first)._
+
 ---
 
 ## Open Questions (not yet decided)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,7 +91,7 @@
 | Ch3 | **Trex** | Thief | **utility** (steal/chests/doors) | winged kobold |
 | Ch4→5 | **Lupin** | Cavalier | 2nd cavalry / mobile melee | direwolf (the wolf *is* the mount; pairs w/ Baxby as "beast-cavalry") |
 | Ch5 | **Sahnar** | Myrmidon | **sword duelist** (crit) | moon-elf mummy |
-| Ch5 | **Basil** | Priest | **2nd healer** | goodberry shrub (heals = handing out berries) |
+| Ch5 | **Basil** | Cleric | **2nd healer** | goodberry shrub (heals = handing out berries) |
 
 By **Ch5** every core FE *role* is covered with zero magic redundancy (we're already deep on
 casters: Marty/Mees dark, Rootis anima, Sclorbo/Basil staff) — but the **roster is not done growing**.

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -633,6 +633,9 @@ CLASS_MAP = {
     'Archer':         'CLASS_ARCHER',
     'Mage':           'CLASS_MAGE',
     'Priest':         'CLASS_PRIEST',
+    'Cleric':         'CLASS_CLERIC',  # Basil (ch05 recruit) -- Priest's twin, but its default
+                                       # promotion is Bishop (light), not Sage (anima)
+
     'Knight':         'CLASS_ARMOR_KNIGHT',
     'Pegasus Knight': 'CLASS_PEGASUS_KNIGHT',
     'Thief':          'CLASS_THIEF',   # Trex (ch03 recruit) -- the army's utility unit
@@ -733,8 +736,11 @@ PORTRAIT_MAP = {
     # line, no map sprite, no death quote -- and, the thing that actually blocked the chapter,
     # no pid for a Talk to name. These two lines are that identity.
     # Basil the goodberry shrub (npcs/basil.yaml) rides ARTUR -- a Monk absent from our ch00-08
-    # and referenced nowhere else, so dressing it is collision-free; Artur's own line promotes to
-    # Bishop, which is Basil's default promotion. His stat line references Natasha (STAT_DONOR).
+    # and referenced nowhere else, so dressing it is collision-free. His stat line references
+    # Natasha (STAT_DONOR) and his class is hers too (Cleric, 2026-08-08). The slot's own gender
+    # does not have to match his: `gender:` in the YAML rewrites .attributes on whatever slot the
+    # unit wears (_set_gender), and promotion is keyed by CLASS in gPromoJidLut, never by the
+    # character -- so a female Cleric on the male Artur slot promotes Bishop/Valkyrie correctly.
     'basil':      'Artur',
     # Sahnar (npcs/sahnar.yaml) rides MARISA -- vanilla's OTHER red-to-blue Myrmidon parley,
     # absent from our ch00-08 and referenced nowhere else. Exact class match, unlike Trex's and
@@ -1704,6 +1710,11 @@ CLASS_LOADOUT = {
     'CLASS_ARCHER':         ['ITEM_BOW_IRON', 'ITEM_VULNERARY'],
     'CLASS_MAGE':           ['ITEM_ANIMA_FIRE', 'ITEM_VULNERARY'],
     'CLASS_PRIEST':         ['ITEM_STAFF_HEAL', 'ITEM_VULNERARY'],
+    'CLASS_CLERIC':         ['ITEM_STAFF_HEAL', 'ITEM_VULNERARY'],  # Basil: same kit as the
+                                                                    # other healer; the classes
+                                                                    # differ by promotion tree
+                                                                    # and bases, not by weapon
+                                                                    # (both are STAFF-only at D)
     'CLASS_ARMOR_KNIGHT':   ['ITEM_LANCE_IRON', 'ITEM_VULNERARY'],
     'CLASS_PEGASUS_KNIGHT': ['ITEM_LANCE_SLIM', 'ITEM_LANCE_JAVELIN', 'ITEM_VULNERARY'],
     'CLASS_THIEF':          ['ITEM_SWORD_IRON', 'ITEM_DOORKEY', 'ITEM_CHESTKEY',

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -7593,14 +7593,26 @@ CH05_BASIL_GREEN_POS = (5, 15)   # the row-15 corridor at the deploy pocket's mo
                                  # deployment. Row 15 is open end-to-end and the four stairs are
                                  # at x=1/3/9/10, so she blocks no exit. Verified walkable and
                                  # connected to Sahnar's tile by assert_green_recruit_placement.
-CH05_BASIL_JOIN_MSG = 0x9C2      # "Oh! Tourists. In the tomb." -> the CUSA. Vanilla's prose
-                                 # until the dialogue pass writes ours AT THIS ID (decisions.md
-                                 # "Vanilla prose is a legitimate PLACEHOLDER"), same as the
-                                 # reliquary visits -- the WIRING here is permanent either way.
+# The join beat is SILENT, and that is a constraint rather than a choice. ch05's YAML labels its
+# scenes `slot: "vanilla 0x9C2"` and the like, but those labels are ANATOMY REFERENCES to the
+# chapter we MINE (vanilla Ch5) -- they are not ids we may write, because ch04 hosts on slot 5 and
+# owns that whole block (HOSTED_CHAPTER_MESSAGE_IDS['ch04'] = 0x9BA..0x9C6). 0x9C2 in the built
+# ROM is ch04's OWN no-parley ending (CH04_ENDING_NO_LUPIN_MSG), so pointing Basil's join at it
+# plays Pinky and Marty discussing supper. Reading an UNWRITTEN vanilla id as a placeholder is
+# fine and we do it (the reliquary visits, and the Talk below); reading one another chapter
+# WRITES is not -- that distinction is the whole reason the registry exists.
+# OWED: the dialogue pass gives this beat an id from ch05's own block (vanilla Ch6, 0x9E4..0x9F5)
+# and registers it. Until then the shrub joins wordlessly -- the WIRING is what ships here.
 CH05_SAHNAR_TALK_SCRIPT = 'MS_Ch05SahnarTalk'   # ours (declare_event_script), not a squatted
                                                 # vanilla symbol -- campaign-owned event scripts,
                                                 # declared AFTER the block-replacement pass.
-CH05_SAHNAR_TALK_MSG = 0x9CC     # the TALK-RECRUIT scene, the chapter's payoff beat
+CH05_SAHNAR_TALK_MSG = 0x9CC     # the TALK-RECRUIT scene. UNCLAIMED by every chapter (checked
+                                 # against HOSTED_CHAPTER_MESSAGE_IDS), so the ROM still holds
+                                 # vanilla's text -- which is vanilla's OWN Natasha->Joshua talk
+                                 # recruit, the exact scene ours is the twin of. The reliquary
+                                 # placeholder pattern (decisions.md "Vanilla prose is a
+                                 # legitimate PLACEHOLDER"). The dialogue pass must MOVE this to
+                                 # ch05's block, not overwrite 0x9CC -- it is ch04's neighbourhood.
 CH05_SAHNAR_TALK_FLAG = 'EVFLAG_TMP(7)'   # vanilla Ch5's own Natasha->Joshua CHAR flag, free
                                           # here: ch05's villages take eid 0 and its Misc list
                                           # is DefeatBoss + CauseGameOverIfLordDies only.
@@ -7727,6 +7739,29 @@ def assert_message_ids_unique(claims=None):
                          % (mid, owner[mid], chapter, chapter))
             owner[mid] = chapter
     return owner
+
+
+def assert_message_id_unclaimed(msg_id, chapter, what):
+    """A chapter may DISPLAY a vanilla message id it does not own -- that is the placeholder
+    pattern (decisions.md "Vanilla prose is a legitimate PLACEHOLDER"), and ch05's reliquary
+    visits and Sahnar Talk both do it. What it may NOT do is display an id ANOTHER hosted
+    chapter WRITES: the player then gets that chapter's scene, in its voice, with its faces.
+
+    The two cases are indistinguishable at the call site -- both are an int in a constant -- so
+    the difference has to be checked rather than remembered. It is an easy mistake to make from
+    the chapter YAML alone, because our scene labels (`slot: "vanilla 0x9C2"`) name the chapter
+    we MINE, not the block we may write into, and for a chapter hosted on a shifted slot those
+    are different vanilla chapters entirely.
+
+    Found by review on #25: ch05's Basil join beat pointed at 0x9C2, which is ch04's own
+    no-parley ending -- so the shrub's join would have played Pinky and Marty discussing supper.
+    """
+    holder = assert_message_ids_unique().get(msg_id)   # the registry, already collision-checked
+    if holder is not None and holder != chapter:
+        sys.exit('ERROR: %s (%s) displays message 0x%X, but %s OWNS and WRITES that id -- the '
+                 'scene would play %s\'s text. Placeholder prose must come from an id NO hosted '
+                 'chapter writes (see HOSTED_CHAPTER_MESSAGE_IDS).'
+                 % (what, chapter, msg_id, holder, holder))
 
 
 def variant_beat(beat, fallback, err_label):
@@ -9399,6 +9434,11 @@ def inject_ch05(campaign, boot=False, verbose=True):
     if recruit_initial_faction(load_unit(campaign, 'sahnar')) != 'RED':
         sys.exit('ERROR: ch05 places Sahnar on the enemy table (RED), but her YAML '
                  'recruit.initial_faction does not say red')
+    # Reading an UNWRITTEN vanilla id as placeholder prose is the reliquary pattern and is fine;
+    # reading one ANOTHER hosted chapter writes shows that chapter's scene instead. Both look
+    # identical here -- an int in a constant -- so the difference has to be a gate. Caught the
+    # Basil join beat pointed at 0x9C2, which is ch04's own no-parley ending.
+    assert_message_id_unclaimed(CH05_SAHNAR_TALK_MSG, 'ch05', "Basil's Talk recruit of Sahnar")
     sahnar_rows = [row.replace(CH05_GENERIC_PID, sahnar_char, 1) for row in sahnar_rows]
     declare_unit_table(CH05_SAHNAR_TABLE, sahnar_rows,
                        'ch05 Sahnar: rises HOSTILE at the eruption; Basil Talks her over (#25)')
@@ -9489,19 +9529,20 @@ def inject_ch05(campaign, boot=False, verbose=True):
                  # Preparations, so revealing the freshly-LOMA'd map here only flashes it.
                  + '    CALL(%s) /* preparations: pick %d; lord force-deployed */\n'
                  % (CH05_PREP_SCRIPT, chap['deployment']['deploy_limit'])
-                 # The join beat, AFTER Preparations and deliberately so. Basil is GREEN across
-                 # the prep screen (prep only ever touches PLAYER units, so a green body is
-                 # invisible to Pick Units and costs no slot), and becomes the party's tenth
-                 # unit the moment the CUSA lands -- on top of the nine the player chose, which
-                 # is what the chapter is priced for. CUSA before the CALL would hand PREP a
-                 # blue unit it never listed. The line is vanilla's until the dialogue pass.
-                 + '    TEXTSTART\n'
-                 '    TEXTSHOW(0x%X) /* "Take me to her?" -- the shrub joins */\n'
-                 '    TEXTEND\n'
-                 '    REMA\n'
-                 '    CUSA(%s) /* green -> blue: Basil is the escort now */\n'
+                 # The join, AFTER Preparations and deliberately so. Basil is GREEN across the
+                 # prep screen (prep only ever touches PLAYER units, so a green body is invisible
+                 # to Pick Units and costs no slot), and becomes the party's tenth unit the moment
+                 # the CUSA lands -- on top of the nine the player chose, which is what the
+                 # chapter is priced for. CUSA before the CALL would hand PREP a blue unit it
+                 # never listed.
+                 # No TEXTSHOW: see CH05_BASIL_JOIN_MSG for why the beat is silent until the
+                 # dialogue pass. Keeping it silent also keeps this script in vanilla's safe
+                 # shape -- a script that continues with VISIBLE content after the prep prologue
+                 # needs its own FADU(16) first (the prologue fades to black and leaves it
+                 # there); the ones that ENDA straight out, as this does, do not.
+                 + '    CUSA(%s) /* green -> blue: Basil is the escort now */\n'
                  '    ENUT(8)\n    EVBIT_T(7)\n    ENDA\n}'
-                 % (CH05_BASIL_JOIN_MSG, basil_char))
+                 % basil_char)
     script = _replace_brace_block(script, CH05_BEGINNING_SCRIPT + '[] =', beginning,
                                   CH05_EVENTSCRIPT_H)
     for turn in sorted(CH05_WAVE_TABLES):

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -7574,7 +7574,36 @@ CH05_ALLY_TABLE = 'MS_Ch05DeployCap'             # the never-LOADed PREP cap tem
 CH05_BOOT_SEED_TABLE = 'MS_Ch05BootSeed'         # --ch05-boot only: an armed party from a cold start
 CH05_LINE_TABLE = 'MS_Ch05Line'                  # the 16 turn-1 tomb-guardians
 CH05_SAHNAR_TABLE = 'MS_Ch05Sahnar'              # the turn-2 convertible (rises hostile)
+CH05_BASIL_TABLE = 'MS_Ch05Basil'                # Basil, GREEN at the pocket mouth (see below)
 CH05_WAVE_TABLES = {2: 'MS_Ch05Wave2', 3: 'MS_Ch05Wave3', 5: 'MS_Ch05Wave5'}
+
+# ── The two-stage ch05 recruit (#25): Basil joins in the OPENING, then Talks Sahnar ──────
+# Vanilla Ch5's Character list is exactly ONE entry -- CHAR(EVFLAG_TMP(7), ..., NATASHA, JOSHUA)
+# -- because its escort is already a party member (Natasha is BLUE in UnitDef_Event_Ch5Ally) and
+# only the DUELIST needs talking down. Ours is the same single entry, and Basil reaches the same
+# state by a different road: she is recruited IN this chapter, so she cannot ride the prep
+# roster (_classed_cast(available_at=5) excludes her). She is LOADed GREEN instead and CUSA'd
+# BLUE by the opening's own join beat -- basil.md Q3, and the locked 0x9C2 ("...I wonder.
+# Sahnar. ...She needs me. Take me to her?"), whose trigger is chapter_start, NOT a Talk.
+# So: no CHAR entry for Basil. One CHAR entry, Basil -> Sahnar, exactly like the twin.
+CH05_BASIL_MOV_TABLE = 'TerrainTable_MovCost_MagicNormal'   # Cleric's own cost row (data_classes.c)
+CH05_BASIL_GREEN_POS = (5, 15)   # the row-15 corridor at the deploy pocket's mouth. NOT one of
+                                 # the nine deploy_slots (rows 16-19) -- those are the party's
+                                 # and PREP fills all nine, so standing on one would cost a
+                                 # deployment. Row 15 is open end-to-end and the four stairs are
+                                 # at x=1/3/9/10, so she blocks no exit. Verified walkable and
+                                 # connected to Sahnar's tile by assert_green_recruit_placement.
+CH05_BASIL_JOIN_MSG = 0x9C2      # "Oh! Tourists. In the tomb." -> the CUSA. Vanilla's prose
+                                 # until the dialogue pass writes ours AT THIS ID (decisions.md
+                                 # "Vanilla prose is a legitimate PLACEHOLDER"), same as the
+                                 # reliquary visits -- the WIRING here is permanent either way.
+CH05_SAHNAR_TALK_SCRIPT = 'MS_Ch05SahnarTalk'   # ours (declare_event_script), not a squatted
+                                                # vanilla symbol -- campaign-owned event scripts,
+                                                # declared AFTER the block-replacement pass.
+CH05_SAHNAR_TALK_MSG = 0x9CC     # the TALK-RECRUIT scene, the chapter's payoff beat
+CH05_SAHNAR_TALK_FLAG = 'EVFLAG_TMP(7)'   # vanilla Ch5's own Natasha->Joshua CHAR flag, free
+                                          # here: ch05's villages take eid 0 and its Misc list
+                                          # is DefeatBoss + CauseGameOverIfLordDies only.
 
 # The four reliquary visits. Each rides OUR OWN script (declare_event_script) but shows VANILLA
 # Ch5's own village line, by pointing at the message id that already holds it -- we never WRITE
@@ -8205,11 +8234,24 @@ def assert_pack_pids_addressable(chap, pack_pids):
                  % ', '.join(clashes))
 
 
-def ch04_parley_recruiters(campaign, chap):
-    """ch04's parley recruiter set = ONLY the YAML parley.by speaker (Nicolas 2026-07-21: Marty
-    specifically, NOT ch03's any-party-member -- the reveal cutscene centres Marty's creature
-    diplomacy). Data-driven from the convertible wave's parley block; returns the CHARACTER_ symbol."""
-    by = (_ch04_reveal_wave(chap).get('parley') or {})['by']
+def parley_recruiters(unit):
+    """The recruiter set for a GATED talk recruit = ONLY the speaker the unit's own `parley.by`
+    names, as a one-entry CHARACTER_ list for talk_recruit_wiring.
+
+    The counterpart to talk_recruiters ("any core party member", ch03's Trex). A chapter picks
+    between them; the wiring downstream is identical either way. Gated recruits are the ones
+    whose fiction is carried by ONE character, so the recruiter is authored data rather than a
+    roster query: ch04's Marty->Lupin (Nicolas 2026-07-21 -- the reveal centres Marty's creature
+    diplomacy) and ch05's Basil->Sahnar (Sahnar does not weigh the argument, she RECOGNISES
+    Basil -- lore/sahnar.md; anyone else gets the killing edge).
+
+    `unit` is whatever dict carries the parley block -- ch04 hands it the convertible WAVE,
+    ch05 the convertible ENEMY entry. Both are just "the thing being parleyed with", which is
+    why this needs neither the campaign nor the chapter."""
+    by = (unit.get('parley') or {})['by']
+    if by not in PORTRAIT_MAP:
+        sys.exit('ERROR: parley.by %r is not a cast member with a PORTRAIT_MAP slot -- a Talk '
+                 'can only be initiated by a unit the engine can address' % by)
     return [char_symbol(PORTRAIT_MAP[by])]
 
 
@@ -8345,6 +8387,40 @@ def assert_scripted_move_reachable(maps_dir, stem, start, dest, mov_table, who):
             '       most north-east tile it CAN reach: %s'
             % (who, start, dest, stem, terrain[dest[1]][dest[0]],
                costs[terrain[dest[1]][dest[0]]], north_east))
+
+
+def assert_green_recruit_placement(chap, maps_dir, stem, pos, mov_table, who, must_reach=None):
+    """Where a GREEN on-map recruit is LOADed has three ways to be quietly wrong, and none of
+    them fails the build or a load-test. Gate all three at injection time.
+
+    1. **On a deploy tile.** The prep flow fills every one of the chapter's `deploy_slots`
+       (the cap IS the slot count -- decisions.md "How the deploy cap + prep screen are actually
+       wired"), so a green body parked on one silently costs the player a deployment on a map
+       balanced for the full cap. Cheapest possible bug to make: the recruit's own vanilla twin
+       usually STANDS on one, because in vanilla it is a blue party member (ch05: Natasha is
+       BLUE in UnitDef_Event_Ch5Ally, on what is now one of our nine tiles).
+    2. **Impassable.** A recruit on terrain its own class cannot occupy is unreachable and
+       untalkable -- the chapter just quietly loses its recruit.
+    3. **Walled off from the unit it must reach.** An escort-recruit exists to cross the map;
+       if the flood-fill says it cannot, the set-piece is dead on arrival and the only symptom
+       is a player who never manages the Talk.
+
+    `must_reach` is the tile the recruit has to be able to WALK to (ch05: Sahnar's). Reuses
+    reachable_tiles, the same flood fill assert_scripted_move_reachable runs."""
+    slots = [tuple(s) for s in chap['deployment']['deploy_slots']]
+    if tuple(pos) in slots:
+        sys.exit('ERROR: %s is placed on %s, which is one of the %d PREP deploy tiles -- the '
+                 'green body would cost the player a deployment.' % (who, tuple(pos), len(slots)))
+    _, _, terrain = _map_terrain_grid(maps_dir, stem)
+    costs = _class_terrain_move_costs(mov_table)
+    if costs[terrain[pos[1]][pos[0]]] <= 0:
+        sys.exit('ERROR: %s is placed on %s, terrain 0x%02X, which its class cannot enter.'
+                 % (who, tuple(pos), terrain[pos[1]][pos[0]]))
+    if must_reach is not None:
+        reachable = reachable_tiles(terrain, costs, tuple(pos))
+        if tuple(must_reach) not in reachable:
+            sys.exit('ERROR: %s at %s cannot WALK to %s -- the escort recruit is unreachable, '
+                     'so the Talk can never happen.' % (who, tuple(pos), tuple(must_reach)))
 
 
 def map_changes_asm(symbol, changes):
@@ -8948,7 +9024,7 @@ def inject_ch04(campaign, boot=False, verbose=True):
         f.write(udefs)
 
     # The Marty->Lupin parley (Stage 2b): the shared talk-recruit wiring (talk_recruit_wiring),
-    # recruiter = Marty ONLY (ch04_parley_recruiters, data-driven from parley.by; Nicolas
+    # recruiter = Marty ONLY (parley_recruiters, data-driven from parley.by; Nicolas
     # 2026-07-21). The talk script's pre_script turns the pack GREEN WHERE IT STANDS -- one
     # CHECK_ALIVE-guarded CUSN per wolf (#203) -- then CUSA flips Lupin blue. One flow with
     # ch03's green Trex; the parley IS the recruit. Because CUSN can only convert wolves that
@@ -8956,16 +9032,18 @@ def inject_ch04(campaign, boot=False, verbose=True):
     parley_pre = convert_survivors_green(
         CH04_PACK_PIDS, CH04_PARLEY_LABEL_BASE, 'Mauthe Doog')
     assert_pack_pids_addressable(chap, CH04_PACK_PIDS)   # #198 review guard, re-aimed by #203
-    parley_recruiters = ch04_parley_recruiters(campaign, chap)
+    recruiters = parley_recruiters(_ch04_reveal_wave(chap))
     lupin_char_events, lupin_talk_script = talk_recruit_wiring(
-        parley_recruiters, char_symbol(lupin[1]),
+        recruiters, char_symbol(lupin[1]),
         CH04_LUPIN_TALK_FLAG, CH04_LUPIN_TALK_SCRIPT, CH04_LUPIN_TALK_MSG,
         pre_script=parley_pre)
     # Force-deploy the parley recruiter(s): the parley is gated on Marty specifically (unlike
     # ch03's any-party-member talk), so benching Marty would miss the recruit. Field him via
     # vanilla's per-chapter ForceDeploymentEnt data path -- no new engine code (harmless if the
     # player chose Marty as lord: the lord check already force-deploys him). Nicolas 2026-07-21.
-    _force_deploy_units(parley_recruiters, CH04_HOST_INDEX)
+    # ch05 needs no counterpart: its gated recruiter (Basil) is not on the prep roster at all --
+    # she is LOADed onto the map by the beginning scene, so there is no Pick Units to bench her.
+    _force_deploy_units(recruiters, CH04_HOST_INDEX)
 
     with open(CH5_EVENTINFO_H, encoding='utf-8') as f:
         info = f.read()
@@ -9307,20 +9385,44 @@ def inject_ch05(campaign, boot=False, verbose=True):
     # a shared pid is unaddressable, which is exactly what #203 cost ch04's wolf pack.
     sahnar_rows = ch05_enemy_rows(chap, arrives_turn=2, exclude=frozenset(
         e['id'] for e in chap['enemy_units'] if e['id'] != 'sahnar'))
-    # Sahnar is NOT a cast member yet -- npcs/sahnar.yaml carries `recruit.via: story` and she
-    # holds no PORTRAIT_MAP slot, so there is no identity to ride (contrast Lupin/Trex, whose
-    # slots exist). Her portrait slot, stat donor and Basil's red-convertible Talk are the
-    # recruit pass (#25); the machinery for it is already there and parameterized
-    # (recruit_initial_faction returns RED for exactly this case).
-    #
-    # She still takes the field NOW, on her own pid: the chapter is balanced with a
-    # crit-threat Myrmidon on it (difficulty.py counts her as a convertible on the line),
-    # and a UNIQUE pid is what keeps her addressable when the Talk lands -- a shared pid is
-    # unaddressable, which is precisely what #203 cost ch04's wolf pack. Until then she is a
-    # hostile you can only kill, which is the honest state of the chapter.
-    sahnar_rows = [row.replace(CH05_GENERIC_PID, CH05_SAHNAR_PID, 1) for row in sahnar_rows]
+    # Sahnar rises on her OWN CHARACTER slot (#251 gave her one -- Marisa), not a raw pid: the
+    # Talk has to address HER and not the nearest identical myrmidon, and a shared pid is
+    # unaddressable, which is precisely what #203 cost ch04's wolf pack. She rides the ENEMY
+    # table, so the row is red by construction -- and that is exactly why her YAML's
+    # `recruit.initial_faction: red` is checked rather than trusted: the field is what the
+    # SHARED recruit flow reads to tell a red parley from a green bystander, so if it ever
+    # disagreed with where she is actually placed, the flow would be reasoning about a unit
+    # that is not on the map in that colour.
+    sahnar = next(r for r in on_map_talk_recruits(campaign, chap['chapter_number'])
+                  if r[0] == 'sahnar')
+    sahnar_char = char_symbol(sahnar[1])
+    if recruit_initial_faction(load_unit(campaign, 'sahnar')) != 'RED':
+        sys.exit('ERROR: ch05 places Sahnar on the enemy table (RED), but her YAML '
+                 'recruit.initial_faction does not say red')
+    sahnar_rows = [row.replace(CH05_GENERIC_PID, sahnar_char, 1) for row in sahnar_rows]
     declare_unit_table(CH05_SAHNAR_TABLE, sahnar_rows,
-                       'ch05 Sahnar: rises HOSTILE at the eruption (Talk recruit owed, #25)')
+                       'ch05 Sahnar: rises HOSTILE at the eruption; Basil Talks her over (#25)')
+
+    # Basil: GREEN at the pocket mouth, the Colm/Trex placement idiom -- her own table so the
+    # PREP cap template stays the pure blue roster. Unlike Trex she is not joined by a CHAR
+    # talk; the opening's own beat CUSAs her (see CH05_BASIL_GREEN_POS). She is a classed cast
+    # member, so her slot/class come from the roster rather than being named here.
+    basil = next(r for r in on_map_talk_recruits(campaign, chap['chapter_number'])
+                 if r[0] == 'basil')
+    basil_char = char_symbol(basil[1])
+    basil_faction = recruit_initial_faction(load_unit(campaign, 'basil'))   # GREEN (the default)
+    assert_green_recruit_placement(
+        chap, maps_dir, CH05_LAYOUT[1], CH05_BASIL_GREEN_POS,
+        CH05_BASIL_MOV_TABLE, 'Basil (ch05 green recruit)',
+        must_reach=tuple(next(e for e in chap['enemy_units']
+                              if e['id'] == 'sahnar')['positions'][0]))
+    bx, by = CH05_BASIL_GREEN_POS
+    declare_unit_table(CH05_BASIL_TABLE, [_ally_unit_entry(
+        leader, basil[1], basil[3], basil[4], bx, by, ', '.join(CLASS_LOADOUT[basil[2]]),
+        ' /* basil -- green until the opening join beat CUSAs her blue (#25) */',
+        allegiance=basil_faction)],
+        'ch05 Basil: %s at the pocket mouth; the opening join makes her the escort'
+        % basil_faction)
 
     # 3. Strip the host slot's event lists and wire ours. The list SYMBOLS are the only
     #    vanilla names left in this function, and they come from CH05_EVENT_LISTS.
@@ -9345,7 +9447,16 @@ def inject_ch05(campaign, boot=False, verbose=True):
         location_events(chap.get('villages', []),
                         {vid: slot[0] for vid, slot in CH05_VILLAGE_SLOTS.items()},
                         CH05_SHOPS), CH05_EVENTINFO_H)
-    for key in ('character', 'select_unit', 'select_dest', 'unit_move', 'tutorial'):
+    # Character = the Basil->Sahnar Talk, and nothing else -- structurally identical to vanilla
+    # Ch5's single CHAR(NATASHA, JOSHUA). Recruiter set is Sahnar's own `parley.by` (Basil), the
+    # gated flavour of the shared flow; ch03's Trex passes the whole roster instead. No
+    # pre_script: unlike ch04's pack parley there is no group to bring over with her.
+    sahnar_char_events, sahnar_talk_script = talk_recruit_wiring(
+        parley_recruiters(next(e for e in chap['enemy_units'] if e['id'] == 'sahnar')),
+        sahnar_char, CH05_SAHNAR_TALK_FLAG, CH05_SAHNAR_TALK_SCRIPT, CH05_SAHNAR_TALK_MSG)
+    info = _replace_brace_block(info, CH05_EVENT_LISTS['character'] + '[] =',
+                                sahnar_char_events, CH05_EVENTINFO_H)
+    for key in ('select_unit', 'select_dest', 'unit_move', 'tutorial'):
         info = _replace_brace_block(info, CH05_EVENT_LISTS[key] + '[] =',
                                     '{\n    END_MAIN\n}', CH05_EVENTINFO_H)
     # Point the group at OUR roster table. Declaring it is not enough -- the engine reads the
@@ -9371,12 +9482,26 @@ def inject_ch05(campaign, boot=False, verbose=True):
                  % CH05_HOST_INDEX
                  + '    LOAD1(0x1, %s) /* the 16 risen tomb-guard */\n    ENUN\n'
                  % CH05_LINE_TABLE
+                 + '    LOAD1(0x1, %s) /* Basil, GREEN at the pocket mouth */\n    ENUN\n'
+                 % CH05_BASIL_TABLE
                  + seed_load
                  # NO FADU: the shared prep prologue fades to black itself before drawing
                  # Preparations, so revealing the freshly-LOMA'd map here only flashes it.
                  + '    CALL(%s) /* preparations: pick %d; lord force-deployed */\n'
+                 % (CH05_PREP_SCRIPT, chap['deployment']['deploy_limit'])
+                 # The join beat, AFTER Preparations and deliberately so. Basil is GREEN across
+                 # the prep screen (prep only ever touches PLAYER units, so a green body is
+                 # invisible to Pick Units and costs no slot), and becomes the party's tenth
+                 # unit the moment the CUSA lands -- on top of the nine the player chose, which
+                 # is what the chapter is priced for. CUSA before the CALL would hand PREP a
+                 # blue unit it never listed. The line is vanilla's until the dialogue pass.
+                 + '    TEXTSTART\n'
+                 '    TEXTSHOW(0x%X) /* "Take me to her?" -- the shrub joins */\n'
+                 '    TEXTEND\n'
+                 '    REMA\n'
+                 '    CUSA(%s) /* green -> blue: Basil is the escort now */\n'
                  '    ENUT(8)\n    EVBIT_T(7)\n    ENDA\n}'
-                 % (CH05_PREP_SCRIPT, chap['deployment']['deploy_limit']))
+                 % (CH05_BASIL_JOIN_MSG, basil_char))
     script = _replace_brace_block(script, CH05_BEGINNING_SCRIPT + '[] =', beginning,
                                   CH05_EVENTSCRIPT_H)
     for turn in sorted(CH05_WAVE_TABLES):
@@ -9413,8 +9538,17 @@ def inject_ch05(campaign, boot=False, verbose=True):
             village_script(msg, village_reward_item(village, CH05_ITEM_IDS), CH05_VISIT_BG),
             'ch05 %s -- gift is ours, prose is vanilla 0x%X until the dialogue pass (#25)'
             % (village['id'], msg))
+    # 4c. The Basil->Sahnar Talk script the Character list points at. Same append-AFTER-the-bulk-
+    #     write rule as the visits above -- declaring it earlier would have the block rewrite
+    #     discard it, and the build would die at link time pointing at the CHAR entry rather
+    #     than at the loss.
+    declare_event_script(
+        CH05_EVENTSCRIPT_H, CH05_SAHNAR_TALK_SCRIPT, sahnar_talk_script,
+        'ch05 Basil Talks Sahnar down -- CUSA red->blue; prose is vanilla 0x%X until the '
+        'dialogue pass (#25)' % CH05_SAHNAR_TALK_MSG)
     assert_event_scripts_defined(
-        CH05_EVENTSCRIPT_H, [slot[0] for slot in CH05_VILLAGE_SLOTS.values()])
+        CH05_EVENTSCRIPT_H, [slot[0] for slot in CH05_VILLAGE_SLOTS.values()]
+        + [CH05_SAHNAR_TALK_SCRIPT])
 
     # 5. Texts + the flagged defeat quote that IS the win trigger.
     with open(TEXTS_TXT, encoding='utf-8') as f:

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6427,7 +6427,15 @@ scenarios.ch05recruit = function()
     -- 3. The Talk. Park Basil orthogonally adjacent (setMapUnit keeps the tile->unit grid in
     --    sync, so adjacency reads with no phase cycle -- the ch03talk/ch04Parley trick); the
     --    point is the recruit landing, not walking a 5-MOV healer across the depression.
+    -- Re-read her: the waits above can span an enemy phase, so the handle from the arrival check
+    -- is stale by here. A nil deref would abort the scenario with a Lua error instead of the
+    -- clean verdict the rest of this function is built to produce.
     local sah = redSahnar()
+    if not sah then
+        shot("ch05recruit")
+        return result("FAIL", "Sahnar left the red array before the Talk -- killed by the AI, "
+            .. "or she never settled on the map")
+    end
     local grid, parked = mapUnitAt(basil.x, basil.y), false
     for _, d in ipairs({ { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }) do
         local tx, ty = sah.x + d[1], sah.y + d[2]

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6376,6 +6376,117 @@ scenarios.ch04packmath = function()
         .. "who survived, so talking early is the reward", killed, spawned, greens))
 end
 
+-- ch05recruit: the REGRESSION GATE for ch05's two-stage recruit (#25). It exists because the
+-- half that is easiest to get wrong produces NO symptom: Basil is LOADed GREEN and flipped BLUE
+-- by the opening's own CUSA, and if that CUSA never fires the chapter still boots, still runs
+-- PREP, still passes ch05village -- you simply have a green shrub nobody can give an order to,
+-- and therefore a Talk that can never happen. `ch05village` cannot see any of that; it exits
+-- Preparations with START and walks a different unit to a door.
+-- So this asserts the CHAIN, in the order the player experiences it:
+--   1. Basil is BLUE and commandable at turn 1        (the opening join CUSA landed)
+--   2. Sahnar rises RED on turn 2                     (the eruption wake still fires)
+--   3. Basil's Talk flips Sahnar BLUE                 (the CHAR entry + MS_Ch05SahnarTalk)
+-- Step 1 is the one with no other witness. Steps 2-3 are ch04Parley's shape with no pack.
+-- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05recruit (needs a CH05BOOT=1 ROM).
+scenarios.ch05recruit = function()
+    local BASIL, SAHNAR = 0x13, 0x16        -- CHARACTER_ARTUR / CHARACTER_MARISA
+    local function blueBasil() return findUnit(SYM.gUnitArrayBlue, 20, BASIL) end
+    local function redSahnar() return findUnit(SYM.gUnitArrayRed, 24, SAHNAR) end
+    local function blueSahnar() return findUnit(SYM.gUnitArrayBlue, 20, SAHNAR) end
+    if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
+    pokeFastConfig()
+    waitFor(function()
+        return faction() == 0 and not menuOpen() and not procActive(SYM.ProcScr_StdEventEngine)
+    end, 6000, true)
+
+    -- 1. The join. A GREEN Basil here means the CUSA after CALL(Preparations) did not land --
+    --    which is invisible to every other scenario, so name the faction we actually found.
+    local basil = blueBasil()
+    if not basil then
+        local green = findUnit(SYM.gUnitArrayGreen, 20, BASIL)
+        shot("ch05recruit")
+        return result("FAIL", green
+            and "Basil is still GREEN at turn 1 -- the opening join CUSA never fired, so she "
+                .. "takes no orders and the Talk can never happen"
+            or "Basil (0x13) is on no unit array at turn 1 -- the green LOAD1 did not run")
+    end
+    log(string.format("ch05recruit: Basil is BLUE at turn 1 on (%d,%d) -- the opening join landed",
+        basil.x, basil.y))
+
+    -- 2. The wake. Wait for the UNIT, not the turn counter: the counter ticks when the player
+    --    phase ends, well before the wave event LOAD1s her (ch04packmath learned this).
+    if not endTurn() then return result("FAIL", "could not end turn 1") end
+    if not waitFor(function() return turn() >= 2 and redSahnar() ~= nil end, 5400) then
+        shot("ch05recruit")
+        return result("FAIL", "Sahnar never rose RED on turn 2 -- the eruption wake did not fire")
+    end
+    waitFor(function()
+        return faction() == 0 and not menuOpen() and not procActive(SYM.ProcScr_StdEventEngine)
+    end, 3600, true)
+
+    -- 3. The Talk. Park Basil orthogonally adjacent (setMapUnit keeps the tile->unit grid in
+    --    sync, so adjacency reads with no phase cycle -- the ch03talk/ch04Parley trick); the
+    --    point is the recruit landing, not walking a 5-MOV healer across the depression.
+    local sah = redSahnar()
+    local grid, parked = mapUnitAt(basil.x, basil.y), false
+    for _, d in ipairs({ { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }) do
+        local tx, ty = sah.x + d[1], sah.y + d[2]
+        if tx >= 0 and ty >= 0 and mapUnitAt(tx, ty) == 0 then
+            setMapUnit(basil.x, basil.y, 0)
+            emu:write8(basil.addr + 0x10, tx); emu:write8(basil.addr + 0x11, ty)
+            setMapUnit(tx, ty, grid)
+            parked = true
+            break
+        end
+    end
+    if not parked then return result("FAIL", "no free tile adjacent to Sahnar to park Basil") end
+    basil = blueBasil()
+    if not basil or not moveUnit(basil.x, basil.y, basil.x, basil.y) then
+        return result("FAIL", "no live command menu for Basil")
+    end
+    -- The gate on the RECRUITER, not just the recruit: if the CHAR list named the wrong talker
+    -- (or nobody), the menu simply has no Talk and the chapter looks fine until a player tries.
+    if not chooseTalk() then
+        shot("ch05recruit")
+        return result("FAIL", "Basil's live command menu did not expose Talk -- the CHAR entry "
+            .. "does not name her as Sahnar's recruiter")
+    end
+    -- The budget must clear the WHOLE scene. This shows VANILLA's 0x9CC until the dialogue pass
+    -- writes ours, and vanilla's is 32 boxes at ~200 frames each -- while the CUSA is the last
+    -- thing MS_Ch05SahnarTalk does, after TEXTEND. The first cut of this loop capped at 3600 and
+    -- expired 18 boxes in, then reported "the CUSA did not fire" about a script that had simply
+    -- not reached it yet. A LOOP CAP MUST NEVER BE WHAT DECIDES FAILURE (decisions.md): hence a
+    -- budget with real headroom AND, below, two distinguishable verdicts.
+    local BUDGET, boxes = 20000, 0
+    for _ = 1, BUDGET do
+        if blueSahnar() then break end
+        if controllerState() == "dialogue_wait" then
+            boxes = boxes + 1
+            if not guardedInput("advance_dialogue", "A", "dialogue input wait clears", function(after)
+                return controllerState(after) ~= "dialogue_wait"
+            end, 120) then return result("FAIL", "recruit dialogue input did not advance") end
+        else
+            yield()
+        end
+    end
+    if not blueSahnar() then
+        shot("ch05recruit")
+        -- Still mid-scene means the harness ran out of road; a FINISHED scene with a red Sahnar
+        -- is the real defect. Reporting one as the other is how a wiring bug gets invented.
+        local running = controllerState() == "dialogue_wait"
+            or procActive(SYM.ProcScr_StdEventEngine)
+        return result("FAIL", running
+            and string.format("the recruit scene was STILL RUNNING after %d frames (%d boxes) "
+                .. "-- the budget expired, not the wiring", BUDGET, boxes)
+            or string.format("the scene finished (%d boxes) and Sahnar is still RED -- "
+                .. "MS_Ch05SahnarTalk's CUSA did not fire", boxes))
+    end
+    runEnemyPhase()      -- the sprite only repaints to the party palette on a phase transition
+    shot("ch05recruit")
+    return result("PASS", "Basil joined blue in the opening, Sahnar rose red on turn 2, and "
+        .. "Basil's Talk brought her over -- the whole ch05 recruit chain")
+end
+
 -- Park an unexhausted blue unit on a village door and take the Visit command, stopping the
 -- moment the location event starts. Split from the dialogue-advancing half so the RECORDER can
 -- own the filmed part: `openVillageVisit` is the unfilmed walk-in (a `pre`), the line itself is

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -250,6 +250,9 @@ scenarios:
   ch05village:
     rom: ch05boot
     host_chapter: 6
+  ch05recruit:
+    rom: ch05boot
+    host_chapter: 6
   ch04snag:
     rom: ch04boot
     host_chapter: 5
@@ -316,6 +319,7 @@ suites:
     - ch04snag
     - clear_ch04_parley
     - ch05village
+    - ch05recruit
 
   ch01:
     - controller_turn

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1549,7 +1549,7 @@ class Ch04RuntimeHost(unittest.TestCase):
     def test_parley_recruiter_is_marty_only(self):
         # Nicolas 2026-07-21: ch04's talker is Marty specifically, NOT ch03's any-party-member.
         # Data-driven from the convertible wave's parley.by; Marty rides the Seth slot.
-        self.assertEqual(bc.ch04_parley_recruiters(self.CAMPAIGN, self._chap()),
+        self.assertEqual(bc.parley_recruiters(bc._ch04_reveal_wave(self._chap())),
                          ['CHARACTER_SETH'])
 
     def test_reveal_cutscene_pans_loads_focuses_lupin_and_plants_the_parley(self):
@@ -1572,7 +1572,7 @@ class Ch04RuntimeHost(unittest.TestCase):
         # code: {pid, route=ANY(0xFF), chapter=host slot}. Redundant-but-harmless if the player
         # chose Marty as lord (IsCharacterForceDeployed_ already returns true for the lead).
         entries = bc._force_deployment_entries(
-            bc.ch04_parley_recruiters(self.CAMPAIGN, self._chap()), bc.CH04_HOST_INDEX)
+            bc.parley_recruiters(bc._ch04_reveal_wave(self._chap())), bc.CH04_HOST_INDEX)
         self.assertIn('{CHARACTER_SETH, 0xFF, %d}' % bc.CH04_HOST_INDEX, entries)
 
     def test_roster_uses_the_vanilla_monster_classes_and_weapons(self):
@@ -1701,6 +1701,38 @@ class Ch05RecruitIdentities(unittest.TestCase):
             seated = {uid for uid, *_ in bc._classed_cast(self.CAMPAIGN, available_at=n)[0]}
             self.assertEqual({'basil', 'sahnar'} <= seated, expected,
                              'wrong prep availability at chapter %d' % n)
+
+    def test_the_gated_recruiter_is_basil_only(self):
+        # Sahnar's recruiter is authored data (her `parley.by`), not a roster query -- she does
+        # not weigh the argument, she recognises Basil (lore/sahnar.md). Same helper ch04's
+        # Marty->Lupin parley uses; the chapter picks parley_recruiters over talk_recruiters.
+        sahnar = next(e for e in bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+                      ['enemy_units'] if e['id'] == 'sahnar')
+        self.assertEqual(bc.parley_recruiters(sahnar), ['CHARACTER_ARTUR'])
+
+    def test_basils_green_tile_costs_no_deployment_and_can_reach_sahnar(self):
+        # The three silent ways a green placement goes wrong (assert_green_recruit_placement).
+        # Worth pinning the tile itself: vanilla's Natasha is BLUE and stands on what is now one
+        # of our nine deploy slots, so copying the twin 1:1 here -- which is this chapter's
+        # standing habit -- would have quietly cost the player a deployment.
+        chap = bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+        slots = [tuple(s) for s in chap['deployment']['deploy_slots']]
+        self.assertNotIn(bc.CH05_BASIL_GREEN_POS, slots)
+        maps = os.path.join(bc.REPO, 'campaigns', self.CAMPAIGN, 'maps')
+        bc.assert_green_recruit_placement(          # sys.exits on any of the three
+            chap, maps, bc.CH05_LAYOUT[1], bc.CH05_BASIL_GREEN_POS,
+            bc.CH05_BASIL_MOV_TABLE, 'Basil',
+            must_reach=tuple(next(e for e in chap['enemy_units']
+                                  if e['id'] == 'sahnar')['positions'][0]))
+
+    def test_the_talk_script_flips_sahnar_and_carries_no_pack_conversion(self):
+        # ch04 splices a pre_script (the wolf pack's conversion sweep) into the same flow;
+        # ch05 has no group to bring over, so the script must be the bare talk -> CUSA.
+        script = bc.talk_recruit_script(bc.CH05_SAHNAR_TALK_MSG, 'CHARACTER_MARISA')
+        self.assertIn('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_MSG, script)
+        self.assertIn('CUSA(CHARACTER_MARISA)', script)
+        self.assertNotIn('CUSN', script)
+        self.assertLess(script.index('TEXTSHOW'), script.index('CUSA'))   # line, then the flip
 
     def test_each_carries_a_death_quote(self):
         # inject_pc_death_quotes hard-exits without one (#6), so a slot with no quote is a

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -133,6 +133,17 @@ class TrexRecruitCast(unittest.TestCase):
         cast = {uid: (slot, cls) for uid, slot, cls, _sms in bc.classed_cast(self.CAMPAIGN)}
         self.assertEqual(cast['trex'], ('Rennac', 'CLASS_THIEF'))
 
+    def test_every_classed_cast_member_has_a_test_loadout(self):
+        # inject_test_chapter walks the WHOLE PORTRAIT_MAP and sys.exits on the first class
+        # with no CLASS_LOADOUT row -- so a cast member's class change can break the art bench
+        # (recordcast/recordanim) without touching a single chapter. Caught exactly that when
+        # Basil moved Priest -> Cleric (2026-08-08): CLASS_CLERIC had no row, and ch05's own
+        # guard could not see it because Basil is recruited IN ch05 and so is not on its field
+        # roster. Assert the invariant, not the one class that happened to be missing.
+        allcast, _ = bc._classed_cast(self.CAMPAIGN)   # available_at=None -> everyone
+        missing = sorted({ce for _uid, _slot, ce, *_ in allcast if ce not in bc.CLASS_LOADOUT})
+        self.assertEqual(missing, [], 'classed cast members with no CLASS_LOADOUT row')
+
     def test_thief_loadout_and_testch_covers_the_whole_cast(self):
         # inject_test_chapter needs a Thief loadout + one spawn tile per classed cast member
         # (13 now: 8 founding + Baxby + Trex + Lupin + ch05's Basil and Sahnar); both would
@@ -1614,10 +1625,12 @@ class Ch05RecruitIdentities(unittest.TestCase):
         self.assertFalse(set(slots) & set(bc.GUEST_PORTRAIT_MAP.values()),
                          'a cast slot collides with a cutscene guest slot')
 
-    def test_the_healer_split_is_donor_deep_not_class_deep(self):
-        # Sclorbo and Basil are both Priests; decisions.md differentiates them by DONOR
-        # (Moulder durable war-priest vs Natasha frail mage-healer), which only exists once
-        # Basil has a STAT_DONOR row -- the YAML design record cannot do it alone.
+    def test_the_healer_split_is_donor_deep(self):
+        # decisions.md differentiates the army's two healers by DONOR (Moulder durable
+        # war-priest vs Natasha frail mage-healer), which only exists once Basil has a
+        # STAT_DONOR row -- the YAML design record cannot do it alone. Since 2026-08-08 the
+        # split is ALSO class-deep (Sclorbo Priest / Basil Cleric), but the donor is still
+        # what separates the stat lines, so this stays the guard.
         self.assertEqual(bc.STAT_DONOR['sclorbo'], 'CHARACTER_MOULDER')
         self.assertEqual(bc.STAT_DONOR['basil'], 'CHARACTER_NATASHA')
         self.assertEqual(bc.STAT_DONOR['sahnar'], 'CHARACTER_JOSHUA')
@@ -1629,11 +1642,57 @@ class Ch05RecruitIdentities(unittest.TestCase):
         recruits = {r[0]: r for r in bc.on_map_talk_recruits(self.CAMPAIGN, self.CH05)}
         self.assertEqual(set(recruits), {'basil', 'sahnar'},
                          'ch05 recruits exactly Basil and Sahnar on the map')
-        self.assertEqual(recruits['basil'][2], 'CLASS_PRIEST')
+        self.assertEqual(recruits['basil'][2], 'CLASS_CLERIC')
         self.assertEqual(recruits['sahnar'][2], 'CLASS_MYRMIDON')
         load = lambda uid: bc.load_unit(self.CAMPAIGN, uid)
         self.assertEqual(bc.recruit_initial_faction(load('basil')), 'GREEN')
         self.assertEqual(bc.recruit_initial_faction(load('sahnar')), 'RED')
+
+    def test_basil_is_a_cleric_because_priest_promotes_into_the_wrong_weapon_type(self):
+        """The whole reason for the class (Nicolas, 2026-08-08). See decisions.md.
+
+        Priest's `ClassData.promotion` is CLASS_SAGE -- an ANIMA mage -- while basil.yaml's
+        `battle_anim.spell_palette_tint` declares STAFF + LIGHT, i.e. Bishop. Cleric's default
+        is CLASS_BISHOP_F, which IS light, so the class table points him at the class his own
+        art already assumes. Pinned against the decomp so the two cannot drift apart again.
+        """
+        table = bc._vanilla_class_table()
+        self.assertEqual(table['CLASS_PRIEST']['promotion'], 'CLASS_SAGE',
+                         'Priest still defaults into anima -- the reason Basil left it')
+        self.assertEqual(table['CLASS_CLERIC']['promotion'], 'CLASS_BISHOP_F')
+        # ...and the YAML's authored branch is the decomp's branch, not a wish.
+        display = {'CLASS_BISHOP_F': 'Bishop', 'CLASS_VALKYRIE': 'Valkyrie'}
+        branches = bc._promotion_branches()['CLASS_CLERIC']
+        promo = bc.load_unit(self.CAMPAIGN, 'basil')['promotion']
+        self.assertEqual(sorted(promo['branch']), sorted(display[c] for c in branches))
+        self.assertEqual(promo['default'], 'Bishop')
+
+    def test_basil_bases_are_vanilla_cleric_class_data_verbatim(self):
+        # basil.yaml claims its stat block is class data "verbatim"; that claim is only worth
+        # anything if something checks it. CON is load-bearing beyond flavour: CanUnitRescue
+        # is `GetUnitAid(actor) >= UNIT_CON(target)` (bmunit.c), so Cleric's CON 4 is what lets
+        # more of the party ferry the ch05 escort than Priest's CON 5 would.
+        bases = bc.class_base_stats('CLASS_CLERIC',
+                                    bc.vanilla_decomp_text('src/data_classes.c'))
+        fe = bc.load_unit(self.CAMPAIGN, 'basil')['fe_stats']
+        for yaml_key, field in (('HP', 'baseHP'), ('MAG', 'basePow'), ('SKL', 'baseSkl'),
+                                ('SPD', 'baseSpd'), ('DEF', 'baseDef'), ('RES', 'baseRes'),
+                                ('CON', 'baseCon'), ('MOV', 'baseMov')):
+            self.assertEqual(fe[yaml_key], bases[field],
+                             'basil.yaml %s drifted from CLASS_CLERIC.%s' % (yaml_key, field))
+        self.assertEqual(fe['CON'], 4, 'the escort-rescue margin is CON 4, not Priest CON 5')
+
+    def test_basil_declares_female_so_the_artur_slot_bit_is_rewritten(self):
+        # Gender rides YAML, not the slot -- _set_gender rewrites .attributes on whatever
+        # character slot the unit wears, explicitly clearing what leaks from the vanilla
+        # entry. So a female Cleric on the male Artur slot needs no slot change. (CA_FEMALE
+        # is inert on a foot unit anyway: both readers, GetUnitAid and koido.c, gate on
+        # CA_MOUNTEDAID first -- it matters only if he ever promotes to mounted Valkyrie.)
+        self.assertEqual(bc.load_unit(self.CAMPAIGN, 'basil').get('gender'), 'female')
+        self.assertIn('.attributes = CA_FEMALE',
+                      bc._set_gender('{\n    .number = 1,\n}', True))
+        self.assertNotIn('CA_FEMALE',
+                         bc._set_gender('{\n    .attributes = CA_FEMALE,\n}', False))
 
     def test_neither_rides_the_ch05_prep_roster(self):
         # They join DURING ch05, so cast_available_at must not seat them in its deploy cap


### PR DESCRIPTION
Two commits, both #25. The chapter's defining set-piece — chaperone a fragile healer across the depression to talk a crit-Myrmidon down — now works end to end in the ROM.

## 1. Basil is a Cleric (`102c43d`)

Priest's `ClassData.promotion` is `CLASS_SAGE` — an **anima** mage — while Basil's own `battle_anim.spell_palette_tint` has always declared `[staff, light]`. Priest pointed her at the one promoted class whose weapon type contradicts her shipped art. `CLASS_CLERIC`'s default is `CLASS_BISHOP_F` (light), and its branch is the tree her kit already assumed.

Verified rather than assumed, because the first cost estimate was wrong on three of four points:

- **Art does not move** — bust, map sprite and battle anim are keyed to the CHARACTER slot (`GetUnitSMSId` override, private `gUnitSpecificBanimConfigs` AnimConf), never the class. `clone_from: bishop` supplies the STAFF+LIGHT pair Bishop_F needs anyway.
- **Locked dialogue does not move** — not one locked Basil line in any chapter genders her.
- **The slot does not move** — `gender:` rewrites `.attributes` on whatever slot the unit wears.

Bonuses that were not the reason: Cleric's bases lean the way the Natasha donor already does, and `CanUnitRescue` is `aid >= target CON` (`bmunit.c:905`), so CON 4 (vs 5) widens who can ferry the escort. Growths are byte-identical.

Caught in passing: `CLASS_LOADOUT` had no CLERIC row, which would have `sys.exit`'d the look-test bench (`recordcast`/`recordanim`) without touching a chapter — ch05's own guard cannot see it, since Basil is recruited *in* ch05 and so is off its field roster.

## 2. The recruit wiring (`84044a6`)

`EventListScr_Ch6_Character` is now `CHAR(EVFLAG_TMP(7), MS_Ch05SahnarTalk, CHARACTER_ARTUR, CHARACTER_MARISA)` — structurally identical to vanilla Ch5's single `CHAR(…, NATASHA, JOSHUA)`.

Basil reaches "blue party member" by a different road than her twin: Natasha is already blue in `UnitDef_Event_Ch5Ally`, but Basil is recruited *in* this chapter and cannot ride the prep roster. She is LOADed GREEN and CUSA'd BLUE by the opening's own join beat (`basil.md` Q3; the locked `0x9C2`, trigger `chapter_start`, **not** a Talk). The CUSA sits *after* `CALL(Preparations)` deliberately — green is invisible to Pick Units and costs no slot.

`ch04_parley_recruiters` generalises to `parley_recruiters(unit)`, the gated counterpart to `talk_recruiters`. No new machinery.

Two guards for symptomless failures:

- **`assert_green_recruit_placement`** — the obvious tile for Basil is her twin's, but Natasha is *blue*, so that tile is one of our nine PREP deploy slots; a green body there silently costs a deployment on a map priced for the full cap. Also gates passability and a flood-fill to the unit she must reach. Basil sits at (5,15).
- **`recruit_initial_faction` is now checked** against where each of the two is actually placed.

## 3. `ch05recruit`, and why it exists

`ch05village` was green across versions of the opening where Basil never joined at all — it leaves prep with START and walks a *different* unit to a door, so a green shrub nobody can command is invisible to it. The new scenario asserts the chain in player order: Basil BLUE and commandable at turn 1 (the step with no other witness), Sahnar RED on turn 2, Talk flips her BLUE. It gates the *recruiter* too — a wrong CHAR entry just means the menu has no Talk.

**It failed its own first run for the wrong reason**, which is recorded as an ADR: it reported "the CUSA did not fire" when the CUSA was fine — the scene shows vanilla's 32-box `0x9CC` and the loop capped at 3600 frames, expiring 18 boxes in. *A loop cap must never be what decides failure.* Fixed with headroom **and** a verdict that distinguishes "still running" from "finished and still red".

## Verification

- `make matrix` **16/16** — `ch05recruit` PASS in 16s, logging `Basil is BLUE at turn 1 on (5,15) -- the opening join landed`
- 266 `build_campaign` tests; `make test` and `make check` clean; `git diff --check` clean
- `verify_text` 3404 messages / 0 runaway
- `make difficulty CH=ch05` still **PARITY**, numbers unmoved (12.7 ×1.11 / 4.8 ×0.84)
- ROM builds; injected `data_characters.c` shows `.defaultClass = CLASS_CLERIC`, `.attributes = CA_FEMALE`, Natasha's growths, intact `._u25`

## Notes for review

- The recruit shows **vanilla's prose** at `0x9C2` and `0x9CC` — the placeholder pattern from #249. The wiring is permanent; the dialogue pass writes our bodies at the same ids.
- ADRs added: "Basil is a Cleric…", "A green recruit's TILE is load-bearing", "Wiring a recruit and PROVING it are different jobs".

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
