### PR TITLE
Scope invalidation per-step, and make the prologue roster real data (#255)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4486,6 +4486,44 @@ bigger lift with much more to get wrong; do not reach for it without a measureme
 it pays.
 _Decided: 2026-08-12 (#255 phase 2)._
 
+**A cache can be right for the wrong reason, and only the artifact says which.**
+The invalidation probe's `prologue` case went red in the most alarming way available: bumping
+`level: 5 → 6` under the ch00 YAML's `enemy_units` — real, chapter-scoped content — moved **no**
+scope digest in any of the four ROM configurations, so nothing re-ran. That is the exact
+signature of a stale-PASS hole, and the manifest is precisely the wrong place to investigate it,
+because the manifest is the thing under suspicion.
+
+Settled by building the prologue ROM **twice**, edited and not: identical sha256. Then tighter,
+by hashing all 20,263 files of the decomp tree after an injector-only run in each state: **zero**
+differed. So the cache was correct, and correct for a reason nobody had written down —
+`inject_prologue` emitted its two `UnitDefinition` rosters as **C literals**, under a comment
+that said "Positions/levels/items from the chapter YAML". Only the boss's *weapon* was ever
+wired (#52). Every literal matched the YAML by hand, so the chapter file looked authoritative
+and the built ROM agreed with it; a rebalance authored in YAML would simply never have shipped,
+with no symptom anywhere. The same three levels were hardcoded a **second** time in step 4b's
+`guest_patch` (`baseLevel` in `data_characters.c`), so the two encodings of one number could
+have drifted apart as well.
+
+`_prologue_roster_blocks` now sources levels, positions, the guard head-count and the enemy
+weapons from the chapter YAML, and `guest_patch` reads the same field the roster does. The
+rewiring was verified **byte-neutral** — same ROM sha256 as before the change — which is the
+proof that it is a plumbing fix and not a balance change. The probe is now green at **7 run, 13
+cached**: the prologue is *hosted on chapter 1*, so `ch01`, `ch01win`, `controller_turn`,
+`gameover`, `lordfloor`, `retreat` and `win` share its data and correctly move with it.
+
+Three durable rules:
+
+- **A comment claiming a value is data-driven is testimony, not proof.** This one had been
+  false for months and read as true because the literals agreed with the data.
+- **When the cache and the content disagree, the ARTIFACT arbitrates.** Two builds and a
+  byte-compare cost ten minutes, need no emulator, and cannot be argued with. Reasoning from
+  the manifest would have "confirmed" whichever answer was reached first.
+- **A red probe case is worth more than a green one, and the fix is upstream more often than
+  it looks.** The expectation was right (`win` *should* re-run on a prologue edit); what was
+  broken was the pipeline that made it true. Adjusting the expectation would have closed the
+  ticket and left the bug.
+_Decided: 2026-08-13 (Claude, #255; the probe's first genuine catch)._
+
 **Honest ceiling of phase 1 alone, kept because it explains why phase 2 exists.** Keying on
 `rom_input_hash` means any
 `build_campaign.py` or `campaign.yaml` edit invalidates every scenario, and nearly every feature

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4524,6 +4524,49 @@ Three durable rules:
   ticket and left the bug.
 _Decided: 2026-08-13 (Claude, #255; the probe's first genuine catch)._
 
+**WHEN a scope is hashed is the whole feature. Hashing at the end of the build undid it.**
+Sticky ownership re-hashed every inherited path in `finish()` — after all steps had run. Every
+chapter injector rewrites the same five whole-campaign tables, so by the end of the build that
+shared file holds the LAST chapter's bytes, and `finish()` charged them to ch04, ch03, ch02 and
+ch01 alike. Editing the chapter under development therefore re-ran the whole campaign's
+scenarios: the measured **18 of 20**. The path-set churn the stickiness was added to fix was
+real; hashing at the wrong moment quietly gave the win back.
+
+Each scope is now fixed to the moment its own step ended (`_claim` → `_freeze`), and the
+previous manifest is seeded in `__init__` rather than merged in `finish()`, because seeding
+after the fact is what forced the late hash. `global` is the deliberate exception — it means
+"the whole build", so its reference point is the end of it.
+
+This is the direction that matters for how the campaign is actually built: **forward**. A ch05
+edit no longer moves ch04's digest, because ch04's claim happens before ch05's step writes
+anything. The reverse (editing an early chapter) still invalidates the later ones, and that is
+correct-but-coarse — the shared table genuinely does carry ch02's bytes into ch05's copy. Fixing
+that needs sub-file attribution, and the note above still applies: do not reach for it without a
+measurement saying it pays. Editing ch02 while building ch06 is not the common case.
+
+Cost measured in the profile: `_freeze` is 0.165s of a 70s injection, and the whole scoping
+machinery 1.8s, nearly all of it the `stat` walks that were already there.
+_Decided: 2026-08-13 (Claude, #255 phase 2 follow-up)._
+
+**The playtest cache was never the biggest drag; the INJECTOR is.** Profiling
+`build_campaign.py` to settle an unrelated question showed where a build's time actually goes:
+of a 63s `make`, the ARM compile is **12s** and the Python injection is **51s**. It is paid on
+every build whether or not a playtest ever runs, and it is single-threaded. `cProfile` (70s under
+profiling overhead) puts almost all of it in two places, both of which look fixable without
+touching what the injector produces:
+
+- **`ref_to_battleframe._cell_is_empty` — ~28s, via 11 MILLION `PIL.Image.getpixel` calls.**
+  180k invocations walking cells pixel-by-pixel in Python. `getpixel` per pixel is the classic
+  PIL antipattern; a numpy view or `getbbox()` over the crop answers the same question in bulk.
+- **YAML parsing — ~22s across 534 `safe_load` calls**, of which `_load_chapter_yaml` alone is
+  9s over 62 calls, i.e. the same chapter files parsed dozens of times per build. Memoizing by
+  path+mtime and using libyaml's `CSafeLoader` are both small, local changes.
+
+Recorded here because the lesson generalises past this repo: the scenario cache was optimising
+*how many scenarios re-run*, which is the visible cost, while a fixed 51s tax sat on every build
+unmeasured. **Profile the thing everything waits on before optimising the thing that waits.**
+_Decided: 2026-08-13 (Nicolas + Claude; measured, not estimated)._
+
 **Honest ceiling of phase 1 alone, kept because it explains why phase 2 exists.** Keying on
 `rom_input_hash` means any
 `build_campaign.py` or `campaign.yaml` edit invalidates every scenario, and nearly every feature

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -11110,7 +11110,8 @@ def main():
     # backwards on byte-identical files, and this attribution watches mtimes.
     _scope_manifest = _scopes.write_manifest(
         BUILD_SCOPES_PATH,
-        touched=[os.path.relpath(p, DECOMP) for p in _decomp_footprint()])
+        touched=[os.path.relpath(p, DECOMP) for p in _decomp_footprint()],
+        previous=build_scopes.load_manifest(BUILD_SCOPES_PATH))
     print('build scopes: %s' % ', '.join(
         '%s=%d file(s)' % (scope, len(entry['paths']))
         for scope, entry in sorted(_scope_manifest.items())))

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -11041,7 +11041,8 @@ def main():
     # ch05 edit from a global one and stop re-running the prologue for it (#255 phase 2).
     # Only the CHAPTER steps are wrapped: everything else falls through to `global`, which
     # every scenario depends on, so the conservative answer is also the default one.
-    _scopes = build_scopes.BuildScopes(DECOMP)
+    _scopes = build_scopes.BuildScopes(
+        DECOMP, previous=build_scopes.load_manifest(BUILD_SCOPES_PATH))
     print('portraits:')
     inject_portraits(args.campaign)
     inject_arena_attendant_portraits(args.campaign)
@@ -11156,8 +11157,7 @@ def main():
     # backwards on byte-identical files, and this attribution watches mtimes.
     _scope_manifest = _scopes.write_manifest(
         BUILD_SCOPES_PATH,
-        touched=[os.path.relpath(p, DECOMP) for p in _decomp_footprint()],
-        previous=build_scopes.load_manifest(BUILD_SCOPES_PATH))
+        touched=[os.path.relpath(p, DECOMP) for p in _decomp_footprint()])
     print('build scopes: %s' % ', '.join(
         '%s=%d file(s)' % (scope, len(entry['paths']))
         for scope, entry in sorted(_scope_manifest.items())))

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5343,6 +5343,116 @@ def _load_prologue_chapter(campaign):
         return yaml.safe_load(f)
 
 
+def _prologue_roster_blocks(by_id, slots, classes, guest_items):
+    """The prologue's two `UnitDefinition` initialisers, driven by the ch00 YAML.
+
+    redaCount=0 places units statically at xPosition/yPosition (like inject_test_chapter);
+    the boss rides the ONEILL slot (CA_BOSS marks it a boss for autolevel/UI -- the
+    DefeatBoss EVENT flag comes from the flagged defeat quote, not from CA_BOSS). AI: boss
+    = Breguet's stationary-aggressive bytes {AI_A_03 ActionStanding, AI_B_03 NeverMove,
+    config} (cp_data.c gAi1/2ScriptTable) -- NOT O'Neill's {0x6,0x3} "DoNothing", which
+    only works because the vanilla tutorial event-scripts his attack. Guards attack in
+    range (AI_A_00).
+
+    Levels, positions (0-indexed x,y), the guard head-count and the enemy weapons are read
+    from the YAML. They used to be literals here under a comment that claimed otherwise,
+    and because every literal happened to match what the YAML said, nothing looked wrong --
+    a rebalance authored in the chapter file simply would not have shipped. #255's
+    invalidation probe is what exposed it: bumping the boss's `level:` changed no injected
+    byte, and two full ROM builds came out byte-identical. Keep this sourced.
+
+    Guest INVENTORIES stay literal (`guest_items`): Hlin carries a Vulnerary, and
+    WEAPON_ITEM_ENUM is weapons-only by the #53 seam rule, so the YAML's consumable has no
+    ITEM_ mapping to resolve through.
+
+    slots       -- (hlin, scramsax, sephek) vanilla CHARACTER_ slot names
+    classes     -- (hlin, scramsax) CLASS_ enums
+    guest_items -- (hlin, scramsax) `.items` initialiser bodies
+    """
+    hlin_slot, scram_slot, sephek_slot = slots
+    hlin_class, scram_class = classes
+    hlin_items, scram_items = guest_items
+    hlin, scram = by_id['hlin-trollbane'], by_id['scramsax']
+    sephek, guard = by_id['sephek-kaltro'], by_id['caravan-guard']
+
+    ally = (
+        '{\n'
+        '    {\n'
+        '        .charIndex = CHARACTER_%(hlin_slot)s, /* Hlin -- frail must-survive lead */\n'
+        '        .classIndex = %(hlin_class)s,\n'
+        '        .leaderCharIndex = CHARACTER_%(hlin_slot)s,\n'
+        '        .allegiance = FACTION_ID_BLUE,\n'
+        '        .level = %(hlin_level)d,\n'
+        '        .xPosition = %(hlin_x)d,\n'
+        '        .yPosition = %(hlin_y)d,\n'
+        '        .redaCount = 0,\n'
+        '        .items = { %(hlin_items)s },\n'
+        '    },\n'
+        '    {\n'
+        '        .charIndex = CHARACTER_%(scram_slot)s, /* Scramsax -- strong veteran (our Jeigan) */\n'
+        '        .classIndex = %(scram_class)s,\n'
+        '        .leaderCharIndex = CHARACTER_%(hlin_slot)s,\n'
+        '        .allegiance = FACTION_ID_BLUE,\n'
+        '        .level = %(scram_level)d,\n'
+        '        .xPosition = %(scram_x)d,\n'
+        '        .yPosition = %(scram_y)d,\n'
+        '        .redaCount = 0,\n'
+        '        .items = { %(scram_items)s },\n'
+        '    },\n'
+        '    { 0 },\n'
+        '}' % {'hlin_slot': hlin_slot, 'hlin_class': hlin_class, 'hlin_items': hlin_items,
+               'hlin_level': hlin['level'],
+               'hlin_x': hlin['position'][0], 'hlin_y': hlin['position'][1],
+               'scram_slot': scram_slot, 'scram_class': scram_class,
+               'scram_items': scram_items, 'scram_level': scram['level'],
+               'scram_x': scram['position'][0], 'scram_y': scram['position'][1]})
+
+    # The guards ride two spare non-cast character slots. `count`/`positions` decide how
+    # many are emitted and where; a disagreement between them would silently ship a roster
+    # nobody authored, so it fails the build instead.
+    guard_slots = (0x80, 0x82)
+    if len(guard['positions']) != guard['count']:
+        sys.exit('ERROR: ch00 caravan-guard has count=%d but %d position(s)'
+                 % (guard['count'], len(guard['positions'])))
+    if guard['count'] > len(guard_slots):
+        sys.exit('ERROR: ch00 caravan-guard count=%d exceeds the %d spare character slot(s); '
+                 'add one to guard_slots in _prologue_roster_blocks'
+                 % (guard['count'], len(guard_slots)))
+    guards = ''.join(
+        '    {\n'
+        '        .charIndex = 0x%02x, /* Torg\'s caravan guard */\n'
+        '        .classIndex = CLASS_FIGHTER,\n'
+        '        .allegiance = FACTION_ID_RED,\n'
+        '        .level = %d,\n'
+        '        .xPosition = %d,\n'
+        '        .yPosition = %d,\n'
+        '        .redaCount = 0,\n'
+        '        .items = { %s },\n'
+        '        .ai = {0x0, 0xa, 0x0, 0x0},\n'
+        '    },\n' % (slot, guard['level'], pos[0], pos[1],
+                      fe_item_enum(guard['inventory'][0]))
+        for slot, pos in zip(guard_slots, guard['positions']))
+
+    enemy = (
+        '{\n'
+        '    {\n'
+        '        .charIndex = CHARACTER_%s, /* Sephek -- boss; escapes in the ending */\n'
+        '        .classIndex = CLASS_MYRMIDON,\n'
+        '        .allegiance = FACTION_ID_RED,\n'
+        '        .level = %d,\n'
+        '        .xPosition = %d,\n'
+        '        .yPosition = %d,\n'
+        '        .redaCount = 0,\n'
+        '        .items = { %s },\n'
+        '        .ai = {0x3, 0x3, 0x9, 0x20}, /* attack in place, never move (Breguet) */\n'
+        '    },\n'
+        '%s'
+        '    { 0 },\n'
+        '}' % (sephek_slot, sephek['level'], sephek['position'][0], sephek['position'][1],
+               fe_item_enum(sephek['inventory'][0]), guards))
+    return ally, enemy
+
+
 def inject_prologue(campaign, verbose=True, montage=False):
     """Wire the designed Prologue (#20) onto chapter 0 as the New Game target."""
     maps_dir = os.path.join(REPO, 'campaigns', campaign, 'maps')
@@ -5356,7 +5466,6 @@ def inject_prologue(campaign, verbose=True, montage=False):
     # Structural data the build emits comes from the ch00 YAML (single source of truth).
     chap = _load_prologue_chapter(campaign)
     by_id = {u['id']: u for u in chap['player_units'] + chap['enemy_units']}
-    sephek_item = fe_item_enum(by_id['sephek-kaltro']['inventory'][0])   # ice-longsword -> steel
     # Hlin = frail must-survive lead -> UNPROMOTED Fighter (frail like vanilla Eirika next to a
     # promoted unit; a custom FEMALE Fighter map sprite distinguishes her from the male Fighter
     # guards -- see inject_map_sprites). Scramsax = dominant promoted "Jeigan" (Hero, the Seth
@@ -5395,78 +5504,10 @@ def inject_prologue(campaign, verbose=True, montage=False):
     with open(CHAPTER_SETTINGS_JSON, 'w', encoding='utf-8') as f:
         json.dump(settings, f, indent=2)
 
-    # 2. Rewrite the two prologue rosters. redaCount=0 places units statically at
-    #    xPosition/yPosition (like inject_test_chapter); the boss rides the ONEILL slot
-    #    (CA_BOSS marks it a boss for autolevel/UI -- the DefeatBoss EVENT flag comes from
-    #    the flagged defeat quote in step 5, not from CA_BOSS). Positions/levels/items from
-    #    the chapter YAML (0-indexed x,y). AI: boss = Breguet's stationary-aggressive bytes
-    #    {AI_A_03 ActionStanding, AI_B_03 NeverMove, config} (cp_data.c gAi1/2ScriptTable) --
-    #    NOT O'Neill's {0x6,0x3} "DoNothing", which only works because the vanilla tutorial
-    #    event-scripts his attack. Guards attack in range (AI_A_00).
-    ally = (
-        '{\n'
-        '    {\n'
-        '        .charIndex = CHARACTER_%s, /* Hlin -- frail must-survive lead */\n'
-        '        .classIndex = %s,\n'
-        '        .leaderCharIndex = CHARACTER_%s,\n'
-        '        .allegiance = FACTION_ID_BLUE,\n'
-        '        .level = 3,\n'
-        '        .xPosition = 8,\n'
-        '        .yPosition = 5,\n'
-        '        .redaCount = 0,\n'
-        '        .items = { %s },\n'
-        '    },\n'
-        '    {\n'
-        '        .charIndex = CHARACTER_%s, /* Scramsax -- strong veteran (our Jeigan) */\n'
-        '        .classIndex = %s,\n'
-        '        .leaderCharIndex = CHARACTER_%s,\n'
-        '        .allegiance = FACTION_ID_BLUE,\n'
-        '        .level = 1,\n'
-        '        .xPosition = 13,\n'
-        '        .yPosition = 9,\n'
-        '        .redaCount = 0,\n'
-        '        .items = { %s },\n'
-        '    },\n'
-        '    { 0 },\n'
-        '}' % (hlin_slot, hlin_class, hlin_slot, hlin_items,
-               scram_slot, scram_class, hlin_slot, scram_items))
-    enemy = (
-        '{\n'
-        '    {\n'
-        '        .charIndex = CHARACTER_%s, /* Sephek -- boss; escapes in the ending */\n'
-        '        .classIndex = CLASS_MYRMIDON,\n'
-        '        .allegiance = FACTION_ID_RED,\n'
-        '        .level = 5,\n'
-        '        .xPosition = 14,\n'
-        '        .yPosition = 8,\n'
-        '        .redaCount = 0,\n'
-        '        .items = { %s },\n'
-        '        .ai = {0x3, 0x3, 0x9, 0x20}, /* attack in place, never move (Breguet) */\n'
-        '    },\n'
-        '    {\n'
-        '        .charIndex = 0x80, /* Torg\'s caravan guard */\n'
-        '        .classIndex = CLASS_FIGHTER,\n'
-        '        .allegiance = FACTION_ID_RED,\n'
-        '        .level = 2,\n'
-        '        .xPosition = 14,\n'
-        '        .yPosition = 7,\n'
-        '        .redaCount = 0,\n'
-        '        .items = { ITEM_AXE_IRON },\n'
-        '        .ai = {0x0, 0xa, 0x0, 0x0},\n'
-        '    },\n'
-        '    {\n'
-        '        .charIndex = 0x82, /* Torg\'s caravan guard */\n'
-        '        .classIndex = CLASS_FIGHTER,\n'
-        '        .allegiance = FACTION_ID_RED,\n'
-        '        .level = 2,\n'
-        '        .xPosition = 13,\n'
-        '        .yPosition = 7,\n'
-        '        .redaCount = 0,\n'
-        '        .items = { ITEM_AXE_IRON },\n'
-        '        .ai = {0x0, 0xa, 0x0, 0x0},\n'
-        '    },\n'
-        '    { 0 },\n'
-        '}' % (sephek_slot, sephek_item))
+    # 2. Rewrite the two prologue rosters from the ch00 YAML (_prologue_roster_blocks).
+    ally, enemy = _prologue_roster_blocks(
+        by_id, (hlin_slot, scram_slot, sephek_slot), (hlin_class, scram_class),
+        (hlin_items, scram_items))
     with open(CH1_UDEFS_H, encoding='utf-8') as f:
         udefs = f.read()
     udefs = _replace_brace_block(udefs, 'UnitDef_Event_Ch1Ally[] =', ally, CH1_UDEFS_H)
@@ -5628,10 +5669,15 @@ def inject_prologue(campaign, verbose=True, montage=False):
     _hlin_donor = 'CHARACTER_GARCIA' if any(c in hlin_class for c in _axe) else 'CHARACTER_GERIK'
     _scram_donor = 'CHARACTER_GARCIA' if any(c in scram_class for c in _axe) else 'CHARACTER_GERIK'
     # (slot, class, level, donor, female) -- female None means "leave attributes alone"
-    # (the boss keeps CA_BOSS; _set_gender would clobber it).
-    guest_patch = [(PROLOGUE_HLIN_SLOT, hlin_class, 3, _hlin_donor, True),
-                   (PROLOGUE_SCRAMSAX_SLOT, scram_class, 1, _scram_donor, False),
-                   (PROLOGUE_SEPHEK_SLOT, 'CLASS_MYRMIDON', 5, 'CHARACTER_JOSHUA', None)]
+    # (the boss keeps CA_BOSS; _set_gender would clobber it). baseLevel comes from the same
+    # YAML field the roster block does: these are two encodings of one number, and a literal
+    # here would drift out of step with the roster the moment the chapter is rebalanced.
+    guest_patch = [(PROLOGUE_HLIN_SLOT, hlin_class, by_id['hlin-trollbane']['level'],
+                    _hlin_donor, True),
+                   (PROLOGUE_SCRAMSAX_SLOT, scram_class, by_id['scramsax']['level'],
+                    _scram_donor, False),
+                   (PROLOGUE_SEPHEK_SLOT, 'CLASS_MYRMIDON', by_id['sephek-kaltro']['level'],
+                    'CHARACTER_JOSHUA', None)]
     with open(CHARACTERS_C, encoding='utf-8') as f:
         chars = f.read()
     for slot, cls, level, donor, female in guest_patch:

--- a/tools/build_scopes.py
+++ b/tools/build_scopes.py
@@ -71,10 +71,15 @@ class BuildScopes(object):
     only the files that actually moved are ever hashed.
     """
 
-    def __init__(self, root, roots=SCOPE_ROOTS):
+    def __init__(self, root, roots=SCOPE_ROOTS, previous=None):
         self.root = root
         self.roots = tuple(roots)
-        self.scopes = {}            # scope -> {relpath: digest}
+        # scope -> {relpath: digest}. Seeded from the previous build's manifest so a scope
+        # starts out owning what it has written before (see `finish`), with digests left
+        # None until the scope's own step claims -- WHEN a path is hashed is the whole
+        # point, so seeding must happen here and not after every step has run.
+        self.scopes = {scope: dict.fromkeys(entry.get('paths', ()))
+                       for scope, entry in (previous or {}).items()}
         self._prev = self._snapshot()
 
     def _snapshot(self):
@@ -92,15 +97,30 @@ class BuildScopes(object):
         return seen
 
     def _claim(self, scope):
-        """Charge everything written since the last snapshot to `scope`."""
+        """Charge everything written since the last snapshot to `scope`, and fix that
+        scope's digests to THIS MOMENT -- the end of the step that just ran.
+
+        The timing is the substance. A chapter scope's answer to "has my content changed"
+        must be read before the chapters after it have written anything, or every shared
+        whole-campaign table hands it the LAST chapter's bytes and a ch05 edit re-runs ch04,
+        ch03, ch02 and ch01. `global` is the exception and is refreshed in `finish` instead:
+        it means "the whole build", so its reference point is the end of it, not the middle.
+        """
         now = self._snapshot()
         bucket = self.scopes.setdefault(scope, {})
         for path, mtime in now.items():
             if self._prev.get(path) != mtime:
-                bucket[os.path.relpath(path, self.root)] = _digest_file(path)
+                bucket.setdefault(os.path.relpath(path, self.root))
         if not bucket:
             del self.scopes[scope]
+        elif scope != 'global':
+            self._freeze(bucket)
         self._prev = now
+
+    def _freeze(self, bucket):
+        """Hash every path a scope owns as the tree stands right now."""
+        for rel in bucket:
+            bucket[rel] = _digest_file(os.path.join(self.root, rel))
 
     def run(self, fn, *args, **kwargs):
         """Run one injection step and charge its writes to the scope its name implies.
@@ -118,7 +138,7 @@ class BuildScopes(object):
             # files look unattributed to the next pass.
             self._claim(scope_of_step(name))
 
-    def finish(self, touched=(), previous=None):
+    def finish(self, touched=()):
         """Close the manifest: {scope: {'paths': [...], 'digest': ...}}.
 
         `touched` is the build's own footprint (git's view of the decomp), used as the
@@ -126,27 +146,33 @@ class BuildScopes(object):
         what lets the per-step walk cover a few named roots instead of the whole tree
         without opening an optimistic gap.
 
-        `previous` is the manifest the last build left, and OWNERSHIP IS STICKY: a scope
+        OWNERSHIP IS STICKY (seeded from the previous manifest in `__init__`): a scope
         keeps a file it has written before, even on a build that did not rewrite it. That
         is not tidiness, it is the difference between the feature working and not. Whether
         a build rewrites a given file depends on what was built BEFORE it -- the matrix
         alternates ROM configurations, and the mtime rewind hands the next build a
         different starting point -- so without this the path SET churns, the digest moves
         with no content behind it, and because every scenario depends on `global`,
-        everything re-runs. Inherited paths are re-hashed as they are NOW, so sticky
-        ownership never means a stale digest; it only ever over-attributes, which costs a
-        re-run rather than a missed one.
+        everything re-runs.
+
+        Inherited paths are still hashed from the tree rather than copied forward, so
+        sticky ownership never means a stale digest -- but they are hashed at the owning
+        step's `_claim`, not here. Hashing them here was the bug: it read every scope's
+        files after ALL steps had run, so a late chapter's writes to a shared table leaked
+        into every earlier chapter's digest. A scope whose step did not run at all this
+        build has nothing to fix its digests to and is filled in below, as it stands now.
         """
         self._claim('global')
-        for scope, entry in (previous or {}).items():
-            bucket = self.scopes.setdefault(scope, {})
-            for rel in entry.get('paths', ()):
-                bucket.setdefault(rel, _digest_file(os.path.join(self.root, rel)))
+        self._freeze(self.scopes.get('global', {}))
         claimed = {rel for bucket in self.scopes.values() for rel in bucket}
         stragglers = {rel: _digest_file(os.path.join(self.root, rel))
                       for rel in touched if rel not in claimed}
         if stragglers:
             self.scopes.setdefault('global', {}).update(stragglers)
+        for bucket in self.scopes.values():
+            for rel, digest in bucket.items():
+                if digest is None:
+                    bucket[rel] = _digest_file(os.path.join(self.root, rel))
         manifest = {}
         for scope, bucket in self.scopes.items():
             h = hashlib.sha256()
@@ -155,8 +181,8 @@ class BuildScopes(object):
             manifest[scope] = {'paths': sorted(bucket), 'digest': h.hexdigest()[:32]}
         return manifest
 
-    def write_manifest(self, path, touched=(), previous=None):
-        manifest = self.finish(touched=touched, previous=previous)
+    def write_manifest(self, path, touched=()):
+        manifest = self.finish(touched=touched)
         with open(path, 'w') as fh:
             json.dump(manifest, fh, indent=2, sort_keys=True)
         return manifest

--- a/tools/build_scopes.py
+++ b/tools/build_scopes.py
@@ -118,15 +118,30 @@ class BuildScopes(object):
             # files look unattributed to the next pass.
             self._claim(scope_of_step(name))
 
-    def finish(self, touched=()):
+    def finish(self, touched=(), previous=None):
         """Close the manifest: {scope: {'paths': [...], 'digest': ...}}.
 
         `touched` is the build's own footprint (git's view of the decomp), used as the
         SAFETY NET: any path in it that no step claimed is charged to `global`. That is
         what lets the per-step walk cover a few named roots instead of the whole tree
         without opening an optimistic gap.
+
+        `previous` is the manifest the last build left, and OWNERSHIP IS STICKY: a scope
+        keeps a file it has written before, even on a build that did not rewrite it. That
+        is not tidiness, it is the difference between the feature working and not. Whether
+        a build rewrites a given file depends on what was built BEFORE it -- the matrix
+        alternates ROM configurations, and the mtime rewind hands the next build a
+        different starting point -- so without this the path SET churns, the digest moves
+        with no content behind it, and because every scenario depends on `global`,
+        everything re-runs. Inherited paths are re-hashed as they are NOW, so sticky
+        ownership never means a stale digest; it only ever over-attributes, which costs a
+        re-run rather than a missed one.
         """
         self._claim('global')
+        for scope, entry in (previous or {}).items():
+            bucket = self.scopes.setdefault(scope, {})
+            for rel in entry.get('paths', ()):
+                bucket.setdefault(rel, _digest_file(os.path.join(self.root, rel)))
         claimed = {rel for bucket in self.scopes.values() for rel in bucket}
         stragglers = {rel: _digest_file(os.path.join(self.root, rel))
                       for rel in touched if rel not in claimed}
@@ -140,8 +155,8 @@ class BuildScopes(object):
             manifest[scope] = {'paths': sorted(bucket), 'digest': h.hexdigest()[:32]}
         return manifest
 
-    def write_manifest(self, path, touched=()):
-        manifest = self.finish(touched=touched)
+    def write_manifest(self, path, touched=(), previous=None):
+        manifest = self.finish(touched=touched, previous=previous)
         with open(path, 'w') as fh:
             json.dump(manifest, fh, indent=2, sort_keys=True)
         return manifest

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -749,6 +749,42 @@ def _read(path):
         return fh.read()
 
 
+# `local NAME = dofile(PLAYTEST_DIR .. "/thing.lua")` -- the only way harness.lua takes a
+# module, so the binding table is READ rather than kept.
+_DOFILE_BINDING = re.compile(
+    r'^local\s+(\w+)\s*=\s*dofile\(PLAYTEST_DIR\s*\.\.\s*"/([\w.]+)"\)', re.M)
+
+
+def driver_modules(harness_source=None):
+    """{module filename: the local it is bound to} for every module harness.lua dofiles.
+
+    A bare `dofile(...)` with no binding (the generated symbol tables) is not a module in
+    this sense -- nothing can reference it selectively, and those are excluded from the key
+    anyway.
+    """
+    harness_source = _read(HARNESS) if harness_source is None else harness_source
+    return {mod: name for name, mod in _DOFILE_BINDING.findall(harness_source)}
+
+
+def scenario_driver_modules(scenario_name, harness_source=None):
+    """The dofile'd modules this scenario can actually reach.
+
+    A module counts as reached when its binding appears in the scenario's own closure, or
+    in harness.lua's shared text. The BINDING LINES are stripped out of the shared text
+    first, and that detail is the whole feature: `local CLEARBOT = dofile(...)` is
+    top-level, so leaving it in would make every module reachable by everyone and the split
+    would do precisely nothing.
+    """
+    harness_source = _read(HARNESS) if harness_source is None else harness_source
+    modules = driver_modules(harness_source)
+    funcs = harness_functions(harness_source)
+    text = _DOFILE_BINDING.sub('', harness_shared(harness_source))
+    for name in reaches(scenario_name, funcs):
+        text += '\n' + funcs[name][0]
+    return {mod for mod, binding in modules.items()
+            if re.search(r'\b%s\b' % re.escape(binding), text)}
+
+
 def driver_source(here=None):
     """Everything OUTSIDE harness.lua that decides what a scenario does.
 
@@ -776,10 +812,28 @@ def driver_source(here=None):
              and os.path.basename(p) != 'harness.lua']
     files.append(os.path.join(here, 'run.sh'))
     files.append(os.path.join(here, 'gen_symbols.py'))
-    parts = []
+    out = {}
     for path in sorted(files):
         if os.path.isfile(path):
-            parts.append('%s\n%s' % (os.path.basename(path), _read(path)))
+            out[os.path.basename(path)] = _read(path)
+    return out
+
+
+# Driver files that are not dofile'd modules, so nothing can reach them selectively:
+# `run.sh` is the launcher (it chooses the fps, the deadline and the wrapper for every
+# run), and `gen_symbols.py` emits the tables every scenario reads.
+GLOBAL_DRIVER_FILES = ('run.sh', 'gen_symbols.py')
+
+
+def scenario_driver_text(scenario_name, files=None, harness_source=None):
+    """The driver text whose contents can change THIS scenario's verdict."""
+    files = driver_source() if files is None else files
+    reached = scenario_driver_modules(scenario_name, harness_source)
+    parts = []
+    for name in sorted(files):
+        if not (name in GLOBAL_DRIVER_FILES or name in reached):
+            continue
+        parts.append('%s\n%s' % (name, files[name]))
     return '\n'.join(parts)
 
 
@@ -905,7 +959,7 @@ def engine_input_hash():
 
 
 def scenario_fingerprint(scenario, rom_digest, harness_source=None, driver=None, env=None,
-                         scopes=None, engine=None, observed=None):
+                         scopes=None, engine=None, observed=None, driver_files=None):
     """The cache key, or None when this run may not be cached at all.
 
     None means "refuse to cache" and is returned whenever an input cannot be pinned: no ROM
@@ -921,7 +975,11 @@ def scenario_fingerprint(scenario, rom_digest, harness_source=None, driver=None,
     if rom_digest is None:
         return None
     harness_source = _read(HARNESS) if harness_source is None else harness_source
-    driver = driver_source() if driver is None else driver
+    if driver is None:
+        files = dict(driver_source())
+        # Tests (and only tests) hand in overrides for individual driver files.
+        files.update(driver_files or {})
+        driver = scenario_driver_text(scenario.name, files, harness_source)
     env = os.environ if env is None else env
     funcs = harness_functions(harness_source)
     if scenario.name not in funcs:
@@ -967,25 +1025,33 @@ def _observed_path(scenario, cache_dir=None):
     return os.path.join(cache_dir or VERDICT_CACHE_DIR, '%s.chapters.json' % scenario)
 
 
-def load_observed_chapters(scenario, cache_dir=None):
+def load_observed(scenario, cache_dir=None):
+    """{'chapters': [...], 'rules': [...]} from this scenario's last run, or {}."""
     try:
         with open(_observed_path(scenario, cache_dir)) as fh:
-            slots = json.load(fh)
+            seen = json.load(fh)
     except (OSError, ValueError):
-        return None
-    return slots if isinstance(slots, list) and slots else None
+        return {}
+    if isinstance(seen, list):            # pre-2.5 file: chapters only
+        return {'chapters': seen or None}
+    return seen if isinstance(seen, dict) else {}
 
 
-def store_observed_chapters(scenario, log_text, cache_dir=None):
-    """Record where this run went, whatever its verdict -- a FAIL's traversal is just as
-    true as a PASS's, and refusing to learn from it would keep the next key coarse."""
-    slots = observed_chapters(log_text)
-    if not slots:
+def load_observed_chapters(scenario, cache_dir=None):
+    return load_observed(scenario, cache_dir).get('chapters') or None
+
+
+def store_observed(scenario, log_text, cache_dir=None):
+    """Record where this run went and which rules decided it, whatever its verdict -- a
+    FAIL's traversal is just as true as a PASS's, and refusing to learn from it would keep
+    the next key coarse."""
+    seen = {'chapters': observed_chapters(log_text)}
+    if not any(seen.values()):
         return
     cache_dir = cache_dir or VERDICT_CACHE_DIR
     os.makedirs(cache_dir, exist_ok=True)
     with open(_observed_path(scenario, cache_dir), 'w') as fh:
-        json.dump(slots, fh)
+        json.dump(seen, fh)
 
 
 def _verdict_slot(scenario, fingerprint, cache_dir=None):
@@ -1124,7 +1190,7 @@ class VerdictCache(object):
         log = os.path.join(outcome.artifacts or '', 'playtest.log')
         if os.path.isfile(log):
             with open(log, errors='replace') as fh:
-                store_observed_chapters(scenario.name, fh.read())
+                store_observed(scenario.name, fh.read())
         fingerprint = self.fingerprints.get(scenario.name) if self.enabled else None
         if fingerprint or outcome.verdict != 'PASS':
             store_cached_verdict(scenario.name, fingerprint, outcome)

--- a/tools/probe_invalidation.py
+++ b/tools/probe_invalidation.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""What does editing X actually re-run? (#255)
+
+The verdict cache is only worth having if its answers are RIGHT in both directions, and
+unit tests cannot show that: they exercise the key arithmetic against synthetic manifests,
+while the failures that actually bit us came from the real build -- shared whole-campaign
+tables, and a path set that churned depending on which ROM configuration was built before.
+Comparing keys by hand missed both.
+
+So this drives the real thing. For each edit it makes the edit, regenerates whatever the
+edit can move (the scope manifest, via `build_campaign.py` -- the injector only, no
+compile), recomputes every scenario's verdict key, and reports which scenarios a matrix run
+would re-execute. Then it puts the tree back.
+
+    python3 tools/probe_invalidation.py                 # every case
+    python3 tools/probe_invalidation.py --case ch05     # one
+    python3 tools/probe_invalidation.py --suite gate    # against a different scenario set
+
+Each case declares what it EXPECTS -- `must_run` and `must_cache` -- so a surprise is a
+failure with a name, not a table somebody has to read carefully. Cases whose edit cannot
+change a ROM input skip the rebuild entirely and answer in milliseconds.
+
+This mutates the working tree while it runs and restores with `git checkout`. It is a
+diagnostic, deliberately NOT part of `make test`: it costs real builds.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(HERE)
+sys.path.insert(0, os.path.join(HERE, 'playtest'))
+sys.path.insert(0, HERE)
+import matrix as mx                                     # noqa: E402
+import build_scopes                                     # noqa: E402
+
+CAMPAIGNS = os.path.join(REPO, 'campaigns', 'rime-of-the-frostmaiden')
+CHAPTERS = os.path.join(CAMPAIGNS, 'chapters')
+
+
+# -- edits ------------------------------------------------------------------
+
+def bump_first_level(path):
+    """Nudge the first `level:` in a chapter YAML -- the smallest real content edit."""
+    def edit():
+        with open(path) as fh:
+            text = fh.read()
+        m = re.search(r'^(\s+level: )(\d+)', text, re.M)
+        with open(path, 'w') as fh:
+            fh.write(text[:m.start()] + m.group(1) + str(int(m.group(2)) + 1) + text[m.end():])
+    return edit, path
+
+
+def bump_enemy_level(path):
+    """Nudge the first level under `enemy_units:` -- content the injector really writes."""
+    def edit():
+        with open(path) as fh:
+            text = fh.read()
+        start = text.index('\nenemy_units:')
+        m = re.search(r'^(\s+level: )(\d+)', text[start:], re.M)
+        at = start + m.start()
+        with open(path, 'w') as fh:
+            fh.write(text[:at] + m.group(1) + str(int(m.group(2)) + 1)
+                     + text[start + m.end():])
+    return edit, path
+
+
+def append_line(path, line):
+    def edit():
+        with open(path, 'a') as fh:
+            fh.write(line)
+    return edit, path
+
+
+def rewrite(path, old, new):
+    def edit():
+        with open(path) as fh:
+            text = fh.read()
+        assert old in text, 'probe anchor missing in %s: %r' % (path, old)
+        with open(path, 'w') as fh:
+            fh.write(text.replace(old, new, 1))
+    return edit, path
+
+
+CASES = [
+    # name, (edit, path to restore), rebuild?, must_run, must_cache
+    ('ch01', bump_first_level(os.path.join(CHAPTERS, 'ch01-the-iron-trail.yaml')), True,
+     ['ch01', 'ch01win', 'lordfloor'], []),
+    ('ch05', bump_first_level(os.path.join(CHAPTERS, 'ch05-the-elven-tomb.yaml')), True,
+     ['ch05arena', 'ch05raid'], ['ch01win', 'ch04moose', 'recordunitlist']),
+    # NOT `level:` in the chapter roster -- that is a PC annotation, and real PC stats live
+    # in campaigns/.../pcs/, so editing it changes no injected byte and the cache is RIGHT to
+    # skip. (First run of this probe asserted otherwise and was wrong.) `enemy_units` is
+    # prologue-scoped content the injector genuinely consumes.
+    # UNRESOLVED (2026-08-12): this edit changes `level: 5 -> 6` under the prologue's
+    # `enemy_units`, and NO injected file changes -- every scope digest is identical across
+    # all four ROM configurations. Either the prologue's enemy levels do not reach the ROM
+    # from this YAML (in which case caching is correct and this expectation is wrong), or
+    # the manifest is blind to a file the injector wrote (a stale-PASS hole). Settle it by
+    # building the prologue ROM twice, edited and not, and comparing the .gba bytes.
+    # Left expecting `win` to re-run ON PURPOSE, so the probe stays RED until answered.
+    ('prologue', bump_enemy_level(os.path.join(CHAPTERS, 'ch00-prologue-a-dagger-of-ice.yaml')),
+     True, ['win'], []),
+    ('docs', append_line(os.path.join(REPO, 'docs', 'decisions.md'), '\n<!-- probe -->\n'),
+     False, [], ['ch01win', 'ch05arena', 'ch04moose', 'win']),
+    ('harness-one-scenario',
+     rewrite(mx.HARNESS, 'scenarios.ch05arena = function()',
+             'scenarios.ch05arena = function()\n    local probe = 1'), False,
+     ['ch05arena'], ['ch01win', 'ch04moose', 'win']),
+    ('harness-shared-helper',
+     rewrite(mx.HARNESS, 'guardedInput = function(intention, key, expected, predicate, frames)',
+             'guardedInput = function(intention, key, expected, predicate, frames)\n    local probe = 1'),
+     False, ['ch01win', 'ch05arena', 'ch04moose'], []),
+    ('clearbot', append_line(os.path.join(HERE, 'playtest', 'clearbot.lua'), '\n-- probe\n'),
+     False, ['clear_ch04_parley'], ['ch05arena', 'ch01win', 'win']),
+    ('controller', append_line(os.path.join(HERE, 'playtest', 'controller.lua'), '\n-- probe\n'),
+     False, ['ch01win', 'ch05arena', 'ch04moose'], []),
+    ('run.sh', append_line(os.path.join(HERE, 'playtest', 'run.sh'), '\n# probe\n'),
+     False, ['ch01win', 'ch05arena'], []),
+    ('matrix.yaml-one-row',
+     rewrite(mx.MANIFEST, '  ch05arena:\n    rom: ch05boot',
+             '  ch05arena:\n    deadline: 999\n    rom: ch05boot'), False,
+     ['ch05arena'], ['ch01win', 'ch05raid']),
+    ('portrait-global',
+     bump_first_level(os.path.join(CAMPAIGNS, 'pcs', sorted(
+         f for f in os.listdir(os.path.join(CAMPAIGNS, 'pcs')) if f.endswith('.yaml'))[0])),
+     True, ['ch01win', 'ch05arena'], []),
+]
+
+
+# -- machinery --------------------------------------------------------------
+
+# make-flag -> the build_campaign.py switch that sets it (Makefile line 39).
+FLAG_ARGS = {'TESTCH': '--test-chapter', 'LORDBOOT': '--lord-boot', 'MONTAGE': '--montage',
+             'CH03BOOT': '--ch03-boot', 'CH04BOOT': '--ch04-boot', 'CH05BOOT': '--ch05-boot'}
+
+
+def keys_for(names, manifests):
+    out = {}
+    for name in names:
+        s = mx.Manifest.load().resolve(name)
+        if s.kind != 'verdict':
+            continue
+        digest = mx.rom_input_hash(s.make_flags)
+        out[name] = mx.scenario_fingerprint(
+            s, digest, scopes=manifests.get(s.rom),
+            observed=mx.load_observed_chapters(name))
+    return out
+
+
+def build_manifests(roms):
+    """Run the injector for each ROM configuration and collect its scope manifest.
+
+    Runs them in the matrix's own order, and that ordering is the point: the churn bug
+    this probe exists to catch only appears when configurations alternate.
+    """
+    out = {}
+    for rom in roms:
+        flags = mx.Manifest.load().resolve_rom(rom)
+        cmd = [sys.executable, os.path.join(HERE, 'build_campaign.py'),
+               '--campaign', 'rime-of-the-frostmaiden']
+        cmd += [FLAG_ARGS[flag.split('=')[0]] for flag in flags]
+        subprocess.run(cmd, cwd=REPO, check=True, capture_output=True)
+        out[rom] = build_scopes.load_manifest(
+            os.path.join(REPO, '.build-scopes.json'))
+    return out
+
+
+def restore(path):
+    subprocess.run(['git', 'checkout', '--', path], cwd=REPO, capture_output=True)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--case', action='append', help='run only these cases')
+    ap.add_argument('--suite', default='gate')
+    args = ap.parse_args(argv)
+
+    names = [n for n in mx.Manifest.load().select(suite=args.suite)
+             if mx.Manifest.load().resolve(n).kind == 'verdict']
+    roms = sorted({mx.Manifest.load().resolve(n).rom for n in names})
+    print('probing %d scenario(s) across %d ROM configuration(s)\n' % (len(names), len(roms)))
+
+    base_manifests = build_manifests(roms)
+    base = keys_for(names, base_manifests)
+
+    failures = []
+    for case, (edit, path), rebuild, must_run, must_cache in CASES:
+        if args.case and case not in args.case:
+            continue
+        edit()
+        try:
+            manifests = build_manifests(roms) if rebuild else base_manifests
+            after = keys_for(names, manifests)
+        finally:
+            restore(path)
+        ran = sorted(n for n in names if base.get(n) != after.get(n))
+        cached = [n for n in names if n not in ran]
+        print('%-22s %2d run, %2d cached   %s' % (case, len(ran), len(cached),
+                                                  ' '.join(ran) if len(ran) < 8 else ''))
+        for want in must_run:
+            if want in names and want not in ran:
+                failures.append('%s: %s should have re-run' % (case, want))
+        for want in must_cache:
+            if want in names and want in ran:
+                failures.append('%s: %s should have stayed cached' % (case, want))
+    # Leave the tree's manifest describing unedited sources, whatever ran above. Cases that
+    # rebuild already start from restored sources, so this is only needed once, at the end.
+    build_manifests(roms)
+
+    print('')
+    if failures:
+        print('SURPRISES (%d):' % len(failures))
+        for f in failures:
+            print('  - ' + f)
+        return 1
+    print('every case matched expectation')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/probe_invalidation.py
+++ b/tools/probe_invalidation.py
@@ -95,15 +95,18 @@ CASES = [
     # in campaigns/.../pcs/, so editing it changes no injected byte and the cache is RIGHT to
     # skip. (First run of this probe asserted otherwise and was wrong.) `enemy_units` is
     # prologue-scoped content the injector genuinely consumes.
-    # UNRESOLVED (2026-08-12): this edit changes `level: 5 -> 6` under the prologue's
-    # `enemy_units`, and NO injected file changes -- every scope digest is identical across
-    # all four ROM configurations. Either the prologue's enemy levels do not reach the ROM
-    # from this YAML (in which case caching is correct and this expectation is wrong), or
-    # the manifest is blind to a file the injector wrote (a stale-PASS hole). Settle it by
-    # building the prologue ROM twice, edited and not, and comparing the .gba bytes.
-    # Left expecting `win` to re-run ON PURPOSE, so the probe stays RED until answered.
+    # SETTLED 2026-08-13, and the cache was NOT at fault. This case was red because bumping
+    # `level: 5 -> 6` under the prologue's `enemy_units` moved no injected byte at all. Two
+    # full ROM builds, edited and not, came out byte-identical (sha256), and the injector
+    # wrote zero differing files across the whole 20k-file decomp tree -- so the cache was
+    # right to serve every PASS. The bug was upstream: inject_prologue emitted the roster as
+    # C literals under a comment claiming it read the chapter YAML, and every literal
+    # happened to match the YAML, so nothing looked wrong. `_prologue_roster_blocks` now
+    # sources levels/positions/head-count (verified byte-neutral: same ROM sha256), and the
+    # field is live. The prologue is HOSTED on chapter 1, which is why ch01's scenarios move
+    # with it. Long form: decisions.md -> "A cache can be right for the wrong reason".
     ('prologue', bump_enemy_level(os.path.join(CHAPTERS, 'ch00-prologue-a-dagger-of-ice.yaml')),
-     True, ['win'], []),
+     True, ['win', 'ch01win', 'lordfloor'], ['ch05arena', 'ch04moose']),
     ('docs', append_line(os.path.join(REPO, 'docs', 'decisions.md'), '\n<!-- probe -->\n'),
      False, [], ['ch01win', 'ch05arena', 'ch04moose', 'win']),
     ('harness-one-scenario',

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -97,6 +97,73 @@ class FeItemEnum(unittest.TestCase):
         self.assertEqual(bc.fe_item_enum({'id': 'iron-axe'}), 'ITEM_AXE_IRON')
 
 
+class PrologueRosterFromYaml(unittest.TestCase):
+    """The prologue roster is DATA, not a hardcode.
+
+    #255's invalidation probe caught the opposite: bumping `level:` under the ch00 YAML's
+    `enemy_units` moved no injected byte, and two full ROM builds -- edited and not --
+    came out byte-identical, because inject_prologue emitted literals while its comment
+    claimed it read the YAML. The values agreed by hand, so nothing looked wrong; a
+    rebalance authored in YAML would simply not have shipped. These pin the wiring.
+    """
+
+    SLOTS = ('Eirika', 'Seth', 'ONeill')
+    CLASSES = ('CLASS_FIGHTER', 'CLASS_HERO')
+    GUEST_ITEMS = ('ITEM_AXE_HANDAXE, ITEM_VULNERARY', 'ITEM_SWORD_STEEL, ITEM_AXE_HANDAXE')
+
+    def by_id(self, **over):
+        units = {
+            'hlin-trollbane': {'level': 3, 'position': [8, 5]},
+            'scramsax': {'level': 1, 'position': [13, 9]},
+            'sephek-kaltro': {'level': 5, 'position': [14, 8],
+                              'inventory': [{'id': 'ice-longsword',
+                                             'fe_base': 'steel-sword'}]},
+            'caravan-guard': {'level': 2, 'count': 2, 'positions': [[14, 7], [13, 7]],
+                              'inventory': [{'id': 'iron-axe'}]},
+        }
+        for uid, fields in over.items():                 # kwarg ids use _ for -
+            units[uid.replace('_', '-')].update(fields)
+        return units
+
+    def blocks(self, **over):
+        return bc._prologue_roster_blocks(self.by_id(**over), self.SLOTS, self.CLASSES,
+                                          self.GUEST_ITEMS)
+
+    def test_boss_level_tracks_the_yaml(self):
+        self.assertIn('.level = 5,', self.blocks()[1])
+        self.assertIn('.level = 6,', self.blocks(sephek_kaltro={'level': 6})[1])
+
+    def test_boss_position_tracks_the_yaml(self):
+        enemy = self.blocks(sephek_kaltro={'position': [3, 4]})[1]
+        self.assertIn('.xPosition = 3,', enemy)
+        self.assertIn('.yPosition = 4,', enemy)
+
+    def test_boss_weapon_still_tracks_the_yaml(self):
+        # #52's wiring, kept: the flavor "ice-longsword" resolves through fe_base.
+        self.assertIn('ITEM_SWORD_STEEL', self.blocks()[1])
+
+    def test_guest_level_and_position_track_the_yaml(self):
+        ally = self.blocks(hlin_trollbane={'level': 4, 'position': [1, 2]})[0]
+        self.assertIn('.level = 4,', ally)
+        self.assertIn('.xPosition = 1,', ally)
+        self.assertIn('.yPosition = 2,', ally)
+
+    def test_guard_count_drives_how_many_are_emitted(self):
+        self.assertEqual(self.blocks()[1].count('CLASS_FIGHTER'), 2)
+        one = self.blocks(caravan_guard={'count': 1, 'positions': [[14, 7]]})[1]
+        self.assertEqual(one.count('CLASS_FIGHTER'), 1)
+
+    def test_guard_count_disagreeing_with_positions_is_fatal(self):
+        # Silently emitting `count` guards at the first `count` positions would ship a
+        # roster nobody authored. Fail the build instead.
+        with self.assertRaises(SystemExit):
+            self.blocks(caravan_guard={'count': 3})
+
+    def test_more_guards_than_spare_slots_is_fatal(self):
+        with self.assertRaises(SystemExit):
+            self.blocks(caravan_guard={'count': 3, 'positions': [[1, 1], [2, 2], [3, 3]]})
+
+
 class DonorMaps(unittest.TestCase):
     def test_shamans_take_ewan_bases_but_keep_dark_rank_donor(self):
         # Bases from Ewan (Ch1-appropriate); ranks stay on Knoll (ITYPE_DARK), so the

--- a/tools/test_build_scopes.py
+++ b/tools/test_build_scopes.py
@@ -198,12 +198,12 @@ class StickyOwnership(unittest.TestCase):
         _write(os.path.join(self.tree, 'data', 'sometimes.s'), 'stable')
 
     def build(self, rewrite, previous=None):
-        scopes = bs.BuildScopes(root=self.tree, roots=('data',))
+        scopes = bs.BuildScopes(root=self.tree, roots=('data',), previous=previous)
         def step():
             if rewrite:
                 _write(os.path.join(self.tree, 'data', 'sometimes.s'), 'stable')
         scopes.run(step, name='inject_ch05')
-        return scopes.finish(previous=previous)
+        return scopes.finish()
 
     def test_a_scope_keeps_a_file_a_later_build_did_not_rewrite(self):
         first = self.build(rewrite=True)
@@ -228,6 +228,55 @@ class StickyOwnership(unittest.TestCase):
         os.remove(os.path.join(self.tree, 'data', 'sometimes.s'))
         second = self.build(rewrite=False, previous=first)
         self.assertIn('data/sometimes.s', second['chapter:ch05']['paths'])
+
+
+class ClaimTimeIsTheStepsEnd(unittest.TestCase):
+    """An earlier chapter's digest must not carry a LATER chapter's writes.
+
+    Every chapter injector rewrites the same five whole-campaign tables, so the shared file
+    ch04 wrote is rewritten by ch05 moments later. Hashing scopes at the END of the build --
+    which is what sticky ownership used to do -- charged ch05's bytes to ch04, ch03, ch02 and
+    ch01 alike, so editing the chapter under development re-ran the whole campaign's
+    scenarios. Measured on the real build: 18 of 20 scenarios. Each scope is now fixed to
+    the moment its own step ended.
+    """
+
+    def setUp(self):
+        self.tree = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.tree, 'data'))
+        self.addCleanup(shutil.rmtree, self.tree, True)
+        self.shared = os.path.join(self.tree, 'data', 'whole_campaign.s')
+
+    def build(self, ch05_body, previous=None):
+        """Two chapter steps that both rewrite one shared table, ch04 then ch05."""
+        scopes = bs.BuildScopes(root=self.tree, roots=('data',), previous=previous)
+        scopes.run(lambda: _write(self.shared, 'ch04 rows\n'), name='inject_ch04')
+        scopes.run(lambda: _write(self.shared, 'ch04 rows\n' + ch05_body), name='inject_ch05')
+        return scopes.finish()
+
+    def test_both_chapters_still_OWN_the_shared_table(self):
+        m = self.build('ch05 rows\n')
+        self.assertIn('data/whole_campaign.s', m['chapter:ch04']['paths'])
+        self.assertIn('data/whole_campaign.s', m['chapter:ch05']['paths'])
+
+    def test_a_ch05_edit_does_not_move_ch04s_digest(self):
+        first = self.build('ch05 rows\n')
+        second = self.build('ch05 rows EDITED\n', previous=first)
+        self.assertEqual(first['chapter:ch04']['digest'], second['chapter:ch04']['digest'])
+
+    def test_a_ch05_edit_still_moves_ch05s_own_digest(self):
+        first = self.build('ch05 rows\n')
+        second = self.build('ch05 rows EDITED\n', previous=first)
+        self.assertNotEqual(first['chapter:ch05']['digest'], second['chapter:ch05']['digest'])
+
+    def test_a_ch04_edit_still_moves_ch04s_digest(self):
+        """The safety direction: an edit to the earlier chapter must not be cached away."""
+        scopes = bs.BuildScopes(root=self.tree, roots=('data',))
+        scopes.run(lambda: _write(self.shared, 'ch04 EDITED\n'), name='inject_ch04')
+        scopes.run(lambda: _write(self.shared, 'ch04 EDITED\nch05 rows\n'), name='inject_ch05')
+        edited = scopes.finish()
+        self.assertNotEqual(self.build('ch05 rows\n')['chapter:ch04']['digest'],
+                            edited['chapter:ch04']['digest'])
 
 
 class ManifestFile(unittest.TestCase):

--- a/tools/test_build_scopes.py
+++ b/tools/test_build_scopes.py
@@ -181,6 +181,55 @@ class Reconciliation(unittest.TestCase):
         scopes.finish(touched=['data/never-existed.s'])
 
 
+class StickyOwnership(unittest.TestCase):
+    """A scope owns a file once it has written it, even on a later build that did not.
+
+    Without this the path SET churns: whether a build rewrites a given file depends on what
+    was built BEFORE it (the matrix alternates ROM configurations, and the mtime rewind
+    hands the next build a different starting point), so a scope's digest moved with no
+    content behind it -- and since every scenario depends on `global`, everything re-ran.
+    Caught by functional test, not by comparing keys.
+    """
+
+    def setUp(self):
+        self.tree = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.tree, 'data'))
+        self.addCleanup(shutil.rmtree, self.tree, True)
+        _write(os.path.join(self.tree, 'data', 'sometimes.s'), 'stable')
+
+    def build(self, rewrite, previous=None):
+        scopes = bs.BuildScopes(root=self.tree, roots=('data',))
+        def step():
+            if rewrite:
+                _write(os.path.join(self.tree, 'data', 'sometimes.s'), 'stable')
+        scopes.run(step, name='inject_ch05')
+        return scopes.finish(previous=previous)
+
+    def test_a_scope_keeps_a_file_a_later_build_did_not_rewrite(self):
+        first = self.build(rewrite=True)
+        self.assertIn('data/sometimes.s', first['chapter:ch05']['paths'])
+        second = self.build(rewrite=False, previous=first)
+        self.assertIn('data/sometimes.s', second['chapter:ch05']['paths'])
+
+    def test_the_digest_therefore_holds_still(self):
+        first = self.build(rewrite=True)
+        second = self.build(rewrite=False, previous=first)
+        self.assertEqual(first['chapter:ch05']['digest'], second['chapter:ch05']['digest'])
+
+    def test_inherited_ownership_still_tracks_CONTENT(self):
+        """Sticky paths must not mean a stale digest: the file is re-hashed as it is now."""
+        first = self.build(rewrite=True)
+        _write(os.path.join(self.tree, 'data', 'sometimes.s'), 'CHANGED')
+        second = self.build(rewrite=False, previous=first)
+        self.assertNotEqual(first['chapter:ch05']['digest'], second['chapter:ch05']['digest'])
+
+    def test_a_deleted_file_does_not_break_the_merge(self):
+        first = self.build(rewrite=True)
+        os.remove(os.path.join(self.tree, 'data', 'sometimes.s'))
+        second = self.build(rewrite=False, previous=first)
+        self.assertIn('data/sometimes.s', second['chapter:ch05']['paths'])
+
+
 class ManifestFile(unittest.TestCase):
     def setUp(self):
         self.tree = tempfile.mkdtemp()

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -941,11 +941,71 @@ class ScopedFingerprint(unittest.TestCase):
         self.assertNotEqual(self.fingerprint(self.MANIFEST), self.fingerprint(without))
 
 
+class DriverModuleReach(unittest.TestCase):
+    """A dofile'd module is reached by the scenarios that USE it, not by all of them.
+
+    Lumping every driver file into one digest meant an edit to `clearbot.lua` -- which only
+    the clear* scenarios touch -- re-ran ch05arena. Same trap #255 warns about for
+    harness.lua, one file over.
+    """
+
+    def test_the_bindings_are_read_out_of_harness_lua(self):
+        """Derived from the dofile lines, not a hand-kept table."""
+        mods = mx.driver_modules()
+        self.assertEqual(mods.get('clearbot.lua'), 'CLEARBOT')
+        self.assertEqual(mods.get('controller.lua'), 'Controller')
+        self.assertEqual(mods.get('pathing.lua'), 'PATHING')
+
+    def test_a_generated_table_has_no_binding_and_is_not_a_module(self):
+        self.assertNotIn('symbols.lua', mx.driver_modules())
+
+    def test_the_binding_LINE_itself_does_not_count_as_a_use(self):
+        """`local CLEARBOT = dofile(...)` is top-level, so it lands in the shared harness
+        text. Counting it would make every module reachable by everyone and the split would
+        do nothing at all."""
+        reached = mx.scenario_driver_modules('ch05arena')
+        self.assertNotIn('clearbot.lua', reached)
+
+    def test_a_scenario_reaches_the_modules_it_actually_uses(self):
+        self.assertIn('clearbot.lua', mx.scenario_driver_modules('clear_ch01'))
+
+    def test_every_verdict_scenario_reaches_the_classifier(self):
+        """controller.lua really is consulted by every guarded input -- that part of the
+        old lumping was right."""
+        for name in ('ch05arena', 'clear_ch01', 'ch01win'):
+            self.assertIn('controller.lua', mx.scenario_driver_modules(name))
+
+    def test_editing_an_unreached_module_does_not_move_the_key(self):
+        m = manifest(scenarios={'ch05arena': {}})
+        s = m.resolve('ch05arena')
+        base = mx.scenario_fingerprint(s, 'r', env={})
+        moved = mx.scenario_fingerprint(s, 'r', env={},
+                                        driver_files={'clearbot.lua': 'CHANGED'})
+        self.assertEqual(base, moved)
+
+    def test_editing_a_reached_module_moves_the_key(self):
+        m = manifest(scenarios={'ch05arena': {}})
+        s = m.resolve('ch05arena')
+        base = mx.scenario_fingerprint(s, 'r', env={})
+        moved = mx.scenario_fingerprint(s, 'r', env={},
+                                        driver_files={'controller.lua': 'CHANGED'})
+        self.assertNotEqual(base, moved)
+
+    def test_run_sh_stays_global(self):
+        """It is the launcher: it decides fps, deadline and the wrapper for every run."""
+        m = manifest(scenarios={'ch05arena': {}})
+        s = m.resolve('ch05arena')
+        self.assertNotEqual(mx.scenario_fingerprint(s, 'r', env={}),
+                            mx.scenario_fingerprint(s, 'r', env={},
+                                                    driver_files={'run.sh': 'CHANGED'}))
+
+
 class DriverSource(unittest.TestCase):
     """Everything OUTSIDE harness.lua that can change what a scenario does."""
 
     def setUp(self):
-        self.text = mx.driver_source()
+        self.files = mx.driver_source()
+        self.text = '\n'.join('%s\n%s' % (k, v) for k, v in sorted(self.files.items()))
 
     def test_it_covers_the_classifier_every_guarded_input_consults(self):
         self.assertIn('function M.classify', self.text)


### PR DESCRIPTION
Closes the #255 driver-scoping branch. Two fixes, both found by driving the real build rather than comparing cache keys.

## 1. The prologue roster was never data-driven (a shipped content bug)

The invalidation probe's `prologue` case was red in the most alarming way available: bumping `level: 5 -> 6` under the ch00 YAML's `enemy_units` moved **no** scope digest, so nothing re-ran. That is the signature of a stale-PASS hole.

It was not one. **Two full ROM builds, edited and not, are byte-identical (sha256)**, and an injector-only run in each state leaves all 20,263 files of the decomp tree identical. The cache was right.

The bug was upstream: `inject_prologue` emitted both `UnitDefinition` rosters as C literals, under a comment reading *"Positions/levels/items from the chapter YAML"*. Only the boss's weapon was ever wired (#52). Every literal matched the YAML by hand, so nothing looked wrong — a prologue rebalance authored in YAML would simply not have shipped. The same three levels were hardcoded a second time in step 4b's `guest_patch`.

`_prologue_roster_blocks` now sources levels, positions, the guard head-count and enemy weapons from the YAML. **Verified byte-neutral: the ROM's sha256 is unchanged**, which is the proof this is plumbing and not a balance change.

## 2. Scopes were hashed at the end of the build, not at their own step

Sticky ownership re-hashed inherited paths in `finish()`, after every step had run. Every chapter injector rewrites the same five whole-campaign tables, so by then the shared file holds the *last* chapter's bytes — charged to ch04, ch03, ch02 and ch01 alike. That is the measured **18 of 20**.

Each scope is now fixed to the moment its own step ended. A ch05 edit no longer moves ch04's digest — the direction that matters, since the campaign is built forward. Editing an *early* chapter still invalidates the later ones; that needs sub-file attribution, and per `decisions.md` I'm not reaching for it without a measurement saying it pays.

## Not in this PR, deliberately

- **Line-level attribution** — dropped. Only helps the backward-edit case.
- **Phase 3 (the local-gate ban)** — left in place. The habit that replaces it is "run your chapter's suite, not the gate", which is not code.

## The finding that outlasts this PR

Profiling the injector to settle an unrelated question: **of a 63s `make`, the ARM compile is 12s and the Python injection is 51s** — 11 million `PIL.getpixel` calls in `_cell_is_empty` (~28s) and 534 `yaml.safe_load` calls (~22s, the same chapter files parsed dozens of times). That tax is paid on every build whether or not a playtest runs. Recorded in `decisions.md`; it is the next thing worth doing.

## Verification

- `make` green; **ROM sha256 identical to the pre-change build**
- `tools/test_build_campaign.py` 249 passed (7 new)
- `tools/test_build_scopes.py` 29 passed (4 new)
- `check.py` clean; `verify_text.py` 3404 messages, 0 runaway
- `probe_invalidation.py --case prologue` green at 7 run / 13 cached

No playtest scenarios were run: nothing here changes a ROM byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)