### PR TITLE
Drive ch05arena's two pre-fight pages with one guarded press each

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1719,6 +1719,29 @@ outside them moves nothing, and a driver that assumed a straight list would go o
 whoever it was still parked on.
 _Decided: 2026-08-06 (#238; extends #220's contract from the shared paths to every verdict scenario)_
 
+**A multi-page screen is driven one guarded press PER PAGE, and the gap between pages is a
+real transition — do not classify it away.** `ch05arena` drove the Arena's two pre-fight
+dialogue pages with a single press on an 1800-frame budget and reached combat only through
+`guardedInput`'s lost-input re-press: a pass by accident, which #255's verdict cache would have
+frozen. The fix is a loop that waits for each page to reach its own input wait, presses once with
+its own postcondition, and **counts the pages** — so the run asserts the screen's anatomy (the two
+`PROC_CALL`s of `gProcScr_ArenaUiMain`, msgs `0x8D5` and `0x8D3`) instead of merely arriving.
+
+The inherited diagnosis was wrong and cost nothing only because it was instrumented before it was
+believed. #269 recorded that a bounded loop of presses failed `not-legal` on a `transition` and
+concluded `controller.lua` must learn to classify the Arena dialogue state. It already does: an
+instrumented run logs `dialogue_wait(talk_wait in talk_wait_input) -> transition(player_phase
+idle=nil is not a known callback) -> dialogue_wait -> transition`. Each page classifies correctly;
+the `transition` is the gap where the talk proc is still PRINTING and no `gProcScr_TalkWaitForInput`
+exists — there is genuinely nothing to advance there, and teaching the classifier to offer
+`advance_dialogue` in it would have manufactured exactly the lost press #238 warns about. The loop
+that fails is the one that presses without waiting. **A `not-legal` on a `transition` usually means
+the driver pressed too early, not that the classifier is missing a state.** Scenarios that walk a
+multi-page screen carry a state TRAIL in their log for this reason: the first run then diagnoses
+itself, instead of costing a second one.
+_Decided: 2026-08-12 (#269; the ch05arena press, measured in-engine — the diagnosis it corrects
+came from the issue itself)_
+
 **Recording a cutscene as a review GIF (the standard way to show Nicolas motion).**
 The harness fast-forwards non-recorded lead-up, so an assert scenario's screenshots can land
 on fades — to SEE a scene play, use a `record*` scenario: it drives the game to the

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6942,19 +6942,51 @@ scenarios.ch05arena = function()
         return result("FAIL", "accepted wager reached instructions without a generated opponent")
     end
     shot("ch05arena-opponent")
-    -- One guarded press with a generous budget, and it is load-bearing that the budget is
-    -- generous: gProcScr_ArenaUiMain runs TWO blocking dialogue pages between the accepted
-    -- wager and the fight -- ArenaUi_InstructionsDialogue (0x8D5) then ArenaUi_GoodLuckDialogue
-    -- (0x8D3), both PROC_CALLs before ArenaUi_StartArenaBattle (src/uiarena.c). This single
-    -- press clears the first and reaches combat only via guardedInput's lost-input re-press,
-    -- which is fragile. It is NOT fixed by simply pressing three times: between the pages the
-    -- controller classifies `transition` and offers no legal advance_dialogue, so a second
-    -- guarded press fails outright on not-legal (measured 2026-08-12). A proper fix needs the
-    -- controller to classify the Arena dialogue state. Tracked in #269 -- do not "fix" this by
-    -- adding presses.
-    if not guardedInput("advance_dialogue", "A", "opponent instructions launch Arena combat",
-        function(after) return after.procs.battle ~= nil end, 1800) then
-        return result("FAIL", "accepted Arena wager never launched its battle")
+    -- TWO blocking dialogue pages stand between the accepted wager and the fight:
+    -- ArenaUi_InstructionsDialogue (0x8D5) then ArenaUi_GoodLuckDialogue (0x8D3), both
+    -- PROC_CALLs of gProcScr_ArenaUiMain before ArenaUi_StartArenaBattle (src/uiarena.c).
+    -- So COUNT them, one guarded press per page, same as the tutorial loop above (#269).
+    -- The predecessor sent a single press on a 1800-frame budget and reached combat only
+    -- through guardedInput's lost-input re-press -- a pass by accident, and #255 is about
+    -- to start caching passes. Pressing three times in a row does not work either: between
+    -- the pages the talk proc is still PRINTING, there is no TalkWaitForInput to advance,
+    -- and the classifier correctly reads `transition`. Waiting for each page to reach its
+    -- own input wait is what makes each press guarded. `arenaTrail` records every state
+    -- change across the whole stretch, so if this ever fails the log already carries the
+    -- anatomy and nobody has to spend a second run to see it.
+    local arenaPages, arenaTrail, arenaLast, arenaFought = 0, {}, nil, false
+    for _ = 1, 3600 do
+        local observation = observeController()
+        local state = controllerState(observation)
+        if state ~= arenaLast then
+            arenaLast = state
+            arenaTrail[#arenaTrail + 1] = string.format("%s(%s)", tostring(state),
+                tostring(Controller.explain(observation).detail))
+        end
+        if observation.procs.battle then arenaFought = true break end
+        if state == "dialogue_wait" then
+            arenaPages = arenaPages + 1
+            if not guardedInput("advance_dialogue", "A", string.format(
+                "Arena dialogue page %d advances toward combat", arenaPages),
+                function(after) return controllerState(after) ~= "dialogue_wait" end, 300) then
+                log("ARENA TRAIL: " .. table.concat(arenaTrail, " -> "))
+                return result("FAIL", string.format(
+                    "Arena dialogue page %d refused to advance toward combat", arenaPages))
+            end
+            arenaLast = nil
+        else
+            yield()
+        end
+    end
+    log("ARENA TRAIL: " .. table.concat(arenaTrail, " -> "))
+    if not arenaFought then
+        return result("FAIL", string.format(
+            "accepted Arena wager never launched its battle (advanced %d pages)", arenaPages))
+    end
+    if arenaPages ~= 2 then
+        return result("FAIL", string.format(
+            "Arena ran %d dialogue pages between the accepted wager and the fight, expected the 2 authored (0x8D5, 0x8D3)",
+            arenaPages))
     end
     -- The special Arena image owns the ENTIRE visible coliseum, floor included, in BG banks
     -- 6..9. Arena mode skips the normal terrain-platform loader (EfxClearScreenFx clears BG2),

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6954,13 +6954,19 @@ scenarios.ch05arena = function()
     -- own input wait is what makes each press guarded. `arenaTrail` records every state
     -- change across the whole stretch, so if this ever fails the log already carries the
     -- anatomy and nobody has to spend a second run to see it.
-    local arenaPages, arenaTrail, arenaLast, arenaFought = 0, {}, nil, false
+    -- The trail compares STRINGS, and `arenaLast` starts at `false` rather than nil, because
+    -- classify() returns nil for a state it has no rule for -- and an UNCLASSIFIED park right
+    -- after a press is exactly the #232/#241 failure this trail exists to name. Comparing raw
+    -- values would make `nil ~= nil` false and drop it silently, logging a trail that stops
+    -- before the press and a FAIL naming nothing.
+    local arenaPages, arenaTrail, arenaLast, arenaFought = 0, {}, false, false
     for _ = 1, 3600 do
         local observation = observeController()
         local state = controllerState(observation)
-        if state ~= arenaLast then
-            arenaLast = state
-            arenaTrail[#arenaTrail + 1] = string.format("%s(%s)", tostring(state),
+        local seen = tostring(state)
+        if seen ~= arenaLast then
+            arenaLast = seen
+            arenaTrail[#arenaTrail + 1] = string.format("%s(%s)", seen,
                 tostring(Controller.explain(observation).detail))
         end
         if observation.procs.battle then arenaFought = true break end
@@ -6973,7 +6979,7 @@ scenarios.ch05arena = function()
                 return result("FAIL", string.format(
                     "Arena dialogue page %d refused to advance toward combat", arenaPages))
             end
-            arenaLast = nil
+            arenaLast = false       -- re-record whatever the press landed in, nil included
         else
             yield()
         end

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -194,6 +194,22 @@ class TestPlaytestHarness(unittest.TestCase):
         self.assertIn('generated its opponent', body,
                       'presentation proof may not replace the real wager/opponent proof')
 
+        # gProcScr_ArenaUiMain runs TWO blocking dialogue pages between the accepted wager
+        # and the fight (ArenaUi_InstructionsDialogue 0x8D5, ArenaUi_GoodLuckDialogue 0x8D3).
+        # A single press on a fat budget reaches combat anyway -- through guardedInput's
+        # lost-input re-press -- so the scenario passed by ACCIDENT for as long as it did
+        # (#269). Counting the pages is what turns arriving at combat into proof, and #255
+        # caches passes, so a silent regression here would be frozen rather than noticed.
+        self.assertIn('arenaPages ~= 2', body,
+                      'the Arena flow must assert its two-page anatomy, not merely arrive '
+                      'at combat -- one press reaches the fight by lost-input retry (#269)')
+        self.assertIn('ARENA TRAIL', body,
+                      'a failure here must carry its own state trail, or diagnosing it costs '
+                      'a second emulator run')
+        self.assertNotIn(', 1800) then', body,
+                         'the 1800-frame single-press budget is what made the accidental pass '
+                         'possible; each page now presses on its own postcondition')
+
         with open(os.path.join(REPO, 'tools/playtest/gen_symbols.py'), encoding='utf-8') as f:
             symbols = f.read()
         self.assertIn("'gFaces'", symbols)


### PR DESCRIPTION
Closes #269.

## What was wrong

`gProcScr_ArenaUiMain` runs **two** blocking dialogue pages between the accepted wager and the fight — `ArenaUi_InstructionsDialogue` (`0x8D5`) then `ArenaUi_GoodLuckDialogue` (`0x8D3`), both `PROC_CALL`s before `ArenaUi_StartArenaBattle` (`src/uiarena.c`). `ch05arena` sent **one** `guardedInput` on an 1800-frame budget and reached combat only through `guardedInput`'s lost-input re-press. It passed, consistently — by accident. #255 is about to start caching passes, and an accidental pass is the worst kind to freeze.

## The fix

The same loop idiom the tutorial half of this scenario already uses: wait for each page to reach its own input wait, press once with its own postcondition, count the pages. The scenario now asserts the screen's **anatomy** (exactly the 2 authored pages) instead of merely arriving at combat, and the 1800-frame budget is gone.

## The issue's proposed fix was wrong, and one instrumented run disproved it

#269 said `controller.lua` must learn to classify the Arena dialogue state, because a bounded loop of presses had failed `fail:not-legal` on a `transition`. It already classifies it. The state trail the scenario now logs:

```
ARENA TRAIL: dialogue_wait(talk_wait in talk_wait_input)
          -> transition(player_phase idle=nil is not a known callback)
          -> dialogue_wait(talk_wait in talk_wait_input)
          -> transition(player_phase idle=nil is not a known callback)
```

Both presses land on a real `dialogue_wait` with `legal:["advance_dialogue"]` and `result:"pass"`. The `transition` is the gap where the talk proc is still **printing** and no `gProcScr_TalkWaitForInput` exists — there is nothing to advance there, and teaching the classifier to offer `advance_dialogue` in it would have manufactured exactly the lost press #238 warns about. The measured loop failed because it pressed too early, not because a state was missing.

**`controller.lua` is unchanged.** The trail is kept in the scenario so a future failure diagnoses itself instead of costing a second run.

## Verification

- `matrix.py run --scenarios ch05arena` → **PASS**, 10s (was 17–20s)
- `python3 tools/check.py` → clean (drift + the 200-local ceiling gate)
- `luac -p tools/playtest/harness.lua` → clean

`docs/decisions.md` records the durable lesson: a `not-legal` on a `transition` usually means the driver pressed too early, not that the classifier is missing a state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
