### PR TITLE
The grell gets a real boss line; the tool learns which slot a boss rides (#284)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch02-cold-welcome.yaml
@@ -226,6 +226,13 @@ enemy_units:
     class: brigand
     level: 6                          # vanilla Bazba is L6 steel-axe (UnitDef_088B44AC)
     autolevel: true                  # boss, modeled exactly on vanilla Bazba
+    # NO `personal:` here, deliberately (#284): Halvar DEPLOYS ON THE BAZBA SLOT, so FE8 already
+    # adds Bazba's own line (HP+5/Pow+3/Skl+4/Spd+2/Def+2/Res+2/Lck+1) on top of the class base
+    # in the built ROM — nothing patches that slot. He fights at HP 29/Def 6 = 3.6 rounds, the
+    # bar exactly. The "1.2 rounds" that opened #284 was the measuring tool projecting him off
+    # naked class base because it did not know which slot he rides; `ENEMY_BASE_SLOT` in
+    # build_campaign.py now tells it. Writing the line here too would be a SECOND source for a
+    # fact the slot already owns, free to drift out of agreement with the ROM.
     inventory:
       - id: steel-axe
         damage_type: slashing

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -124,8 +124,22 @@ enemy_units:
     count: 1
     positions: [[14, 1]]        # vanilla seize tile = the deep workings / grell lair
     class: mogall               # FE8 monster (floating eye-aberration) — the real creature, not a reskin
-    level: 12                   # BUMP over Bazba's L6: mogall bases are frail; level holds boss pressure (iterate on difficulty tool)
+    level: 12                   # mogall bases are frail; the level carries its OFFENCE (threat 7.6)
     autolevel: true
+    personal:                   # FE8's OWN boss mechanism — a named boss is class base PLUS a
+      baseHP: 15                # personal line, and the level was never a substitute for one:
+      baseDef: 5                # a naked L12 mogall folded in 1.1 rounds against a bar of 3.6
+                                # (#284). Modelled on the decomp's only DEFENSIVE monster boss,
+                                # Maelduin (data_characters.c [CHARACTER_MAELDUIN_CHUnk - 1]:
+                                # HP+15/Pow+6/Skl+6/Spd+2/Def+4/Res+8) — its defensive half taken
+                                # near-verbatim, its OFFENSIVE half deliberately dropped. Every
+                                # vanilla monster boss is a promoted late-game unit, so any of
+                                # their Pow lines put a ch03 magic boss (Evil Eye reads RES 4,
+                                # and FE8 Ch3 fields no magic at all) past the twin's own threat
+                                # ceiling of 6.8. Durability was the deficit; offence was not.
+                                # Lands at 3.6 rounds — Bazba's bar exactly, the same place ch02's
+                                # Halvar lands — at HP 36/Def 8, just inside Ravisin's 37/10 two
+                                # chapters later, so the boss curve stays monotonic.
     inventory:
       - id: evil-eye            # the mogall's innate ranged magic gaze (hits RES); flavor = lightning tentacle
     ai_pattern: aggressive      # guards the lair; VISIBLE from turn 1 like vanilla Bazba — Pinky's shaft-scout moved into the opening cutscene (player sees the mogall up top), so no in-battle reveal

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5448,6 +5448,127 @@ injection-keyed skip; a test that reads HEAD needs none.
 
 _Decided: 2026-08-16 (found by CI on #286, after the dormant-test fix woke the class)._
 
+### A boss on a vanilla SLOT already has its line — measure what deploys (2026-08-16, #284)
+
+#284 opened on a measurement, not on the game: *"ch02's and ch03's bosses carry no personal
+line, so they are naked class bases and fold in about a third of the time their vanilla
+counterparts take."* Half of that was true. **ch02's was never wrong at all.**
+
+FE8 builds a named boss as **class base plus a personal stat line** — vanilla Bazba is a L6
+Brigand *plus* HP+5/Pow+3/Skl+4/Spd+2/Def+2/Res+2/Lck+1, and that line is most of why he reads
+as a wall. Halvar **deploys on the Bazba slot**, and nothing in the build patches it (only
+`PORTRAIT_MAP` cast slots get rewritten), so the ROM has been adding Bazba's line to him the
+whole time. He fights at HP 29/Def 6 — **3.6 rounds, the bar exactly**. What folded in 1.2
+rounds was `difficulty.py`'s model of him, which projected every enemy off naked class base
+because it had no idea which character slot the unit rides.
+
+**The tool knew two of the three ways a personal line reaches a unit.** `unit_real_article()`
+read `personal:` in the chapter YAML (Ravisin) and `BASE_DONOR` for a cast member deployed
+hostile (Sahnar on Joshua's). The third — an enemy deployed on a vanilla CHARACTER slot — had
+no representation at all. `ENEMY_BASE_SLOT` is now that third source, and each entry points at
+the constant the injector already builds the unit from, so the slot name is written once.
+
+Verified against the **built** character table rather than by reading the injector, because the
+question is what survives the build:
+
+| our unit | slot | personal bases after injection | measured |
+|---|---|---|---|
+| ch01 `goblin-chief` | BREGUET | unchanged: HP+3/Pow+3/Spd+1/Lck+2 | 5.2 → **6.2 rounds** (bar 6.2) |
+| ch02 `raider-captain` | BAZBA | unchanged: Bazba's full line | 1.2 → **3.6 rounds** (bar 3.6) |
+| ch02 `raider-bruiser` | BONE | unchanged: HP+3/Pow+1/Skl+3/Def+1 | — |
+| ch00 `sephek-kaltro` | ONEILL | **zeroed by the build** | 2.1 rounds (bar 2.2) |
+
+**Riding a slot is not enough — the slot has to survive the build, and one does not.**
+`inject_prologue` deliberately zeroes its guests' personal bases so they read as pure class
+base, so Sephek is genuinely naked *despite* deploying on O'Neill's slot. Mapping him anyway
+inflated his threat to **2.9x the Prologue's ceiling** and reddened CH0 — caught by the very
+gate this issue added, on its first run. `PROLOGUE_ZEROED_GUEST_SLOTS` now names that exclusion
+and an assert keeps it in step with the injector.
+
+**ch03's grell is the one that was really wrong**, and for the opposite reason: it rides raw pid
+`0xb7`, and a CharacterData gap is all zeros. It goes from 1.1 to **3.6 rounds** on an authored
+line, HP 21/Def 3 → HP 36/Def 8.
+
+**A `personal:` block is not injected by writing it.** `RAW_PID_PERSONAL_SOURCES` is what carries
+one into the ROM, and it was a passenger inside the loop over `RAW_PID_PORTRAITS` — so a line
+authored for a pid with no portrait binding would have been silently dropped, which is exactly
+the grell's shape (it keeps the generic monster name plate on purpose). The two bindings are now
+independent passes. Declaring the line in YAML and confirming the tool's number would have
+"verified" a boss that never changed in the game: *a declaration is not art*, again.
+
+**ch03 could not take any monster boss's line verbatim, and the reason generalizes.** Every
+named monster in the decomp with a personal line (Maelduin, Cyclops, Wight, Deathgoyle, Gorgon)
+is a **promoted late-game** unit, so all five carry Pow+5..+10. Applied to a ch03 boss they fix
+durability and blow out threat — measured, at the Grell's own level: 9.6–20.0 against FE8 Ch3's
+threat ceiling of **6.8**, every one of them tripping the outlier check. Dropping the Grell's
+level does not rescue it (a L4 Deathgoyle line still reads 9.6). **A vanilla boss line is
+calibrated against the party that faces it**, and lifting one across eight chapters imports that
+calibration with it.
+
+So the Grell takes Maelduin's **defensive half near-verbatim** (HP+15/Def+5 against its
+HP+15/Def+4) and drops its offensive half. Maelduin is the decomp's one defensive monster boss,
+which is what makes it the honest donor: durability was the deficit, offence never was. The
+result is 3.6 rounds at HP 36/Def 8 — Bazba's bar exactly, and just inside Ravisin's 37/10 two
+chapters later, so the boss curve stays monotonic. Threat is unchanged at 7.6, which matters:
+the Grell hits RES with an Evil Eye in a chapter whose twin fields no magic at all, and that
+hazard was a deliberate ch03 choice already shipped, not something to re-open here.
+
+**The rule: a named boss is class base plus a personal line, and the line is what carries its
+durability.** Where a level was bumped to fake one — the Grell's `level: 12` carried the comment
+*"level holds boss pressure"* — the bump is offence, not survivability, and the two are not
+interchangeable.
+
+**No parity ratio moves, and that is not a bug.** The AGGREGATE resolves both sides off class
+base on purpose, so a personal line is invisible to it: ch02 reads x0.79/x0.75 before and after,
+ch03 x1.12/x0.99 before and after. **ch02 is `[locked]` and its lock needs no re-baseline** — the
+numbers under the lock are byte-identical, so the "deliberate re-baseline, Nicolas's call" the
+issue anticipated never arises here. That question belongs entirely to #285, which changes the
+footing; measured on that footing the grell's line lands ch03 at x1.03/x1.00, near-centre.
+
+**The audit the fix demanded.** Every boss was measured against its own twin's bar, on the real
+article. ch00's Sephek (2.1 vs 2.2) and ch01's chief (6.2 vs 6.2) clear it — the chief on
+Breguet's inherited line plus class Def 10, Sephek on class base alone against a twin whose own
+boss is nearly as bare. **A personal line is the MECHANISM, not a checkbox**: a boss already at
+its bar needs nothing, and the rule to write down is about the measurement, not about a required
+YAML key. Two are open and belong elsewhere: ch06's Messie reads 2.7 against 12.9 but is
+`status: planned` brainstorm seed, and ch08's ice troll is **undentable** (Def 15 vs the
+yardstick's 13 attack) — the same `inf` that blocks #285, on our side of the table for once.
+That one matters to #285 beyond ch08: the exclusion policy cannot be written as "a vanilla
+quirk we tolerate" when our own content produces it too.
+
+**The prologue is the mirror case, deliberately left alone.** Asked whether the guests need
+lines to match a boss that got one, the measurement says the boss needs nothing (Sephek 2.1
+against a 2.2 bar) and points at the player side instead. Vanilla's prologue pair splits in
+half: **Eirika's personal line is Lck+5 and nothing else** — she is essentially class base, so
+the zeroing costs Hlin nothing and her frailty is authored (`level: 3`, "the weak lead"). But
+**Seth's line is most of what Seth is** (HP+7/Pow+7/Skl+9/Spd+5/Def+3/Res+5/Lck+13); stripped,
+he falls from surviving 23.8 rounds to 5.5. Scramsax measures **5.7** — a Seth-analog Jeigan,
+authored as one ("promoted prepromote — high stats despite low internal level (cf. Seth)"),
+missing the line that makes a Jeigan one. Not changed and not filed (Nicolas, 2026-08-16): ch00
+is `[locked]`, has shipped and been played, and this is the STATIC proxy, which assumes the
+worst foe reaches a unit and cannot see that Hlin sits back at (8,5) while Scramsax stands
+forward at (13,9). Recorded here so a prologue that ever plays wrong starts with the number.
+
+**And the gate now reads what it had been printing.** ch03's paper boss shipped for months under
+a green `--curve --check` because the aggregate sums the force and divides by the deploy cap, so
+one soft unit dissolves into a 23-unit average — the same blind spot as *"One unit can BE the
+parity overage"*, in the opposite direction. `role_findings()` had been emitting the warning the
+entire time and **nothing consumed it**. `curve_gate_failures` now fails a `locked` chapter that
+has an open role finding, and the curve prints the findings under the table. A chapter marked
+balance-final with a per-unit check still complaining is a contradiction; the opt-in stays
+per-chapter, so mid-authoring chapters warn without reddening CI. It earned itself immediately:
+the bad Sephek mapping above was caught by this gate, not by review.
+
+**The lesson under all of it: an issue's premise is a hypothesis too.** #284 stated a defect in
+two chapters, with a measurement table, and the measurement was the thing that was broken. One
+of the two chapters needed no content change at all, and authoring the "fix" it asked for would
+have added a second source of truth for a line the slot already owns — agreeing with the ROM
+today and free to drift from it tomorrow. Checking what the BUILT character table contains,
+before changing content to match a number, is what separated the two cases.
+
+_Decided: 2026-08-16 (#284; the grell's donor and sizing are new, ch02 turned out to need no
+content change)._
+
 ---
 
 ## Open Questions (not yet decided)

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -174,6 +174,10 @@ PROLOGUE_EVENTSCRIPT_H = os.path.join(DECOMP, 'src', 'events', 'prologue-eventsc
 PROLOGUE_HLIN_SLOT = 'NATASHA'      # frail must-survive lead (our "lord")
 PROLOGUE_SCRAMSAX_SLOT = 'KYLE'     # strong veteran (our "Jeigan")
 PROLOGUE_SEPHEK_SLOT = 'ONEILL'     # boss (recurring villain; escapes in the ending)
+# The guest slots whose personal bases inject_prologue zeroes, so each fights at pure class
+# base. Named because it is the exception to ENEMY_BASE_SLOT: a unit on one of these slots does
+# NOT inherit the vanilla character's line, however much the deployment looks like it should.
+PROLOGUE_ZEROED_GUEST_SLOTS = (PROLOGUE_HLIN_SLOT, PROLOGUE_SCRAMSAX_SLOT, PROLOGUE_SEPHEK_SLOT)
 PROLOGUE_LAYOUT = ('Ch00PrologueMap', 'ch00-prologue')  # (asset label, maps/ source stem)
 PROLOGUE_CHAPTER_YAML = 'ch00-prologue-a-dagger-of-ice.yaml'
 
@@ -727,6 +731,31 @@ BASE_DONOR = dict(STAT_DONOR, marty='CHARACTER_EWAN', meesmickle='CHARACTER_EWAN
 # Ranks stay on STAT_DONOR so both shamans keep Knoll's ITYPE_DARK rank (Ewan is Anima-only,
 # so his tome wouldn't equip). docs/decisions.md "Party-side parity" / issue #45.
 GROWTH_DONOR = dict(STAT_DONOR, meesmickle='CHARACTER_EWAN')
+
+
+# The ENEMY-side counterpart of BASE_DONOR: our enemy id -> the vanilla CHARACTER_ slot it is
+# actually deployed on. Nothing patches these slots (they are not in PORTRAIT_MAP), so the built
+# ROM adds the slot's OWN personal line on top of the class base, exactly as FE8 does for its own
+# bosses -- Halvar fights as a Brigand *plus* Bazba's HP+5/Def+2/..., because he IS Bazba's slot.
+#
+# It exists so the difficulty tool can measure what actually fights (#284). Reading these units
+# off naked class base understated ch02's boss by 3x -- 1.2 rounds against a bar of 3.6 -- and
+# opened a balance issue against content that was never wrong. The slot names are NOT repeated
+# here: each entry points at the one constant the injector already builds the unit from, so the
+# two cannot drift apart. A boss on a RAW pid (ch03's grell, ch05's Ravisin) has no entry -- its
+# CharacterData gap is all zeros, so it is a genuine naked class base until a `personal:` line is
+# authored in its chapter YAML *and* registered in RAW_PID_PERSONAL_SOURCES to reach the ROM.
+#
+# Riding a vanilla slot is NOT sufficient on its own -- the slot must also survive the build
+# unpatched. The prologue's guests do not: inject_prologue ZEROES their personal bases so their
+# stats read as pure class base, so Sephek is genuinely naked despite deploying on O'Neill's
+# slot, and belongs here no more than a raw pid does. PROLOGUE_ZEROED_GUEST_SLOTS is the
+# authoritative list of that exclusion and the two are asserted disjoint.
+ENEMY_BASE_SLOT = {
+    'goblin-chief':  'CHARACTER_%s' % CH01_BOSS_SLOT,
+    'raider-captain': 'CHARACTER_%s' % CH02_BOSS_SLOT,
+    'raider-bruiser': 'CHARACTER_%s' % CH02_MINIBOSS_SLOT,
+}
 
 
 # our cast bust  ->  vanilla portrait slot whose graphic files we overwrite.
@@ -2420,6 +2449,11 @@ def raw_pid_portrait_data(text, campaign):
     own named Great Dragon, which is a monster character with a miniPortrait and no portraitId
     at all -- the right donor shape for a monster, and the reason the moose gains a name without
     gaining a bust.
+
+    The two bindings are INDEPENDENT (#284). A raw-pid boss can need a stat line and no identity
+    at all -- ch03's grell keeps the generic monster name plate on purpose -- so the personal
+    pass walks its own table rather than riding along inside the portrait loop. Coupling them
+    would have made a `personal:` block silently do nothing for any pid without a bust.
     """
     for pid, (_unit_id, slot, portrait_id, _name) in sorted(RAW_PID_PORTRAITS.items()):
         marker = '[%s - 1]' % pid.lower()
@@ -2427,19 +2461,21 @@ def raw_pid_portrait_data(text, campaign):
         block = _bind_raw_pid_identity(block=text[start:end], marker=marker,
                                        name_text_id=raw_pid_name_text_id(slot),
                                        portrait_id=portrait_id)
+        text = text[:start] + block + text[end:]
 
-        personal_source = RAW_PID_PERSONAL_SOURCES.get(pid)
-        if personal_source:
-            chapter_yaml, unit_id = personal_source
-            chapter = _load_chapter_yaml(campaign, chapter_yaml)
-            unit = next((enemy for enemy in chapter['enemy_units']
-                         if enemy['id'] == unit_id), None)
-            if unit is None or 'personal' not in unit:
-                sys.exit('ERROR: raw pid %s personal source %s/%s is missing'
-                         % (pid, chapter_yaml, unit_id))
-            for field in BASE_FIELDS:
-                block = _set_field(block, field, int(unit['personal'].get(field, 0)),
-                                   CHARACTERS_C, marker)
+    for pid, (chapter_yaml, unit_id) in sorted(RAW_PID_PERSONAL_SOURCES.items()):
+        marker = '[%s - 1]' % pid.lower()
+        start, end = _find_brace_block(text, marker, CHARACTERS_C)
+        block = text[start:end]
+        chapter = _load_chapter_yaml(campaign, chapter_yaml)
+        unit = next((enemy for enemy in chapter['enemy_units']
+                     if enemy['id'] == unit_id), None)
+        if unit is None or 'personal' not in unit:
+            sys.exit('ERROR: raw pid %s personal source %s/%s is missing'
+                     % (pid, chapter_yaml, unit_id))
+        for field in BASE_FIELDS:
+            block = _set_field(block, field, int(unit['personal'].get(field, 0)),
+                               CHARACTERS_C, marker)
         text = text[:start] + block + text[end:]
     return text
 
@@ -6151,6 +6187,10 @@ def inject_prologue(campaign, verbose=True, montage=False):
                     _scram_donor, False),
                    (PROLOGUE_SEPHEK_SLOT, 'CLASS_MYRMIDON', by_id['sephek-kaltro']['level'],
                     'CHARACTER_JOSHUA', None)]
+    # The zeroing below is what disqualifies these slots from ENEMY_BASE_SLOT (a unit here does
+    # NOT inherit the vanilla character's personal line). Keep the two statements of that in step.
+    assert tuple(s for s, _c, _l, _d, _f in guest_patch) == PROLOGUE_ZEROED_GUEST_SLOTS, \
+        'guest_patch and PROLOGUE_ZEROED_GUEST_SLOTS disagree about which slots get zeroed'
     with open(CHARACTERS_C, encoding='utf-8') as f:
         chars = f.read()
     for slot, cls, level, donor, female in guest_patch:
@@ -9075,6 +9115,11 @@ RAW_PID_PORTRAITS = {
 # through patch_character_data(), which only visits the regular CHARACTER_* portrait map.
 RAW_PID_PERSONAL_SOURCES = {
     CH05_BOSS_PID: (CH05_CHAPTER_YAML, 'ravisin'),
+    # ch03's grell (#284). Unlike Ravisin it has no entry in RAW_PID_PORTRAITS -- it keeps the
+    # generic monster name plate -- which is exactly why the personal pass had to stop being a
+    # passenger inside the portrait loop. Its gap's bases are all zeros in vanilla, so without
+    # this row the boss really does fight as a naked Mogall and folds in 1.1 rounds.
+    CH03_BOSS_PID: (CH03_CHAPTER_YAML, 'grell'),
 }
 # Named raw-pid creatures whose BATTLE ANIM binds to a gCharacterData gap instead of a
 # vanilla CHARACTER_ slot. Row = unit id -> (chapter YAML that declares it, its raw pid).

--- a/tools/check.py
+++ b/tools/check.py
@@ -363,9 +363,19 @@ def check_personal_line_injection_routes(fail):
     Covers the registries from both ends -- a `personal:` block with no injection route, and an
     `ENEMY_BASE_SLOT` key naming a unit no chapter fields (a rename leaves the key stale and
     silently reverts that boss to its pre-#284 measurement).
+
+    The registries live in build_campaign, which pulls in the art pipeline (Pillow). The `checks`
+    CI job runs on a bare interpreter with neither Pillow nor the submodule, so this skips there
+    exactly as the submodule-dependent checks do -- `make test` in the BUILD job drives the same
+    public gate through test_check_chapter_schema, so nothing goes unchecked.
     """
     sys.path.insert(0, os.path.join(REPO, 'tools'))
-    import build_campaign as bc
+    try:
+        import build_campaign as bc
+    except ImportError as e:
+        print('check_personal_line_injection_routes: skipping (%s; the build job\'s '
+              '`make test` covers this gate)' % e)
+        return
     injected_ids = {uid for _yaml, uid in bc.RAW_PID_PERSONAL_SOURCES.values()}
     slot_ids = set(bc.ENEMY_BASE_SLOT)
     seen = set()

--- a/tools/check.py
+++ b/tools/check.py
@@ -328,6 +328,57 @@ def check_chapter_status(fail):
                         'chapter is an ungrounded seed; ground it and flip to active first' % rel)
 
 
+def _personal_line_route_violations(rel, d, injected_ids, slot_ids):
+    """A declared `personal:` line must have exactly ONE route into the built ROM.
+
+    Two ways to get this wrong, both silent before #284:
+      * declared and never injected -- `RAW_PID_PERSONAL_SOURCES` is what carries a line into
+        gCharacterData, and a raw pid missing from it keeps its all-zero gap. The chapter then
+        MEASURES fixed and PLAYS naked, which is exactly how ch03's grell shipped;
+      * declared for a unit deployed on a vanilla CHARACTER slot, which already carries that
+        character's own line in the ROM. The YAML block cannot reach the slot, and the tool
+        prefers it, so it REPLACES a real line with a smaller invented one -- understating the
+        boss further than the bug that opened #284, with every gate green.
+    """
+    out = []
+    for unit in (d.get('enemy_units') or []):
+        if not unit.get('personal'):
+            continue
+        uid = unit.get('id')
+        if uid in slot_ids:
+            out.append('%s: enemy %r declares `personal:` but deploys on a vanilla character '
+                       'slot that already carries its own line (ENEMY_BASE_SLOT) -- the block '
+                       'never reaches the ROM and hides the real line from the metric; delete '
+                       'it' % (rel, uid))
+        elif uid not in injected_ids:
+            out.append('%s: enemy %r declares `personal:` with no way into the ROM -- add it to '
+                       'RAW_PID_PERSONAL_SOURCES in build_campaign.py, or the boss will measure '
+                       'fixed and play as a naked class base' % (rel, uid))
+    return out
+
+
+def check_personal_line_injection_routes(fail):
+    """#284's guard: every authored boss line reaches the game, and every mapped slot is real.
+
+    Covers the registries from both ends -- a `personal:` block with no injection route, and an
+    `ENEMY_BASE_SLOT` key naming a unit no chapter fields (a rename leaves the key stale and
+    silently reverts that boss to its pre-#284 measurement).
+    """
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    import build_campaign as bc
+    injected_ids = {uid for _yaml, uid in bc.RAW_PID_PERSONAL_SOURCES.values()}
+    slot_ids = set(bc.ENEMY_BASE_SLOT)
+    seen = set()
+    for rel, d in _chapters():
+        fail.extend(_personal_line_route_violations(rel, d, injected_ids, slot_ids))
+        seen.update(u.get('id') for u in (d.get('enemy_units') or []))
+    for uid in sorted(slot_ids - seen):
+        fail.append('ENEMY_BASE_SLOT maps %r, which no chapter fields -- a stale key silently '
+                    'drops that boss back to a naked-class-base measurement (#284)' % uid)
+    for uid in sorted(injected_ids - seen):
+        fail.append('RAW_PID_PERSONAL_SOURCES names enemy %r, which no chapter fields' % uid)
+
+
 def _chapters():
     """Yield (relpath, parsed_dict) for every chapter YAML. THE chapter iterator --
     per-chapter gates consume this so the glob + parse-error policy (parse errors
@@ -1245,6 +1296,7 @@ def main():
                   check_lua_local_headroom, check_hosted_chapters_declared,
                   check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
+                  check_personal_line_injection_routes,
                   check_injection_order, check_playtest_matrix,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -930,16 +930,25 @@ def unit_real_article(enemy_def, combatant):
 
     A named unit's personal line is most of what makes it named -- FE8 adds those
     CharacterData values on top of the deployed class bases -- and it reaches our units from
-    TWO places:
+    THREE places:
       * `personal:` on the chapter YAML, for a raw-pid enemy authored there (Ravisin);
       * BASE_DONOR, for a CAST member deployed hostile, whose donor's line is written into its
-        character slot by the build (Sahnar rides Joshua's, Lupin rides Kyle's).
+        character slot by the build (Sahnar rides Joshua's, Lupin rides Kyle's);
+      * ENEMY_BASE_SLOT, for an enemy deployed on a VANILLA character slot, which keeps that
+        slot's own line because nothing patches it (ch02's Halvar rides Bazba's).
     Reading only the first is why ch05's red Myrmidon measured 6.2 against the 21.4 she
-    actually fights at. Units with neither are unchanged.
+    actually fights at; missing the third is why ch02's boss measured 1.2 rounds against a
+    3.6 bar while the ROM had been fighting it at 3.6 the whole time (#284). Units with none
+    of the three are unchanged -- which is the honest answer for a raw pid, whose
+    CharacterData gap really is all zeros.
+
+    The sources do not stack: an authored `personal:` is the explicit article and wins, or a
+    unit riding a named slot would count its bases twice.
     """
     personal = enemy_def.get('personal')
     if not personal:
-        donor = bc.BASE_DONOR.get(enemy_def.get('id'))
+        uid = enemy_def.get('id')
+        donor = bc.BASE_DONOR.get(uid) or bc.ENEMY_BASE_SLOT.get(uid)
         if donor:
             personal = vanilla_personal_line(donor)
     return _apply_personal(combatant, personal) if personal else combatant
@@ -1463,12 +1472,21 @@ def curve_gate_failures(rows):
     `balance_locked: true` in its YAML -- so we can author chapters as we go without an
     unwritten or mid-authoring chapter reddening CI. A LOCKED chapter fails when it is off-parity
     (`verdict != 'OK'`), unreliably measured (`boss_drop` -- its scariest unit carries an
-    unmodeled weapon, so even an 'OK' verdict can't be trusted), or has no curated reference at
+    unmodeled weapon, so even an 'OK' verdict can't be trusted), has no curated reference at
     all (`not has_ref` -- you can't lock a chapter the metric can't measure; a config mistake,
-    surfaced loudly). UNLOCKED chapters are informational and never gate; with zero locks the
-    gate passes, so --check can ship before any chapter is locked."""
+    surfaced loudly), or carries an open per-unit `role` finding. UNLOCKED chapters are
+    informational and never gate; with zero locks the gate passes, so --check can ship before
+    any chapter is locked.
+
+    The `role` arm is #284's lesson. ch02 and ch03 shipped bosses that folded in a third of
+    their twin's time, for months, while this gate read OK -- the aggregate sums the whole force
+    and divides by the deploy cap, so one paper boss dissolves into a 23-unit average. The
+    per-unit check had been PRINTING the warning the entire time and nothing read it. A chapter
+    marked balance-final while a per-unit check still has something to say is a contradiction,
+    so locking one now means clearing them first."""
     return [r['label'] for r in rows
-            if r['locked'] and (not r['has_ref'] or r['verdict'] != 'OK' or r['boss_drop'])]
+            if r['locked'] and (not r['has_ref'] or r['verdict'] != 'OK' or r['boss_drop']
+                                or r.get('role'))]
 
 
 def curve_report(campaign, band=0.25):
@@ -1523,8 +1541,13 @@ def curve_report(campaign, band=0.25):
             flag += '  [locked]'
         has_ref = p['vanilla'] is not None
         verdict = p['verdict']['verdict'] if has_ref else None
+        # The per-unit findings ride along so the gate can read them (#284) -- the aggregate
+        # above cannot see a single soft unit, which is exactly how two paper bosses shipped.
+        role = role_findings(chap, p['reference']) if has_ref else []
+        if role:
+            flag += '  !!role'
         rows.append({'label': label[:22].strip(), 'locked': locked, 'has_ref': has_ref,
-                     'verdict': verdict, 'boss_drop': boss_drop})
+                     'verdict': verdict, 'boss_drop': boss_drop, 'role': role})
         if not has_ref:
             print('  %-22s %-13s %5.1f           %5.1f             (no ref)%s'
                   % (label[:22], (p['reference'] or '?')[:13], ot, ol, flag))
@@ -1537,6 +1560,13 @@ def curve_report(campaign, band=0.25):
     if any_dropped_boss:
         print('\n  !! a dropped boss means that row\'s verdict is unreliable -- its scariest '
               'unit\n     carries an unmodeled weapon. Add fe_base to its YAML inventory (#51/#52).')
+    flagged = [r for r in rows if r.get('role')]
+    if flagged:
+        print('\n  !! per-unit findings the per-slot averages above cannot show (#284):')
+        for r in flagged:
+            for f in r['role']:
+                print('     %-6s %s%s' % (r['label'].split()[0], f,
+                                          '' if r['locked'] else '   [not locked -- advisory]'))
     return rows
 
 

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -1607,8 +1607,9 @@ def main():
                     help='emit the campaign-wide enemy-pressure curve (all chapters)')
     ap.add_argument('--check', action='store_true',
                     help='with --curve: the hard CI gate (#48 (b)) -- exit non-zero if any '
-                         'balance_locked chapter is off-parity, unreliably measured, or '
-                         'missing its reference (UNLOCKED chapters never gate)')
+                         'balance_locked chapter is off-parity, unreliably measured, '
+                         'missing its reference, or carrying an open per-unit role '
+                         'finding (UNLOCKED chapters never gate)')
     ap.add_argument('--lord-floor', action='store_true',
                     help='emit the per-lord survivability-floor table instead of the parity report')
     ap.add_argument('--target', type=float, default=3.5, help='floor: target bulk rounds-to-down')
@@ -1621,7 +1622,8 @@ def main():
         if args.check:
             fails = curve_gate_failures(rows)
             if fails:
-                print('\n!! PARITY GATE: %d chapter(s) off-parity or unreliable: %s'
+                print('\n!! PARITY GATE: %d locked chapter(s) off-parity, unreliable, or '
+                      'carrying a role finding: %s'
                       % (len(fails), ', '.join(fails)))
                 bc.sys.exit(1)
             print('\nPARITY GATE: all referenced chapters at parity.')

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -2000,8 +2000,24 @@ class RavisinPortrait(unittest.TestCase):
 
     def test_raw_boss_pid_gets_the_riev_identity(self):
         # The fixture carries EVERY registered raw pid, because raw_pid_portrait_data binds all
-        # of them in one pass -- the moose (0xb9) joined the registry in #25.
-        source = '''[0xb8 - 1] = {
+        # of them -- the moose (0xb9) joined the registry in #25, the grell (0xb7) in #284.
+        # The grell is the case that proves the two bindings are independent: it takes a personal
+        # line and NO identity, so it must keep the generic 0x255 name plate and gain no portrait.
+        source = '''[0xb7 - 1] = {
+        .nameTextId = 0x255,
+        .number = 0xb7,
+        .defaultClass = CLASS_MOGALL,
+        .miniPortrait = 0x4,
+        .baseHP = 0,
+        .basePow = 0,
+        .baseSkl = 0,
+        .baseSpd = 0,
+        .baseDef = 0,
+        .baseRes = 0,
+        .baseLck = 0,
+        .baseCon = 0,
+    },
+    [0xb8 - 1] = {
         .nameTextId = 0x255,
         .defaultClass = CLASS_ARCH_MOGALL,
         .miniPortrait = 0x4,
@@ -2022,18 +2038,21 @@ class RavisinPortrait(unittest.TestCase):
     },'''
         patched = bc.raw_pid_portrait_data(source, self.CAMPAIGN)
         self.assertIn('.nameTextId = 0x246,', patched)
-        self.assertNotIn('.nameTextId = 0x255,', patched)
         self.assertIn('.portraitId = 0x48,', patched)
-        # Ravisin is the only DRESSED raw pid; the moose is named without a bust.
+        # Ravisin is the only DRESSED raw pid; the moose is named without a bust, and the grell
+        # takes neither -- so exactly one name plate stays generic.
         self.assertEqual(1, patched.count('.portraitId'))
         self.assertIn('.nameTextId = 0xD4C,', patched)
-        self.assertEqual(2, patched.count('.miniPortrait = 0x4,'))
+        self.assertEqual(1, patched.count('.nameTextId = 0x255,'))
+        self.assertEqual(3, patched.count('.miniPortrait = 0x4,'))
 
-        ravisin = next(enemy for enemy in bc._load_chapter_yaml(
-            self.CAMPAIGN, bc.CH05_CHAPTER_YAML)['enemy_units']
-            if enemy['id'] == 'ravisin')
-        for field in bc.BASE_FIELDS:
-            self.assertIn('.%s = %d,' % (field, ravisin['personal'].get(field, 0)), patched)
+        for chapter_yaml, uid in ((bc.CH05_CHAPTER_YAML, 'ravisin'),
+                                  (bc.CH03_CHAPTER_YAML, 'grell')):
+            unit = next(enemy for enemy in bc._load_chapter_yaml(
+                self.CAMPAIGN, chapter_yaml)['enemy_units'] if enemy['id'] == uid)
+            for field in bc.BASE_FIELDS:
+                self.assertIn('.%s = %d,' % (field, unit['personal'].get(field, 0)), patched,
+                              '%s personal %s did not reach the character table' % (uid, field))
 
     def test_name_injector_retitles_the_repurposed_riev_slot(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_check_chapter_schema.py
+++ b/tools/test_check_chapter_schema.py
@@ -159,12 +159,51 @@ class TestMalformedYamlIsAViolationNotACrash(unittest.TestCase):
         self.assertTrue(any('is_prologue' in m for m in violations(d)))
 
 
+class TestPersonalLineRoutes(unittest.TestCase):
+    """#284: a `personal:` block is not injected by writing it. The grell's line sat in YAML
+    with no route into the ROM, so it would have measured fixed and played naked -- and the
+    mirror mistake (writing one for a unit whose vanilla SLOT already carries the line) would
+    silently REPLACE the real line with a smaller one and keep the gate green. Every declared
+    line must have exactly one route."""
+
+    def routes(self, d, injected=('grell',), slots=('raider-captain',)):
+        return check._personal_line_route_violations(
+            'chNN.yaml', d, injected_ids=set(injected), slot_ids=set(slots))
+
+    def _chap(self, unit):
+        return {'status': 'active', 'enemy_units': [unit]}
+
+    def test_a_line_with_an_injection_route_is_fine(self):
+        self.assertEqual(self.routes(self._chap(
+            {'id': 'grell', 'personal': {'baseHP': 15}})), [])
+
+    def test_a_unit_with_no_line_is_fine(self):
+        self.assertEqual(self.routes(self._chap({'id': 'whatever'})), [])
+
+    def test_a_line_with_no_injection_route_is_caught(self):
+        msgs = self.routes(self._chap({'id': 'newboss', 'personal': {'baseHP': 9}}))
+        self.assertEqual(len(msgs), 1, msgs)
+        self.assertIn('RAW_PID_PERSONAL_SOURCES', msgs[0])
+
+    def test_a_line_on_a_slot_riding_unit_is_caught(self):
+        # The dangerous direction: it never reaches the ROM *and* it displaces the slot's real
+        # line in the measurement, understating the boss worse than the bug that started #284.
+        msgs = self.routes(self._chap({'id': 'raider-captain', 'personal': {'baseHP': 1}}))
+        self.assertEqual(len(msgs), 1, msgs)
+        self.assertIn('already carries', msgs[0])
+
+
 class TestRealChapters(unittest.TestCase):
     def test_all_repo_chapters_pass(self):
         # Exercise the PUBLIC gate exactly as CI runs it (glob + parse policy
         # included), not a hand-rolled copy of its loop.
         fail = []
         check.check_chapter_deployment_schema(fail)
+        self.assertEqual(fail, [])
+
+    def test_personal_line_routes_gate_passes(self):
+        fail = []
+        check.check_personal_line_injection_routes(fail)
         self.assertEqual(fail, [])
 
 

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -16,6 +16,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import fe_combat as fc
 import difficulty as df
+import build_campaign as bc
 
 
 def combatant(name='u', hp=20, pow_=0, skl=8, spd=0, dfc=0, res=0, lck=0, con=20,
@@ -127,9 +128,10 @@ class CurveGate(unittest.TestCase):
     in-progress chapter never reddens CI. With zero locks the gate passes (enforces
     nothing), so --check can ship before any chapter is locked. (#48 (b), per-chapter)."""
 
-    def _row(self, label, locked=False, has_ref=True, verdict='OK', boss_drop=False):
+    def _row(self, label, locked=False, has_ref=True, verdict='OK', boss_drop=False,
+             role=()):
         return {'label': label, 'locked': locked, 'has_ref': has_ref,
-                'verdict': verdict, 'boss_drop': boss_drop}
+                'verdict': verdict, 'boss_drop': boss_drop, 'role': list(role)}
 
     def test_no_locked_chapters_passes_even_when_some_are_off_parity(self):
         # The unwritten-chapters case: CH3-7 read OFF but aren't locked -> no gate.
@@ -159,6 +161,25 @@ class CurveGate(unittest.TestCase):
 
     def test_unlocked_off_parity_chapter_never_gates(self):
         rows = [self._row('CH2', locked=False, verdict='OFF', boss_drop=True)]
+        self.assertEqual(df.curve_gate_failures(rows), [])
+
+    def test_locked_chapter_with_a_role_finding_fails_even_at_parity(self):
+        # #284: ch02/ch03 shipped paper bosses for months while the aggregate read OK,
+        # because a single soft boss dissolves into a 23-unit average and nothing ever READ
+        # the per-unit warning. A balance-final chapter with an open role finding is a
+        # contradiction, so the gate now reads it.
+        rows = [self._row('CH2', locked=True, verdict='OK',
+                          role=['boss raider-captain takes 1.2 rounds to kill; ...'])]
+        self.assertEqual(df.curve_gate_failures(rows), ['CH2'])
+
+    def test_unlocked_chapter_with_a_role_finding_stays_informational(self):
+        # Mid-authoring chapters warn without reddening CI -- same opt-in as every other
+        # arm of this gate.
+        rows = [self._row('CH6', locked=False, verdict='OK', role=['boss messie takes 2.7 ...'])]
+        self.assertEqual(df.curve_gate_failures(rows), [])
+
+    def test_locked_chapter_with_no_role_findings_passes(self):
+        rows = [self._row('CH2', locked=True, verdict='OK', role=[])]
         self.assertEqual(df.curve_gate_failures(rows), [])
 
 
@@ -997,6 +1018,44 @@ class PersonalBossLine(unittest.TestCase):
         strong = dict(plain, personal={'baseHP': 15, 'baseDef': 5})
         found = df.role_findings({'enemy_units': [strong]}, self.REF)
         self.assertFalse(any('fold too fast' in f for f in found), found)
+
+    def test_a_unit_deployed_on_a_vanilla_slot_inherits_that_slot_s_line(self):
+        """The THIRD source of a personal line (#284). ch02's Halvar deploys on the BAZBA slot
+        and nothing patches it, so FE8 adds Bazba's own line in the built ROM. Measuring him
+        off naked class base understated the boss by 3x and opened an issue against content
+        that was never wrong."""
+        halvar = {'id': 'raider-captain', 'class': 'brigand', 'level': 6, 'is_boss': True,
+                  'inventory': [{'id': 'steel-axe', 'fe_base': 'steel-axe'}]}
+        base = df.enemy_combatants(halvar)[0]
+        real = df.unit_real_article(halvar, base)
+        bazba = df.vanilla_personal_line('CHARACTER_BAZBA')
+        self.assertEqual(real.hp, base.hp + bazba['baseHP'])
+        self.assertEqual(real.df, base.df + bazba['baseDef'])
+
+    def test_a_unit_on_no_vanilla_slot_is_unchanged(self):
+        """A raw-pid creature sits in a CharacterData GAP whose bases are all zero, so it
+        really is a naked class base until a `personal:` line is authored AND injected."""
+        grell = {'id': 'grell', 'class': 'mogall', 'level': 12,
+                 'inventory': [{'id': 'evil-eye', 'fe_base': 'evil-eye'}]}
+        base = df.enemy_combatants(grell)[0]
+        self.assertEqual(df.unit_real_article(grell, base).hp, base.hp)
+
+    def test_no_mapped_slot_is_one_the_build_zeroes(self):
+        """Riding a vanilla slot only counts if the slot survives the build. inject_prologue
+        zeroes its guests' personal bases, so Sephek is a naked class base despite deploying
+        on O'Neill's slot -- reading him off that line inflated his threat to 2.9x the
+        Prologue's ceiling and tripped the gate, which is how this was caught."""
+        zeroed = {'CHARACTER_%s' % s for s in bc.PROLOGUE_ZEROED_GUEST_SLOTS}
+        self.assertEqual(zeroed & set(bc.ENEMY_BASE_SLOT.values()), set())
+
+    def test_an_authored_line_wins_over_the_slot(self):
+        """`personal:` is the explicit authored article; it must not be silently added to a
+        slot's line, or a unit riding a named slot would count its bases twice."""
+        halvar = {'id': 'raider-captain', 'class': 'brigand', 'level': 6,
+                  'personal': {'baseHP': 1},
+                  'inventory': [{'id': 'steel-axe', 'fe_base': 'steel-axe'}]}
+        base = df.enemy_combatants(halvar)[0]
+        self.assertEqual(df.unit_real_article(halvar, base).hp, base.hp + 1)
 
     def test_stacking_terrain_onto_a_boss_line_is_flagged(self):
         """Personal Def and terrain stack; together they can make a boss undentable."""


### PR DESCRIPTION
Closes #284.

## The issue's premise was half wrong, and the wrong half mattered

#284 said ch02 and ch03 both ship naked class-base bosses. **ch03 does. ch02 never did.**

ch02's Halvar **deploys on the BAZBA slot**, and nothing in the build patches it (only `PORTRAIT_MAP` cast slots get rewritten), so the ROM has been adding Bazba's `HP+5/Pow+3/Skl+4/Spd+2/Def+2/Res+2/Lck+1` the whole time. He fights at **HP 29/Def 6 — 3.6 rounds, the bar exactly.** What folded in 1.2 rounds was `difficulty.py`'s model of him.

Doing what the issue asked would have written Bazba's line into ch02's YAML — "fixing" a boss that was never broken and leaving a second copy of a stat line the slot already owns, free to drift from the ROM later. ch02 gets a comment explaining the deliberate absence instead.

## The tool knew two of the three ways a personal line reaches a unit

`unit_real_article()` read `personal:` in chapter YAML and `BASE_DONOR` for a cast member deployed hostile. An enemy on a **vanilla CHARACTER slot** had no representation. `ENEMY_BASE_SLOT` is that third source; each entry points at the constant the injector already builds the unit from, so the slot name is written once.

Verified against the **built** character table rather than by reading the injector:

| our unit | slot | after injection | measured |
|---|---|---|---|
| ch01 `goblin-chief` | BREGUET | unchanged | 5.2 → **6.2** (bar 6.2) |
| ch02 `raider-captain` | BAZBA | unchanged | 1.2 → **3.6** (bar 3.6) |
| ch02 `raider-bruiser` | BONE | unchanged | — |
| ch00 `sephek-kaltro` | ONEILL | **zeroed by the build** | 2.1 (bar 2.2) |

**Riding a slot is not enough — it has to survive the build.** `inject_prologue` zeroes its guests' personal bases on purpose, so Sephek is genuinely naked despite deploying on O'Neill's slot. Mapping him anyway put his threat at **2.9x the Prologue's ceiling** and reddened CH0 — caught by the gate this PR adds, on its first run. `PROLOGUE_ZEROED_GUEST_SLOTS` plus an assert pin that exception to the injector.

## ch03's grell — the one that was really wrong

Raw pid `0xb7`, and a CharacterData gap is all zeros.

No monster boss donor works verbatim. All five named ones (Maelduin, Cyclops, Wight, Deathgoyle, Gorgon) are **promoted late-game** units carrying Pow+5..+10; applied at any level they measure 9.6–20.0 threat against FE8 Ch3's ceiling of **6.8**. Dropping the grell's level doesn't rescue it (a L4 Deathgoyle line still reads 9.6). A vanilla boss line is calibrated against the party that faces it.

So it takes **Maelduin's defensive half near-verbatim** (HP+15/Def+5 against its HP+15/Def+4) and drops the offensive half — Maelduin being the decomp's one defensive monster boss. **3.6 rounds at HP 36/Def 8**: Bazba's bar exactly, just inside Ravisin's 37/10 two chapters later, threat unchanged at 7.6.

Its `level: 12` carried the comment *"level holds boss pressure"* — the bump was standing in for the missing line. It buys offence, not survivability.

## A `personal:` block was not injected by writing it

`RAW_PID_PERSONAL_SOURCES` ran as a **passenger inside the loop over `RAW_PID_PORTRAITS`**, so a line authored for a pid with no portrait binding was silently dropped — exactly the grell's shape, since it keeps the generic monster name plate on purpose. The two bindings are now independent passes. Without this the YAML would have measured fixed and played identical.

## The gate now reads what it had been printing

`role_findings()` emitted ch03's warning for months and nothing consumed it — the aggregate sums the force and divides by the deploy cap, so one soft boss dissolves into a 23-unit average. `curve_gate_failures` now fails a `locked` chapter with an open role finding, and the curve prints findings under the table. Proven in both directions.

## No parity ratio moves — ch02's lock needs no re-baseline

The aggregate resolves both sides off class base on purpose. ch02 reads x0.79/x0.75 before and after; ch03 x1.12/x0.99. **The deliberate re-baseline #284 and HANDOFF anticipated never arises.** That is entirely #285's question; on that footing the grell's line lands ch03 at x1.03/x1.00.

## Audit of every boss

ch00 2.1/2.2 · ch01 6.2/6.2 · ch02 3.6/3.6 · ch03 3.6/3.6 · ch05 13.4/12.9 — all clear. Two open, both elsewhere: **ch06** Messie 2.7 vs 12.9 (`status: planned` seed) and **ch08**'s ice troll **undentable** (Def 15 vs the yardstick's 13) — the same `inf` blocking #285, on our side of the table.

The prologue's mirror case is measured and recorded in the ADR, deliberately not filed (Nicolas, 2026-08-16): Eirika's line is Lck+5 and nothing else, so Hlin loses nothing to the zeroing, but Scramsax measures 5.7 rounds against Seth's 23.8 — a Jeigan missing the line that makes one. ch00 is locked, has shipped, and this is the static proxy.

## Verification

`make test` green (490 + the lua suites) · `tools/check.py` clean · `difficulty.py --curve --check` exit 0 · the grell's line asserted to reach the character table · both new invariants under test. No playtest run: nothing here changes event scripting or map data, and the stat change is asserted at the table it is written to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
