### PR TITLE
The aggregate reads the real article; a floor replaces the exclusion (#285)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5569,6 +5569,70 @@ before changing content to match a number, is what separated the two cases.
 _Decided: 2026-08-16 (#284; the grell's donor and sizing are new, ch02 turned out to need no
 content change)._
 
+### A zero is a cliff, not a measurement — the aggregate reads the real article (2026-08-16, #285)
+
+The parity AGGREGATE projected every unit off **class base**, dropping personal lines on both
+sides. That was defensible while it was symmetric, and it stopped being symmetric the moment
+either side's named units mattered. Both halves are now the real article, and the change moves
+every chapter *toward* 1.00:
+
+| chapter | threat, class base → real | clear-load, class base → real | |
+|---|---|---|---|
+| CH0 | x1.23 → **x1.13** | x1.07 → **x1.00** | `[locked]` |
+| CH1 | x0.89 → **x0.89** | x0.97 → **x0.97** | `[locked]` |
+| CH2 | x0.79 → **x0.81** | x0.75 → **x0.79** | `[locked]` |
+| CH3 | x1.12 → **x1.03** | x0.99 → **x1.00** | |
+| CH4 | x1.15 → **x1.15** | x1.19 → **x1.19** | |
+| CH5 | x1.08 → **x1.04** | x0.84 → **x0.94** | |
+
+**ch02 never falls to x0.64, and finding out why is what unblocked this.** That number was
+measured before #284, when the tool could not see a personal line inherited from a vanilla
+CHARACTER slot — so ch02's boss contributed Bazba's line to the twin's side of the comparison
+and a naked Brigand to ours. With `ENEMY_BASE_SLOT` supplying the third source, ch02 reads
+**x0.79**, inside the band. The blocker was the same missing mechanism that opened #284, not a
+content problem and not the exclusion policy.
+
+**The undentable problem is real, and EXCLUSION was the wrong answer to it.** Vanilla Ch5's Saar
+with his own line sits at Def 13 against the yardstick's 13 attack: exactly zero damage, so
+`rounds_to_kill` is `inf`. The repo's existing mechanism dropped such units from clear-load —
+and dropping them is not symmetric in practice, because the two sides do not field walls in the
+same places:
+
+| | class base | real article |
+|---|---|---|
+| vanilla Saar | 12.9 rounds | **excluded → 0.0** |
+| our Ravisin | 2.9 rounds | **13.4 rounds** |
+
+Ravisin was *deliberately built to Saar's bar* — 13.4 against his 12.9, that is the whole point
+of her personal line — and the metric counted ours in full while zeroing the twin's. On a
+9-slot cap that one asymmetry is +2.9 clear-load per slot: **ch05 read x1.34 with exclusion and
+nothing in the chapter had changed.** An exclusion policy cannot be fixed by applying it
+"symmetrically", because symmetry in the RULE is not symmetry in the RESULT.
+
+**So the metric floors the damage instead of dropping the unit.** `metric_rounds_to_kill()`
+scores an undentable unit as if each hit chipped 1. FE8 really does deal 0 there — the floor is
+a property of the measurement, not a claim about the game — and it earns its place on three
+counts: every unit stays in the comparison on both sides, the load becomes **monotonic in Def**
+(more armour is never less work, where `rounds_to_kill` has a cliff from 12.9 straight to
+infinite), and it preserves the ordering that matters — Saar scores **18.0** against Ravisin's
+**13.4**, which is the truth about which is the harder wall. ch05 lands at **x0.94**.
+
+That also retires the "N yardstick-proof units excluded from clear-load" note as a *mechanism*;
+the count is still printed for planned chapters, because it is worth knowing that a chapter you
+are about to write fields a wall, but nothing is skipped any more.
+
+**No locked baseline goes out of band, and none needed content changes.** All three locked
+chapters move toward parity. The re-baseline this issue and #284 both anticipated turned out to
+be a re-reading, not a re-tuning.
+
+**One consistency fix rode along.** `solo_contributors()` still built our side off class base,
+so the note it prints (*"X alone is N% of this force's threat"*) was computed on a different
+footing from the verdict printed directly above it. A note that cannot reconcile with the number
+it explains is worse than no note.
+
+_Decided: 2026-08-16 (#285). The three locked baselines were re-measured on the new footing and
+all move toward parity; re-locking them is Nicolas's call on the PR._
+
 ---
 
 ## Open Questions (not yet decided)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5583,7 +5583,7 @@ every chapter *toward* 1.00:
 | CH2 | x0.79 → **x0.81** | x0.75 → **x0.79** | `[locked]` |
 | CH3 | x1.12 → **x1.03** | x0.99 → **x1.00** | |
 | CH4 | x1.15 → **x1.15** | x1.19 → **x1.19** | |
-| CH5 | x1.08 → **x1.04** | x0.84 → **x0.94** | |
+| CH5 | x1.08 → **x1.04** | x0.84 → **x0.88** | |
 
 **ch02 never falls to x0.64, and finding out why is what unblocked this.** That number was
 measured before #284, when the tool could not see a personal line inherited from a vanilla
@@ -5614,8 +5614,19 @@ scores an undentable unit as if each hit chipped 1. FE8 really does deal 0 there
 a property of the measurement, not a claim about the game — and it earns its place on three
 counts: every unit stays in the comparison on both sides, the load becomes **monotonic in Def**
 (more armour is never less work, where `rounds_to_kill` has a cliff from 12.9 straight to
-infinite), and it preserves the ordering that matters — Saar scores **18.0** against Ravisin's
-**13.4**, which is the truth about which is the harder wall. ch05 lands at **x0.94**.
+infinite), and it preserves the ordering that matters — Saar scores **22.8** against Ravisin's
+**13.4**, which is the truth about which is the harder wall. ch05 lands at **x0.88**.
+
+**The floor must carry the same accuracy divisor `rounds_to_kill` uses**, and the first
+implementation did not — which broke the very property it was introduced for. Scoring `hp/hits`
+instead of `hp/(hits × accuracy)` made the load jump *down* across the cliff: real Saar read
+**46.8 rounds at Def 11 and 36.0 at Def 12**, a tougher unit costing less work. Worse, the test
+asserting monotonicity could not fail, because its fixture had Spd 0 and Lck 0 — 100% hit chance
+is the one case where the divisor-free form happens to be continuous. **A property test whose
+fixture sits on the only point where the bug is invisible is not a test**; the fixture now uses a
+unit that can be missed. With the divisor the floor is not merely monotonic but *continuous*: a
+unit taking exactly 1 damage per hit already scores `hp/(hits × accuracy)`, so the floor meets
+the last dentable value rather than stepping at it. Caught by `/code-review`, not by the suite.
 
 That also retires the "N yardstick-proof units excluded from clear-load" note as a *mechanism*;
 the count is still printed for planned chapters, because it is worth knowing that a chapter you
@@ -5625,10 +5636,13 @@ are about to write fields a wall, but nothing is skipped any more.
 chapters move toward parity. The re-baseline this issue and #284 both anticipated turned out to
 be a re-reading, not a re-tuning.
 
-**One consistency fix rode along.** `solo_contributors()` still built our side off class base,
-so the note it prints (*"X alone is N% of this force's threat"*) was computed on a different
-footing from the verdict printed directly above it. A note that cannot reconcile with the number
-it explains is worse than no note.
+**One consistency fix rode along, and it was a duplicated force builder.** `solo_contributors()`
+kept its own copy of the our-side expansion, which multiplied `count` over `enemy_combatants` —
+and that collapses a `composition` entry to its DISTINCT classes. On ch01 it therefore counted
+six bodies where the verdict counted three, and printed *"without it the chapter is x1.14"*
+directly beneath a row reading x0.89. Both now come from one `chapter_units()`. A note that
+cannot reconcile with the number it explains is worse than no note, and two functions that must
+agree about the same force will not stay agreeing.
 
 _Decided: 2026-08-16 (#285). The three locked baselines were re-measured on the new footing and
 all move toward parity; re-locking them is Nicolas's call on the PR._

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -356,13 +356,15 @@ def vanilla_enemies(parity_ref):
             weapon = _weapon_from_item_enums(d['items'])
             if weapon is None:
                 continue
-            # NB class base only -- personal boss lines are deliberately excluded from the
-            # AGGREGATE parity metric so both sides resolve on the same footing (adding them
-            # here shifts every curated baseline and can make a boss undentable -> inf
-            # clear-load). The role check below models them, on both sides, where the
-            # boss-vs-boss question actually lives.
-            out.append(_enemy_from_enum('%s#%d' % (array_name, i),
-                                        d['classIndex'], d['level'], weapon))
+            # The REAL ARTICLE (#285): a named vanilla unit fights as class base PLUS its own
+            # CharacterData line, so the aggregate reads it that way -- symmetric with our side,
+            # which resolves its lines through unit_real_article(). Measured off class base,
+            # both sides understated their named units and did so unevenly, because the two
+            # sides carry lines through different mechanisms. `inf` is no longer a hazard here:
+            # metric_rounds_to_kill floors the damage rather than dropping the unit.
+            ch = d.get('charIndex')
+            out.append(_enemy_from_enum('%s#%d' % (array_name, i), d['classIndex'], d['level'],
+                                        weapon, vanilla_personal_line(ch)))
     return out
 
 
@@ -411,20 +413,20 @@ def vanilla_boss_bar(parity_ref):
 
 def vanilla_projection(parity_ref, deploy_cap):
     """Forward target for a PLANNED chapter (#123): its vanilla reference's own pressure,
-    printed as the bar the authored chapter must land within the parity band of. threat/slot
-    counts the FULL force (every enemy attacks); clear-load/slot skips units the fixed
-    YARDSTICK cannot damage at all (a promoted wall would otherwise read `inf` -- their count
-    is returned so the row can say so instead of hiding them). None if the reference isn't
-    curated. Purely informational: planned chapters never gate."""
+    printed as the bar the authored chapter must land within the parity band of. Both halves
+    count the FULL force: `proof` still reports how many units the fixed YARDSTICK cannot dent,
+    because that is worth knowing about a chapter you are about to write, but they are no longer
+    SKIPPED -- metric_rounds_to_kill floors them (#285). Skipping made a chapter with a wall
+    look cheaper to clear than one without. None if the reference isn't curated. Purely
+    informational: planned chapters never gate."""
     van = vanilla_enemies(parity_ref)
     if van is None:
         return None
     cap = max(1, deploy_cap)
     threat = sum(fc.damage_per_round(e, YARDSTICK) for e in van) / cap
-    dentable = [e for e in van if fc.damage(YARDSTICK, e) > 0]
-    clearload = sum(fc.rounds_to_kill(YARDSTICK, e) for e in dentable) / cap
-    return {'threat': threat, 'clearload': clearload,
-            'n': len(van), 'proof': len(van) - len(dentable)}
+    clearload = sum(metric_rounds_to_kill(e) for e in van) / cap
+    return {'threat': threat, 'clearload': clearload, 'n': len(van),
+            'proof': sum(1 for e in van if fc.damage(YARDSTICK, e) <= 0)}
 
 
 def _ally_combatant(char_enum, class_enum, weapon):
@@ -479,7 +481,13 @@ def pressure_verdict(ours, vanilla, band=0.25):
 def chapter_enemy_force(chap):
     """Our chapter's full enemy force as a flat per-unit Combatant list (bosses included),
     honoring each entry's `count`/`composition` -- the multiplicity enemy_combatants drops.
-    This is the our-side input to enemy_pressure (the parity comparand to vanilla_enemies)."""
+    This is the our-side input to enemy_pressure (the parity comparand to vanilla_enemies).
+
+    Every unit resolves to its REAL ARTICLE (#285) -- class base plus whichever of the three
+    personal-line sources applies (`personal:`, BASE_DONOR, ENEMY_BASE_SLOT). A `composition`
+    entry is a mixed bag of generics, which carry no line, so unit_real_article is a no-op
+    there; it is applied uniformly anyway so the footing is a property of this function rather
+    than of which branch a chapter's YAML happens to take."""
     out = []
     for ed in chap.get('enemy_units', []):
         if 'composition' in ed and 'class' not in ed:
@@ -488,10 +496,11 @@ def chapter_enemy_force(chap):
             by_class = ed.get('inventory_by_class', {})
             for cls in ed.get('composition', []):
                 weapon = _weapon_for([{'id': w} for w in by_class.get(cls, [])])
-                out.append(_one_enemy('%s-%s' % (name, cls), cls, level, weapon))
+                out.append((ed, _one_enemy('%s-%s' % (name, cls), cls, level, weapon)))
         else:
-            out.extend(enemy_combatants(ed) * int(ed.get('count', 1)))
-    return [u for u in out if u.weapon is not None]   # drop unmodeled-weapon (staff) enemies
+            out.extend([(ed, c) for c in enemy_combatants(ed)] * int(ed.get('count', 1)))
+    # drop unmodeled-weapon (staff) enemies
+    return [unit_real_article(ed, u) for ed, u in out if u.weapon is not None]
 
 
 def unmodeled_enemies(chap):
@@ -556,17 +565,40 @@ YARDSTICK = fc.Combatant('yardstick', hp=24, pow=8, skl=8, spd=8, df=6, res=4, l
                          con=10, weapon=fc.W['iron-sword'])
 
 
+def metric_rounds_to_kill(enemy, yardstick=YARDSTICK):
+    """`rounds_to_kill` with a MEASUREMENT floor: a unit the yardstick cannot dent is scored as
+    if each hit chipped 1, instead of reading `inf`.
+
+    FE8 really does deal 0 damage there -- this floor is a property of the metric, not a claim
+    about the game. It exists because `rounds_to_kill` is a CLIFF at the damage boundary: one
+    more point of Def takes a unit from 12.9 rounds to infinite, and a ratio against infinity is
+    undefined. The old answer was to EXCLUDE such units from clear-load, and that is what made
+    the aggregate asymmetric (#285): vanilla Ch5's Saar dropped out of the twin's sum entirely
+    while our Ravisin -- deliberately built to Saar's own bar, 13.4 rounds against his 12.9 --
+    stayed in, moving ch05 from x0.84 to x1.34 without a single unit changing.
+
+    The floor keeps every unit in the comparison on both sides, keeps the load monotonic in Def
+    (more armour is never less work), and preserves the ordering that matters: Saar at Def 13
+    scores 18.0 against Ravisin's 13.4, which is the truth about which is the harder wall.
+    """
+    rounds = fc.rounds_to_kill(yardstick, enemy)
+    if rounds != float('inf'):
+        return rounds
+    hits = 2 if fc.doubles(yardstick, enemy) else 1
+    return float(enemy.hp) / hits
+
+
 def enemy_pressure(enemies, deploy_cap, yardstick=YARDSTICK):
     """Per-deploy-slot enemy pressure of an enemy list, as (threat/slot, clear-load/slot).
 
     threat/slot = Σ damage_per_round(enemy -> yardstick) ÷ deploy_cap -- how much incoming
-    damage each of our slots must weather. clear-load/slot = Σ yardstick rounds_to_kill(enemy)
+    damage each of our slots must weather. clear-load/slot = Σ metric_rounds_to_kill(enemy)
     ÷ deploy_cap -- how much killing each slot must do to clear the map. Both measured against
     the fixed YARDSTICK so ours and the vanilla reference land on one scale; the metric is a
     static proxy (no positioning/AI/terrain), read as a ratio within a tolerance band."""
     cap = max(1, deploy_cap)
     threat = sum(fc.damage_per_round(e, yardstick) for e in enemies) / cap
-    clearload = sum(fc.rounds_to_kill(yardstick, e) for e in enemies) / cap
+    clearload = sum(metric_rounds_to_kill(e, yardstick) for e in enemies) / cap
     return threat, clearload
 
 
@@ -998,8 +1030,11 @@ def solo_contributors(chap, parity_ref, deploy_cap, floor=1.0, share=0.10):
     rows = []
     for ed in chap.get('enemy_units', []):
         for c in enemy_combatants(ed):
+            # Real article, matching the verdict this note is printed under (#285) -- a note
+            # computed on a different footing than the number it explains is worse than none.
+            real = unit_real_article(ed, c)
             rows += [(ed.get('id') or c.name, int(ed.get('count', 1)),
-                      fc.damage_per_round(c, YARDSTICK))] * int(ed.get('count', 1))
+                      fc.damage_per_round(real, YARDSTICK))] * int(ed.get('count', 1))
     total = sum(t for _u, _n, t in rows)
     full = (total / cap) / vt
     if full <= floor:
@@ -1526,7 +1561,7 @@ def curve_report(campaign, band=0.25):
                 print('  %-22s %-13s   -- planned (seed; reference not curated yet) --'
                       % (label[:22], ref[:13]))
             else:
-                note = (' (%d yardstick-proof units excluded from clear-load)'
+                note = (' (%d yardstick-proof units, clear-load floored)'
                         % proj['proof']) if proj['proof'] else ''
                 print('  %-22s %-13s %4.1f (target)    %4.1f (target)      planned%s'
                       % (label[:22], ref[:13], proj['threat'], proj['clearload'], note))

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -485,9 +485,20 @@ def chapter_enemy_force(chap):
 
     Every unit resolves to its REAL ARTICLE (#285) -- class base plus whichever of the three
     personal-line sources applies (`personal:`, BASE_DONOR, ENEMY_BASE_SLOT). A `composition`
-    entry is a mixed bag of generics, which carry no line, so unit_real_article is a no-op
-    there; it is applied uniformly anyway so the footing is a property of this function rather
-    than of which branch a chapter's YAML happens to take."""
+    entry is a mixed bag of GENERICS, so no personal line is applied to its members -- a
+    `personal:` or a donor-matching id on such an entry describes the group, and adding a full
+    character line to every body in the bag would be a silent multiplier."""
+    return [u for _ed, u in chapter_units(chap)]
+
+
+def chapter_units(chap):
+    """(enemy_def, real-article Combatant) for every BODY our chapter fields, weapons modeled.
+
+    THE our-side force builder. It exists as one function because it was two: `solo_contributors`
+    kept a second copy that expanded `count` over `enemy_combatants` -- which collapses a
+    `composition` to its DISTINCT classes -- so on ch01 it counted 6 bodies where this counts 3
+    and printed a share that contradicted the verdict directly above it (#285).
+    """
     out = []
     for ed in chap.get('enemy_units', []):
         if 'composition' in ed and 'class' not in ed:
@@ -496,11 +507,12 @@ def chapter_enemy_force(chap):
             by_class = ed.get('inventory_by_class', {})
             for cls in ed.get('composition', []):
                 weapon = _weapon_for([{'id': w} for w in by_class.get(cls, [])])
+                # generics: no personal line, deliberately (see chapter_enemy_force)
                 out.append((ed, _one_enemy('%s-%s' % (name, cls), cls, level, weapon)))
         else:
-            out.extend([(ed, c) for c in enemy_combatants(ed)] * int(ed.get('count', 1)))
-    # drop unmodeled-weapon (staff) enemies
-    return [unit_real_article(ed, u) for ed, u in out if u.weapon is not None]
+            out.extend([(ed, unit_real_article(ed, c)) for c in enemy_combatants(ed)]
+                       * int(ed.get('count', 1)))
+    return [(ed, u) for ed, u in out if u.weapon is not None]  # drop staff-only enemies
 
 
 def unmodeled_enemies(chap):
@@ -579,13 +591,23 @@ def metric_rounds_to_kill(enemy, yardstick=YARDSTICK):
 
     The floor keeps every unit in the comparison on both sides, keeps the load monotonic in Def
     (more armour is never less work), and preserves the ordering that matters: Saar at Def 13
-    scores 18.0 against Ravisin's 13.4, which is the truth about which is the harder wall.
+    scores 22.8 against Ravisin's 13.4, which is the truth about which is the harder wall.
+
+    It must carry the SAME hit-chance divisor `rounds_to_kill` uses, or it is not a floor at
+    all: dropping it makes the load jump DOWN across the cliff (real Saar read 46.8 rounds at
+    Def 11 and 36.0 at Def 12 -- tougher unit, less work), which is the exact pathology this
+    function exists to remove. With it the floor is not merely monotonic but CONTINUOUS: a unit
+    taking exactly 1 damage per hit already scores hp/(hits x accuracy), so the floor meets the
+    last dentable value instead of stepping at it.
     """
     rounds = fc.rounds_to_kill(yardstick, enemy)
     if rounds != float('inf'):
         return rounds
     hits = 2 if fc.doubles(yardstick, enemy) else 1
-    return float(enemy.hp) / hits
+    accuracy = fc.hit_chance(yardstick, enemy) / 100.0
+    if accuracy <= 0:                 # cannot connect at all -- no finite load to report
+        return float('inf')
+    return float(enemy.hp) / (hits * accuracy)
 
 
 def enemy_pressure(enemies, deploy_cap, yardstick=YARDSTICK):
@@ -1027,14 +1049,10 @@ def solo_contributors(chap, parity_ref, deploy_cap, floor=1.0, share=0.10):
     vt = sum(fc.damage_per_round(e, YARDSTICK) for e in van) / cap
     if vt <= 0:
         return []
-    rows = []
-    for ed in chap.get('enemy_units', []):
-        for c in enemy_combatants(ed):
-            # Real article, matching the verdict this note is printed under (#285) -- a note
-            # computed on a different footing than the number it explains is worse than none.
-            real = unit_real_article(ed, c)
-            rows += [(ed.get('id') or c.name, int(ed.get('count', 1)),
-                      fc.damage_per_round(real, YARDSTICK))] * int(ed.get('count', 1))
+    # Built from the SAME force builder as the verdict this note is printed under (#285) -- a
+    # note computed on a different footing than the number it explains is worse than none.
+    rows = [(ed.get('id') or u.name, int(ed.get('count', 1)),
+             fc.damage_per_round(u, YARDSTICK)) for ed, u in chapter_units(chap)]
     total = sum(t for _u, _n, t in rows)
     full = (total / cap) / vt
     if full <= floor:
@@ -1071,7 +1089,10 @@ def role_findings(chap, parity_ref):
         return []
     out = []
     van_threat = vanilla_threat_ceiling(parity_ref)
-    van_tank = max(fc.rounds_to_kill(YARDSTICK, e) for e in van)
+    # Floored (#285): vanilla_enemies now carries personal lines, so the twin's tankiest unit can
+    # be undentable -- FE8 Ch5 went 12.9 -> inf. This is the fallback bar used when the twin has
+    # no named boss, and an `inf` bar would flag every boss we ever field as folding too fast.
+    van_tank = max(metric_rounds_to_kill(e) for e in van)
     for uid, _is_boss, c, conv, _tile in ours:
         t = fc.damage_per_round(c, YARDSTICK)
         if van_threat > 0 and t > van_threat * 1.25:

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -926,9 +926,10 @@ class RoleCheck(unittest.TestCase):
         cap, so one unit's 24.6 becomes +2.7 a slot and vanishes under a +-25% band. This prints
         the sentence that had to be computed by hand to catch it."""
         # sized to clear the x1.0 floor, as the real ch05 force does -- the note is about a
-        # chapter that PASSES while one unit carries the excess.
+        # chapter that PASSES while one unit carries the excess. (#285 raised the vanilla side
+        # by giving its named units their real lines, so the grunt count rose with it.)
         chap = self._chap([
-            {'id': 'grunt', 'class': 'soldier', 'level': 5, 'count': 15,
+            {'id': 'grunt', 'class': 'soldier', 'level': 5, 'count': 20,
              'inventory': [{'id': 'iron-lance', 'fe_base': 'iron-lance'}]},
             {'id': 'monster', 'class': 'gwyllgi', 'level': 6,
              'inventory': [{'id': 'claw', 'fe_base': 'hell-fang'}]},
@@ -1001,14 +1002,24 @@ class PersonalBossLine(unittest.TestCase):
         self.assertEqual(df.vanilla_personal_line('0x80'), {})
         self.assertEqual(df.vanilla_personal_line(None), {})
 
-    def test_aggregate_stays_class_base_only(self):
-        """Personal lines must not leak into enemy_combatants -- that is what keeps ours and
-        the vanilla reference on the same footing (and keeps a Def-13 boss from reading inf)."""
+    def test_enemy_combatants_is_still_the_class_base_primitive(self):
+        """enemy_combatants stays the raw class-base projection -- the real article is layered
+        on by chapter_enemy_force, so the primitive has one job and callers choose the footing."""
         plain = {'id': 'b', 'class': 'druid', 'level': 7,
                  'inventory': [{'id': 'flux', 'fe_base': 'flux'}]}
         withline = dict(plain, personal={'baseHP': 15, 'baseDef': 5})
         self.assertEqual(df.enemy_combatants(plain)[0].hp,
                          df.enemy_combatants(withline)[0].hp)
+
+    def test_the_aggregate_force_carries_personal_lines(self):
+        """#285: the aggregate reads the REAL ARTICLE on our side. Measuring a boss off class
+        base understated every named unit, and it understated them asymmetrically -- ours by
+        `personal:`, the twin's by its own character lines."""
+        chap = {'enemy_units': [{'id': 'b', 'class': 'druid', 'level': 7, 'count': 1,
+                                 'personal': {'baseHP': 15, 'baseDef': 5},
+                                 'inventory': [{'id': 'flux', 'fe_base': 'flux'}]}]}
+        force = df.chapter_enemy_force(chap)
+        self.assertEqual(force[0].hp, df.enemy_combatants(chap['enemy_units'][0])[0].hp + 15)
 
     def test_personal_line_lifts_the_boss_in_the_role_check(self):
         plain = {'id': 'boss', 'class': 'druid', 'level': 7, 'is_boss': True,
@@ -1064,6 +1075,36 @@ class PersonalBossLine(unittest.TestCase):
                 'inventory': [{'id': 'flux', 'fe_base': 'flux'}]}
         found = df.role_findings({'enemy_units': [boss]}, self.REF)
         self.assertTrue(any('cannot be damaged' in f for f in found), found)
+
+
+class MetricRoundsToKill(unittest.TestCase):
+    """#285: `rounds_to_kill` is a CLIFF at the damage boundary -- one more point of Def takes a
+    unit from 12.9 rounds to infinite, because FE8 has no chip-damage floor. Excluding those
+    units was the old answer and it is not symmetric: vanilla Ch5's Saar dropped out of the
+    twin's clear-load while our Ravisin -- built to Saar's own bar, 13.4 rounds against his
+    12.9 -- stayed in, which alone moved ch05 from x0.84 to x1.34. The METRIC floors damage at
+    1; the game does not."""
+
+    def _wall(self, df_):
+        return combatant('wall', hp=36, dfc=df_, spd=0, con=20)
+
+    def test_a_dentable_unit_is_untouched_by_the_floor(self):
+        u = self._wall(4)
+        self.assertEqual(df.metric_rounds_to_kill(u), fc.rounds_to_kill(df.YARDSTICK, u))
+
+    def test_an_undentable_unit_is_finite_not_infinite(self):
+        u = self._wall(30)
+        self.assertEqual(fc.rounds_to_kill(df.YARDSTICK, u), float('inf'))
+        self.assertLess(df.metric_rounds_to_kill(u), float('inf'))
+
+    def test_the_floor_is_monotonic_across_the_damage_cliff(self):
+        """The property that makes it a measurement: more Def is never LESS load."""
+        loads = [df.metric_rounds_to_kill(self._wall(d)) for d in range(2, 24)]
+        self.assertEqual(loads, sorted(loads), loads)
+
+    def test_a_wall_outweighs_a_merely_tough_unit(self):
+        self.assertGreater(df.metric_rounds_to_kill(self._wall(20)),
+                           df.metric_rounds_to_kill(self._wall(10)))
 
 
 class Terrain(unittest.TestCase):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -1086,7 +1086,10 @@ class MetricRoundsToKill(unittest.TestCase):
     1; the game does not."""
 
     def _wall(self, df_):
-        return combatant('wall', hp=36, dfc=df_, spd=0, con=20)
+        """A wall that can be MISSED. spd/lck 0 would pin hit chance at 100%, which is the one
+        case where a floor without the accuracy divisor happens to be continuous -- i.e. the
+        fixture that cannot catch the bug this class exists to prevent."""
+        return combatant('wall', hp=36, dfc=df_, spd=6, lck=4, con=20)
 
     def test_a_dentable_unit_is_untouched_by_the_floor(self):
         u = self._wall(4)
@@ -1098,9 +1101,19 @@ class MetricRoundsToKill(unittest.TestCase):
         self.assertLess(df.metric_rounds_to_kill(u), float('inf'))
 
     def test_the_floor_is_monotonic_across_the_damage_cliff(self):
-        """The property that makes it a measurement: more Def is never LESS load."""
+        """The property that makes it a measurement: more Def is never LESS load. Dropping the
+        accuracy divisor breaks exactly this -- real Saar read 46.8 rounds at Def 11 and 36.0
+        at Def 12, a tougher unit scoring less work."""
         loads = [df.metric_rounds_to_kill(self._wall(d)) for d in range(2, 24)]
         self.assertEqual(loads, sorted(loads), loads)
+
+    def test_the_floor_meets_the_last_dentable_value_without_stepping(self):
+        """Stronger than monotonic: a unit taking exactly 1 damage per hit already scores
+        hp/(hits x accuracy), so the floor is CONTINUOUS with the curve it extends."""
+        one_dmg = max(d for d in range(2, 30)
+                      if fc.damage(df.YARDSTICK, self._wall(d)) == 1)
+        self.assertAlmostEqual(df.metric_rounds_to_kill(self._wall(one_dmg)),
+                               df.metric_rounds_to_kill(self._wall(one_dmg + 1)), places=6)
 
     def test_a_wall_outweighs_a_merely_tough_unit(self):
         self.assertGreater(df.metric_rounds_to_kill(self._wall(20)),


### PR DESCRIPTION
Closes #285.

**Needs your sign-off on one thing:** re-locking CH0/CH1/CH2 on the new footing (the DoD item). All three move *toward* parity and none leaves the band — table below.

## Both sides now read the real article

| chapter | threat | clear-load | |
|---|---|---|---|
| CH0 | x1.23 → **x1.13** | x1.07 → **x1.00** | `[locked]` |
| CH1 | x0.89 → **x0.89** | x0.97 → **x0.97** | `[locked]` |
| CH2 | x0.79 → **x0.81** | x0.75 → **x0.79** | `[locked]` |
| CH3 | x1.12 → **x1.03** | x0.99 → **x1.00** | |
| CH4 | x1.15 → **x1.15** | x1.19 → **x1.19** | |
| CH5 | x1.08 → **x1.04** | x0.84 → **x0.88** | |

Every chapter moves toward 1.00, which is the point: class base was not a conservative footing, it was a systematically wrong one.

## ch02 never falls to x0.64

That number was measured **before #284**, when the tool could not see a personal line inherited from a vanilla CHARACTER slot. ch02's boss was contributing Bazba's line to the *twin's* side of the comparison and a naked Brigand to ours. With `ENEMY_BASE_SLOT` supplying the third source it reads **x0.79**, inside the band.

So this issue's stated blocker was the same missing mechanism that opened #284 — not a content problem in ch02, and not the exclusion policy. **The DoD item "ch02 resolved (expected to follow from #284)" is satisfied, though not for the reason either issue predicted.**

## Exclusion was the wrong answer, and "apply it symmetrically" could not have saved it

Vanilla Ch5's Saar with his own line sits at Def 13 against the yardstick's 13 attack — exactly zero damage, `rounds_to_kill` = `inf`. The existing mechanism dropped such units from clear-load. But the two sides do not field walls in the same places:

| | class base | real article |
|---|---|---|
| vanilla Saar | 12.9 rounds | **excluded → 0.0** |
| our Ravisin | 2.9 rounds | **13.4 rounds** |

Ravisin was *deliberately built to Saar's bar* — 13.4 against his 12.9 is the entire purpose of her personal line. The metric counted ours in full and zeroed the twin's. On a 9-slot cap that one asymmetry is +2.9 clear-load per slot: **ch05 read x1.34 with exclusion and nothing in the chapter had changed.**

Symmetry in the *rule* is not symmetry in the *result*.

## A floor instead

`metric_rounds_to_kill()` scores an undentable unit as if each hit chipped 1. FE8 really does deal 0 there — this is a property of the measurement, not a claim about the game. It earns its place three ways:

- **both sides stay whole** — nothing is ever dropped from the comparison;
- **load becomes monotonic in Def** — `rounds_to_kill` cliffs from 12.9 straight to infinite, so one point of armour could swing a chapter's verdict;
- **the ordering survives** — Saar scores **22.8** against Ravisin's **13.4**, which is the truth about which is the harder wall.

ch05 lands at **x0.88**. The "N yardstick-proof units excluded from clear-load" mechanism is retired; the *count* is still printed for planned chapters, because it's worth knowing a chapter you're about to write fields a wall.

## What `/code-review` caught, before you sign anything off

**The floor had a correctness bug, and its test couldn't fail.** `metric_rounds_to_kill` scored `hp/hits` but `rounds_to_kill` also divides by hit chance — so the load jumped *down* across the cliff it was introduced to smooth: real Saar read **46.8 rounds at Def 11 and 36.0 at Def 12**, a tougher unit costing less work. The monotonicity test used a wall with Spd 0/Lck 0, pinning hit chance at 100% — the one point where the divisor-free form happens to be continuous. A property test whose fixture sits where the bug is invisible is not a test.

Fixed, and the numbers above are the corrected ones (Saar 22.8 not 18.0; ch05 x0.88 not x0.94). With the divisor the floor is *continuous*, not merely monotonic: a unit taking exactly 1 damage per hit already scores `hp/(hits × accuracy)`, so the floor meets the last dentable value instead of stepping at it.

Three more from the same review:

- `solo_contributors()` kept a **duplicate our-side force builder** that expanded `count` over `enemy_combatants`, which collapses a `composition` to its distinct classes. On ch01 it counted 6 bodies against the verdict's 3, printing *"without it the chapter is x1.14"* under a row reading x0.89. Both now come from one `chapter_units()`.
- `van_tank` was the last `vanilla_enemies` consumer without the floor — with personal lines the twin's tankiest unit can be undentable (FE8 Ch5: 12.9 → `inf`), and it's the fallback bar used when a twin has no named boss.
- the composition branch applied the *group's* `enemy_def` to every member, so a `personal:` there would have added a full character line to each generic. Now enforced rather than asserted.

## Verification

`make test` green (35 blocks) · `tools/check.py` clean · `difficulty.py --curve --check` exit 0 · 4 new tests pin the floor's properties (identity below the cliff, finite above it, monotonic across it, ordering preserved). The measurement bench was validated against the tool's own class-base output on all six chapters before any of it was trusted.

No chapter needed a content change. The re-baseline #284 and #285 both anticipated turned out to be a re-reading, not a re-tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
