### PR TITLE
Wire the Ch05 arena tutorial

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -886,8 +886,8 @@ events:
       # (The moose throws its head back and BELLOWS -- then breaks and comes straight at them.)
       - meesmickle: "You had to ask?"
       # (Cue battle. -> PREP -> turn 1.)
-  # ── 0x9D5/0x9D6 — the FORGE's systemic tutorial. Vanilla teaches the arena HERE, in Ch5. ──
-  - trigger: forge_tile_visited   # flag-gated, like vanilla's own arena tutorial
+  # ── 0x9D5/0x9D6 — the arena's systemic tutorial. Vanilla teaches it HERE, in Ch5. ──
+  - trigger: arena_tile_visited   # flag-gated, like vanilla's own arena tutorial
     slot: "vanilla 0x9D5 + 0x9D6"
     type: tutorial
     description: >
@@ -904,8 +904,9 @@ events:
       multiplier, a permadeath risk, a panic button), so it rides vanilla-style tutorial boxes —
       NOT Wolfram's dialogue. His 0x9BE beat is the narrative seed and deliberately states no
       numbers; splitting them is what keeps his voice from turning into a rules manual.
-      OWED WHEN WRITTEN: an `introduces:` entry for the forge/wager mechanic + rerun
-      `gen_onboarding_index.py` (the concept debuts once, and `test_onboarding.py` gates it).
+      ONBOARDING LEDGER: `introduces: arena-wager` above owns this debut; regenerate
+      `docs/ONBOARDING.md` with `gen_onboarding_index.py` (the concept debuts once, and
+      `test_onboarding.py` gates both the ledger and the live wiring).
       RESOLVED 2026-07-29: no gear upgrades. That was the "Forge" label leaking a mechanic we do
       not have; Wolfram's 0x9BE lines promise practice and nothing else.
       TEXT = VANILLA'S, VERBATIM, and that is the finding rather than a shortcut. Because we kept

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -7802,8 +7802,11 @@ CH05_SAHNAR_TALK_MSG = 0x9CC     # the TALK-RECRUIT scene. UNCLAIMED by every ch
                                  # legitimate PLACEHOLDER"). The dialogue pass must MOVE this to
                                  # ch05's block, not overwrite 0x9CC -- it is ch04's neighbourhood.
 CH05_SAHNAR_TALK_FLAG = 'EVFLAG_TMP(7)'   # vanilla Ch5's own Natasha->Joshua CHAR flag, free
-                                          # here: ch05's villages take eid 0 and its Misc list
-                                          # is DefeatBoss + CauseGameOverIfLordDies only.
+                                          # here: ch05's villages use 9..12, and Misc uses 13
+                                          # for the arena tutorial.
+CH05_ARENA_TUTORIAL_FLAG = 'EVFLAG_TMP(13)'  # 7 Talk; 8 prep; 9..12 reliquaries; next free
+CH05_ARENA_TRIGGER_SCRIPT = 'MS_Ch05ArenaTutorialTrigger'
+CH05_ARENA_TUTORIAL_SCRIPT = 'MS_Ch05ArenaTutorial'
 
 # The four reliquary visits. Each rides OUR OWN script (declare_event_script) but shows VANILLA
 # Ch5's own village line, by pointing at the message id that already holds it -- we never WRITE
@@ -7902,6 +7905,8 @@ CH05_GOAL_DONOR = 7                              # vanilla slot 7 = a clean defe
 # from vanilla Ch5's -- ch04 hosts on slot 5 and already owns that block (#207).
 CH05_ERUPTION_MSG = 0x9E4                     # turn-2 Ravisin warning; first free Ch6-host id
 CH05_RAVISIN_DEATH_MSG = 0x9E5                # locked Ravisin death quote; next Ch6-host id
+CH05_ARENA_FOUND_MSG = 0x9E6                  # vanilla 0x9D5 anatomy, in ch05's host block
+CH05_ARENA_RULES_MSG = 0x9E7                  # vanilla 0x9D6 anatomy, in ch05's host block
 CH05_GOAL_WINDOW_MSG = 0x9F4
 CH05_GOAL_STATUS_MSG = 0x9F5
 # Raw charIndexes. Pids need only be unique WITHIN a chapter -- gDefeatTalkList entries carry
@@ -7986,6 +7991,7 @@ HOSTED_CHAPTER_MESSAGE_IDS = {
     # OUTSIDE ch05's host block on purpose -- see CH05_VILLAGE_SLOTS for why that is safe here
     # and why spending ch05's own ids on them was the worse trade.
     'ch05': (CH05_ERUPTION_MSG, CH05_RAVISIN_DEATH_MSG,
+             CH05_ARENA_FOUND_MSG, CH05_ARENA_RULES_MSG,
              CH05_GOAL_WINDOW_MSG, CH05_GOAL_STATUS_MSG,
              *(slot[1] for slot in CH05_VILLAGE_SLOTS.values())),
     # Goal ids only -- ch01/ch02 predate the per-chapter block registry, but their goal strings
@@ -8328,11 +8334,81 @@ def ch05_map_changes(chap, maps_dir):
 
 
 def ch05_location_events(chap):
-    """ch05's Location list: the four reliquaries, each armed with its race flag, plus the
-    elven store. Vanilla Ch5's own list, one for one (four villages, an armory and a vendor)."""
+    """ch05's Location list: the four reliquaries and the elven store."""
     return location_events(chap.get('villages', []),
                            {vid: slot[0] for vid, slot in CH05_VILLAGE_SLOTS.items()},
                            CH05_SHOPS, flags=CH05_VILLAGE_FLAGS)
+
+
+def ch05_misc_events():
+    """ch05's automatic win/lose checks plus the one-shot arena tutorial AREA.
+
+    Vanilla places AREA rows in Misc, whose post-action scan evaluates them against the active
+    unit. Location is reserved for commands such as Village, Armory, and Vendor.
+    """
+    return ('{\n'
+            '    DefeatBoss(%s)\n'
+            '    AREA(%s, %s, 12, 6, 12, 6) /* one-shot arena tutorial (#264) */\n'
+            '    CauseGameOverIfLordDies\n'
+            '    END_MAIN\n}'
+            % (CH05_ENDING_SCRIPT, CH05_ARENA_TUTORIAL_FLAG,
+               CH05_ARENA_TRIGGER_SCRIPT))
+
+
+def ch05_arena_trigger_script():
+    """Player-only AREA target that preserves vanilla's tutorial-mode channel gate."""
+    return ('{\n'
+            '    SVAL(EVT_SLOT_2, FACTION_ID_BLUE)\n'
+            '    CALL(EventScr_UnTriggerIfNotFaction)\n'
+            '    SVAL(EVT_SLOT_2, %s)\n'
+            '    CALL(EventScr_CallOnTutorialMode)\n'
+            '    EVBIT_T(7)\n'
+            '    ENDA\n}' % CH05_ARENA_TUTORIAL_SCRIPT)
+
+
+def ch05_arena_tutorial_script():
+    """Vanilla EventScr_089F23B4 anatomy, pointed at ch05-owned message ids."""
+    return ('{\n'
+            '    TUTORIALTEXTBOXSTART\n'
+            '    SVAL(EVT_SLOT_B, 0xffffffff)\n'
+            '    TEXTSHOW(0x%X)\n'
+            '    TEXTEND\n'
+            '    REMA\n'
+            '    CAMERA(12, 6)\n'
+            '    CURSOR_FLASHING(12, 6)\n'
+            '    STAL(60)\n'
+            '    TUTORIALTEXTBOXSTART\n'
+            '    SVAL(EVT_SLOT_B, 0x28ffff)\n'
+            '    TEXTSHOW(0x%X)\n'
+            '    TEXTEND\n'
+            '    REMA\n'
+            '    ENUT(234)\n'
+            '    CURE\n'
+            '    ENDA\n}' % (CH05_ARENA_FOUND_MSG, CH05_ARENA_RULES_MSG))
+
+
+def ch05_arena_onboarding_wiring(chap):
+    """One contract for every output that makes the active arena-wager claim executable.
+
+    Keeping the Misc row, both scripts, and both messages in one value means ``inject_ch05``
+    cannot grow a declaration that is never placed or text that is never reached. The onboarding
+    guard exercises these generated bodies, then pins the three injection call sites that consume
+    them.
+    """
+    found, rules = ch05_arena_messages(chap)
+    return {
+        'misc': ch05_misc_events(),
+        'scripts': [
+            (CH05_ARENA_TUTORIAL_SCRIPT, ch05_arena_tutorial_script(),
+             'ch05 arena tutorial -- vanilla 0x9D5/0x9D6 anatomy on host-owned ids (#264)'),
+            (CH05_ARENA_TRIGGER_SCRIPT, ch05_arena_trigger_script(),
+             'ch05 arena tile trigger -- one-shot AREA, tutorial-mode gated (#264)'),
+        ],
+        'messages': [
+            (CH05_ARENA_FOUND_MSG, found),
+            (CH05_ARENA_RULES_MSG, rules),
+        ],
+    }
 
 
 def assert_village_tiles_visitable(chap, maps_dir, stem):
@@ -9778,6 +9854,49 @@ def ch05_ravisin_death_message(chap):
         width=29)
 
 
+def _vanilla_message_body(msg_id, source=None):
+    """One committed vanilla message body, immune to the mutable injected text tree."""
+    source = vanilla_decomp_text('texts/texts.txt') if source is None else source
+    match = re.search(r'^## MSG_%03X\n(.*?)(?=\n\n## MSG_|\Z)' % msg_id,
+                      source, re.M | re.S)
+    if not match:
+        sys.exit('ERROR: vanilla MSG_%03X is absent from texts/texts.txt at HEAD' % msg_id)
+    return match.group(1).strip()
+
+
+def _tutorial_plain_boxes(body):
+    """Visible prose per [A] page, discarding FE text controls and layout padding."""
+    boxes = []
+    for page in body.split('[A]'):
+        plain = re.sub(r'\[[^]]+\]', '', page)
+        plain = ' '.join(plain.split())
+        if plain:
+            boxes.append(plain)
+    return boxes
+
+
+def ch05_arena_messages(chap):
+    """The locked arena tutorial as vanilla's exact 1+5 message bodies.
+
+    The YAML is the authored source; vanilla's committed messages are the layout template. The
+    semantic comparison makes a future YAML edit fail rather than silently injecting stale prose,
+    while the template preserves hand-placed line breaks, colour toggles and padding byte for byte.
+    """
+    event = next((e for e in chap.get('events', []) if e.get('trigger') == 'arena_tile_visited'),
+                 None)
+    if event is None:
+        sys.exit('ERROR: ch05 has no arena_tile_visited tutorial event')
+    authored = [_fe_dialogue_text(next(iter(box.values())))
+                .replace('[red]', '').replace('[/red]', '') for box in event.get('script', [])]
+    found = _vanilla_message_body(0x9D5)
+    rules = _vanilla_message_body(0x9D6)
+    vanilla_boxes = _tutorial_plain_boxes(found) + _tutorial_plain_boxes(rules)
+    if authored != vanilla_boxes:
+        sys.exit('ERROR: ch05 arena tutorial is locked to vanilla MSG_9D5 + MSG_9D6 verbatim; '
+                 'YAML boxes differ: %r != %r' % (authored, vanilla_boxes))
+    return found, rules
+
+
 def ch05_ravisin_defeat_quote():
     """The displayed quote and unchanged flag that together drive ch05's boss win."""
     return flag_defeat_quote(
@@ -9837,14 +9956,14 @@ def inject_ch05(campaign, boot=False, verbose=True):
     seven, so squatting would have meant borrowing Ch6's world-map ENCOUNTER rosters -- and
     the name would have lied either way.
 
-    DEFERRED to follow-up passes (all authored, none blocking a load-test): the four
-    reliquary village visits (their `visit_text` is still owed, #25), Basil's Talk recruit of
-    Sahnar (the red-convertible flow already exists -- recruit_initial_faction), the opening/
-    ending cutscenes (dialogue LOCKED in PR #196), the arena tutorial, and the title-card art.
-    ch05's ending parks on the dev placeholder until ch06 hosts, exactly as ch04's did.
+    DEFERRED to follow-up passes: Basil's Talk-recruit prose, the opening/ending cutscenes
+    (dialogue LOCKED in PR #196), and the title-card art. The four reliquary visits and arena
+    tutorial are live. ch05's ending parks on the dev placeholder until ch06 hosts, exactly as
+    ch04's did.
     """
     maps_dir = os.path.join(REPO, 'campaigns', campaign, 'maps')
     chap = _load_chapter_yaml(campaign, CH05_CHAPTER_YAML)
+    arena_wiring = ch05_arena_onboarding_wiring(chap)
     # A retile inherits vanilla's gift PLACEMENT, not just its terrain. Runs before anything is
     # written: the failure it catches is invisible to the parity read (same items, same total,
     # different tiles), so it has to be a gate rather than a review note.
@@ -9959,8 +10078,7 @@ def inject_ch05(campaign, boot=False, verbose=True):
     # Ravisin's FLAGGED defeat quote sets on her death (step 5) -- CA_BOSS alone fires nothing.
     info = _replace_brace_block(
         info, CH05_EVENT_LISTS['misc'] + '[] =',
-        '{\n    DefeatBoss(%s)\n    CauseGameOverIfLordDies\n    END_MAIN\n}'
-        % CH05_ENDING_SCRIPT, CH05_EVENTINFO_H)
+        arena_wiring['misc'], CH05_EVENTINFO_H)
     # Location = the four reliquary visits + the elven store. The shops are wired for good (a
     # shop needs no script and no text); the visits own their rewards, and each carries its
     # CH05_VILLAGE_FLAGS event id -- the race (#25).
@@ -10065,9 +10183,12 @@ def inject_ch05(campaign, boot=False, verbose=True):
         CH05_EVENTSCRIPT_H, CH05_SAHNAR_TALK_SCRIPT, sahnar_talk_script,
         'ch05 Basil Talks Sahnar down -- CUSA red->blue; prose is vanilla 0x%X until the '
         'dialogue pass (#25)' % CH05_SAHNAR_TALK_MSG)
+    for symbol, body, comment in arena_wiring['scripts']:
+        declare_event_script(CH05_EVENTSCRIPT_H, symbol, body, comment)
     assert_event_scripts_defined(
         CH05_EVENTSCRIPT_H, [slot[0] for slot in CH05_VILLAGE_SLOTS.values()]
-        + [CH05_SAHNAR_TALK_SCRIPT])
+        + [CH05_SAHNAR_TALK_SCRIPT]
+        + [symbol for symbol, _body, _comment in arena_wiring['scripts']])
 
     # 5. Texts + the flagged defeat quote that IS the win trigger.
     with open(TEXTS_TXT, encoding='utf-8') as f:
@@ -10079,6 +10200,8 @@ def inject_ch05(campaign, boot=False, verbose=True):
     set_message_body(lines, host['goal']['windowTextId'], goal_window_body('Defeat boss'))
     set_message_body(lines, CH05_ERUPTION_MSG, ch05_eruption_message(chap))
     set_message_body(lines, CH05_RAVISIN_DEATH_MSG, ch05_ravisin_death_message(chap))
+    for msg_id, body in arena_wiring['messages']:
+        set_message_body(lines, msg_id, body)
     # The four reliquary visits (#25). Each site's speaker is one of the tomb's risen dead, over
     # BG_HOUSE -- a full-screen backdrop, so these wrap at 42 like the other BG scenes and NOT at
     # the on-map bubble's 29. One `visit_text` entry per BOX, ch04's lesson: the authored A-press

--- a/tools/playtest/controller.lua
+++ b/tools/playtest/controller.lua
@@ -17,6 +17,7 @@ local MENU_TALK = 0x5A
 local MENU_VISIT = 0x5C
 local MENU_CHEST = 0x5D
 local MENU_DOOR = 0x5E
+local MENU_ARENA = 0x62
 local MENU_ITEM = 0x67
 local MENU_SUPPLY = 0x69
 local MENU_WAIT = 0x6B
@@ -60,7 +61,8 @@ local function menuKinds(observation)
         if item.override_id == MENU_SEIZE or item.override_id == MENU_ATTACK
             or item.override_id == MENU_BALLISTA_ATTACK
             or item.override_id == MENU_TALK or item.override_id == MENU_CHEST
-            or item.override_id == MENU_DOOR or item.override_id == MENU_ITEM
+            or item.override_id == MENU_DOOR or item.override_id == MENU_ARENA
+            or item.override_id == MENU_ITEM
             or item.override_id == MENU_SUPPLY or item.override_id == MENU_WAIT then unit = true end
         if item.override_id == MENU_END_PHASE then map = true end
     end
@@ -153,19 +155,23 @@ local RULES = {
         -- it would answer "press A", the choice's key handler would CONSUME that A, and the
         -- prompt would be answered by accident with the run still green (#241 review).
         -- General rule for this table: the more SPECIFIC state outranks the more general
-        -- one -- a live YesNoChoice in its key handler owns the A button, whatever else is
-        -- on screen.
+        -- one -- a live choice in its key handler owns the A button, whatever else is on
+        -- screen. FE8 has two implementations: cgtext.c's YesNoChoice and scene.c's inline
+        -- TalkChoice used by [Yes] text controls such as the arena wager.
         name = "yes_no_choice",
         check = function(observation)
-            if not proc(observation, "yes_no") then return rejected("yes_no proc absent") end
-            if not idleIs(observation, "yes_no", "yes_no_input") then
-                return matched("transition", string.format("yes_no idle=%s, not its key handler",
-                    tostring(idleOf(observation, "yes_no"))))
+            local name = proc(observation, "yes_no") and "yes_no"
+                or (proc(observation, "talk_choice") and "talk_choice")
+            if not name then return rejected("choice proc absent") end
+            local input = name == "yes_no" and "yes_no_input" or "talk_choice_input"
+            if not idleIs(observation, name, input) then
+                return matched("transition", string.format("%s idle=%s, not its key handler",
+                    name, tostring(idleOf(observation, name))))
             end
             if not observation.choice then
-                return matched("transition", "yes_no live with no observed choice")
+                return matched("transition", name .. " live with no observed choice")
             end
-            return matched("yes_no_choice", "yes_no in its key handler")
+            return matched("yes_no_choice", name .. " in its key handler")
         end,
     },
     {
@@ -627,6 +633,7 @@ function M.legalActions(observation)
         -- the run stays green (#238).
         addMenuCommand(actions, observation, MENU_CHEST, "open_chest")
         addMenuCommand(actions, observation, MENU_DOOR, "open_door")
+        addMenuCommand(actions, observation, MENU_ARENA, "arena")
         addMenuCommand(actions, observation, MENU_ITEM, "open_items")
         addMenuCommand(actions, observation, MENU_SUPPLY, "open_supply")
         addMenuCommand(actions, observation, MENU_WAIT, "wait")
@@ -757,6 +764,7 @@ M.MENU_SEIZE = MENU_SEIZE
 M.MENU_BALLISTA_ATTACK = MENU_BALLISTA_ATTACK
 M.MENU_TALK = MENU_TALK
 M.MENU_VISIT = MENU_VISIT
+M.MENU_ARENA = MENU_ARENA
 M.MENU_WAIT = MENU_WAIT
 M.MENU_STATUS = MENU_STATUS
 M.MENU_END_PHASE = MENU_END_PHASE

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -54,6 +54,7 @@ Symbol = namedtuple('Symbol', 'name type addr')
 # the decomp header they came from.
 WANTED = [
     'gPlaySt',                  # chapter index / phase / turn (include/types.h)
+    'gArenaState',              # accepted wager/opponent state (include/bmarena.h)
     'gBmSt',                    # live map cursor (include/types.h)
     'gUnitArrayBlue',           # player units (include/bmunit.h)
     'gUnitArrayRed',            # enemy units
@@ -134,6 +135,8 @@ WANTED = [
     'YesNoChoice_Loop_KeyHandler', # exact Yes/No input callback. currentChoice is s16 at
                                 # +0x2A: TALK_CHOICE_YES = 1, TALK_CHOICE_NO = 2
                                 # (include/scene.h); A commits whichever is highlighted.
+    'gProcScr_TalkChoice',      # scene.c inline [Yes] choice (arena wager / shop prompts)
+    'TalkChoice_OnIdle',        # exact inline-choice input callback; selectedChoice @ +0x2A
     'ProcScr_AtMenu',           # preparations main-menu owner
     'ProcScr_PrepMenu',         # live semantic preparations command list
     'PrepMenu_CtrlLoop',        # exact preparations input callback

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -371,6 +371,7 @@ local CALLBACK_NAMES = {
     [SYM.ChapterIntro_KeyListen_Loop] = "chapter_intro_input",
     [SYM.TalkWaitForInput_OnIdle] = "talk_wait_input",
     [SYM.YesNoChoice_Loop_KeyHandler] = "yes_no_input",
+    [SYM.TalkChoice_OnIdle] = "talk_choice_input",
     [SYM.Menu_OnIdle] = "menu_input",
     [SYM.PrepMenu_CtrlLoop] = "prep_menu_input",
     [SYM.ProcPrepUnit_Idle] = "prep_units_input",
@@ -543,17 +544,21 @@ local function observeController()
     put("chapter_intro", introKey or observedProc(SYM.gProcScr_ChapterIntro))
     put("talk_wait", observedProc(SYM.gProcScr_TalkWaitForInput))
     local yesNo = observedProc(SYM.gProcScr_YesNoChoice)
+    local talkChoice = observedProc(SYM.gProcScr_TalkChoice)
     put("yes_no", yesNo)
-    if yesNo then
-        -- struct YesNoChoiceProc.currentChoice (include/cgtext.h): s16 @ +0x2A,
-        -- TALK_CHOICE_YES = 1 / TALK_CHOICE_NO = 2 (include/scene.h).
-        local choice = rs16(yesNo.addr + 0x2A)
+    put("talk_choice", talkChoice)
+    if yesNo or talkChoice then
+        -- Both struct YesNoChoiceProc.currentChoice (include/cgtext.h) and struct
+        -- TalkChoiceProc.selectedChoice (include/scene.h) are s16 @ +0x2A;
+        -- TALK_CHOICE_YES = 1 / TALK_CHOICE_NO = 2.
+        local choiceProc = yesNo or talkChoice
+        local choice = rs16(choiceProc.addr + 0x2A)
         observation.choice = {
             current = (choice == 1 and "yes") or (choice == 2 and "no") or nil,
             raw = choice,
         }
         if not observation.choice.current then
-            observation.error = string.format("malformed YesNoChoiceProc currentChoice=%d", choice)
+            observation.error = string.format("malformed choice proc currentChoice=%d", choice)
         end
     end
     local rawMenu = anyMenuProc()
@@ -6740,6 +6745,172 @@ scenarios.ch05reliquaries = function()
             .. table.concat(silent, ", "))
     end
     return result("PASS", "all four reliquaries spoke and handed over their own gift")
+end
+
+-- ch05arena (#264): the active onboarding ledger claims a tutorial on the real arena tile.
+-- Park the leader one step away, take the engine's real move+Wait path onto (12,6), and count
+-- the six authored pages. Then step off and back on during the same turn (manually clearing its
+-- acted/moved bits between legal actions) to prove EVFLAG_TMP(13) makes it one-shot. Run:
+-- PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05arena (needs a CH05BOOT=1 ROM).
+scenarios.ch05arena = function()
+    local ARENA_X, ARENA_Y, GUARD, REARM_MASK = 12, 6, 13, 0x42
+    if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
+    pokeFastConfig()
+    if not waitFor(function()
+        return faction() == 0 and not menuOpen() and not procActive(SYM.ProcScr_StdEventEngine)
+            and controllerState() == "player_map_idle"
+    end, 6000, true) then
+        return result("FAIL", "ch05 never settled at player control")
+    end
+    if eventFlag(GUARD) then
+        return result("FAIL", "arena tutorial guard 13 is already set before the tile is entered")
+    end
+    if mapUnitAt(ARENA_X, ARENA_Y) ~= 0 then
+        return result("FAIL", "arena tile (12,6) is occupied before the turn-2 Sahnar wake")
+    end
+    local hero = blue(0x01)
+    if not hero then return result("FAIL", "leader (0x01) is not deployed") end
+    local grid = mapUnitAt(hero.x, hero.y)
+    setMapUnit(hero.x, hero.y, 0)
+    emu:write8(hero.addr + 0x10, ARENA_X); emu:write8(hero.addr + 0x11, ARENA_Y)
+    setMapUnit(ARENA_X, ARENA_Y, grid)
+    if not cursorTo(ARENA_X, ARENA_Y)
+        or not guardedInput("select_unit", "A", "arena staging reach map is generated", function(after)
+            return controllerState(after) == "unit_selected"
+        end, 120) then
+        return result("FAIL", "could not generate the arena staging reach map")
+    end
+    local fromX, fromY
+    for _, d in ipairs({ { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } }) do
+        local x, y = ARENA_X + d[1], ARENA_Y + d[2]
+        if mapUnitAt(x, y) == 0 and reachCost(x, y) < 120 then
+            fromX, fromY = x, y; break
+        end
+    end
+    if not guardedInput("cancel_selection", "B", "arena staging selection returns to the map",
+        function(after) return controllerState(after) == "player_map_idle" end, 120) then
+        return result("FAIL", "could not close the arena staging reach map")
+    end
+    if not fromX then return result("FAIL", "no reachable empty tile beside the arena") end
+    setMapUnit(ARENA_X, ARENA_Y, 0)
+    emu:write8(hero.addr + 0x10, fromX); emu:write8(hero.addr + 0x11, fromY)
+    setMapUnit(fromX, fromY, grid)
+    -- Raw placement updates the unit/grid but not FE8's standing-map-sprite pool. Make the
+    -- engine select and cancel the staged unit once so PlayerPhase's normal cancel path calls
+    -- RefreshUnitSprites before the proof frame; otherwise the old SMS and the live MU can both
+    -- be drawn and make one Braulo look like two.
+    if not cursorTo(fromX, fromY)
+        or not guardedInput("select_unit", "A", "staged unit enters the live reach map",
+            function(after) return controllerState(after) == "unit_selected" end, 120)
+        or not guardedInput("cancel_selection", "B", "staged unit refreshes back to the map",
+            function(after) return controllerState(after) == "player_map_idle" end, 120) then
+        return result("FAIL", "could not refresh the arena staging placement through PlayerPhase")
+    end
+
+    if not moveUnit(fromX, fromY, ARENA_X, ARENA_Y) or not chooseWait() then
+        return result("FAIL", "could not take the live move+Wait path onto the arena")
+    end
+    local pages = 0
+    for _ = 1, 3600 do
+        local state = controllerState()
+        if state == "dialogue_wait" then
+            pages = pages + 1
+            if pages == 1 then
+                INSPECT.units("ch05arena-tutorial")
+                shot("ch05arena")
+            end
+            if not guardedInput("advance_dialogue", "A", "arena tutorial page advances",
+                function(after) return controllerState(after) ~= "dialogue_wait" end, 120) then
+                return result("FAIL", "arena tutorial dialogue did not advance")
+            end
+        elseif eventFlag(GUARD) and not procActive(SYM.ProcScr_StdEventEngine)
+            and state == "player_map_idle" then
+            break
+        else
+            yield()
+        end
+    end
+    if pages ~= 6 then
+        return result("FAIL", string.format(
+            "arena tile fired %d tutorial pages, expected the locked 1+5 anatomy", pages))
+    end
+    if not eventFlag(GUARD) then
+        return result("FAIL", "arena tutorial finished but EVFLAG_TMP(13) stayed unset")
+    end
+    wait(20)
+    shot("ch05arena-after-tutorial")
+
+    -- Re-arm only this unit so we can exercise the same tile twice without advancing to turn 2,
+    -- when Sahnar legitimately occupies it. Every move still goes through FE8's live command menu.
+    hero = blue(0x01)
+    -- Wait sets both US_UNSELECTABLE (0x02) and US_HAS_MOVED (0x40). Clear both: clearing only
+    -- the former makes the unit selectable but leaves every destination outside its own tile.
+    emu:write32(hero.addr + 0x0C, hero.state & (~REARM_MASK))
+    if not moveUnit(ARENA_X, ARENA_Y, fromX, fromY) or not chooseWait() then
+        return result("FAIL", "could not step off the arena for the replay check")
+    end
+    waitFor(function() return controllerState() == "player_map_idle" end, 600, true)
+    hero = blue(0x01)
+    emu:write32(hero.addr + 0x0C, hero.state & (~REARM_MASK))
+    if not moveUnit(fromX, fromY, ARENA_X, ARENA_Y) or not chooseWait() then
+        return result("FAIL", "could not step back onto the arena for the replay check")
+    end
+    local replayed = false
+    for _ = 1, 300 do
+        if controllerState() == "dialogue_wait" then replayed = true; break end
+        if controllerState() == "player_map_idle"
+            and not procActive(SYM.ProcScr_StdEventEngine) then break end
+        yield()
+    end
+    if replayed then
+        return result("FAIL", "arena tutorial replayed after EVFLAG_TMP(13) was set")
+    end
+
+    -- Now exercise the tile's real command rather than stopping at the onboarding event. FE8's
+    -- Arena command is only offered before a unit moves, so re-arm Braulo in place. Seed enough
+    -- money to accept whatever matchup vanilla generates, then prove the accepted wager is
+    -- deducted and a live opponent is built before the instructions page appears.
+    hero = blue(0x01)
+    emu:write32(hero.addr + 0x0C, hero.state & (~REARM_MASK))
+    local beforeGold = 5000
+    emu:write32(SYM.gPlaySt + 0x08, beforeGold)
+    if not moveUnit(ARENA_X, ARENA_Y, ARENA_X, ARENA_Y) then
+        return result("FAIL", "could not open Braulo's command menu on the arena")
+    end
+    if not selectSemantic("arena", "Arena opens its welcome dialogue", function(after)
+        return controllerState(after) == "dialogue_wait"
+    end, 600) then
+        return result("FAIL", "the live arena tile offered no Arena command")
+    end
+    shot("ch05arena-welcome")
+    if ru32(SYM.gArenaState) ~= hero.addr then
+        return result("FAIL", "Arena command opened without binding Braulo as the entrant")
+    end
+    local wager = ru16(SYM.gArenaState + 0x08)
+    if wager <= 0 or wager > beforeGold then
+        return result("FAIL", string.format("arena generated unusable wager %d", wager))
+    end
+    if not guardedInput("advance_dialogue", "A", "welcome advances to the live wager choice",
+        function(after) return controllerState(after) == "yes_no_choice" end, 300) then
+        return result("FAIL", "arena welcome never reached its wager choice")
+    end
+    shot("ch05arena-wager")
+    if not selectSemantic("answer_yes", "accepting the wager shows opponent instructions",
+        function(after) return controllerState(after) == "dialogue_wait" end, 300) then
+        return result("FAIL", "could not accept the arena wager")
+    end
+    if ru32(SYM.gPlaySt + 0x08) ~= beforeGold - wager then
+        return result("FAIL", string.format(
+            "accepted wager %d but gold changed %d -> %d", wager, beforeGold,
+            ru32(SYM.gPlaySt + 0x08)))
+    end
+    if ru32(SYM.gArenaState + 0x04) == 0 then
+        return result("FAIL", "accepted wager reached instructions without a generated opponent")
+    end
+    shot("ch05arena-opponent")
+    return result("PASS", string.format(
+        "arena (12,6) taught once, blocked replay, then Arena accepted %dG and generated its opponent",
+        wager))
 end
 
 -- ch05village (#25): does the SOUTH reliquary at (12,19) actually hand over its Dracoshield?

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -253,6 +253,9 @@ scenarios:
   ch05reliquaries:
     rom: ch05boot
     host_chapter: 6
+  ch05arena:
+    rom: ch05boot
+    host_chapter: 6
   ch05recruit:
     rom: ch05boot
     host_chapter: 6
@@ -341,6 +344,7 @@ suites:
     - clear_ch04_parley
     - ch05village
     - ch05reliquaries
+    - ch05arena
     - ch05recruit
     - ch05raid
     - ch05crest
@@ -394,6 +398,7 @@ suites:
   ch05:
     - ch05village
     - ch05reliquaries
+    - ch05arena
     - ch05recruit
     - ch05raid
     - ch05crest

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -181,6 +181,7 @@ local unitMenu = {
             { slot = 0, override_id = 0x5A, availability = 1 },
             { slot = 1, override_id = 0x6B, availability = 1 },
             { slot = 2, override_id = 0x5C, availability = 1 },
+            { slot = 5, override_id = 0x62, availability = 1 },
         },
     },
 }
@@ -195,6 +196,8 @@ a = action(unitMenu, "attack")
 check(a and a.target, 3, "Attack resolves from semantic id 0x4F")
 a = action(unitMenu, "seize")
 check(a and a.target, 4, "Seize resolves from semantic id 0x4E")
+a = action(unitMenu, "arena")
+check(a and a.target, 5, "Arena resolves from semantic id 0x62")
 a = action(unitMenu, "cancel_menu")
 check(a and a.key, "B", "standard menu cancellation comes from its live B callback")
 check(a and a.source, "menu.on_b=0x0804F000", "menu cancel records the live callback")
@@ -612,6 +615,16 @@ local noHighlighted = {
 check(action(noHighlighted, "answer_no").key, "A", "A commits the highlighted No")
 check(action(noHighlighted, "answer_yes").key, nil, "Yes is not committable while No is up")
 check(action(noHighlighted, "select_yes").key, "LEFT", "LEFT moves the choice back to Yes")
+
+-- Inline [Yes] choices use scene.c's older gProcScr_TalkChoice, not cgtext.c's
+-- gProcScr_YesNoChoice. The arena wager is the first driven flow to expose that distinction.
+local inlineChoice = {
+    procs = proc("talk_choice", "talk_choice_input"),
+    choice = { current = "yes" },
+}
+classify(inlineChoice, "yes_no_choice", "inline talk choice in its key handler")
+check(action(inlineChoice, "answer_yes").key, "A", "A accepts an inline arena wager")
+check(action(inlineChoice, "select_no").key, "RIGHT", "RIGHT moves an inline choice to No")
 
 -- The prompt animating in offers nothing, and says so by name.
 classify({ procs = proc("yes_no", "yes_no_fade"), choice = { current = "yes" } }, "transition",

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -1926,6 +1926,73 @@ class Ch05RavisinDeathQuote(unittest.TestCase):
         self.assertNotIn('.msg     = 0,', quote)
 
 
+class Ch05ArenaTutorial(unittest.TestCase):
+    """The Elven Tomb inherits vanilla Ch5's arena lesson on a live tile trigger (#264).
+
+    The YAML's ``vanilla 0x9D5 + 0x9D6`` label is anatomy, not permission to write into
+    ch04's host block. The live tutorial therefore owns two ids from ch05's real Ch6 host
+    block and reaches them through a one-shot event on the arena tile itself.
+    """
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def _chap(self):
+        return bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+
+    def _event(self):
+        return next(e for e in self._chap()['events']
+                    if e['trigger'] == 'arena_tile_visited')
+
+    def test_the_two_messages_are_named_owned_and_inside_ch05s_host_block(self):
+        self.assertEqual(0x9E6, bc.CH05_ARENA_FOUND_MSG)
+        self.assertEqual(0x9E7, bc.CH05_ARENA_RULES_MSG)
+        claimed = set(bc.HOSTED_CHAPTER_MESSAGE_IDS['ch05'])
+        for msg in (bc.CH05_ARENA_FOUND_MSG, bc.CH05_ARENA_RULES_MSG):
+            self.assertTrue(0x9E4 <= msg <= 0x9F3)
+            self.assertIn(msg, claimed)
+            self.assertEqual('ch05', bc.assert_message_ids_unique()[msg])
+
+    def test_the_locked_six_boxes_keep_vanillas_one_plus_five_anatomy(self):
+        event = self._event()
+        self.assertEqual('vanilla 0x9D5 + 0x9D6', event['slot'])
+        self.assertEqual(6, len(event['script']))
+        self.assertEqual({'tutorial'}, {next(iter(box)) for box in event['script']})
+
+        found, rules = bc.ch05_arena_messages(self._chap())
+        self.assertEqual(1, found.count('[A]'))
+        self.assertEqual(5, rules.count('[A]'))
+        self.assertIn('[ToggleRed]arena', found)
+        for phrase in ('one-on-one', 'twice', 'will not', 'press the B Button quickly'):
+            self.assertIn(phrase, rules)
+
+    def test_the_misc_list_fires_once_on_exactly_the_arena_tile(self):
+        self.assertEqual('EVFLAG_TMP(13)', bc.CH05_ARENA_TUTORIAL_FLAG)
+        location = bc.ch05_location_events(self._chap())
+        misc = bc.ch05_misc_events()
+        area = ('AREA(%s, %s, 12, 6, 12, 6)'
+                % (bc.CH05_ARENA_TUTORIAL_FLAG, bc.CH05_ARENA_TRIGGER_SCRIPT))
+        self.assertNotIn(area, location)
+        self.assertEqual(1, misc.count(area))
+        self.assertIn('DefeatBoss(%s)' % bc.CH05_ENDING_SCRIPT, misc)
+        self.assertIn('CauseGameOverIfLordDies', misc)
+
+    def test_the_trigger_preserves_tutorial_mode_and_vanillas_event_shape(self):
+        trigger = bc.ch05_arena_trigger_script()
+        self.assertIn('SVAL(EVT_SLOT_2, FACTION_ID_BLUE)', trigger)
+        self.assertIn('CALL(EventScr_UnTriggerIfNotFaction)', trigger)
+        self.assertLess(trigger.index('CALL(EventScr_UnTriggerIfNotFaction)'),
+                        trigger.index('CALL(EventScr_CallOnTutorialMode)'))
+        self.assertIn('SVAL(EVT_SLOT_2, %s)' % bc.CH05_ARENA_TUTORIAL_SCRIPT, trigger)
+        self.assertIn('CALL(EventScr_CallOnTutorialMode)', trigger)
+
+        tutorial = bc.ch05_arena_tutorial_script()
+        self.assertLess(tutorial.index('TEXTSHOW(0x%X)' % bc.CH05_ARENA_FOUND_MSG),
+                        tutorial.index('CAMERA(12, 6)'))
+        self.assertIn('CURSOR_FLASHING(12, 6)', tutorial)
+        self.assertLess(tutorial.index('CAMERA(12, 6)'),
+                        tutorial.index('TEXTSHOW(0x%X)' % bc.CH05_ARENA_RULES_MSG))
+        self.assertIn('ENUT(234)', tutorial)
+
+
 class Ch05VillageRaidRace(unittest.TestCase):
     """ch05's declared structure: the eruption's dead race the party for the four reliquaries,
     and saving all four pays out (#25). Vanilla Ch5 is the reference for both halves -- it wires

--- a/tools/test_onboarding.py
+++ b/tools/test_onboarding.py
@@ -9,10 +9,12 @@ concepts) and the generated-doc freshness, so a drift can't land silently.
 Run:  python3 tools/test_onboarding.py
 """
 import os
+import inspect
 import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import build_campaign as bc
 import gen_onboarding_index as onb
 
 
@@ -64,6 +66,33 @@ class GeneratedDoc(unittest.TestCase):
         if uncovered:
             self.assertIn('Pending', md,
                           'concepts with no chapter coverage must show in a Pending section')
+
+    def test_active_ch05_arena_claim_is_backed_by_live_wiring(self):
+        coverage = [(label, entry) for label, entry in onb.load_chapter_coverage()
+                    if entry.get('concept') == 'arena-wager']
+        self.assertEqual(1, len(coverage))
+        label, entry = coverage[0]
+        self.assertEqual(('Ch 5', 'active'), (label, entry.get('status')))
+
+        chap = bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.CH05_CHAPTER_YAML)
+        wiring = bc.ch05_arena_onboarding_wiring(chap)
+
+        area = ('AREA(%s, %s, 12, 6, 12, 6)'
+                % (bc.CH05_ARENA_TUTORIAL_FLAG, bc.CH05_ARENA_TRIGGER_SCRIPT))
+        self.assertEqual(1, wiring['misc'].count(area))
+        self.assertEqual(
+            [bc.CH05_ARENA_TUTORIAL_SCRIPT, bc.CH05_ARENA_TRIGGER_SCRIPT],
+            [symbol for symbol, _body, _comment in wiring['scripts']])
+        self.assertEqual(
+            [bc.CH05_ARENA_FOUND_MSG, bc.CH05_ARENA_RULES_MSG],
+            [msg_id for msg_id, _body in wiring['messages']])
+
+        inject = inspect.getsource(bc.inject_ch05)
+        self.assertEqual(1, inject.count('ch05_arena_onboarding_wiring(chap)'))
+        for output in ("arena_wiring['misc']", "arena_wiring['scripts']",
+                       "arena_wiring['messages']"):
+            self.assertIn(output, inject,
+                          'inject_ch05 does not consume live onboarding output %s' % output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- add the one-shot Ch05 Arena tutorial trigger at the actual arena tile
- preserve vanilla FE8 tutorial camera, cursor, text, and tutorial-flag behavior
- guard the trigger to the blue faction and prove its live builder wiring
- extend the mGBA playtest harness through the real semantic Arena command, wager acceptance, gold deduction, and generated opponent

## Verification

- `python3 tools/test_onboarding.py` — 9 passed
- `python3 -m unittest tools.test_build_campaign.Ch05ArenaTutorial` — 4 passed
- `python3 -m unittest tools.test_build_campaign` — 303 passed
- `lua tools/playtest/test_controller.lua` — 254 assertions
- `python3 -m unittest tools.playtest.test_gen_symbols tools.test_playtest_harness tools.test_playtest_matrix` — 98 passed
- `make check` — clean
- CH05BOOT build — green
- default campaign build — green
- `python3 tools/verify_text.py` — 3404 messages, 0 runaway
- `PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05arena` — tutorial fired once, replay stayed blocked, Arena accepted 690G, and generated an opponent
- independent code review — no remaining findings

The winterized Arena presentation and Ch05-only skeleton attendant are tracked separately in #265.

Closes #264
Refs #25