### PR TITLE
Wire Ravisin's ch05 death quote

### DIFF
--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5797,20 +5797,20 @@ def midmap_minibosses(chap):
     return [e for e in chap.get('enemy_units', []) if e.get('is_miniboss')]
 
 
-def flag_defeat_quote(pid, chapter_const, flag, comment):
-    """A SILENT (msg=0) gDefeatTalkList entry keying `pid`'s death in `chapter_const` to `flag`.
+def flag_defeat_quote(pid, chapter_const, flag, comment, msg=0):
+    """A gDefeatTalkList entry keying `pid`'s death in `chapter_const` to `flag`.
     SetPidDefeatedFlag sets the flag on ANY matching pid's death (no CA_BOSS gate, eventinfo.c),
-    while DisplayDefeatTalkForPid suppresses the quote because msg=0 -- so a faceless unit sets
-    an event flag without rendering a boxless, unreadable line. Shared by the ch03 boss WIN
-    (flag=EVFLAG_DEFEAT_BOSS -> the DefeatBoss AFEV) and the Brute miniboss's mid-map death
-    trigger (flag=a tmp flag watched by a Misc AFEV)."""
+    while DisplayDefeatTalkForPid shows `msg` when nonzero or suppresses it when zero. The silent
+    form lets a faceless unit set an event flag without rendering a boxless, unreadable line;
+    the faced form lets the same flag path carry its authored quote."""
+    msg_value = '0' if msg == 0 else '0x%X' % msg
     return ('    {\n'
             '        .pid     = %s, /* %s */\n'
             '        .route   = CHAPTER_MODE_ANY,\n'
             '        .chapter = %s,\n'
             '        .flag    = %s,\n'
-            '        .msg     = 0,\n'
-            '    },' % (pid, comment, chapter_const, flag))
+            '        .msg     = %s,\n'
+            '    },' % (pid, comment, chapter_const, flag, msg_value))
 
 
 def midmap_afev(guard_flag, script, watch_flag):
@@ -7901,6 +7901,7 @@ CH05_GOAL_DONOR = 7                              # vanilla slot 7 = a clean defe
 # ch05's goal strings come from its HOST SLOT's dead block (vanilla Ch6 = 0x9E4..0x9F5), not
 # from vanilla Ch5's -- ch04 hosts on slot 5 and already owns that block (#207).
 CH05_ERUPTION_MSG = 0x9E4                     # turn-2 Ravisin warning; first free Ch6-host id
+CH05_RAVISIN_DEATH_MSG = 0x9E5                # locked Ravisin death quote; next Ch6-host id
 CH05_GOAL_WINDOW_MSG = 0x9F4
 CH05_GOAL_STATUS_MSG = 0x9F5
 # Raw charIndexes. Pids need only be unique WITHIN a chapter -- gDefeatTalkList entries carry
@@ -7984,7 +7985,8 @@ HOSTED_CHAPTER_MESSAGE_IDS = {
     # The four reliquary visit lines joined the block 2026-08-08 (dialogue-pass). They sit
     # OUTSIDE ch05's host block on purpose -- see CH05_VILLAGE_SLOTS for why that is safe here
     # and why spending ch05's own ids on them was the worse trade.
-    'ch05': (CH05_ERUPTION_MSG, CH05_GOAL_WINDOW_MSG, CH05_GOAL_STATUS_MSG,
+    'ch05': (CH05_ERUPTION_MSG, CH05_RAVISIN_DEATH_MSG,
+             CH05_GOAL_WINDOW_MSG, CH05_GOAL_STATUS_MSG,
              *(slot[1] for slot in CH05_VILLAGE_SLOTS.values())),
     # Goal ids only -- ch01/ch02 predate the per-chapter block registry, but their goal strings
     # still have to be unique against every other hosted chapter (#207).
@@ -9757,6 +9759,33 @@ def ch05_eruption_message(chap):
         width=29)
 
 
+def ch05_ravisin_death_message(chap):
+    """Render Ravisin's one locked death box from the chapter event source of truth.
+
+    The event's ``vanilla 0x9C8`` label cites the donor scene; ch05 writes the body to its
+    own Ch6 host block. The separate enemy ``death_quote`` field predates the locked dialogue
+    pass and is deliberately not consulted here.
+    """
+    _card, beats = _split_event_beats(
+        chap, 'boss_death', 'ch05 Ravisin death quote', (CH05_RAVISIN_DEATH_MSG,),
+        card_required=False)
+    beat = beats[0]
+    if len(beat) != 1 or next(iter(beat[0])) != 'ravisin':
+        sys.exit('ERROR: ch05 Ravisin death quote must remain one locked Ravisin box')
+    return _script_to_message(
+        beat,
+        {'ravisin': ('[OpenMidRight]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))},
+        width=29)
+
+
+def ch05_ravisin_defeat_quote():
+    """The displayed quote and unchanged flag that together drive ch05's boss win."""
+    return flag_defeat_quote(
+        CH05_BOSS_PID, chapter_label_constant(CH05_HOST_INDEX), 'EVFLAG_DEFEAT_BOSS',
+        'Ravisin (ch05 boss): locked death quote -> DefeatBoss WIN flag',
+        msg=CH05_RAVISIN_DEATH_MSG)
+
+
 def ch05_wave_script(turn, wave_table, sahnar_table=None):
     """Build one ch05 reinforcement script; only turn 2 speaks and wakes Sahnar.
 
@@ -10049,6 +10078,7 @@ def inject_ch05(campaign, boot=False, verbose=True):
                      name_message_body('Defeat ' + (boss.get('fe_name') or boss['name'])))
     set_message_body(lines, host['goal']['windowTextId'], goal_window_body('Defeat boss'))
     set_message_body(lines, CH05_ERUPTION_MSG, ch05_eruption_message(chap))
+    set_message_body(lines, CH05_RAVISIN_DEATH_MSG, ch05_ravisin_death_message(chap))
     # The four reliquary visits (#25). Each site's speaker is one of the tomb's risen dead, over
     # BG_HOUSE -- a full-screen backdrop, so these wrap at 42 like the other BG scenes and NOT at
     # the on-map bubble's 29. One `visit_text` entry per BOX, ch04's lesson: the authored A-press
@@ -10062,14 +10092,10 @@ def inject_ch05(campaign, boot=False, verbose=True):
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     _write_chapter_title_card(host, 'Ch.5: ' + chap['title'])
-    # .msg = 0 -> silent, like ch03's grell: Ravisin's authored death quote still needs its own
-    # allocated id from ch05's host block. Her portrait is live now (#259); message ownership is
-    # the remaining seam. The engine sets the flag either way -- DisplayDefeatTalkForPid only
-    # SHOWS a quote if msg != 0, but SetPidDefeatedFlag runs regardless (eventinfo.c:595), and
-    # the flag is what fires DefeatBoss.
-    _prepend_defeat_quote(flag_defeat_quote(
-        CH05_BOSS_PID, chapter_label_constant(CH05_HOST_INDEX), 'EVFLAG_DEFEAT_BOSS',
-        'Ravisin (ch05 boss): silent defeat -> DefeatBoss WIN flag'))
+    # Keep the already-proven flag path and make its quote visible now that Ravisin's portrait
+    # and host-owned message both exist. SetPidDefeatedFlag still fires EVFLAG_DEFEAT_BOSS;
+    # DisplayDefeatTalkForPid now shows the one locked box before the ending AFEV runs.
+    _prepend_defeat_quote(ch05_ravisin_defeat_quote())
 
     if verbose:
         print('  ch05 map (obj1=%d pal=%d cfg=%d layout=%d) hosted on chapter %d; defeat_boss '

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -7010,6 +7010,86 @@ scenarios.ch05crest = function()
     return result("PASS", "all four reliquaries saved -> the ending paid out its Guiding Ring")
 end
 
+-- recordch05ravisindeath (#262): the smallest real-map proof for Ravisin's locked death quote.
+-- Setup is unfilmed: boot ch05, park a one-hit Ravisin beside one live melee attacker, and drive
+-- the game's own Attack path. chooseAttack hands control back at the FIRST dialogue wait after
+-- Ravisin is dead, so the recorder films the one death box rather than the battle or ending.
+-- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh recordch05ravisindeath (CH05BOOT=1 ROM).
+scenarios.recordch05ravisindeath = function()
+    local RAVISIN, boxes = 0xb8, 0
+    return recordCutscene({
+        tag = "ch05ravisindeath", speed = "normal", maxFrames = 1800, shotEvery = 1,
+        pressEvery = 90,
+        pre = function()
+            pokeFastConfig()
+            if not bootToMap() then return false, "never reached the ch05 map" end
+            if not waitFor(function()
+                return faction() == 0 and not menuOpen()
+                    and not procActive(SYM.ProcScr_StdEventEngine)
+            end, 6000, true) then
+                return false, "ch05 map never became idle"
+            end
+            local boss = red(RAVISIN)
+            if not boss then return false, "Ravisin (pid 0xb8) is not in the red array" end
+            local hero, hmin, hmax
+            for i = 0, 23 do
+                local u = unitAt(SYM.gUnitArrayBlue, i)
+                if u and not isDead(u) and (u.state & 0x3) == 0
+                    and mapUnitAt(u.x, u.y) ~= 0 then
+                    local mn, mx = unitAttackRange(u)
+                    if mn and mn <= 1 and mx >= 1 then
+                        hero, hmin, hmax = u, mn, mx
+                        break
+                    end
+                end
+            end
+            if not hero then return false, "no selectable blue melee attacker" end
+
+            pokeFrail(boss)
+            pokeHarmless(boss)
+            emu:write8(hero.addr + 0x14, 30) -- deterministic might for the proof strike
+            emu:write8(hero.addr + 0x15, 30) -- deterministic hit for the proof strike
+            boss = red(RAVISIN)
+            local bossGrid = mapUnitAt(boss.x, boss.y)
+            local mapw, maph = mapSize()
+            local parked = false
+            for _, d in ipairs({ { 1, 0 }, { -1, 0 }, { 0, 1 }, { 0, -1 } }) do
+                local tx, ty = hero.x + d[1], hero.y + d[2]
+                if tx >= 0 and tx < mapw and ty >= 0 and ty < maph
+                    and mapUnitAt(tx, ty) == 0 then
+                    setMapUnit(boss.x, boss.y, 0)
+                    emu:write8(boss.addr + 0x10, tx); emu:write8(boss.addr + 0x11, ty)
+                    setMapUnit(tx, ty, bossGrid)
+                    parked = true
+                    break
+                end
+            end
+            if not parked then return false, "no free tile beside the melee attacker" end
+            hero = blue(hero.charId) or hero
+            if not canAttackFromHere(hero, hmin, hmax) then
+                return false, "parked Ravisin is not in the attacker's live range"
+            end
+            if not moveUnit(hero.x, hero.y, hero.x, hero.y) then
+                return false, "could not open the attacker's command menu"
+            end
+            if not chooseAttack(hero.addr, function()
+                return isDead(red(RAVISIN)) and controllerState() == "dialogue_wait"
+            end) then
+                return false, "the proof strike did not resolve"
+            end
+            if not (isDead(red(RAVISIN)) and controllerState() == "dialogue_wait") then
+                return false, "Ravisin died without opening her death quote"
+            end
+            return true
+        end,
+        afterPre = pokeNormalConfig,
+        until_ = function()
+            if controllerState() == "dialogue_wait" then boxes = boxes + 1 end
+            return boxes == 1 and eventFlag(2) and controllerState() ~= "dialogue_wait"
+        end,
+    })
+end
+
 -- ch04cottage (#24): the SECOND village at (1,11), whose reward is its line.
 -- The shipped bug was not a bad reward, it was NO VISIT: the tile was visitable-capable but had
 -- no Location entry, and FE8 runs the village off that event -- so the player saw a cottage they

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -7013,7 +7013,8 @@ end
 -- recordch05ravisindeath (#262): the smallest real-map proof for Ravisin's locked death quote.
 -- Setup is unfilmed: boot ch05, park a one-hit Ravisin beside one live melee attacker, and drive
 -- the game's own Attack path. chooseAttack hands control back at the FIRST dialogue wait after
--- Ravisin is dead, so the recorder films the one death box rather than the battle or ending.
+-- Ravisin is dead, so the recorder starts on her death box; the expected unwired-ending placeholder
+-- may follow after EVFLAG_DEFEAT_BOSS is set.
 -- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh recordch05ravisindeath (CH05BOOT=1 ROM).
 scenarios.recordch05ravisindeath = function()
     local RAVISIN, boxes = 0xb8, 0

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -270,6 +270,10 @@ scenarios:
     rom: ch05boot
     host_chapter: 6
     kind: record
+  recordch05ravisindeath:
+    rom: ch05boot
+    host_chapter: 6
+    kind: record
   ch04snag:
     rom: ch04boot
     host_chapter: 5

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1882,6 +1882,50 @@ class Ch05EruptionWarning(unittest.TestCase):
             self.assertNotIn('CUMO_CHAR(', script)
 
 
+class Ch05RavisinDeathQuote(unittest.TestCase):
+    """Ravisin's locked death box speaks without changing the DefeatBoss flag path."""
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def _chap(self):
+        return bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+
+    def _event(self):
+        return next(e for e in self._chap()['events'] if e['trigger'] == 'boss_death')
+
+    def test_death_quote_owns_the_next_named_id_in_ch05s_real_host_block(self):
+        self.assertTrue(hasattr(bc, 'CH05_RAVISIN_DEATH_MSG'),
+                        'Ravisin needs a named host-block id for her death quote')
+        self.assertEqual(0x9E5, bc.CH05_RAVISIN_DEATH_MSG)
+        self.assertTrue(0x9E4 <= bc.CH05_RAVISIN_DEATH_MSG <= 0x9F3)
+        self.assertIn(bc.CH05_RAVISIN_DEATH_MSG, bc.HOSTED_CHAPTER_MESSAGE_IDS['ch05'])
+        self.assertEqual('ch05', bc.assert_message_ids_unique()[bc.CH05_RAVISIN_DEATH_MSG])
+
+    def test_locked_one_box_emits_ravisins_live_face_from_the_event_yaml(self):
+        event = self._event()
+        self.assertEqual('vanilla 0x9C8', event['slot'])
+        self.assertEqual([{'ravisin': 'Frostmaiden... the winter is yours...'}], event['script'])
+        self.assertTrue(hasattr(bc, 'ch05_ravisin_death_message'),
+                        'the locked YAML beat needs a message emitter')
+
+        body = bc.ch05_ravisin_death_message(self._chap())
+        flowed = body.replace('[LF]\n', ' ')
+        self.assertIn('[LoadFace][FID_Riev]', body)
+        self.assertEqual(1, body.count('[A]'))
+        self.assertIn('Frostmaiden', flowed)
+        self.assertIn('the winter is yours', flowed)
+        self.assertNotIn('I gave you everything', flowed)
+
+    def test_flagged_defeat_entry_shows_the_quote_and_preserves_the_win_flag(self):
+        self.assertTrue(hasattr(bc, 'ch05_ravisin_defeat_quote'),
+                        'ch05 needs a testable owner for Ravisin defeat-talk wiring')
+        quote = bc.ch05_ravisin_defeat_quote()
+        self.assertIn('.pid     = %s' % bc.CH05_BOSS_PID, quote)
+        self.assertIn('.chapter = %s' % bc.chapter_label_constant(bc.CH05_HOST_INDEX), quote)
+        self.assertIn('.flag    = EVFLAG_DEFEAT_BOSS', quote)
+        self.assertIn('.msg     = 0x%X' % bc.CH05_RAVISIN_DEATH_MSG, quote)
+        self.assertNotIn('.msg     = 0,', quote)
+
+
 class Ch05VillageRaidRace(unittest.TestCase):
     """ch05's declared structure: the eruption's dead race the party for the four reliquaries,
     and saving all four pays out (#25). Vanilla Ch5 is the reference for both halves -- it wires

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -166,6 +166,31 @@ class TestPlaytestHarness(unittest.TestCase):
         self.assertIn('turn() >= 2', body)
         self.assertIn('not procActive(SYM.ProcScr_StdEventEngine)', body)
 
+    def test_recordch05ravisindeath_records_one_real_boss_death_box(self):
+        harness = _read_harness()
+        self.assertIn('scenarios.recordch05ravisindeath = function()', harness)
+        body = _block(harness, 'scenarios.recordch05ravisindeath = function()',
+                      '\n-- ch04cottage')
+        self.assertIn('bootToMap()', body)
+        self.assertIn('pokeFrail(boss)', body)
+        self.assertIn('chooseAttack(', body)
+        self.assertIn('recordCutscene({', body)
+        self.assertIn('shotEvery = 1', body,
+                      'the two-frame recorder must capture before it advances the waiting box')
+        self.assertIn('controllerState() == "dialogue_wait"', body)
+        self.assertIn('eventFlag(2)', body,
+                      'the recorder must preserve the DefeatBoss flag as its terminal proof')
+        self.assertIn('boxes == 1', body,
+                      'the focused proof must require exactly the one locked death box')
+
+        matrix = os.path.join(REPO, 'tools/playtest/matrix.yaml')
+        with open(matrix, encoding='utf-8') as source:
+            registry = source.read()
+        self.assertIn('  recordch05ravisindeath:\n'
+                      '    rom: ch05boot\n'
+                      '    host_chapter: 6\n'
+                      '    kind: record\n', registry)
+
     def test_ch04snag_accepts_the_native_fallen_snag_crossing(self):
         harness = _read_harness()
         body = _block(harness, 'scenarios.ch04snag = function()', '\n-- attackprobe')

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -176,7 +176,7 @@ class TestPlaytestHarness(unittest.TestCase):
         self.assertIn('chooseAttack(', body)
         self.assertIn('recordCutscene({', body)
         self.assertIn('shotEvery = 1', body,
-                      'the two-frame recorder must capture before it advances the waiting box')
+                      'per-frame capture must preserve the death box before advancing it')
         self.assertIn('controllerState() == "dialogue_wait"', body)
         self.assertIn('eventFlag(2)', body,
                       'the recorder must preserve the DefeatBoss flag as its terminal proof')


### PR DESCRIPTION
## Summary

- allocate `CH05_RAVISIN_DEATH_MSG` at `0x9E5` in Chapter 5's real Ch6 host block
- render the locked `boss_death` YAML line with Ravisin's live `FID_Riev` face
- preserve the existing `EVFLAG_DEFEAT_BOSS` win path while replacing the silent `.msg = 0` entry
- add focused generator tests and a one-scenario real-map emulator proof

## Validation

- `python3 -m unittest tools.test_build_campaign.Ch05RavisinDeathQuote tools.test_build_campaign.Ch05EruptionWarning tools.test_playtest_harness.TestPlaytestHarness.test_recordch05ravisindeath_records_one_real_boss_death_box tools.test_playtest_harness.TestHarnessLoads.test_harness_lua_compiles -v` — 9 passed
- `python3 tools/verify_text.py` — 3,404 messages, 0 runaway
- `PYTHONPYCACHEPREFIX=/tmp/manchego-stars-pycache make check` — clean
- `make CAMPAIGN=rime-of-the-frostmaiden CH05BOOT=1 fireemblem8.gba -j8` — passed
- `PT_HOST_CHAPTER=6 tools/playtest/run.sh recordch05ravisindeath` — passed; Ravisin's quote appeared before the expected unwired-ending placeholder
- `make CAMPAIGN=rime-of-the-frostmaiden fireemblem8.gba -j8` — passed

Closes #262.
Refs #25.