### PR TITLE
Stage Ravisin's ch05 eruption warning

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -501,7 +501,8 @@ enemy_units:
 #   0x9C4 ( 4)     on-map    other recruit's beat before Talk    the MOOSE triggers the fight
 #                                                                 (position reused, not content)
 #   ══ everything above is ONE pre-map event list (98 boxes); below is triggered ══
-#   0x9C5 ( 3)     on-map    mid-battle ESCALATION               the eruption
+#   0x9C5 ( 3)     on-map    mid-battle ESCALATION               the eruption (4 boxes;
+#                                                                 hosted at 0x9E4)
 #   0x9CC (32)     on-map    TALK-RECRUIT scene                  Basil Talks Sahnar (payoff)
 #   0x9C6 ( 1)     quote     ESCORT-NPC death quote (Natasha)    Basil's death quote
 #   0x9C7 ( 1)     quote     BOSS TAUNT — one box                Ravisin taunt
@@ -515,9 +516,9 @@ enemy_units:
 # 9BA-9C4 are ELEVEN messages inside ONE event list, `EventScr_Ch5_BeginningScene`, played
 # start to finish BEFORE the map loads. They are not separately-triggered scenes, so there is
 # no ordering to design between them and nothing can interleave: our 9C3 (Sahnar sealed in the
-# dark) cannot race our 9C5 (the sarcophagus cracking), because 9C3 is over before the player
+# dark) cannot race our eruption beat (the sarcophagus cracking), because 9C3 is over before the player
 # ever takes a turn. Only three things below it carry real triggers, exactly as vanilla wires
-# them: 9C5 = a mid-battle turn event (`EventScr_089F22A4`), 9C6 = a Talk
+# them: 9C5 anatomy = a mid-battle turn event (`EventScr_089F22A4`), 9C6 = a Talk
 # (`EventScr_089F2270`), 9C9 = `EventScr_Ch5_EndingScene`.
 # CHANNEL drives the LINE WIDTH we hand-box to: on-map bubbles wrap at 29 chars, Text_BG at
 # ~42. Vanilla puts the two command scenes on a backdrop because they happen elsewhere -- which
@@ -874,7 +875,7 @@ events:
       Meesmickle is the right voice — dry, one sentence, "a wit, not a bully" (his bible), and the
       line is aimed at the universe's timing rather than at Pinky.
       RAVISIN STAYS SILENT through this. The fight begins on the quarry's terms, not hers; her
-      first words on the map are the eruption (0x9C5).
+      first words on the map are the eruption (host message 0x9E4; vanilla anatomy 0x9C5).
       Basil's steeling-himself beat — the twin's actual content — is CUT (Nicolas, 2026-07-29).
       Not deferred, not homeless: cut. Her nerve is not a beat this chapter needs stated, and 0x9BB
       already establishes what she is walking toward.
@@ -932,7 +933,7 @@ events:
       - tutorial: "If your HP drops near zero in a fight, [red]press the B Button quickly[/red] to concede."
       - tutorial: "You'll lose your entry fee, but you'll save your unit to fight again."
   - trigger: eruption_turn        # scripted turn (~2/3/5, the Ch5 wave cadence) — EARTHQUAKE/TILECHANGE
-    slot: "vanilla 0x9C5"
+    slot: "vanilla 0x9C5"        # anatomy/source only; ch05 writes this beat at host-owned 0x9E4
     type: scripted_event
     ea_file: events/ch05-eruption.ea
     description: >
@@ -944,8 +945,9 @@ events:
       fresh corpse, and does NOT puppet her — see lore/sahnar.md). Sahnar walks HOSTILE of her
       own will, believing the party are the intruders she was left for; a fast crit-Myrmidon
       (smells faintly of pumpkin spice). She flips only when Basil reaches her.
-      DIALOGUE BUDGET — 3 boxes, the twin's exact spend (`EventScr_089F22A4`, the bandits who
-      join the fight mid-map). The structural rule taken from it: **the ARRIVING FORCE speaks
+      DIALOGUE BUDGET — vanilla spends 3 boxes (`EventScr_089F22A4`, the bandits who join the
+      fight mid-map); ours spends 4 because the wired reliquary race needs an explicit warning.
+      The structural rule taken from the twin: **the ARRIVING FORCE speaks
       and the party never reacts.** Vanilla gives Eirika and Seth not one line here. So these
       boxes belong to the arriving side. (Phantom Ship's quake beat does the opposite —
       Ephraim reacts to it — but Ch11b is only our THEME base for the EARTHQUAKE/TILECHANGE
@@ -969,8 +971,9 @@ events:
       Frostmaiden has need of you" (she is named plenty elsewhere and does not need a third
       mention); and "the BLADE under the stone" keeps Sahnar as inventory, echoing 9BD where
       Ravisin appraises her as exactly that.
-      TWIN = EventScr_089F22A4, 3 boxes, and its structural rule is that the ARRIVING FORCE
-      speaks while the party never reacts (vanilla gives Eirika and Seth no lines). Both twins
+      TWIN = EventScr_089F22A4, 3 boxes; ours is 4 after adding the race warning. Its structural
+      rule is that the ARRIVING FORCE speaks while the party never reacts (vanilla gives Eirika
+      and Seth no lines). Both twins
       agree the SPECTACLE lives in the event macros, never in the prose.
       THE RACE IS NAMED HERE, and that is what the second box buys (Nicolas, 2026-08-09). Vanilla
       spends its equivalent box on the raiders' intent — "steal our way through this pathetic
@@ -1109,8 +1112,8 @@ events:
       Ours is the twin with one word swapped (Nicolas, 2026-07-29): empire -> Frostmaiden. That is
       the entire change, and it is the right size of change. The line already does what her
       register needs — direct address plus an insult-name, then contempt — and swapping the
-      allegiance is what makes it hers. "Frostmaiden" is the reverent epithet used everywhere else
-      in the chapter (9BC twice, 9C5 once); Auril is never named (see 9C8).
+      allegiance is what makes it hers. "Frostmaiden" is the chapter's established reverent
+      epithet (9BC twice, this taunt, and the later death quote); Auril is never named (see 9C8).
       Note it is contempt, not grievance: she is not owed anything and is not avenging anything,
       which keeps it clear of her bible's banned grudge/revenge framing.
       LOCKED 2026-07-29 (dialogue-pass, co-written with Nicolas). 1 box.
@@ -1128,7 +1131,7 @@ events:
       everything...") drifted off that shape twice over — it read as an invoice rather than a
       salute, putting Ravisin at the centre of her own death instead of her goddess, and it was
       the ONLY place in the whole chapter the goddess's proper name appeared. Everywhere else
-      she is the reverent epithet ("the Frostmaiden": 9BC twice, 9C5 once) and never appears, so
+      she is the reverent epithet ("the Frostmaiden": 9BC twice, 9C7 and this quote) and never appears, so
       a one-box death quote was the worst possible spot for a first-and-only lore drop
       (Nicolas, 2026-07-29). "The winter is yours" is a HANDOFF, which is truer to a chapter
       where killing her does not stop the cold.
@@ -1487,7 +1490,8 @@ villages:
     # The "shouting outside" is a second, quieter warning, and it is now literally true: this is
     # the site the turn-2 raiders spawn beside, and it is the one `ch05raid` watches fall. It was
     # written to promise nothing back when the race was prose; the race is wired (#25), so the
-    # line stands as-is and simply means what it says. The loud warning is Ravisin's, in 0x9C5.
+    # line stands as-is and simply means what it says. The loud warning is Ravisin's, in host
+    # message 0x9E4 (the beat mined from vanilla 0x9C5).
     visit_text:
       - "Hello! Hello. Oh, you're warm. Nothing has been warm in two years."
       - "Sorry. Sorry. I'll slow down."

--- a/campaigns/rime-of-the-frostmaiden/lore/ravisin.md
+++ b/campaigns/rime-of-the-frostmaiden/lore/ravisin.md
@@ -38,7 +38,7 @@ way you'd give up a fever.
   Reason: our story never pays the name off, so its only appearances would be lore-drops in
   places too small to carry them — which is exactly how it went wrong (it was, briefly, the
   goddess's SOLE proper-name drop in ch05, sitting in a one-box death quote). Checked
-  2026-07-29: 9BC ×2, 9C5 ×1 and 9C7 all use the epithet.
+  2026-08-11: 9BC ×2, 9C7 and 9C8 use the epithet; the revised eruption warning does not.
 
 ## Voice
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -869,8 +869,9 @@ that force a two-front race. So we keep the twins' maps and layer the theme on t
   **Natasha→Joshua escort** becomes **Basil (Natasha-donor Cleric) chaperoned to Talk Sahnar (Joshua-donor
   Myrmidon)** — a convertible crit-threat you neutralize by recruiting; (b) the **village-raid race**
   becomes the **Phantom-Ship eruption** (injected `EARTHQUAKE`/`TILECHANGE`) spawning undead that raid
-  **spread reward-sites** (elven reliquaries), with the **crest-of-cold-iron** (promotion relic) as the
-  save-all reward — our Guiding Ring. Ch5-magnitude economy incl. the **elven store** (Armory + Vendor);
+  **spread reward-sites** (elven reliquaries), with vanilla's **Guiding Ring** as the save-all reward
+  (the earlier crest-of-cold-iron name was retired 2026-08-09). Ch5-magnitude economy incl. the
+  **elven store** (Armory + Vendor);
   ch05 is the first chapter at/above the FE8-Ch5 reward tier, so stat-boosters + a promotion item unlock
   here (per §Reward budget above).
 
@@ -3179,9 +3180,10 @@ _Decided: 2026-05-29_
 
 **The promotion seam (Ch 8 → 9): foreshadow in the MVP, pay off at Revel's End**
 The MVP plays entirely **unpromoted** (5e levels 1–5); promotions are post-MVP. The seam:
-- **Foreshadow in MVP.** The **Ch 5 (Elven Tomb)** frost-druid boss **Ravisin** drops a
-  *flavored, locked relic* — the **crest of cold iron** ("it hums, but none of you know how
-  to use it yet"). It sits in the convoy, unusable, as a Chekhov's gun for promotion.
+- **Foreshadow in MVP (updated 2026-08-09).** Saving all four **Ch 5 (Elven Tomb)** reliquaries
+  awards vanilla's **Guiding Ring**. The earlier plan for Ravisin to drop a flavored
+  **crest of cold iron** was retired: it had no item id and lived on an unread `drops:` key.
+  The real ring sits in the convoy, unusable, as the same Chekhov's gun for promotion.
 - **Pay off at the seam.** The **first Master-Seal-equivalent** is obtained in/after the
   Revel's End break (**Ch 9**, post-MVP) — diegetically looted from the prison or earned in
   the escape. This matches FE8 holding promotions until the route-split era
@@ -4208,8 +4210,13 @@ rather than handed over for killing the boss.
 **The race also has to be SAID.** Vanilla spends its turn-2 box on the raiders' intent ("steal our
 way through this pathetic town"); ours said only that more dead were coming, so the first warning
 the player got was the engine's "The village was destroyed." popup, after a site was gone.
-`0x9C5` now names the reliquaries. "Houses" and "mausoleums" were both tried and both collide with
-the fiction: the west resident calls the whole tomb *"this house"*, and only Orem is buried here.
+The beat mined from vanilla `0x9C5` now names the reliquaries. Its YAML slot label is anatomy only:
+ch04 writes literal `0x9C5` as its Status objective, while ch05 hosts through `Ch6Events` and writes
+the warning at its own `0x9E4`. That id is named and registered in `HOSTED_CHAPTER_MESSAGE_IDS`, so
+the ownership guard fails before any later scene can double-claim it. "Houses" and "mausoleums"
+were both tried and both collide with the fiction: the west resident calls the whole tomb *"this
+house"*, and only Orem is buried here.
+_Implemented: 2026-08-11 (#260)._
 
 **Two scenarios, because one run cannot walk both paths.** `ch05raid` idles and proves a site is
 LOST (terrain `0x03 → 0x25`, no gift, event id still unset — `TILE_COMMAND_20` changes the tile

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -7900,6 +7900,7 @@ CH05_GOAL_DONOR = 7                              # vanilla slot 7 = a clean defe
                                                  # is in the middle of replacing.
 # ch05's goal strings come from its HOST SLOT's dead block (vanilla Ch6 = 0x9E4..0x9F5), not
 # from vanilla Ch5's -- ch04 hosts on slot 5 and already owns that block (#207).
+CH05_ERUPTION_MSG = 0x9E4                     # turn-2 Ravisin warning; first free Ch6-host id
 CH05_GOAL_WINDOW_MSG = 0x9F4
 CH05_GOAL_STATUS_MSG = 0x9F5
 # Raw charIndexes. Pids need only be unique WITHIN a chapter -- gDefeatTalkList entries carry
@@ -7977,12 +7978,13 @@ HOSTED_CHAPTER_MESSAGE_IDS = {
     # slot 5 and already owns that block. This is the sharpest case of the two offsets: the
     # chapter we MINE and the block we WRITE INTO are different vanilla chapters, and the
     # YAML's `slot: "vanilla 0x9BB"` labels are anatomy references to the mined chapter, not
-    # claims on ids. Only the goal strings are claimed here; the dialogue ids land with the
-    # cutscene pass (#25), and this guard is what will refuse them if any collide.
+    # claims on ids. The eruption warning is the first dialogue claim from that block; later
+    # cutscene ids land with the remaining dialogue pass (#25), and this guard will refuse them
+    # if any collide.
     # The four reliquary visit lines joined the block 2026-08-08 (dialogue-pass). They sit
     # OUTSIDE ch05's host block on purpose -- see CH05_VILLAGE_SLOTS for why that is safe here
     # and why spending ch05's own ids on them was the worse trade.
-    'ch05': (CH05_GOAL_WINDOW_MSG, CH05_GOAL_STATUS_MSG,
+    'ch05': (CH05_ERUPTION_MSG, CH05_GOAL_WINDOW_MSG, CH05_GOAL_STATUS_MSG,
              *(slot[1] for slot in CH05_VILLAGE_SLOTS.values())),
     # Goal ids only -- ch01/ch02 predate the per-chapter block registry, but their goal strings
     # still have to be unique against every other hosted chapter (#207).
@@ -9734,6 +9736,60 @@ def ch05_enemy_rows(chap, arrives_turn=None, exclude=()):
     return rows
 
 
+def ch05_eruption_message(chap):
+    """Render the locked turn-2 Ravisin warning from the chapter YAML.
+
+    The YAML's ``vanilla 0x9C5`` label is an anatomy citation, not a destination: ch04
+    writes that literal id. The caller stores this body at CH05_ERUPTION_MSG, which belongs
+    to the Ch6 host block ch05 actually owns.
+    """
+    _card, beats = _split_event_beats(
+        chap, 'eruption_turn', 'ch05 eruption warning', (CH05_ERUPTION_MSG,),
+        card_required=False)
+    beat = beats[0]
+    speakers = {next(iter(entry)) for entry in beat}
+    if len(beat) != 4 or speakers != {'ravisin'}:
+        sys.exit('ERROR: ch05 eruption warning must remain the four locked Ravisin boxes; '
+                 'got %d boxes from %s' % (len(beat), sorted(speakers)))
+    return _script_to_message(
+        beat,
+        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))},
+        width=29)
+
+
+def ch05_wave_script(turn, wave_table, sahnar_table=None):
+    """Build one ch05 reinforcement script; only turn 2 speaks and wakes Sahnar.
+
+    The order carries the fiction: the arriving dead establish the escalation, Ravisin names
+    the reliquary race and decides to spend the blade under the stone, then Sahnar LOADs.
+    Later waves are silent reinforcements and must not replay the warning.
+    """
+    warning = ''
+    wake = ''
+    if turn == 2:
+        if not sahnar_table:
+            sys.exit('ERROR: ch05 turn-2 wave needs Sahnar\'s wake table')
+        warning = (
+            '    CUMO_CHAR(%s) /* Ravisin answers the party\'s pressure */\n'
+            '    STAL(45)\n'
+            '    CURE\n'
+            '    TEXTSTART\n'
+            '    TEXTSHOW(0x%X) /* four locked boxes: the reliquary race + Sahnar */\n'
+            '    TEXTEND\n'
+            '    REMA\n'
+            % (CH05_BOSS_PID, CH05_ERUPTION_MSG))
+        wake = (
+            '    LOAD1(0x1, %s) /* Sahnar rises from the cracked sarcophagus */\n'
+            '    ENUN\n' % sahnar_table)
+    elif sahnar_table is not None:
+        sys.exit('ERROR: ch05 Sahnar may rise only in the turn-2 eruption script')
+    return ('{\n'
+            '    LOAD1(0x1, %s)\n'
+            '    ENUN\n'
+            '%s%s'
+            '    ENDA\n}' % (wave_table, warning, wake))
+
+
 def inject_ch05(campaign, boot=False, verbose=True):
     """Host Ch5 "The Elven Tomb" (#25) on slot 6: the winterised 1:1 retile of vanilla Ch5,
     the sixteen-strong risen tomb-guard on vanilla Ch5's own fighting tiles, the three
@@ -9944,14 +10000,11 @@ def inject_ch05(campaign, boot=False, verbose=True):
     script = _replace_brace_block(script, CH05_BEGINNING_SCRIPT + '[] =', beginning,
                                   CH05_EVENTSCRIPT_H)
     for turn in sorted(CH05_WAVE_TABLES):
-        # Turn 2 brings the wave AND wakes Sahnar -- one script, two LOADs, so her rise is
-        # the same beat as the eruption that causes it.
-        extra = ('    LOAD1(0x1, %s) /* Sahnar rises from the cracked sarcophagus */\n'
-                 '    ENUN\n' % CH05_SAHNAR_TABLE) if turn == 2 else ''
         script = _replace_brace_block(
             script, CH05_WAVE_SCRIPTS[turn] + '[] =',
-            '{\n    LOAD1(0x1, %s)\n    ENUN\n%s    ENDA\n}'
-            % (CH05_WAVE_TABLES[turn], extra), CH05_EVENTSCRIPT_H)
+            ch05_wave_script(
+                turn, CH05_WAVE_TABLES[turn], CH05_SAHNAR_TABLE if turn == 2 else None),
+            CH05_EVENTSCRIPT_H)
     # The ending: the save-all-four payout, then the win. ch06 is not hosted yet, so the win
     # lands on the dev placeholder exactly as ch03's did until ch04 hosted (chain_ch04_to_ch05
     # advances the real path below).
@@ -9995,6 +10048,7 @@ def inject_ch05(campaign, boot=False, verbose=True):
     set_message_body(lines, host['goal']['statusObjectiveTextId'],
                      name_message_body('Defeat ' + (boss.get('fe_name') or boss['name'])))
     set_message_body(lines, host['goal']['windowTextId'], goal_window_body('Defeat boss'))
+    set_message_body(lines, CH05_ERUPTION_MSG, ch05_eruption_message(chap))
     # The four reliquary visits (#25). Each site's speaker is one of the tomb's risen dead, over
     # BG_HOUSE -- a full-screen backdrop, so these wrap at 42 like the other BG scenes and NOT at
     # the on-map bubble's 29. One `visit_text` entry per BOX, ch04's lesson: the authored A-press
@@ -10008,10 +10062,11 @@ def inject_ch05(campaign, boot=False, verbose=True):
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     _write_chapter_title_card(host, 'Ch.5: ' + chap['title'])
-    # .msg = 0 -> silent, like ch03's grell: Ravisin's authored death quote (0x9C8) belongs to
-    # the cutscene pass, and a faceless line renders boxless. The engine sets the flag either
-    # way -- DisplayDefeatTalkForPid only SHOWS a quote if msg != 0, but SetPidDefeatedFlag
-    # runs regardless (eventinfo.c:595), and the flag is what fires DefeatBoss.
+    # .msg = 0 -> silent, like ch03's grell: Ravisin's authored death quote still needs its own
+    # allocated id from ch05's host block. Her portrait is live now (#259); message ownership is
+    # the remaining seam. The engine sets the flag either way -- DisplayDefeatTalkForPid only
+    # SHOWS a quote if msg != 0, but SetPidDefeatedFlag runs regardless (eventinfo.c:595), and
+    # the flag is what fires DefeatBoss.
     _prepend_defeat_quote(flag_defeat_quote(
         CH05_BOSS_PID, chapter_label_constant(CH05_HOST_INDEX), 'EVFLAG_DEFEAT_BOSS',
         'Ravisin (ch05 boss): silent defeat -> DefeatBoss WIN flag'))

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -321,6 +321,10 @@ local function recordCutscene(o)
     while fr < maxFrames do
         fr = fr + 1
         if fr % shotEvery == 0 then shot(tag) end
+        -- Let a function terminal observe the frame before the recorder consumes an
+        -- input state.  #260's turn-event proof remembers that dialogue_wait occurred;
+        -- checking only after the guarded A press made a good four-box scene time out.
+        if doneFn() then reached = true break end
         if autoAdvanceDialogue and controllerState() == "dialogue_wait" then
             if not guardedInput("advance_dialogue", "A", "dialogue input wait clears", function(after)
                 return controllerState(after) ~= "dialogue_wait"
@@ -328,7 +332,6 @@ local function recordCutscene(o)
                 return result("FAIL", tag .. " dialogue input postcondition failed")
             end
         end
-        if doneFn() then reached = true break end
         yield()
     end
     shot(tag)
@@ -6449,11 +6452,32 @@ scenarios.ch05recruit = function()
         basil.x, basil.y))
 
     -- 2. The wake. Wait for the UNIT, not the turn counter: the counter ticks when the player
-    --    phase ends, well before the wave event LOAD1s her (ch04packmath learned this).
+    --    phase ends, well before the wave event LOAD1s her (ch04packmath learned this). The
+    --    turn-2 event now speaks BEFORE Sahnar LOADs, so advance only observed dialogue waits
+    --    and count them: merely reaching turn 2 no longer proves the locked warning played.
     if not endTurn() then return result("FAIL", "could not end turn 1") end
-    if not waitFor(function() return turn() >= 2 and redSahnar() ~= nil end, 5400) then
+    local eruptionBoxes = 0
+    for _ = 1, 7200 do
+        if turn() >= 2 and redSahnar() then break end
+        if controllerState() == "dialogue_wait" then
+            eruptionBoxes = eruptionBoxes + 1
+            if not guardedInput("advance_dialogue", "A", "eruption dialogue wait clears",
+                function(after) return controllerState(after) ~= "dialogue_wait" end, 120) then
+                return result("FAIL", "eruption dialogue input did not advance")
+            end
+        else
+            yield()
+        end
+    end
+    if not redSahnar() then
         shot("ch05recruit")
         return result("FAIL", "Sahnar never rose RED on turn 2 -- the eruption wake did not fire")
+    end
+    if eruptionBoxes ~= 4 then
+        shot("ch05recruit")
+        return result("FAIL", string.format(
+            "eruption warning showed %d boxes, expected the four locked Ravisin boxes",
+            eruptionBoxes))
     end
     waitFor(function()
         return faction() == 0 and not menuOpen() and not procActive(SYM.ProcScr_StdEventEngine)
@@ -6528,6 +6552,28 @@ scenarios.ch05recruit = function()
     shot("ch05recruit")
     return result("PASS", "Basil joined blue in the opening, Sahnar rose red on turn 2, and "
         .. "Basil's Talk brought her over -- the whole ch05 recruit chain")
+end
+
+-- recordch05eruption: the smallest visual proof for #260. Boot the real ch05 map, idle turn 1,
+-- then record only Ravisin's four-box turn-2 warning through Sahnar's rise and the return of
+-- player control. The recorder advances dialogue while filming; the terminal requires that a
+-- real dialogue wait was observed, so reaching turn 2 without the warning cannot pass.
+-- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh recordch05eruption (needs a CH05BOOT=1 ROM).
+scenarios.recordch05eruption = function()
+    if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
+    waitFor(function()
+        return faction() == 0 and not menuOpen() and not procActive(SYM.ProcScr_StdEventEngine)
+    end, 6000, true)
+    if not endTurn() then return result("FAIL", "could not end turn 1") end
+    local sawWarning = false
+    return recordCutscene({
+        tag = "ch05eruption", maxFrames = 5400, pressEvery = 90,
+        until_ = function()
+            if turn() >= 2 and controllerState() == "dialogue_wait" then sawWarning = true end
+            return sawWarning and turn() >= 2 and faction() == 0 and not menuOpen()
+                and not procActive(SYM.ProcScr_StdEventEngine)
+        end,
+    })
 end
 
 -- Park an unexhausted blue unit on a village door and take the Visit command, stopping the

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -266,6 +266,10 @@ scenarios:
     rom: ch05boot
     host_chapter: 6
     kind: record
+  recordch05eruption:
+    rom: ch05boot
+    host_chapter: 6
+    kind: record
   ch04snag:
     rom: ch04boot
     host_chapter: 5

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1822,6 +1822,66 @@ class RavisinPortrait(unittest.TestCase):
         self.assertEqual('Ravisin[.][X]', body.strip())
 
 
+class Ch05EruptionWarning(unittest.TestCase):
+    """The turn-2 race warning belongs to ch05's HOST block, not its vanilla-Ch5 twin.
+
+    The YAML label ``vanilla 0x9C5`` describes scene anatomy. Literal 0x9C5 is ch04's
+    status-objective string, so using it here silently overwrites another chapter while
+    every text decoder remains green. The warning also has to precede Sahnar's LOAD: the
+    final locked box is Ravisin deciding to use the blade under the stone.
+    """
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def _chap(self):
+        return bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+
+    def test_warning_owns_a_named_id_from_ch05s_real_host_block(self):
+        self.assertTrue(hasattr(bc, 'CH05_ERUPTION_MSG'),
+                        'ch05 needs a named host-block id for the eruption warning')
+        self.assertEqual(0x9E4, bc.CH05_ERUPTION_MSG)
+        self.assertTrue(0x9E4 <= bc.CH05_ERUPTION_MSG <= 0x9F3)
+        self.assertNotEqual(bc.CH04_GOAL_STATUS_MSG, bc.CH05_ERUPTION_MSG)
+        self.assertIn(bc.CH05_ERUPTION_MSG, bc.HOSTED_CHAPTER_MESSAGE_IDS['ch05'])
+        self.assertEqual('ch05', bc.assert_message_ids_unique()[bc.CH05_ERUPTION_MSG])
+
+    def test_locked_four_boxes_emit_one_faced_ravisin_message(self):
+        self.assertTrue(hasattr(bc, 'ch05_eruption_message'),
+                        'the locked YAML beat needs a message emitter')
+        event = next(e for e in self._chap()['events'] if e['trigger'] == 'eruption_turn')
+        self.assertEqual(4, len(event['script']))
+        self.assertEqual({'ravisin'}, {next(iter(box)) for box in event['script']})
+        for box in event['script']:
+            self.assertLessEqual(len(bc._wrap_fe_lines(next(iter(box.values())), 29)), 2)
+
+        body = bc.ch05_eruption_message(self._chap())
+        self.assertIn('[LoadFace][FID_Riev]', body)
+        self.assertEqual(4, body.count('[A]'))
+        for box in event['script']:
+            for word in next(iter(box.values())).replace("'", '').split()[:3]:
+                self.assertIn(word, body)
+
+    def test_turn_two_stages_the_warning_before_sahnar_rises(self):
+        self.assertTrue(hasattr(bc, 'ch05_wave_script'),
+                        'the wave script needs a testable owner for its ordering')
+        script = bc.ch05_wave_script(2, 'MS_Ch05WaveT2', 'MS_Ch05Sahnar')
+        self.assertEqual(1, script.count('TEXTSHOW(0x%X)' % bc.CH05_ERUPTION_MSG))
+        self.assertIn('CUMO_CHAR(%s)' % bc.CH05_BOSS_PID, script)
+        self.assertLess(script.index('LOAD1(0x1, MS_Ch05WaveT2)'),
+                        script.index('CUMO_CHAR(%s)' % bc.CH05_BOSS_PID))
+        self.assertLess(script.index('CUMO_CHAR(%s)' % bc.CH05_BOSS_PID),
+                        script.index('TEXTSHOW(0x%X)' % bc.CH05_ERUPTION_MSG))
+        self.assertLess(script.index('TEXTSHOW(0x%X)' % bc.CH05_ERUPTION_MSG),
+                        script.index('LOAD1(0x1, MS_Ch05Sahnar)'))
+
+    def test_later_waves_do_not_repeat_the_turn_two_warning(self):
+        self.assertTrue(hasattr(bc, 'ch05_wave_script'),
+                        'the wave script needs a testable owner for its ordering')
+        for turn in (3, 5):
+            script = bc.ch05_wave_script(turn, 'MS_Ch05WaveT%d' % turn)
+            self.assertNotIn('TEXTSHOW(', script)
+            self.assertNotIn('CUMO_CHAR(', script)
+
+
 class Ch05VillageRaidRace(unittest.TestCase):
     """ch05's declared structure: the eruption's dead race the party for the four reliquaries,
     and saving all four pays out (#25). Vanilla Ch5 is the reference for both halves -- it wires

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -129,6 +129,43 @@ class TestAwaitControllerState(unittest.TestCase):
 
 
 class TestPlaytestHarness(unittest.TestCase):
+    def test_recorder_terminal_observes_dialogue_before_advancing_it(self):
+        # #260's visual proof records whether its four-box warning was actually seen.
+        # If recordCutscene advances the wait first and calls doneFn second, the callback
+        # can never observe dialogue_wait and the scenario times out after a good scene.
+        harness = _read_harness()
+        body = _block(harness, 'local function recordCutscene(o)',
+                      '\nlocal function tileOccupied')
+        loop = body[body.index('while fr < maxFrames do'):]
+        observe = loop.index('if doneFn() then reached = true break end')
+        advance = loop.index('if autoAdvanceDialogue and controllerState() == "dialogue_wait" then')
+        self.assertLess(observe, advance,
+                        'the terminal callback must see a dialogue wait before the recorder '
+                        'consumes it')
+
+    def test_ch05recruit_advances_and_counts_the_new_eruption_boxes(self):
+        harness = _read_harness()
+        body = _block(harness, 'scenarios.ch05recruit = function()',
+                      '\n-- Park an unexhausted blue unit')
+        self.assertIn('eruptionBoxes', body,
+                      'the recruit gate would hang before Sahnar LOADs if it never advances '
+                      'Ravisin\'s newly visible warning')
+        self.assertIn('dialogue_wait', body)
+        self.assertIn('advance_dialogue', body)
+        self.assertIn('eruption warning showed %d boxes', body,
+                      'the gate must distinguish the locked four-box scene from merely '
+                      'reaching turn 2')
+
+    def test_recordch05eruption_records_only_the_turn_two_scene(self):
+        harness = _read_harness()
+        self.assertIn('scenarios.recordch05eruption = function()', harness)
+        body = _block(harness, 'scenarios.recordch05eruption = function()',
+                      '\n-- Park an unexhausted blue unit')
+        self.assertIn('endTurn()', body)
+        self.assertIn('recordCutscene({', body)
+        self.assertIn('turn() >= 2', body)
+        self.assertIn('not procActive(SYM.ProcScr_StdEventEngine)', body)
+
     def test_ch04snag_accepts_the_native_fallen_snag_crossing(self):
         harness = _read_harness()
         body = _block(harness, 'scenarios.ch04snag = function()', '\n-- attackprobe')


### PR DESCRIPTION
## Summary

- allocate host-owned message `0x9E4` for Ravisin's locked four-box turn-2 eruption warning
- register the ID in `HOSTED_CHAPTER_MESSAGE_IDS` and inject the warning before Sahnar rises
- add focused ownership, box-shape, ordering, harness, and matrix coverage
- correct stale ch05 documentation around vanilla anatomy IDs, Frostmaiden wording, and the retired crest
- fix `recordCutscene` so function terminals observe a dialogue wait before the recorder advances it

## Why

The chapter YAML's `vanilla 0x9C5` label describes the source scene's anatomy. Literal `0x9C5` is already ch04's Status objective, while hosted ch05 owns the Ch6 block. Without an explicit host allocation, wiring this line would silently overwrite another chapter.

The real-map proof initially false-failed because the recorder consumed `dialogue_wait` before invoking the terminal callback. Moving that observation first lets the proof remember that the warning appeared while preserving guarded dialogue input.

## Player impact

Turn 2 now visibly tells the player that Ravisin's dead are racing for the reliquaries, then stages Sahnar's rise from the final locked box. Later reinforcement waves remain silent.

## Verification

- `PYTHONPYCACHEPREFIX=/tmp/manchego-stars-pycache make check` — pass; drift clean
- `python3 tools/verify_text.py` — 3404 messages, 0 runaway
- `python3 tools/verify_text.py 0x9E4` — exact four-box message
- `python3 tools/playtest/matrix.py run --scenarios recordch05eruption` — PASS; four guarded dialogue advances
- `git diff --check` — pass

Closes #260
