### PR TITLE
Basil is she, including in the ending that mourns her (#25)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -1570,6 +1570,9 @@ events:
       had one for her" works in both worlds and is the harder line anyway.
       LOCKED 2026-07-30 (dialogue-pass, co-written with Nicolas) after two red-pen passes.
       10 boxes; twin is 24.
+      PRONOUNS CORRECTED 2026-08-19: two boxes called Basil "he" ("...He's gone.", "If he'd
+      lived"). She is `gender: female` (npcs/basil.yaml) — settled 2026-08-08, AFTER this text
+      was locked, so the lock simply predates the decision. Box count and rhythm unchanged.
     status: locked                    # ADOPTED + LOCKED 2026-07-30 after two red-pen passes
     script:                           # LOCKED 2026-07-30 (dialogue-pass, co-written with Nicolas)
       # (The hollow. Ravisin down. Basil is in the snow where she fell, root-feet turned up,
@@ -1593,12 +1596,12 @@ events:
       #  is universal rather than about Sahnar, so it does not collide with the death quote.)
       - basil: "...I couldn't make enough berries..."
       - basil: "......"
-      - prof-rbg: "...He's gone."
+      - prof-rbg: "...She's gone."
       # (From here it is 0x9C9's back half, near-verbatim, as vanilla does it.)
       - prof-rbg: "...The fishing town would be Bremen."
       # (CUT 2026-07-30 (Nicolas): "Nobody's hired us for a lake" -- out of BOTH endings. See 0x9C9.)
       # (The ONE changed line, in vanilla's own place: what the loss cost the party in facts.)
-      - braulo: "If he'd lived we'd know more. ...We go down the coast."
+      - braulo: "If she'd lived we'd know more. ...We go down the coast."
     no_lupin_fallback:                # TEXT CHOSEN 2026-07-30 (Nicolas) — WIRING NOT BUILT.
       boxes: [3]                      #   The locked script above is unchanged and still plays
                                       #   whenever Lupin WAS recruited.


### PR DESCRIPTION
Scene 17 (`0x9CA`, the Basil-died ending) called her **"he"** twice — RBG's `"...He's gone."` and Braulo's `"If he'd lived we'd know more."` She is `gender: female` in `npcs/basil.yaml`.

Not a contradiction anyone introduced: that text was **locked 2026-07-30**, her pronouns were settled **2026-08-08**, so the lock simply predates the decision. Found while reading the endings ahead of wiring them.

The scene is unwired, so nothing has shipped — but it would have been written straight into the ROM by the endings work, in the one scene whose entire job is to mourn her.

Box count, rhythm, and the deliberate one-changed-clause structure are unchanged. Drift check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)