### PR TITLE
ch05: the Talk recruit's no-Lupin arm, in vanilla's shape (#25)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -1369,9 +1369,9 @@ events:
       - sahnar: "...Thank you, little one."
       # (Last box before gameplay resumes. She never answers.)
       - basil: "...Can I give you a berry now?"
-    no_lupin_fallback:                # TEXT CHOSEN 2026-07-30 (Nicolas, L5) — WIRING NOT BUILT.
-      boxes: [8]                      #   The locked script above is unchanged and still plays
-                                      #   whenever Lupin WAS recruited.
+    no_lupin_fallback:                # TEXT CHOSEN 2026-07-30 (Nicolas, L5); BOXED + WIRED
+      boxes: [8]                      #   2026-08-21 (#25). The locked script above is unchanged
+                                      #   and still plays whenever Lupin WAS recruited.
       replaces:                       # anchored to the text, so an index cannot silently drift
         - "A wolf. Him and his whole pack. They're out there now, with travelers."
       reason: >-
@@ -1385,8 +1385,21 @@ events:
         OPEN: box 6 is kept at v0 (Nicolas), but "SOME of her creatures broke free" asserts a
         plural this branch has no evidence for — the wolf is the only other one. One word ("One
         of her creatures") closes it; flagged rather than changed, because v0 was an explicit pick.
+      # ONE replaced box, TWO boxes of substitute — the nested list is the shape that says so.
+      # HAND-BOXED, which is VANILLA'S CONVENTION and not a house style: every [LF] and every
+      # [A] in `texts.txt` is authored, and MSG_9CC — the Natasha→Joshua recruit this very
+      # scene is the twin of — places all 32 of its own page breaks. Nothing there is flowed.
+      # The substitute is 61 characters against the bubble's 29, so it cannot be one box; left
+      # to the wrapper it paged itself at "We could go free as" / "well.", which is the
+      # mid-clause break the reliquary lines and scene 5's fallback both already taught.
+      # BREAK ON THE ELLIPSIS. It is the only punctuation the line has, and it is also the
+      # right read: the observation lands flat, and then the OFFER — which IS proof #1 in this
+      # arm, Basil arguing the two of them could go rather than citing a wolf who went — takes
+      # its own press instead of trailing the clause it answers. Same 2-lines-then-1 asymmetry
+      # scene 6 took at its own full stop.
       script:
-        - basil: "There is nothing holding us here... We could go free as well."
+        - - basil: "There is nothing holding us here..."
+          - basil: "We could go free as well."
   # ── 9C7 — BOSS TAUNT. One box. Vanilla's Saar taunt is ONE A-press. ──────────
   # BASIL HAS NO CHAPTER-SPECIFIC DEATH BOX, and the empty vanilla 0x9C6 anatomy slot is not an
   # invitation to write one (Nicolas, 2026-08-16). Vanilla fills it for Natasha because the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4536,6 +4536,90 @@ Against #25's four states this settles **two**: *never recruited* (the plain boo
 still only a decomp reading — `CHECK_ALIVE` ignores `US_NOT_DEPLOYED` and treats `US_DEAD` as
 absent — and a reading is not a run.
 
+### Two arms of one branch can be the same LENGTH — so box count is not a witness (2026-08-21, #25)
+
+Every ch05 scene is gated in-engine by counting A-presses: a scene of the wrong length is a scene
+from the wrong place, and that is what caught the Talk recruit pointing at vanilla's 32-box `0x9CC`
+for months. Building the Talk's no-Lupin arm broke the technique, and it broke it **silently**.
+
+The locked box 8 (*"A wolf. Him and his whole pack. They're out there now, with travelers."*) is 70
+characters against the bubble's 29, so the wrapper pages it in **two**. The substitute is **two
+authored boxes**. Both arms therefore render to **21 presses exactly**, and `ch05recruit` — which
+asserts 21 — passes on either one. A gate that can only fail when the length changes cannot see a
+branch that took the wrong arm, which is the one thing a branch can get wrong.
+
+**The witness is `sActiveMsg` (`src/msg.c`).** `GetStringFromIndex` caches the index it last decoded
+(`if (index == sActiveMsg) return sMsgString.buffer1;`), so reading that int names the message on
+screen. Two rules for using it:
+
+- **Sample it WHILE A BOX IS UP.** Unit names, menus and item descriptions all decode through the
+  same buffer, so by the verdict at the bottom of a scenario it is long overwritten. `ch05recruit`
+  latches it on the first `dialogue_wait` of the scene.
+- **It names the id, not the prose.** It cannot tell you the text is right — only which id played.
+  The prose is the build tests' job; this is the runtime half.
+
+Generalises past this scene: **the box count is a shape check and the message id is an identity
+check, and #25 wanted identity all along** ("Assert *which* message id played … not merely that a
+scene ran"). Box counts were standing in for identity only because two ids had always differed in
+length. Prefer `INSPECT.activeMsg()` for any new dialogue gate.
+
+_Recorded: 2026-08-21, found while wiring the Talk recruit's fallback (#25)._
+
+### The last two `CHECK_ALIVE` states, proved (2026-08-21, #25)
+
+The four states vanilla distinguishes are now all four run, not three run and one read. The two
+that were owed were settled on the `ch05lupinboot` ROM by putting the wolf in each state at the map
+and reading which message the Talk played:
+
+| Roster state | Poked | Arm played | |
+|---|---|---|---|
+| recruited, alive, **BENCHED** | `US_NOT_DEPLOYED`, off the tile grid, `xPos = -1` | the wolf's | ✅ `ch05lupinbenched` |
+| recruited, then **KILLED** | `US_DEAD` | the no-Lupin one | ✅ `ch05lupinkilled` |
+
+**The benched run is the one that matters**, and it is why "test whether Lupin is on the ch05 field"
+was recorded as *actively wrong* rather than merely inelegant: ch05 deploys 9 of a 10-unit pool, so
+a field test passes every other gate in this chapter and then tells a player who WON the wolf that
+he does not exist. The run says our build reads the roster, not the map — which is what
+`eventscr.c:3212` says, now with a run behind it.
+
+**Both rode the existing scenario rather than new ones.** `ch05recruit` is parameterised over the
+wolf's roster state and the expected arm; the two states are four-line callers. That also keeps
+`harness.lua` at its 2 free top-level local slots — the ceiling that, hit, stops the whole chunk
+loading (`check.py` says so on every run, and names the escape hatch: hang the helper off an
+existing table). `INSPECT.activeMsg` went on `INSPECT` for exactly that reason.
+
+Not covered, and not pretended otherwise: the poke reproduces the STATE a benched unit is in, not
+the route by which a player gets there. The real ch04 → ch05 chain remains the only thing that
+exercises `ReadGameSave` filling the array.
+
+_Recorded: 2026-08-21 (Nicolas: "Run them")._
+
+### A page break is AUTHORED, and vanilla is the reason (2026-08-21, #25)
+
+Written down because it kept being re-derived per scene as a house preference ("the authored A-press
+breaks ARE the pacing") when it is simply **what vanilla does**, and citing the source ends the
+argument.
+
+**Every `[LF]` and every `[A]` in `texts.txt` is hand-placed.** `MSG_9CC` — vanilla's
+Natasha→Joshua recruit, the scene ch05's Talk is the twin of — sets all thirty-two of its own page
+breaks. Nothing in it is flowed. So when a substitute line is chosen as prose and overruns its
+channel, authoring the break is not an extra step imposed by our wrapper; leaving it to the wrapper
+is the divergence.
+
+The Talk recruit's substitute is 61 characters against 29 and cannot be one box. Flowed, the wrapper
+put the break at *"We could go free as"* / *"well."* — mid-clause, the same failure the reliquary
+lines and scene 5's fallback each found independently. **It breaks on the ellipsis**: the
+observation lands flat and finishes, then the OFFER — which *is* proof #1 in that arm, Basil
+arguing the two of them could go rather than citing a wolf who went — takes its own press instead of
+trailing the clause it answers.
+
+**Where an A-press goes is still Nicolas's call on any line where the read is genuinely open.** This
+one had a single candidate: the ellipsis is the line's only punctuation, and every other break is
+mid-clause by construction.
+
+_Recorded: 2026-08-21 (Nicolas: "For the A presses you don't need my input, follow vanilla style
+conventions")._
+
 ### A letterbox mat is not picture, and a CENTRE crop keeps half of it (2026-08-14, #25)
 
 Nicolas, looking at the shipped ch05 opening: *"you see the black bar to the right in the

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -6781,7 +6781,7 @@ def talk_recruit_char_entries(recruiters, target, flag, script):
                    for r in recruiters)
 
 
-def talk_recruit_script(msg_id, target, pre_script='', variant=None):
+def talk_recruit_script(msg_id, target, pre_script='', variant=None, label_base=0):
     """The shared talk-recruit script (cf. vanilla EventScr_Ch3_Talk_NeimiColm): show the
     migrated talk line, then CUSA `target` to BLUE (EvtChangeFaction), set the map-event
     visibility evbit, end. MUSS/STAL are trimmed -- the line rides the map talk window, not a
@@ -6805,13 +6805,20 @@ def talk_recruit_script(msg_id, target, pre_script='', variant=None):
 
     Only TEXTSHOW+TEXTEND go inside the arms. `TEXTSTART`, the `REMA` and above all the CUSA
     stay SHARED, exactly as ch14a shares everything past its LABEL -- a recruit duplicated into
-    both arms is one recruit to fix twice."""
+    both arms is one recruit to fix twice.
+
+    `label_base` offsets the branch's label PAIR. It exists because `pre_script` can carry
+    labels of its own -- ch04's parley passes a `convert_survivors_green` sweep, one skip label
+    per wolf -- and BEQ/GOTO scan the whole list for a matching LABEL, so a collision jumps into
+    the wrong arm. ch04 sits at 0x40 and does not currently pass a `variant`, which is the only
+    reason 0 is safe as a default; a caller doing both must move one of them."""
     beat = ('    TEXTSHOW(0x%X)\n'
             '    TEXTEND\n')
     return ('{\n'
             '    TEXTSTART\n'
             + (beat % msg_id if variant is None
-               else branch_on_check_alive(variant[0], beat % msg_id, beat % variant[1]))
+               else branch_on_check_alive(variant[0], beat % msg_id, beat % variant[1],
+                                          label_base=label_base))
             + '    REMA\n'
             + pre_script
             + '    CUSA(%s) /* -> blue: the talk recruits the target */\n'
@@ -6820,7 +6827,7 @@ def talk_recruit_script(msg_id, target, pre_script='', variant=None):
 
 
 def talk_recruit_wiring(recruiters, target, flag, script_symbol, msg_id, pre_script='',
-                        variant=None):
+                        variant=None, label_base=0):
     """Assemble the reusable on-map talk-recruit event wiring (ch03 Trex / ch04 Lupin / ch05
     Basil+Sahnar). Returns (char_events, talk_script):
       char_events -- the EventListScr_..._Character body: one CHAR(flag, script, recruiter,
@@ -6833,7 +6840,7 @@ def talk_recruit_wiring(recruiters, target, flag, script_symbol, msg_id, pre_scr
     char_events = ('{\n' + talk_recruit_char_entries(recruiters, target, flag, script_symbol)
                    + '    END_MAIN\n}')
     return char_events, talk_recruit_script(msg_id, target, pre_script=pre_script,
-                                           variant=variant)
+                                           variant=variant, label_base=label_base)
 
 
 def midmap_minibosses(chap):
@@ -8723,7 +8730,10 @@ CH04_LUPIN_TALK_FLAG = 'EVFLAG_TMP(9)'         # one-shot recruit flag (ch03's C
 # byte-identical to 0xb3's, and the wolf's CLASS comes from the unit definition (bmunit.c:697),
 # so the split is invisible in play. Guarded by assert_pack_pids_addressable.
 CH04_PACK_PIDS = ('0xb0', '0xb1', '0xb2', '0xb4', '0xb5')
-CH04_PARLEY_LABEL_BASE = 0x40   # one skip label per wolf; the talk script has no other labels
+CH04_PARLEY_LABEL_BASE = 0x40   # one skip label per wolf. The talk script HAS carried labels of
+                                # its own since ch05's Talk grew a no-Lupin branch (0 and 1), so
+                                # this is no longer "the only labels here" -- it is a base that
+                                # must stay clear of talk_recruit_script's own `label_base`.
 CH04_GREEN_PACK_CLASS = 'CLASS_MTD_LYCANROC_PACK'  # campaign.yaml enemy_class_reskins: a Mauthe
                                                # Doog clone wearing the Lycanroc map sprite.
                                                # DECLARED BUT UNWORN since #203: converting the

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -6781,26 +6781,46 @@ def talk_recruit_char_entries(recruiters, target, flag, script):
                    for r in recruiters)
 
 
-def talk_recruit_script(msg_id, target, pre_script=''):
+def talk_recruit_script(msg_id, target, pre_script='', variant=None):
     """The shared talk-recruit script (cf. vanilla EventScr_Ch3_Talk_NeimiColm): show the
     migrated talk line, then CUSA `target` to BLUE (EvtChangeFaction), set the map-event
     visibility evbit, end. MUSS/STAL are trimmed -- the line rides the map talk window, not a
     fanfare. Faction-agnostic: a GREEN bystander (Trex/Basil) and a RED parley (Lupin/Sahnar)
     both end at BLUE via this one CUSA. `pre_script` is spliced in AFTER the talk line and
     BEFORE the CUSA -- a group parley passes its own conversion sweep there (ch04: the wolf
-    pack, convert_survivors_green), so the whole outcome still rides the single recruit path."""
+    pack, convert_survivors_green), so the whole outcome still rides the single recruit path.
+
+    `variant` is (character, msg_id): the scene addresses a unit the player may never have
+    recruited, so ask the roster and show the other copy when it is not there. The SHAPE is
+    vanilla's own and is not invented here -- `ch14a-eventscript.h` branches on
+    CHECK_ALIVE(CHARACTER_JOSHUA), Sahnar's donor and vanilla Ch5's optional Talk recruit,
+    and picks a WHOLE MESSAGE per arm before converging:
+
+        CHECK_ALIVE(CHARACTER_JOSHUA)
+        BEQ(0xa, EVT_SLOT_C, EVT_SLOT_0)
+        TEXTSHOW(0xa93) / TEXTEND / GOTO(0xb)
+    LABEL(0xa)
+        TEXTSHOW(0xa95) / TEXTEND
+    LABEL(0xb)
+
+    Only TEXTSHOW+TEXTEND go inside the arms. `TEXTSTART`, the `REMA` and above all the CUSA
+    stay SHARED, exactly as ch14a shares everything past its LABEL -- a recruit duplicated into
+    both arms is one recruit to fix twice."""
+    beat = ('    TEXTSHOW(0x%X)\n'
+            '    TEXTEND\n')
     return ('{\n'
             '    TEXTSTART\n'
-            '    TEXTSHOW(0x%X)\n'
-            '    TEXTEND\n'
-            '    REMA\n' % msg_id
+            + (beat % msg_id if variant is None
+               else branch_on_check_alive(variant[0], beat % msg_id, beat % variant[1]))
+            + '    REMA\n'
             + pre_script
             + '    CUSA(%s) /* -> blue: the talk recruits the target */\n'
               '    EVBIT_T(7)\n'
               '    ENDA\n}' % target)
 
 
-def talk_recruit_wiring(recruiters, target, flag, script_symbol, msg_id, pre_script=''):
+def talk_recruit_wiring(recruiters, target, flag, script_symbol, msg_id, pre_script='',
+                        variant=None):
     """Assemble the reusable on-map talk-recruit event wiring (ch03 Trex / ch04 Lupin / ch05
     Basil+Sahnar). Returns (char_events, talk_script):
       char_events -- the EventListScr_..._Character body: one CHAR(flag, script, recruiter,
@@ -6812,7 +6832,8 @@ def talk_recruit_wiring(recruiters, target, flag, script_symbol, msg_id, pre_scr
     Both flavours share ONE flow instead of a per-chapter green/red copy."""
     char_events = ('{\n' + talk_recruit_char_entries(recruiters, target, flag, script_symbol)
                    + '    END_MAIN\n}')
-    return char_events, talk_recruit_script(msg_id, target, pre_script=pre_script)
+    return char_events, talk_recruit_script(msg_id, target, pre_script=pre_script,
+                                           variant=variant)
 
 
 def midmap_minibosses(chap):
@@ -8919,6 +8940,11 @@ CH05_SAHNAR_TALK_MSG = 0x9E8     # the TALK-RECRUIT scene, the chapter's payoff.
                                  # player actually saw was Hlin Trollbane's bust (dressed onto the
                                  # Natasha slot) talking to vanilla Joshua. First free id in the
                                  # block; 0x9E9..0x9F3 remain for the opening and endings.
+# ...and the no-Lupin arm's id. 0x9D1 is vanilla Ch5's TUTORIAL text (EventScr_089F231C),
+# reachable only from EventListScr_Ch5_Tutorial -- which inject_ch04 zeroes along with the other
+# three unused lists. Exactly the sweep that freed 0x9D2 for the moose quip and 0x9CD..0x9D0 for
+# the reliquary visits, and verified against HEAD rather than assumed.
+CH05_SAHNAR_TALK_NO_LUPIN_MSG = 0x9D1
 CH05_SAHNAR_TALK_FLAG = 'EVFLAG_TMP(7)'   # vanilla Ch5's own Natasha->Joshua CHAR flag, free
                                           # here: ch05's villages use 9..12, and Misc uses 13
                                           # for the arena tutorial.
@@ -9416,7 +9442,7 @@ HOSTED_CHAPTER_MESSAGE_IDS = {
     # and why spending ch05's own ids on them was the worse trade.
     'ch05': (CH05_ERUPTION_MSG, CH05_RAVISIN_DEATH_MSG, CH05_RAVISIN_TAUNT_MSG,
              CH05_ARENA_FOUND_MSG, CH05_ARENA_RULES_MSG,
-             CH05_SAHNAR_TALK_MSG,
+             CH05_SAHNAR_TALK_MSG, CH05_SAHNAR_TALK_NO_LUPIN_MSG,
              *(msg for _slot, msg, _boxes, _what in CH05_OPENING_SLOTS),
              CH05_ARRIVAL_SLOT[1], CH05_ARRIVAL_NO_LUPIN_MSG,
              CH05_BASIL_JOIN_SLOT[1], CH05_BASIL_JOIN_NO_LUPIN_MSG,
@@ -9549,6 +9575,24 @@ def variant_beat(beat, fallback, err_label):
     for i, entry in enumerate(beat):
         out.extend(replacement.get(i, [entry]))
     return out
+
+
+def locked_and_variant(script, fallback, render, err_label, msgs):
+    """A branched scene as its TWO rendered bodies: the locked one and its substituted twin.
+
+    The pairing every fallback in this campaign takes, kept independent of the CHANNEL because
+    the two channels render nothing alike -- a backdrop scene goes through `_ch05_opening_body`
+    (podium-checked, width 42) while an on-map one goes straight to `_script_to_message` at the
+    bubble's 29. `render` is whatever turns a beat into a body; everything else here is the part
+    that must not be written twice.
+
+    Whole copies rather than a prefix/arm/suffix split, which is vanilla's own economy: ch14a's
+    ending branches to `TEXTSHOW(0xa93)` or `TEXTSHOW(0xa95)`, two complete messages, and shares
+    the script around them. Duplicated text is free; seams in a scene are not.
+    """
+    locked_msg, variant_msg = msgs
+    return [(locked_msg, render(script)),
+            (variant_msg, render(variant_beat(script, fallback, err_label)))]
 
 
 def _branch_on_slot_c(test, if_true, if_false, label_base, why):
@@ -11580,7 +11624,7 @@ def ch05_ravisin_death_message(chap):
         width=29)
 
 
-def ch05_sahnar_talk_message(chap):
+def ch05_sahnar_talk_messages(chap):
     """Render the locked Basil->Sahnar Talk recruit -- the chapter's payoff -- from the YAML.
 
     The event's ``vanilla 0x9CC`` label cites the scene we MINE (vanilla's own Natasha->Joshua
@@ -11607,11 +11651,19 @@ def ch05_sahnar_talk_message(chap):
     if len(beat) != 16 or not speakers <= {'sahnar', 'basil'}:
         sys.exit('ERROR: ch05 Talk recruit must remain the sixteen locked Sahnar/Basil boxes; '
                  'got %d boxes from %s' % (len(beat), sorted(speakers)))
-    return _script_to_message(
-        beat,
+    event = next(e for e in chap['events'] if e.get('trigger') == 'sahnar_talk')
+    if 'no_lupin_fallback' not in event:
+        sys.exit('ERROR: ch05 Talk recruit is a branched scene and must carry a '
+                 'no_lupin_fallback -- without it the no-Lupin arm proves Sahnar with a wolf '
+                 'the player may never have recruited')
+    render = lambda script: _script_to_message(
+        script,
         {'basil':  ('[OpenMidLeft]',  _fid_tag(PORTRAIT_MAP['basil'])),
          'sahnar': ('[OpenMidRight]', _fid_tag(PORTRAIT_MAP['sahnar']))},
         width=29)
+    return locked_and_variant(
+        beat, event['no_lupin_fallback'], render, 'ch05 Talk recruit no-Lupin fallback',
+        (CH05_SAHNAR_TALK_MSG, CH05_SAHNAR_TALK_NO_LUPIN_MSG))
 
 
 def _ch05_opening_scene(chap, slot, boxes, what, podiums, fid, width=42):
@@ -12518,6 +12570,8 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
     # that catches a re-point into a neighbour's block, which is exactly how the Basil join beat
     # once ended up on 0x9C2 -- ch04's own no-parley ending.
     assert_message_id_unclaimed(CH05_SAHNAR_TALK_MSG, 'ch05', "Basil's Talk recruit of Sahnar")
+    assert_message_id_unclaimed(CH05_SAHNAR_TALK_NO_LUPIN_MSG, 'ch05',
+                                "the Talk recruit's no-Lupin arm")
     sahnar_rows = [row.replace(CH05_GENERIC_PID, sahnar_char, 1) for row in sahnar_rows]
     declare_unit_table(CH05_SAHNAR_TABLE, sahnar_rows,
                        'ch05 Sahnar: summoned HOSTILE in scene 3, on the arena from turn 1; '
@@ -12600,7 +12654,10 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
     # pre_script: unlike ch04's pack parley there is no group to bring over with her.
     sahnar_char_events, sahnar_talk_script = talk_recruit_wiring(
         parley_recruiters(next(e for e in chap['enemy_units'] if e['id'] == 'sahnar')),
-        sahnar_char, CH05_SAHNAR_TALK_FLAG, CH05_SAHNAR_TALK_SCRIPT, CH05_SAHNAR_TALK_MSG)
+        sahnar_char, CH05_SAHNAR_TALK_FLAG, CH05_SAHNAR_TALK_SCRIPT, CH05_SAHNAR_TALK_MSG,
+        # Proof #1 is a wolf ch04's optional parley may never have handed the player, so the
+        # scene asks the roster and shows the other copy when he is not on it (#25).
+        variant=(CH05_LUPIN_CHARACTER, CH05_SAHNAR_TALK_NO_LUPIN_MSG))
     info = _replace_brace_block(info, CH05_EVENT_LISTS['character'] + '[] =',
                                 sahnar_char_events, CH05_EVENTINFO_H)
     for key in ('select_unit', 'select_dest', 'unit_move', 'tutorial'):
@@ -12668,8 +12725,9 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
     #     than at the loss.
     declare_event_script(
         CH05_EVENTSCRIPT_H, CH05_SAHNAR_TALK_SCRIPT, sahnar_talk_script,
-        'ch05 Basil Talks Sahnar down -- the locked recruit scene at 0x%X, then CUSA red->blue'
-        % CH05_SAHNAR_TALK_MSG)
+        'ch05 Basil Talks Sahnar down -- the locked recruit scene at 0x%X (or its no-Lupin arm '
+        'at 0x%X), then CUSA red->blue'
+        % (CH05_SAHNAR_TALK_MSG, CH05_SAHNAR_TALK_NO_LUPIN_MSG))
     for symbol, body, comment in arena_wiring['scripts']:
         declare_event_script(CH05_EVENTSCRIPT_H, symbol, body, comment)
     assert_event_scripts_defined(
@@ -12688,7 +12746,8 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
     set_message_body(lines, CH05_ERUPTION_MSG, ch05_eruption_message(chap))
     set_message_body(lines, CH05_RAVISIN_DEATH_MSG, ch05_ravisin_death_message(chap))
     set_message_body(lines, CH05_RAVISIN_TAUNT_MSG, ch05_ravisin_taunt_message(chap))
-    set_message_body(lines, CH05_SAHNAR_TALK_MSG, ch05_sahnar_talk_message(chap))
+    for msg_id, body in ch05_sahnar_talk_messages(chap):
+        set_message_body(lines, msg_id, body)
     for msg_id, body in ch05_ending_messages(chap):
         set_message_body(lines, msg_id, body)
     for msg_id, body in (ch05_opening_messages(chap) + ch05_basil_join_messages(chap)

--- a/tools/playtest/gen_symbols.py
+++ b/tools/playtest/gen_symbols.py
@@ -105,6 +105,13 @@ WANTED = [
     'gBmMapFog',                # u8** fog map (include/bmmap.h): non-zero = the player can SEE
                                 # that tile this turn. A red unit standing on a zero tile is not
                                 # drawn at all -- which looks exactly like a broken map sprite.
+    'sActiveMsg',               # int (src/msg.c): the message index GetStringFromIndex last
+                                # DECODED into its buffer. The only witness to WHICH message a
+                                # scene actually showed -- box counts cannot tell two arms of a
+                                # branch apart when they render to the same number of A-presses,
+                                # which ch05's Talk recruit does exactly (#25). Read it WHILE a
+                                # box is up: every menu and unit name decodes through the same
+                                # function and overwrites it the moment the scene ends.
     'gChapterFlagBits',         # event flags < 100, bit (flag-1) (src/eventinfo.c)
     'gPermanentFlagBits',       # event flags > 100, bit (flag-101)
     'ProcScr_GameOverScreen',   # proc script: game-over screen active

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -1299,6 +1299,14 @@ end
 -- Exact-match only. A script address that matches no symbol is reported as unknown:
 -- a confidently wrong name (the old PROC_NAME string, where three distinct scripts all
 -- read as "E_FACE") cost #232 its last failure, and silence would have been cheaper.
+-- WHICH message a scene actually showed. `GetStringFromIndex` (src/msg.c) caches the index it
+-- last decoded in `sActiveMsg`, so reading it WHILE a box is up names the message id on screen.
+-- Box counting is the witness everywhere else in this chapter and it is strictly weaker: two
+-- arms of one branch can render to the same number of A-presses, which ch05's Talk recruit does
+-- (its locked box 8 wraps in two; its substitute is two authored boxes). Read it during a
+-- dialogue wait -- unit names and menus decode through the same function and overwrite it.
+INSPECT.activeMsg = function() return ru32(SYM.sActiveMsg) end
+
 INSPECT.scriptName = function(addr)
     return PROCSCR[addr] or string.format("unknown@0x%08X", addr)
 end
@@ -6563,12 +6571,23 @@ end
 -- is satisfied the instant the counter ticks, BEFORE Ravisin says a word. Left alone this gate
 -- would have failed on 0 eruption boxes and blamed the warning.
 -- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05recruit (needs a CH05BOOT=1 ROM).
-scenarios.ch05recruit = function()
+scenarios.ch05recruit = function(opts)
     local BASIL, SAHNAR = 0x13, 0x16        -- CHARACTER_ARTUR / CHARACTER_MARISA
-    -- A-presses our locked 0x9E8 recruit renders to: sixteen authored boxes, five of which
+    local LUPIN = 0x1D                      -- CHARACTER_DUESSEL, the slot ch05 gives the wolf
+    -- A-presses either arm of the recruit renders to: sixteen authored boxes, five of which
     -- wrap past two lines at the map bubble's 29 and so take a second page. Scenario-local
     -- rather than a TUNE entry -- it is this scene's shape, not a harness timing knob.
+    -- BOTH ARMS COME TO 21, which is why this number can no longer say which one played: the
+    -- locked box 8 is 70 characters and the wrapper pages it in two, while the substitute is
+    -- two AUTHORED boxes. `arm` below is the real witness; the count only guards the shape.
     local RECRUIT_BOXES = 21
+    -- `opts.lupin` is the ROSTER STATE to put the wolf in before the Talk, and `opts.arm` the
+    -- message id that state must produce. Default: no Lupin on the roster at all, which is what
+    -- the plain `ch05boot` ROM is (he is not in the boot seed), so the Talk takes its no-Lupin
+    -- arm. The two named states are #25's last two owed CHECK_ALIVE cases and ride
+    -- `ch05lupinboot`, whose LOAD1 is the only way any of these ROMs gets a Lupin at all.
+    opts = opts or {}
+    local ARM = opts.arm or 0x9D1
     local function blueBasil() return findUnit(SYM.gUnitArrayBlue, 20, BASIL) end
     local function redSahnar() return findUnit(SYM.gUnitArrayRed, 24, SAHNAR) end
     local function blueSahnar() return findUnit(SYM.gUnitArrayBlue, 20, SAHNAR) end
@@ -6577,6 +6596,38 @@ scenarios.ch05recruit = function()
     waitFor(function()
         return faction() == 0 and not menuOpen() and not procActive(SYM.ProcScr_StdEventEngine)
     end, 6000, true)
+
+    -- 0. The wolf, in whatever roster state this run is about. CHECK_ALIVE reads the ROSTER and
+    --    not the field (eventscr.c:3212 -- missing OR US_DEAD gives slot C = 0, while
+    --    US_NOT_DEPLOYED is CHECK_DEPLOYED's business alone), so these two pokes are the whole
+    --    experiment: a benched Lupin must still take the wolf's arm, a dead one must not.
+    if opts.lupin then
+        local wolf = findUnit(SYM.gUnitArrayBlue, 62, LUPIN)
+        if not wolf then
+            return result("FAIL", "no Lupin on the roster -- this scenario needs the "
+                .. "ch05lupinboot ROM, whose LOAD1 is the only thing that puts him there")
+        end
+        if opts.lupin == "benched" then
+            -- Recruited, alive, LEFT AT HOME. ch05 deploys 9 of a 10-unit pool, so this is
+            -- ordinary play, and it is exactly where a field-presence test would have failed.
+            -- The ROM cannot produce it -- --ch05-lupin LOAD1s him ONTO the map -- so the state
+            -- is written here: off the tile grid, off the map, and flagged not-deployed, which
+            -- is what a unit the player never placed looks like to both CHECK_ commands.
+            setMapUnit(wolf.x, wolf.y, 0)
+            emu:write8(wolf.addr + 0x10, 0xFF)          -- xPos -1: nowhere on the map
+            emu:write8(wolf.addr + 0x11, 0xFF)
+            emu:write32(wolf.addr + 0x0C, wolf.state | 8)  -- US_NOT_DEPLOYED, bmunit.h (1 << 3)
+        elseif opts.lupin == "killed" then
+            -- Recruited, then LOST. Collapses onto the no-Lupin arm on purpose: a dead wolf is
+            -- no more "out there now, with travelers" than one who was never won.
+            setMapUnit(wolf.x, wolf.y, 0)
+            emu:write32(wolf.addr + 0x0C, wolf.state | US_DEAD)
+        else
+            return result("FAIL", "unknown lupin state " .. tostring(opts.lupin))
+        end
+        log(string.format("ch05recruit: Lupin (0x%X) put in the %s state before the Talk",
+            LUPIN, opts.lupin))
+    end
 
     -- 1. The join. A GREEN Basil here means the CUSA after CALL(Preparations) did not land --
     --    which is invisible to every other scenario, so name the faction we actually found.
@@ -6689,11 +6740,15 @@ scenarios.ch05recruit = function()
     -- capped at 3600 and expired 18 boxes in, then reported "the CUSA did not fire" about a
     -- script that had simply not reached it yet. A LOOP CAP MUST NEVER BE WHAT DECIDES FAILURE
     -- (decisions.md): hence a budget with real headroom AND, below, two distinguishable verdicts.
-    local BUDGET, boxes = 20000, 0
+    local BUDGET, boxes, playedMsg = 20000, 0, nil
     for _ = 1, BUDGET do
         if blueSahnar() then break end
         if controllerState() == "dialogue_wait" then
             boxes = boxes + 1
+            -- WHICH message is on screen, sampled while the FIRST box of the scene is up.
+            -- After the scene ends every menu and unit name decodes through the same buffer
+            -- and overwrites it, so this cannot be read from the verdict at the bottom.
+            playedMsg = playedMsg or INSPECT.activeMsg()
             if not guardedInput("advance_dialogue", "A", "dialogue input wait clears", function(after)
                 return controllerState(after) ~= "dialogue_wait"
             end, 120) then return result("FAIL", "recruit dialogue input did not advance") end
@@ -6718,21 +6773,56 @@ scenarios.ch05recruit = function()
     --    bug this chapter shipped with for months -- Hlin Trollbane's bust talking to vanilla
     --    Joshua, with every text decoder green. Box COUNT is the cheapest in-engine witness to
     --    which message id the script actually showed: ours is 21 A-presses, vanilla's is 32.
-    log(string.format("ch05recruit: the recruit scene ran %d boxes", boxes))
+    log(string.format("ch05recruit: the recruit scene ran %d boxes, message 0x%X",
+        boxes, playedMsg or 0))
     if boxes ~= RECRUIT_BOXES then
         shot("ch05recruit")
         return result("FAIL", string.format(
             "the recruit scene ran %d boxes, expected %d -- %s", boxes, RECRUIT_BOXES,
             boxes >= 30 and "that is vanilla's 0x9CC, so the Talk is pointed at the twin's "
                 .. "scene again and plays it in Natasha's and Joshua's faces"
-                or "the locked 0x9E8 scene changed underneath this gate"))
+                or "the recruit scene changed underneath this gate"))
+    end
+    -- WHICH ARM. Both arms recruit her and both run 21 boxes, so everything above passes on
+    -- either one -- that is the whole hazard #25 names, and a gate that only watched the flip
+    -- would be green with the wrong scene on screen. `sActiveMsg` is the only thing here that
+    -- can tell 0x9E8 (Basil proves it with the wolf) from 0x9D1 (Basil proves it with herself).
+    if playedMsg ~= ARM then
+        shot("ch05recruit")
+        return result("FAIL", string.format(
+            "the Talk played message 0x%X, expected 0x%X -- %s", playedMsg or 0, ARM,
+            ARM == 0x9E8
+                and "CHECK_ALIVE did not find the wolf on the roster, so a player who WON him "
+                    .. "is being told he does not exist"
+                or "CHECK_ALIVE found a wolf this run does not have, so the scene proves "
+                    .. "itself with a unit the player never recruited"))
     end
     runEnemyPhase()      -- the sprite only repaints to the party palette on a phase transition
     shot("ch05recruit")
     return result("PASS", string.format(
         "Basil joined blue in the opening, Sahnar stood red on the arena from turn 1, the "
-        .. "eruption spoke its four, and Basil's Talk brought her over in %d boxes of our own "
-        .. "locked prose -- the whole ch05 recruit chain", boxes))
+        .. "eruption spoke its four, and Basil's Talk brought her over in %d boxes of message "
+        .. "0x%X -- the whole ch05 recruit chain, on the arm this roster earns", boxes, playedMsg))
+end
+
+-- ch05lupinbenched: RECRUITED, ALIVE, BENCHED -> the wolf's arm (#25). The case that matters
+-- most and the last one owed: ch05 deploys 9 of a 10-unit pool, so a player can win Lupin in
+-- ch04 and leave him home here in ordinary play. If the Talk asked the FIELD instead of the
+-- roster, this run is where that shows -- the player would be told the wolf does not exist by
+-- a scene proving its point with him. `eventscr.c` says CHECK_ALIVE cannot see the bench; this
+-- is the run that says our build agrees.
+-- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05lupinbenched (needs CH05BOOT=1 CH05LUPIN=1).
+scenarios.ch05lupinbenched = function()
+    return scenarios.ch05recruit({ lupin = "benched", arm = 0x9E8 })
+end
+
+-- ch05lupinkilled: RECRUITED, THEN LOST -> the no-Lupin arm, deliberately (#25). `eventscr.c`
+-- writes slot C = 0 for US_DEAD exactly as it does for a unit that was never found, and the
+-- prose wants that collapse: a dead wolf is no more "out there now, with travelers" than one
+-- the player never won.
+-- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05lupinkilled (needs CH05BOOT=1 CH05LUPIN=1).
+scenarios.ch05lupinkilled = function()
+    return scenarios.ch05recruit({ lupin = "killed", arm = 0x9D1 })
 end
 
 -- recordch05eruption: the smallest visual proof for #260. Boot the real ch05 map, idle turn 1,

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -1299,17 +1299,17 @@ end
 -- Exact-match only. A script address that matches no symbol is reported as unknown:
 -- a confidently wrong name (the old PROC_NAME string, where three distinct scripts all
 -- read as "E_FACE") cost #232 its last failure, and silence would have been cheaper.
--- WHICH message a scene actually showed. `GetStringFromIndex` (src/msg.c) caches the index it
--- last decoded in `sActiveMsg`, so reading it WHILE a box is up names the message id on screen.
--- Box counting is the witness everywhere else in this chapter and it is strictly weaker: two
--- arms of one branch can render to the same number of A-presses, which ch05's Talk recruit does
--- (its locked box 8 wraps in two; its substitute is two authored boxes). Read it during a
--- dialogue wait -- unit names and menus decode through the same function and overwrite it.
-INSPECT.activeMsg = function() return ru32(SYM.sActiveMsg) end
-
 INSPECT.scriptName = function(addr)
     return PROCSCR[addr] or string.format("unknown@0x%08X", addr)
 end
+
+-- WHICH message a scene actually showed. `GetStringFromIndex` (src/msg.c) caches the index it
+-- last decoded in `sActiveMsg`, so reading it WHILE a box is up names the message id on screen.
+-- Box counting is the witness everywhere else in ch05 and it is strictly weaker: two arms of one
+-- branch can render to the same number of A-presses, which the Talk recruit does exactly (its
+-- locked box 8 wraps in two; its substitute is two authored boxes). Read it during a dialogue
+-- wait -- unit names and menus decode through the same function and overwrite it.
+INSPECT.activeMsg = function() return ru32(SYM.sActiveMsg) end
 
 local function procLine(i, p, prev)
     -- scrCur as an offset from the script head: the exact PROC_* command it sits on.
@@ -6613,15 +6613,23 @@ scenarios.ch05recruit = function(opts)
             -- The ROM cannot produce it -- --ch05-lupin LOAD1s him ONTO the map -- so the state
             -- is written here: off the tile grid, off the map, and flagged not-deployed, which
             -- is what a unit the player never placed looks like to both CHECK_ commands.
+            -- US_HIDDEN IS NOT OPTIONAL, and leaving it off is not merely untidy:
+            -- `RefreshUnitsOnBmMap` (bmmap.c:523) skips a unit on US_HIDDEN and on NOTHING
+            -- ELSE, so on the next phase transition it would write this unit's index to
+            -- gBmMapUnit[-1][-1] -- off the map array entirely. The engine always sets the
+            -- pair (bmio.c:1260 and bmsave.c:417 both write US_HIDDEN | US_NOT_DEPLOYED).
             setMapUnit(wolf.x, wolf.y, 0)
             emu:write8(wolf.addr + 0x10, 0xFF)          -- xPos -1: nowhere on the map
             emu:write8(wolf.addr + 0x11, 0xFF)
-            emu:write32(wolf.addr + 0x0C, wolf.state | 8)  -- US_NOT_DEPLOYED, bmunit.h (1 << 3)
+            emu:write32(wolf.addr + 0x0C, wolf.state | 8 | 1)  -- US_NOT_DEPLOYED | US_HIDDEN
         elseif opts.lupin == "killed" then
             -- Recruited, then LOST. Collapses onto the no-Lupin arm on purpose: a dead wolf is
             -- no more "out there now, with travelers" than one who was never won.
+            -- Same pairing, same reason: without US_HIDDEN the refresh puts the corpse
+            -- back on the tile grid at its old position. bmsave.c:414 writes the dead
+            -- state as US_HIDDEN | US_DEAD.
             setMapUnit(wolf.x, wolf.y, 0)
-            emu:write32(wolf.addr + 0x0C, wolf.state | US_DEAD)
+            emu:write32(wolf.addr + 0x0C, wolf.state | US_DEAD | 1)  -- ... | US_HIDDEN
         else
             return result("FAIL", "unknown lupin state " .. tostring(opts.lupin))
         end

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -298,6 +298,15 @@ scenarios:
   ch05recruit:
     rom: ch05boot
     host_chapter: 6
+  # The two CHECK_ALIVE states the Talk recruit's no-Lupin branch turns on, and the only two
+  # #25 still owed. Both ride `ch05lupinboot` -- the ONLY ROM with Lupin on the roster at all --
+  # and differ solely in what the harness does to him before the Talk.
+  ch05lupinbenched:
+    rom: ch05lupinboot
+    host_chapter: 6
+  ch05lupinkilled:
+    rom: ch05lupinboot
+    host_chapter: 6
   ch05raid:
     rom: ch05boot
     host_chapter: 6

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -430,6 +430,10 @@ suites:
     - ch05reliquaries
     - ch05arena
     - ch05recruit
+    # ch05recruit alone only ever walks the no-Lupin arm (the gate ROM has no wolf), so an
+    # inverted BEQ or a swapped pair of message ids would pass it. This is the run that
+    # walks the OTHER arm, and it is the only one that does.
+    - ch05lupinbenched
     - ch05raid
     - ch05crest
 
@@ -484,6 +488,8 @@ suites:
     - ch05reliquaries
     - ch05arena
     - ch05recruit
+    - ch05lupinbenched
+    - ch05lupinkilled
     - ch05raid
     - ch05crest
 

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -2569,7 +2569,7 @@ class Ch05SahnarTalkRecruit(unittest.TestCase):
         self.assertEqual(16, len(event['script']))
         self.assertEqual({'sahnar', 'basil'}, {next(iter(box)) for box in event['script']})
 
-        body = bc.ch05_sahnar_talk_message(self._chap())
+        body = dict(bc.ch05_sahnar_talk_messages(self._chap()))[bc.CH05_SAHNAR_TALK_MSG]
         self.assertIn('[LoadFace][FID_Artur]', body)     # Basil
         self.assertIn('[LoadFace][FID_Marisa]', body)    # Sahnar
         self.assertNotIn('[FID_Natasha]', body)          # the bug: Hlin's dressed slot
@@ -2585,7 +2585,7 @@ class Ch05SahnarTalkRecruit(unittest.TestCase):
     def test_the_two_shot_stages_recruiter_left_and_the_turned_unit_right(self):
         """ch04's parley idiom: the recruiter holds the party's side, the unit being turned
         holds the other, so neither podium swaps faces mid-scene."""
-        body = bc.ch05_sahnar_talk_message(self._chap())
+        body = dict(bc.ch05_sahnar_talk_messages(self._chap()))[bc.CH05_SAHNAR_TALK_MSG]
         self.assertIn('[OpenMidLeft][LoadFace][FID_Artur]', body)
         self.assertIn('[OpenMidRight][LoadFace][FID_Marisa]', body)
         self.assertNotIn('[ClearFace]', body)
@@ -2593,7 +2593,7 @@ class Ch05SahnarTalkRecruit(unittest.TestCase):
     def test_every_box_fits_the_map_talk_bubble(self):
         """The Talk rides TEXTSHOW -> PutTalkBubble, whose right-side branch computes
         x = 29 - width with no clamp: a line over 29 runs off the tilemap (the ch03 crier bug)."""
-        body = bc.ch05_sahnar_talk_message(self._chap())
+        body = dict(bc.ch05_sahnar_talk_messages(self._chap()))[bc.CH05_SAHNAR_TALK_MSG]
         for line in body.split('\n'):
             printable = re.sub(r'\[[^\]]*\]', '', line)
             self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
@@ -2606,6 +2606,144 @@ class Ch05SahnarTalkRecruit(unittest.TestCase):
         self.assertNotIn('TEXTSHOW(0x9CC)', script)
         self.assertLess(script.index('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_MSG),
                         script.index('CUSA(CHARACTER_MARISA)'))
+
+
+class Ch05SahnarTalkNoLupinFallback(unittest.TestCase):
+    """The Talk recruit's no-Lupin arm -- the LAST of ch05's five fallbacks (#25).
+
+    Box 8 is PROOF #1, the evidence that turns Sahnar, and it is a wolf ch04's optional parley
+    may never have handed the player. The substitute makes the proof BASIL instead: not
+    "someone else already walked free" but "the two of us could".
+
+    Shape is vanilla's, not ours. `ch14a-eventscript.h` branches on CHECK_ALIVE(CHARACTER_JOSHUA)
+    -- Sahnar's own donor, and vanilla Ch5's optional Talk recruit -- and picks a WHOLE message
+    per arm before converging on a shared LABEL (`TEXTSHOW(0xa93)` / `TEXTSHOW(0xa95)` ->
+    `LABEL(0xb)`). Everything below asserts that shape rather than a second mechanism.
+    """
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def _chap(self):
+        return bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+
+    def _event(self):
+        return next(e for e in self._chap()['events'] if e['trigger'] == 'sahnar_talk')
+
+    def _fallback(self):
+        event = self._event()
+        return bc.variant_beat(event['script'], event['no_lupin_fallback'], 'test')
+
+    def _wiring(self):
+        _chars, script = bc.talk_recruit_wiring(
+            ['CHARACTER_ARTUR'], 'CHARACTER_MARISA', bc.CH05_SAHNAR_TALK_FLAG,
+            bc.CH05_SAHNAR_TALK_SCRIPT, bc.CH05_SAHNAR_TALK_MSG,
+            variant=(bc.CH05_LUPIN_CHARACTER, bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG))
+        return script
+
+    # -- the id ---------------------------------------------------------------
+    def test_the_fallback_id_is_claimed_owned_and_outside_no_ones_reach(self):
+        """0x9D1 is vanilla Ch5's TUTORIAL text (EventScr_089F231C), reachable only from
+        EventListScr_Ch5_Tutorial -- which inject_ch04 zeroes. Same sweep that freed 0x9D2 for
+        the moose quip, and the reliquary lines' 0x9CD..0x9D0 before it."""
+        self.assertEqual(0x9D1, bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG)
+        self.assertIn(bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG, bc.HOSTED_CHAPTER_MESSAGE_IDS['ch05'])
+        self.assertEqual('ch05',
+                         bc.assert_message_ids_unique()[bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG])
+
+    def test_the_fallback_costs_one_extra_id_not_two(self):
+        """`variant_beat` splices the substitute and the WHOLE scene goes to a second id --
+        vanilla's own move. Splitting the scene around the differing box would cost two."""
+        self.assertEqual({bc.CH05_SAHNAR_TALK_MSG, bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG},
+                         set(dict(bc.ch05_sahnar_talk_messages(self._chap()))))
+
+    # -- the substitution -----------------------------------------------------
+    def test_the_proof_moves_off_the_wolf_and_onto_basil_herself(self):
+        event = self._event()
+        self.assertEqual([8], event['no_lupin_fallback']['boxes'])
+        self.assertIn('A wolf.', next(iter(event['script'][7].values())))
+        for box in self._fallback():
+            self.assertNotIn('wolf', next(iter(box.values())).lower())
+
+    def test_every_box_but_the_proof_rides_through_unchanged(self):
+        """Boxes 1-7 and 9-16 are shared, box 9's "we" included -- it already covers her."""
+        locked, fallback = self._event()['script'], self._fallback()
+        self.assertEqual(locked[:7], fallback[:7])
+        self.assertEqual(locked[8:], fallback[9:])
+        self.assertIn('That we have a choice', next(iter(fallback[9].values())))
+
+    def test_the_substitute_is_hand_boxed_rather_than_left_to_the_wrapper(self):
+        """VANILLA'S CONVENTION: every [LF] and every [A] in texts.txt is authored -- MSG_9CC,
+        the scene we mine, places all 32 of its own page breaks. Flowed, our 61-character
+        substitute pages itself at "We could go free as" / "well.", mid-clause. The break goes
+        on the ellipsis, so the observation lands flat and the OFFER -- which is the whole
+        proof -- takes its own press."""
+        fallback = self._fallback()
+        self.assertEqual(17, len(fallback), 'one replaced box, two of substitute')
+        self.assertEqual('There is nothing holding us here...',
+                         next(iter(fallback[7].values())))
+        self.assertEqual('We could go free as well.', next(iter(fallback[8].values())))
+
+    def test_neither_arm_lets_the_wrapper_page_the_substitute(self):
+        bodies = dict(bc.ch05_sahnar_talk_messages(self._chap()))
+        body = bodies[bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG]
+        for authored in ('There is nothing holding us here...', 'We could go free as well.'):
+            page = [p for p in body.split('[A]') if authored.split('.')[0][:20] in
+                    re.sub(r'\[[^\]]*\]', '', p).replace('\n', '')]
+            self.assertTrue(page, 'the substitute lost its authored box: %r' % authored)
+
+    # -- the channel ----------------------------------------------------------
+    def test_both_arms_fit_the_map_talk_bubble(self):
+        for _msg, body in bc.ch05_sahnar_talk_messages(self._chap()):
+            for line in body.split('\n'):
+                printable = re.sub(r'\[[^\]]*\]', '', line)
+                self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
+
+    def test_both_arms_keep_the_two_shot_and_never_vanillas_faces(self):
+        for _msg, body in bc.ch05_sahnar_talk_messages(self._chap()):
+            self.assertIn('[OpenMidLeft][LoadFace][FID_Artur]', body)
+            self.assertIn('[OpenMidRight][LoadFace][FID_Marisa]', body)
+            self.assertNotIn('[FID_Natasha]', body)
+            self.assertNotIn('[FID_Joshua]', body)
+
+    # -- the branch, in vanilla's shape ---------------------------------------
+    def test_the_branch_picks_a_WHOLE_message_per_arm_like_ch14as_ending(self):
+        script = self._wiring()
+        self.assertIn('CHECK_ALIVE(%s)' % bc.CH05_LUPIN_CHARACTER, script)
+        alive = script.index('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_MSG)
+        absent = script.index('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG)
+        self.assertLess(script.index('CHECK_ALIVE'), alive)
+        self.assertLess(alive, absent, 'the locked arm is the fall-through, as in ch14a')
+
+    def test_the_arms_converge_before_the_single_CUSA_that_recruits_her(self):
+        """One recruit, not one per arm. ch14a shares everything after LABEL(0xb) the same way,
+        and a CUSA duplicated into both arms is how a branch grows a second bug per fix."""
+        script = self._wiring()
+        self.assertEqual(1, script.count('CUSA(CHARACTER_MARISA)'))
+        self.assertEqual(1, script.count('TEXTSTART'), 'the window opens once, before the branch')
+        self.assertEqual(1, script.count('REMA'))
+        self.assertLess(script.index('TEXTSTART'), script.index('CHECK_ALIVE'))
+        self.assertLess(script.index('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG),
+                        script.index('CUSA(CHARACTER_MARISA)'))
+
+    def test_an_unbranched_talk_still_emits_no_branch_at_all(self):
+        """ch03's Trex and ch04's Lupin pass no variant and must be byte-identical to before --
+        the whole point of parameterising the ONE flow rather than forking it."""
+        _chars, plain = bc.talk_recruit_wiring(
+            ['CHARACTER_EIRIKA'], 'CHARACTER_MARISA', bc.CH05_SAHNAR_TALK_FLAG,
+            'MS_Test', bc.CH05_SAHNAR_TALK_MSG)
+        self.assertNotIn('CHECK_ALIVE', plain)
+        self.assertNotIn('BEQ', plain)
+        self.assertNotIn('LABEL', plain)
+
+    # -- the hazard this scene carries ----------------------------------------
+    def test_the_two_arms_render_to_the_SAME_press_count(self):
+        """A TRAP, pinned so nobody builds a gate on it. The locked box 8 is 70 characters and
+        the wrapper pages it in two; the substitute is two AUTHORED boxes. Both arms therefore
+        come to the same number of A-presses, so `ch05recruit`'s box-count witness -- which is
+        what proves WHICH id played everywhere else in this chapter -- cannot tell these two
+        apart. The in-engine proof reads `sActiveMsg` instead."""
+        presses = [body.count('[A]') for _msg, body in bc.ch05_sahnar_talk_messages(self._chap())]
+        self.assertEqual(presses[0], presses[1],
+                         'if these ever diverge, a counting gate becomes possible again')
 
 
 class Ch05OpeningBackdropScenes(unittest.TestCase):

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -2724,6 +2724,20 @@ class Ch05SahnarTalkNoLupinFallback(unittest.TestCase):
         self.assertLess(script.index('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG),
                         script.index('CUSA(CHARACTER_MARISA)'))
 
+    def test_the_branchs_labels_can_be_moved_off_a_pre_scripts_own(self):
+        """BEQ/GOTO scan the whole event list for a matching LABEL, so a branch left at 0 in a
+        script whose `pre_script` also uses 0 jumps into the wrong arm. ch04's parley passes
+        exactly such a sweep (one skip label per wolf), and it is only the distance between
+        0x40 and 0 that keeps that safe today -- so the offset has to be reachable."""
+        _chars, moved = bc.talk_recruit_wiring(
+            ['CHARACTER_ARTUR'], 'CHARACTER_MARISA', bc.CH05_SAHNAR_TALK_FLAG, 'MS_Test',
+            bc.CH05_SAHNAR_TALK_MSG,
+            variant=(bc.CH05_LUPIN_CHARACTER, bc.CH05_SAHNAR_TALK_NO_LUPIN_MSG),
+            label_base=0x50)
+        self.assertIn('LABEL(0x50)', moved)
+        self.assertIn('LABEL(0x51)', moved)
+        self.assertNotIn('LABEL(0x0)', moved)
+
     def test_an_unbranched_talk_still_emits_no_branch_at_all(self):
         """ch03's Trex and ch04's Lupin pass no variant and must be byte-identical to before --
         the whole point of parameterising the ONE flow rather than forking it."""

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -145,8 +145,8 @@ class TestPlaytestHarness(unittest.TestCase):
 
     def test_ch05recruit_advances_and_counts_the_new_eruption_boxes(self):
         harness = _read_harness()
-        body = _block(harness, 'scenarios.ch05recruit = function()',
-                      '\n-- Park an unexhausted blue unit')
+        body = _block(harness, 'scenarios.ch05recruit = function(opts)',
+                      '\n-- ch05lupinbenched')
         self.assertIn('eruptionBoxes', body,
                       'the recruit gate would hang before Sahnar LOADs if it never advances '
                       'Ravisin\'s newly visible warning')
@@ -155,6 +155,31 @@ class TestPlaytestHarness(unittest.TestCase):
         self.assertIn('eruption warning showed %d boxes', body,
                       'the gate must distinguish the locked four-box scene from merely '
                       'reaching turn 2')
+
+    def test_ch05recruit_names_the_message_id_it_saw_not_just_the_box_count(self):
+        """The Talk recruit's two arms both recruit Sahnar and both run 21 boxes (#25), so
+        every other assertion in this gate passes on either one. `sActiveMsg` is the only
+        witness that separates them, and it has to be SAMPLED WHILE A BOX IS UP -- menus and
+        unit names decode through the same buffer the moment the scene ends."""
+        harness = _read_harness()
+        body = _block(harness, 'scenarios.ch05recruit = function(opts)',
+                      '\n-- ch05lupinbenched')
+        self.assertIn('INSPECT.activeMsg()', body)
+        self.assertIn('playedMsg = playedMsg or INSPECT.activeMsg()', body,
+                      'the id must be latched on the FIRST box, not read after the scene')
+        self.assertIn('if playedMsg ~= ARM then', body,
+                      'sampling the arm without asserting it is a gate that cannot fail')
+
+    def test_the_two_owed_check_alive_states_each_name_their_expected_arm(self):
+        """benched -> the wolf's arm (0x9E8); killed -> the no-Lupin arm (0x9D1). The pair IS
+        the proof #25 still owed, and getting either expectation backwards would make the run
+        certify the bug it exists to catch."""
+        harness = _read_harness()
+        for scenario, state, arm in (('ch05lupinbenched', 'benched', '0x9E8'),
+                                     ('ch05lupinkilled', 'killed', '0x9D1')):
+            body = _block(harness, 'scenarios.%s = function()' % scenario, '\nend')
+            self.assertIn('lupin = "%s"' % state, body)
+            self.assertIn('arm = %s' % arm, body)
 
     def test_ch05arena_proves_the_loaded_winter_palette_and_skeleton_face(self):
         harness = _read_harness()

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -386,6 +386,17 @@ class RealManifest(unittest.TestCase):
         missing = sorted(self.harness - set(self.m.scenarios))
         self.assertEqual(missing, [], 'new scenarios in harness.lua need a matrix.yaml row')
 
+    def test_the_talk_recruits_other_arm_is_actually_gated(self):
+        """`ch05recruit` runs on a ROM with no wolf, so it only ever walks the no-Lupin arm --
+        an inverted BEQ or a swapped pair of message ids passes it. A scenario in no suite runs
+        in no gate, which is how a branch ends up with one tested arm and one hoped-for one."""
+        for scenario in ('ch05lupinbenched', 'ch05lupinkilled'):
+            self.assertIn(scenario, self.m.scenarios)
+            member_of = [s for s, members in self.m.suites.items() if scenario in members]
+            self.assertTrue(member_of, '%s is in no suite, so nothing runs it' % scenario)
+        self.assertIn('ch05lupinbenched', self.m.suites['gate'],
+                      'the gate must walk the arm ch05recruit cannot reach')
+
     def test_every_manifest_row_still_exists_in_harness(self):
         stale = sorted(set(self.m.scenarios) - self.harness)
         self.assertEqual(stale, [], 'matrix.yaml rows for scenarios harness.lua no longer defines')


### PR DESCRIPTION
The last of ch05's five fallbacks, and with it #25's last two owed `CHECK_ALIVE` states.

**Review page (plain language, with the on-screen text):** https://claude.ai/code/artifact/0253bb73-7d6b-44b9-90b3-767b8b6dfe12

## What it does

Box 8 of the Talk recruit is PROOF #1 — the evidence that turns Sahnar — and it is a wolf ch04's optional parley may never have handed the player. The substitute makes the proof **Basil**: not "someone else already walked free" but "the two of us could".

## Nothing here is new machinery

`ch14a-eventscript.h` branches on `CHECK_ALIVE(CHARACTER_JOSHUA)` — Sahnar's own donor, and vanilla Ch5's optional Talk recruit — and picks a *whole message* per arm before converging on a shared `LABEL`. `talk_recruit_script` now emits exactly that shape; only `TEXTSHOW`+`TEXTEND` go inside the arms, while `TEXTSTART`, the `REMA` and above all the `CUSA` stay shared. An unbranched Talk (ch03's Trex, ch04's Lupin) emits no branch at all.

The substitute is **hand-boxed**, which is vanilla's convention rather than a house style: every `[LF]` and `[A]` in `texts.txt` is authored, and `MSG_9CC` — the Natasha->Joshua recruit this scene is the twin of — places all 32 of its own page breaks. The break falls on the ellipsis, so the *offer* takes its own press rather than trailing the clause it answers.

## The trap this turned up

**Both arms run 21 A-presses.** The locked box 8 is 70 characters and the wrapper pages it in two; the substitute is two authored boxes. So `ch05recruit`'s box count — the witness that proves *which id played* everywhere else in this chapter — cannot tell these two apart, and a gate built on it would go green with the wrong scene on screen.

The harness now reads `sActiveMsg` (`src/msg.c`) — the index `GetStringFromIndex` last decoded, sampled while the first box is up. Strictly better than counting, and available to every other dialogue gate.

## Proved in-engine

| scenario | roster state | arm played |
|---|---|---|
| `ch05lupinbenched` | `US_NOT_DEPLOYED`, off-map | the wolf's (`0x9E8`) PASS |
| `ch05lupinkilled` | `US_DEAD` | the no-Lupin one (`0x9D1`) PASS |
| `ch05recruit` | no roster entry | the no-Lupin one (`0x9D1`) PASS |

The **benched** run is the one that mattered: it says our build reads the ROSTER and not the field, so a player who won the wolf and benched him is not told he does not exist. All three ran 21 boxes — the trap above, demonstrated rather than predicted.

Both new scenarios ride the existing `ch05lupinboot` ROM and the existing `ch05recruit` scenario (parameterised over the wolf's state), which also keeps `harness.lua` at its 2 free top-level local slots.

## Also

- `0x9D1` swept free from vanilla Ch5's tutorial text, whose only reference is a list `inject_ch04` zeroes — verified against HEAD.
- Three ADRs in `docs/decisions.md`: box-count-vs-identity, the four states now all run, and the authored page break with vanilla as its source.

`make check` clean · 540 build tests · `verify_text` 0 runaway.

Refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
