### PR TITLE
Make the injector fast: 50s -> 18s, byte-identical ROM (#274)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4651,6 +4651,47 @@ Two traps it encodes, both settled from the decomp rather than by guessing:
   that wrong renders a sheared picture that looks like a decode bug in the image data.
 _Decided: 2026-08-12 (Claude, #265)._
 
+### The injector was slow in Python, not in work
+
+`build_campaign.py` was 50s of a 64s `make` — paid on every build, whether or not a playtest
+ever ran. None of it was the work it does; all of it was the shape of the loops doing it. Three
+fixes took it to 18s (`make`: 64.5s → 21.0s) with the ROM **byte-identical**:
+
+- **Per-pixel PIL is the antipattern that costs the most.** `_cell_is_empty` asked
+  `getpixel` 11 million times whether a cell was transparent, re-entering PIL's pixel-access
+  machinery on every read (~28s). The alpha band reshapes into `(rows, TILE, cols, TILE)` and
+  answers the whole image in one `any()`. `nonzero()` walks row-major, which is what keeps
+  tiles emitting in the original order — the ordering is the part a rewrite here can silently
+  break.
+- **Parse each YAML once, and parse it in C.** PyYAML's pure-Python scanner walks a document
+  one character at a time (6M `reader.forward` calls, ~22s); libyaml's `CSafeLoader` builds the
+  identical documents an order of magnitude faster. Separately, injectors re-parsed the same
+  handful of chapter files 62 times because each wanted one line, so `_load_chapter_yaml`
+  memoizes on path + mtime + size. **It hands back a deep copy**: several injectors edit the
+  dict they are given, and a shared parse must not leak one injector's edits into the next
+  one's view.
+- **The remaining per-pixel loops** (`_load_frame`, the swatch strip) vectorize the same way.
+
+**The negative result, so nobody re-attempts it: `getcolors(1 << 24)` is load-bearing.** PIL
+sizes the histogram from `maxcolors`, so that bound costs a fresh multi-megabyte allocation on
+every call — 42ms per frame against 0.15ms at `1 << 16`, 8.6s of the injection. It cannot be
+tightened, because **getcolors returns colours in hash-bucket order and the bucket count comes
+from `maxcolors`**: a smaller bound reorders the palette, which reorders every sheet index with
+it and moves ROM bytes for no visual change. The trap is that it looks safe — a single
+7-colour frame compares equal both ways. Baxby's 5-frame set is where `(112, 80, 128)` jumps
+five slots. Buying the 8.6s back means accepting a new palette order and re-proving the anims
+in-engine, which is a playtest this repo does not want to spend.
+
+**The acceptance test for injector performance work is a byte-compare, and it is cheap.** These
+changes are meant to be output-identical, so the proof is `shasum -a 256
+fireemblem8u/fireemblem8.gba` matching the pre-change build — no emulator, no playtest. Cheaper
+still when bisecting a difference: run `build_campaign.py` alone and hash the files it wrote
+into the decomp (tracked-modified + untracked), which names the offending artifact directly
+instead of leaving you with one changed ROM hash. That is what identified the palette
+reordering above. Do not accept a speedup that moves a ROM byte.
+
+_Decided: 2026-08-13 (Claude, #274)._
+
 ---
 
 ## Open Questions (not yet decided)

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -24,6 +24,7 @@ Milestones B+ (characters, chapter, dialogue codegen) hang off the same CLI.
 
 import argparse
 import collections
+import copy
 import glob
 import hashlib
 import json
@@ -52,6 +53,17 @@ from inject.decomp import (  # noqa: E402  shared decomp paths + patch primitive
     BATTLEQUOTES_C, BMUNIT_C, LORDSEL_FLAG_BASE,
     WEAPON_ITEM_ENUM, fe_item_enum)  # shared weapon<->ITEM map (used by inject_prologue)
 from inject import engine_hooks  # noqa: E402  campaign-agnostic engine C-source hooks
+
+# PyYAML's pure-Python scanner walks a document one character at a time through a chain of
+# Python calls, which made YAML parsing ~22s of a 51s injection (6M reader.forward calls) for
+# a few hundred KB of campaign data. libyaml's C scanner produces the identical documents an
+# order of magnitude faster; fall back to the Python one where libyaml is not built in.
+_YAML_LOADER = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+
+
+def _yaml_load(stream):
+    """yaml.safe_load, through libyaml's C scanner when it is available."""
+    return yaml.load(stream, Loader=_YAML_LOADER)
 # The host-slot registry. Stdlib-only and OWNED there so tools/check.py can lint it in the
 # CI job that has no Pillow; re-exported here so the constants read the same at every call
 # site below (#241).
@@ -971,7 +983,7 @@ def load_unit(campaign, unit_id):
         path = os.path.join(base, sub, unit_id + '.yaml')
         if os.path.isfile(path):
             with open(path, encoding='utf-8') as f:
-                return yaml.safe_load(f)
+                return _yaml_load(f)
     sys.exit('ERROR: no YAML for unit %r under %s/{pcs,npcs}' % (unit_id, base))
 
 
@@ -1354,7 +1366,7 @@ def inject_item_icons(campaign, verbose=True):
     every copy shows the new art (cf. inject_item_names for the name)."""
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        icons = (yaml.safe_load(f) or {}).get('item_icons') or {}
+        icons = (_yaml_load(f) or {}).get('item_icons') or {}
     if not icons:
         if verbose:
             print('  (no item_icons declared)')
@@ -1511,7 +1523,7 @@ def arena_presentation_config(campaign):
     campaign_dir = os.path.join(REPO, 'campaigns', campaign)
     campaign_path = os.path.join(campaign_dir, 'campaign.yaml')
     with open(campaign_path, encoding='utf-8') as f:
-        root = yaml.safe_load(f) or {}
+        root = _yaml_load(f) or {}
     campaign_cfg = root.get('arena_presentation') or {}
     if not isinstance(campaign_cfg, dict):
         sys.exit('ERROR: %s: arena_presentation must be a mapping' % campaign_path)
@@ -1521,7 +1533,7 @@ def arena_presentation_config(campaign):
     chapter_dir = os.path.join(campaign_dir, 'chapters')
     for chapter_path in sorted(glob.glob(os.path.join(chapter_dir, 'ch*.yaml'))):
         with open(chapter_path, encoding='utf-8') as f:
-            chapter = yaml.safe_load(f) or {}
+            chapter = _yaml_load(f) or {}
         section = chapter.get('arena_presentation') or {}
         if not section:
             continue
@@ -1674,7 +1686,7 @@ def _pal2_icon_ids(campaign):
     """The iconIds (gItemData.iconId) of the campaign's item_icon_pal2.icons, sorted."""
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        pal2 = (yaml.safe_load(f) or {}).get('item_icon_pal2') or {}
+        pal2 = (_yaml_load(f) or {}).get('item_icon_pal2') or {}
     return sorted(item_icon_id(e) for e in (pal2.get('icons') or []))
 
 
@@ -1697,7 +1709,7 @@ def inject_item_icon_pal2(campaign, verbose=True):
     """
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        pal2 = (yaml.safe_load(f) or {}).get('item_icon_pal2') or {}
+        pal2 = (_yaml_load(f) or {}).get('item_icon_pal2') or {}
     if not pal2:
         if verbose:
             print('  (no item_icon_pal2 declared)')
@@ -1721,7 +1733,7 @@ def inject_item_names(campaign, verbose=True):
     documentation only -- the engine can't differ them)."""
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        renames = (yaml.safe_load(f) or {}).get('item_names') or {}
+        renames = (_yaml_load(f) or {}).get('item_names') or {}
     if not renames:
         if verbose:
             print('  (no item_names declared)')
@@ -2434,7 +2446,7 @@ def inject_world_tour(campaign, verbose=True):
     montage_yaml = os.path.join(REPO, 'campaigns', campaign, 'events',
                                 'opening-montage.yaml')
     with open(montage_yaml, encoding='utf-8') as f:
-        cards = yaml.safe_load(f)['town_tour']['cards']
+        cards = _yaml_load(f)['town_tour']['cards']
 
     # 1. Backdrop binaries -> decomp graphics (make LZ-compresses 4bpp + tsa).
     os.makedirs(WORLD_MAP_GFX_DIR, exist_ok=True)
@@ -2808,7 +2820,7 @@ def _declared_donor_bases(campaign):
                           recursive=True):
         try:
             with open(path, encoding='utf-8') as f:
-                data = yaml.safe_load(f)
+                data = _yaml_load(f)
         except Exception:
             continue
 
@@ -3618,7 +3630,7 @@ def declared_map_sprite_units(campaign):
             if not name.endswith('.yaml'):
                 continue
             with open(os.path.join(d, name), encoding='utf-8') as f:
-                unit = yaml.safe_load(f) or {}
+                unit = _yaml_load(f) or {}
             ms = (unit.get('art') or {}).get('map_sprite')
             if ms and (ms or {}).get('wiring') != 'pending':
                 declared[unit.get('id') or name[:-5]] = '%s/%s' % (sub, name)
@@ -3627,7 +3639,7 @@ def declared_map_sprite_units(campaign):
         if not name.endswith('.yaml'):
             continue
         with open(os.path.join(chapters, name), encoding='utf-8') as f:
-            chap = yaml.safe_load(f) or {}
+            chap = _yaml_load(f) or {}
         for key in ('neutral_units', 'green_units'):
             for unit in (chap.get(key) or []):
                 if ((unit.get('art') or {}).get('map_sprite')) and unit.get('id'):
@@ -4164,7 +4176,7 @@ def enemy_class_reskins(campaign):
     as a list of dicts {id, base, slot, sprite}. Empty if none declared."""
     cfg = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg, encoding='utf-8') as f:
-        return (yaml.safe_load(f) or {}).get('enemy_class_reskins') or []
+        return (_yaml_load(f) or {}).get('enemy_class_reskins') or []
 
 
 # --- Faked battle animations (#65) -----------------------------------------------
@@ -4367,6 +4379,9 @@ def _banim_palette(frame_imgs):
     """A <=16-colour palette for the frames: index 0 transparent + each opaque colour."""
     pal = [(0, 0, 0)]
     for im in frame_imgs:
+        # 1<<24 is load-bearing, not slack: it fixes getcolors' bucket order, and hence this
+        # palette's order (feditor_to_banim._palette carries the long note; decisions.md ->
+        # "The injector was slow in Python, not in work").
         for cnt, rgba in im.getcolors(1 << 24):
             rgb = rgba[:3]
             # OBJ palette index 0 is transparent even when its BGR555 colour is black.
@@ -4388,7 +4403,7 @@ def units_with_battle_anim(campaign):
             if not fn.endswith('.yaml'):
                 continue
             with open(os.path.join(d, fn), encoding='utf-8') as f:
-                u = yaml.safe_load(f)
+                u = _yaml_load(f)
             if u and u.get('battle_anim'):
                 out.append((u.get('id', fn[:-5]), u))
     return out
@@ -5253,7 +5268,7 @@ def inject_title_theme(campaign, verbose=True):
 
     cfg_path = os.path.join(REPO, 'campaigns', campaign, 'campaign.yaml')
     with open(cfg_path, encoding='utf-8') as f:
-        theme = (yaml.safe_load(f) or {}).get('title_theme')
+        theme = (_yaml_load(f) or {}).get('title_theme')
     if not theme:
         return
     letters = [tuple(int(h.lstrip('#')[i:i + 2], 16) for i in (0, 2, 4))
@@ -5340,7 +5355,7 @@ def inject_title_theme(campaign, verbose=True):
 def _load_prologue_chapter(campaign):
     path = os.path.join(REPO, 'campaigns', campaign, 'chapters', PROLOGUE_CHAPTER_YAML)
     with open(path, encoding='utf-8') as f:
-        return yaml.safe_load(f)
+        return _yaml_load(f)
 
 
 def _prologue_roster_blocks(by_id, slots, classes, guest_items):
@@ -5808,10 +5823,26 @@ def inject_prologue(campaign, verbose=True, montage=False):
               % (hlin_slot, scram_slot, sephek_slot))
 
 
+_CHAPTER_YAML_CACHE = {}
+
+
 def _load_chapter_yaml(campaign, filename):
+    """Parse a chapter YAML, reusing the parse when the file on disk has not changed.
+
+    A build asks for the same handful of chapter files dozens of times (62 calls, ~9s of a
+    51s injection) because every injector that needs one line of a chapter parses the whole
+    document. The cache is keyed on the file's identity AND its mtime/size, so editing a
+    chapter mid-build is still picked up. Callers get a deep copy: several injectors edit
+    the dict they are handed, and a shared parse must not let one injector's edits leak
+    into the next one's view of the chapter.
+    """
     path = os.path.join(REPO, 'campaigns', campaign, 'chapters', filename)
-    with open(path, encoding='utf-8') as f:
-        return yaml.safe_load(f)
+    st = os.stat(path)
+    key = (path, st.st_mtime_ns, st.st_size)
+    if key not in _CHAPTER_YAML_CACHE:
+        with open(path, encoding='utf-8') as f:
+            _CHAPTER_YAML_CACHE[key] = _yaml_load(f)
+    return copy.deepcopy(_CHAPTER_YAML_CACHE[key])
 
 
 # --- Shared chapter-injection helpers (#104): hoisted from inject_ch01/inject_ch02 ---

--- a/tools/feditor_to_banim.py
+++ b/tools/feditor_to_banim.py
@@ -21,6 +21,7 @@ import collections
 import os
 import re
 
+import numpy as np
 from PIL import Image
 
 import ref_to_battleframe as rb
@@ -260,11 +261,11 @@ SWATCH_ROWS = 2
 def _strip_top_swatch(rgba, rows=SWATCH_ROWS):
     """Return `rgba` with its top `rows` cleared to transparent (drops the FEditor palette swatch)."""
     out = rgba.copy()
-    px = out.load()
-    for y in range(min(rows, out.height)):
-        for x in range(out.width):
-            px[x, y] = (0, 0, 0, 0)
+    out.paste((0, 0, 0, 0), (0, 0, out.width, min(rows, out.height)))
     return out
+
+
+GBA5_MASK = 0xF8  # the GBA shows 5 bits per channel; the low 3 do not survive the hardware
 
 
 def _quantize5(rgb):
@@ -272,7 +273,7 @@ def _quantize5(rgb):
     dropped). Colours that quantize equal are one colour on hardware, so they share a palette
     slot -- keeps a PNG with hardware-identical near-duplicates inside the 15-colour budget."""
     r, g, b = rgb
-    return (r & 0xF8, g & 0xF8, b & 0xF8)
+    return (r & GBA5_MASK, g & GBA5_MASK, b & GBA5_MASK)
 
 
 def _load_frame(path):
@@ -281,14 +282,15 @@ def _load_frame(path):
     only content -- clean tiling, a correct bbox, and no hardware-duplicate palette overflow)."""
     im = Image.open(path)
     bg = im.getpixel((0, 0))            # the light-green backdrop sits at the canvas corner
-    rgb = im.convert("RGB")
-    out = Image.new("RGBA", im.size, (0, 0, 0, 0))
-    src, col, dst = im.load(), rgb.load(), out.load()
-    for y in range(im.height):
-        for x in range(im.width):
-            if src[x, y] != bg:
-                dst[x, y] = _quantize5(col[x, y]) + (255,)
-    return _strip_top_swatch(out)
+    src = np.asarray(im)
+    # An FEditor frame is indexed, so the backdrop test is one index compare; keep working for
+    # a truecolour PNG (where getpixel hands back a tuple) by comparing the whole pixel.
+    keep = (src != bg) if src.ndim == 2 else np.any(src != np.array(bg, dtype=src.dtype), axis=-1)
+    out = np.zeros(src.shape[:2] + (4,), dtype=np.uint8)
+    out[..., :3] = np.asarray(im.convert("RGB")) & GBA5_MASK   # _quantize5, whole-image
+    out[..., 3] = np.where(keep, 255, 0)
+    out[~keep, :3] = 0                  # transparent pixels carry no colour, as before
+    return _strip_top_swatch(Image.fromarray(out, "RGBA"))
 
 
 def _palette(frame_imgs):
@@ -298,6 +300,11 @@ def _palette(frame_imgs):
     pal = [(0, 0, 0)]
     seen = set()
     for im in frame_imgs:
+        # 1<<24 is load-bearing, not slack. PIL sizes getcolors' histogram from `maxcolors`
+        # and returns colours in HASH-BUCKET order, so a tighter bound (much faster -- it is
+        # a multi-megabyte allocation per call) silently REORDERS this palette, and every
+        # sheet index with it. A 7-colour frame compares equal and will tell you it is safe.
+        # Long form: decisions.md -> "The injector was slow in Python, not in work".
         for _cnt, rgba in im.getcolors(1 << 24):
             if rgba[3] == 0:
                 continue

--- a/tools/ref_to_battleframe.py
+++ b/tools/ref_to_battleframe.py
@@ -12,6 +12,7 @@ This module is built bottom-up, TDD'd in test_ref_to_battleframe.py (in `make te
 """
 import struct
 
+import numpy as np
 from PIL import Image
 
 TILE = 8  # GBA OBJ tiles are 8x8
@@ -445,13 +446,21 @@ def build_battle_anim(abbr, frame_imgs, palette, center_px=None, motion="ranged"
             "motion_s": emit_motion_s(abbr, frames, motion, cadence)}
 
 
-def _cell_is_empty(im, ox, oy):
-    """True if the 8x8 cell at (ox, oy) is fully transparent."""
-    for y in range(oy, oy + TILE):
-        for x in range(ox, ox + TILE):
-            if im.getpixel((x, y))[3] != 0:
-                return False
-    return True
+def _empty_cell_grid(im):
+    """Which 8x8 cells of `im` (RGBA) are fully transparent, as a [row][col] bool array.
+
+    Answered for the whole image in one pass instead of per pixel. The per-pixel form of this
+    was the single most expensive thing the injector did -- 11M PIL.getpixel calls, ~28s of a
+    51s injection -- because getpixel re-enters the pixel-access machinery on every read. The
+    alpha band reshapes into (rows, TILE, cols, TILE), so "does this cell hold any opaque
+    pixel" is one vectorized any() over the tile axes.
+    """
+    alpha = np.asarray(im.getchannel("A"))
+    rows, cols = alpha.shape[0] // TILE, alpha.shape[1] // TILE
+    if (rows * TILE, cols * TILE) != alpha.shape:
+        raise ValueError("tile_sprite needs a tile-aligned sprite; got %dx%d, which is not a "
+                         "whole number of %dx%d cells" % (im.width, im.height, TILE, TILE))
+    return ~alpha.reshape(rows, TILE, cols, TILE).any(axis=(1, 3))
 
 
 def tile_sprite(im):
@@ -462,19 +471,19 @@ def tile_sprite(im):
     offset of its cell in `im`. Fully-transparent cells carry no hardware sprite and are
     skipped (no tile, no OAM entry) -- that's what keeps a sparse sprite cheap.
     """
-    w, h = im.size
     tiles, oam = [], []
     index = {}  # tile bytes -> sheet index, so identical cells share one tile
-    for oy in range(0, h, TILE):
-        for ox in range(0, w, TILE):
-            if _cell_is_empty(im, ox, oy):
-                continue
-            cell = im.crop((ox, oy, ox + TILE, oy + TILE))
-            key = cell.tobytes()
-            idx = index.get(key)
-            if idx is None:
-                idx = len(tiles)
-                index[key] = idx
-                tiles.append(cell)
-            oam.append({"tile": idx, "dx": ox, "dy": oy})
+    empty = _empty_cell_grid(im)
+    # nonzero() walks row-major, so cells are still visited (and tiles still emitted) in
+    # exactly the order the per-cell scan used to visit them.
+    for row, col in zip(*(~empty).nonzero()):
+        oy, ox = int(row) * TILE, int(col) * TILE
+        cell = im.crop((ox, oy, ox + TILE, oy + TILE))
+        key = cell.tobytes()
+        idx = index.get(key)
+        if idx is None:
+            idx = len(tiles)
+            index[key] = idx
+            tiles.append(cell)
+        oam.append({"tile": idx, "dx": ox, "dy": oy})
     return tiles, oam


### PR DESCRIPTION
`build_campaign.py` was **50s of a 64s `make`**, paid on every build whether or not a playtest
ever ran. None of it was the work it does; all of it was the shape of the loops doing it.

**`make`: 64.5s → 21.0s warm. Injector: 50.0s → 18.1s.**

## What changed

- **`_cell_is_empty` (~28s)** — asked `PIL.getpixel` 11 million times whether a cell was
  transparent, re-entering PIL's pixel-access machinery on every read. The alpha band reshapes
  into `(rows, TILE, cols, TILE)` and answers the whole image in one `any()`. `nonzero()` walks
  row-major, so tiles still emit in exactly the original order — the part a rewrite here can
  silently break.
- **YAML (~22s)** — PyYAML's pure-Python scanner walks a document one character at a time (6M
  `reader.forward` calls), so load through libyaml's `CSafeLoader`. Separately,
  `_load_chapter_yaml` re-parsed the same handful of chapter files 62 times because each
  injector wanted one line, so it memoizes on path + mtime + size. **Callers get a deep copy** —
  several injectors edit the dict they are handed, and a shared parse must not leak one
  injector's edits into the next one's view.
- **The remaining per-pixel loops** (`_load_frame`, the swatch strip) vectorize the same way.

## The one I had to give back

`getcolors(1 << 24)` costs 42ms per frame purely in hash-table allocation — 0.15ms at `1 << 16`,
8.6s of the injection. **It cannot be tightened.** PIL sizes the histogram from `maxcolors` and
returns colours in *hash-bucket* order, so a smaller bound silently reorders every banim palette,
and every sheet index with it — moving ROM bytes for no visual change. The trap is that it looks
safe: a single 7-colour frame compares equal both ways. Baxby's 5-frame set is where
`(112, 80, 128)` jumps five slots. Reverted, and recorded as a negative result in `decisions.md`
and at both call sites so nobody re-attempts it.

## Verification — output-identical, not merely green

- The **666 files the injector writes into the decomp are byte-for-byte unchanged**.
- The built ROM hashes to the pre-change
  `57a456233535f50a6a513944e0b14d3443116b3d04ec3fbf371178e6a09008e3`.
- `verify_text.py` passes; 1021 unit tests pass; `check.py` drift clean.

No emulator, no playtest — per `decisions.md`, the acceptance test for injector performance work
is a byte-compare, and hashing the injector's own output (rather than one ROM hash) is what
localized the palette reordering above.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)
