### PR TITLE
text: wrap dialogue by PIXELS, at vanilla's own width

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4536,6 +4536,77 @@ Against #25's four states this settles **two**: *never recruited* (the plain boo
 still only a decomp reading — `CHECK_ALIVE` ignores `US_NOT_DEPLOYED` and treats `US_DEAD` as
 absent — and a reading is not a run.
 
+### A reskin keeps its donor's CLASS NAME, and that is the intent (2026-08-21)
+
+ch05's skeletons read "Soldier"/"Fighter", ch01's goblins "Soldier", ch03's kobolds "Brigand". No
+reskin in `campaign.yaml` carries a `name:`, and none needs one.
+
+**RULED (Nicolas, 2026-08-21): "the skins saying the real class is the expected pattern, so just
+leave it as is."** The reskin changes what a unit LOOKS like, not what it IS — an FE8 Soldier
+dressed as a skeleton is still a Soldier, and the class name is the player's read on its stats,
+weapon type and movement. Renaming it would hide the one piece of information the class name
+exists to carry.
+
+Closed as a question. Do not re-open it per chapter.
+
+### We wrapped on-map talk at 29 CHARACTERS; the engine measures PIXELS (2026-08-21)
+
+`_wrap_fe_lines`' default was 29, and its docstring derived that from vanilla: *"MSG_910/911 top
+out at 29 chars"*. Both halves are true and the conclusion does not follow — **`MSG_910` is simply
+a narrow message**, and the rule generalised one short sample into a ceiling.
+
+**The engine never counts characters.** `StartTalkExt` (scene.c:403) sets
+`activeWidth = Div(GetStrTalkLen(str, 0) + 7, 8) + 2` — `GetStrTalkLen` accumulates
+`glyph->width` **in pixels** (`fontgrp.c` → `GetStringTextLenASCII`), and the `/8 + 2` converts to
+tiles plus the bubble border. The talk font is **variable-width**: measured out of `TextGlyphs_Talk`
+in the built ROM, `i` is 2px, `.` is 2px, space is 4px, `a` and `m` are 6px, `W` is 8px. A
+29-character line can be anywhere from ~60px to ~230px, so a character count is not a conservative
+proxy — it is an unrelated quantity that happens to correlate.
+
+Measured, in this exact channel (on-map `TEXTSHOW`, widest DRAWN line):
+
+| | widest line | |
+|---|---|---|
+| `MSG_9CC` — vanilla's Natasha→Joshua Talk, the scene ch05's Talk is the twin of | **203px** (43 ch) | |
+| `MSG_9C3` — vanilla, same channel | 182px (39 ch) | |
+| `MSG_910` — the message the 29 rule was read off | 140px (29 ch) | the narrow sample |
+| ch05's Talk recruit, ours | **132px** (29 ch) | **65% of vanilla's** |
+
+**So there is no tradeoff to weigh, which was the question.** Vanilla ships 203px lines in the
+same window, from the same podiums, and 203px + the 2-tile border is 219px against a 240px screen.
+Wrapping at 29 characters buys nothing and costs A-presses: re-flowing ch05's authored dialogue at
+vanilla's own budget saves **27 of 152 presses (18%)** without touching one word or one authored
+break.
+
+The budget is per-PODIUM in principle — the bubble anchors at `gTalkFaceHPosLut` and is clamped to
+[0,30] tiles — but vanilla's 203px line sits on `[OpenMidRight]`, which is exactly where ours sit,
+so the comparison is like-for-like rather than a hope.
+
+**HOW THE ROLLOUT MUST BE GATED, learned the hard way.** Changing the wrapper means changing
+every call site of a function whose parameter CHANGED UNITS, and a regex sweep over those sites
+broke three things the 546 unit tests all passed through:
+
+- it stripped `width=` from function DEFINITIONS as well as calls, so their bodies referenced an
+  undefined name;
+- it missed a POSITIONAL `29`, and ch05's moose scene silently re-wrapped to seven characters
+  a line;
+- it flattened two sites that are **not the talk window at all** — the lord-select CARD (a fixed
+  20-column panel drawn by our own generated `LordSelect_DrawCard` through its own font) and
+  ch03's faceless narration beats (the auto-centered `SOLOTEXTBOXSTART` box, `helpbox.c`).
+  Those keep character widths and now pass `measure=len`, because the talk font's glyph widths
+  do not describe either renderer and extending a measurement past what it measured is how the
+  29 rule got made in the first place.
+
+None of that was caught by tests. What caught all three was **rendering every message body under
+the old code and the new and diffing them**: 3404 messages, and the invariants are that no body
+loses a WORD and — for a widening — no body costs MORE A-presses. That diff is the gate for any
+future wrap change; run it before the test suite, not after. Result here: 86 bodies re-wrapped,
+0 words moved, 0 bodies more expensive, **60 fewer A-presses campaign-wide**.
+
+_Answered: 2026-08-21 (Nicolas: "I really don't understand if there's a tradeoff which is why I
+keep pointing to vanilla as reference. Do you really need my input for this?" — no, and this is
+what the reference says)._
+
 ### Two arms of one branch can be the same LENGTH — so box count is not a witness (2026-08-21, #25)
 
 Every ch05 scene is gated in-engine by counting A-presses: a scene of the wrong length is a scene
@@ -4562,6 +4633,14 @@ Generalises past this scene: **the box count is a shape check and the message id
 check, and #25 wanted identity all along** ("Assert *which* message id played … not merely that a
 scene ran"). Box counts were standing in for identity only because two ids had always differed in
 length. Prefer `INSPECT.activeMsg()` for any new dialogue gate.
+
+**POSTSCRIPT, same day: the collision is gone, and the rule stands anyway.** Retiring the
+29-character wrap (see the ADR above) means nothing pages itself: presses now equal AUTHORED
+boxes, so these two arms are 16 and 17 and a count *could* tell them apart again. That is a
+happy accident of one scene's arithmetic, not a property anyone should lean on — the next branch
+whose arms are the same length brings the blindness straight back. The gate keeps reading
+`sActiveMsg`. What did change is that a press count is now a fact about the SCRIPT rather than
+about the wrap, which makes it a much better SHAPE check than it was.
 
 _Recorded: 2026-08-21, found while wiring the Talk recruit's fallback (#25)._
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -1419,7 +1419,10 @@ def _script_to_message(script, staging, width=fe8_talk_font.TALK_BUDGET_PX, face
     skipped here. `stage_break` is the exception that IS rendered: it emits
     vanilla's `[BreakTalk]`, a pause the event script resumes with `TEXTCONT`, so
     a wordless action can happen mid-message without buying a second message id
-    (see SCRIPT_DIRECTIVES). `width` is the wrap width (29 = map speech bubble;
+    (see SCRIPT_DIRECTIVES). `width` is a PIXEL budget and `measure` the function that
+    applies it -- fe8_talk_font.TALK_BUDGET_PX for the talk bubble, BATTLE_QUOTE_BUDGET_PX for
+    a quote shown during a battle animation, SOLO_BOX_BUDGET_PX for the auto-centered helpbox.
+    Passing a character count here is the failure this parameter used to invite (was:
     ~42 for a full-screen scenic BG -- see _wrap_fe_lines).
 
     `trailing` is a raw text-code string appended just before the [X] terminator --
@@ -6285,9 +6288,9 @@ def inject_prologue(campaign, verbose=True, montage=False):
     set_message_body(lines, 0x918, _script_to_message(
         events['chapter_end']['script'], ending_staging))
     set_message_body(lines, 0x936, _script_to_message(
-        [{'sephek': by_id['sephek-kaltro']['death_quote']}], opening_staging))
+        [{'sephek': by_id['sephek-kaltro']['death_quote']}], opening_staging, width=fe8_talk_font.BATTLE_QUOTE_BUDGET_PX))
     set_message_body(lines, 0x917, _script_to_message(
-        [{'hlin': by_id['hlin-trollbane']['death_quote']}], ending_staging))
+        [{'hlin': by_id['hlin-trollbane']['death_quote']}], ending_staging, width=fe8_talk_font.BATTLE_QUOTE_BUDGET_PX))
     set_message_body(lines, 0xC25, _script_to_message(
         [{'scramsax': by_id['scramsax']['defeat_quote']}], ending_staging))
 
@@ -6543,9 +6546,9 @@ def _emit_scene_beats(lines, msg_ids, beats, fid, home, overrides=None,
                       preloads=None, width=None, trailings=None):
     """Write one message per scenic beat (staging via _stage_beat, body via
     _script_to_message). width=None picks per beat: faceless-narration beats ride
-    the opaque, auto-centered SOLOTEXTBOXSTART box (#58) wrapped at the on-map 28
-    (42 overflows the centered box); faced beats use the full-screen scenic 42.
-    A fixed width (e.g. 42) overrides for scenes with no narration beats.
+    the opaque, auto-centered SOLOTEXTBOXSTART box (#58) at SOLO_BOX_BUDGET_PX (helpbox.c
+    clamps that box to 0xC0 while its text draws unclamped); faced beats take the talk
+    bubble's TALK_BUDGET_PX. A fixed width overrides for scenes with no narration beats.
     `trailings` (parallel to beats) appends a raw text-code to a beat's body -- see
     _script_to_message's `trailing` (the single-face-exit fade)."""
     overrides = overrides or [None] * len(beats)
@@ -6560,9 +6563,14 @@ def _emit_scene_beats(lines, msg_ids, beats, fid, home, overrides=None,
         # Faced scene beats render via _scenic_beat_calls -> Text() -> a TALK BUBBLE (PutTalkBubble),
         # NOT a full-screen box -- and a bubble line over 29 tiles hits the unclamped x = 29 - width
         # < 0 branch and overflows off the right edge (the ch03 crier "...pays fifty gold to whoever
-        # cle|" bug). So faced beats must wrap at the map-bubble 29 (the entrance line already does);
-        # narration keeps the 28 that fits the auto-centered SOLOTEXTBOXSTART.
-        w = width if width is not None else fe8_talk_font.TALK_BUDGET_PX
+        # cle|" bug). So faced beats take the talk bubble's pixel budget; narration keeps the
+        # narrower one that fits the auto-centered SOLOTEXTBOXSTART.
+        # width=None still picks PER BEAT, and the pair is not cosmetic: a faceless narration
+        # beat rides the opaque auto-centered SOLOTEXTBOXSTART box, which helpbox.c clamps to
+        # 0xC0 while its text draws unclamped. Only a FACED beat gets the talk bubble's budget.
+        w = width if width is not None else (
+            fe8_talk_font.SOLO_BOX_BUDGET_PX if _beat_is_narration(beat)
+            else fe8_talk_font.TALK_BUDGET_PX)
         set_message_body(lines, msg_id, _script_to_message(
             beat, _stage_beat(beat, fid, home, override), width=w, preload=preload,
             trailing=trailing))
@@ -7952,9 +7960,9 @@ def inject_ch01(campaign, verbose=True):
     # both from the chapter YAML (lore/izobai.md voice). She/her throughout.
     izobai_face = {'izobai': ('[OpenMidRight]', _fid_tag(CH01_BOSS_SLOT))}
     set_message_body(lines, CH01_TAUNT_MSG, _script_to_message(
-        [{'izobai': chief['taunt']}], izobai_face))
+        [{'izobai': chief['taunt']}], izobai_face, width=fe8_talk_font.BATTLE_QUOTE_BUDGET_PX))
     set_message_body(lines, 0x961, _script_to_message(
-        [{'izobai': chief['death_quote']}], izobai_face))
+        [{'izobai': chief['death_quote']}], izobai_face, width=fe8_talk_font.BATTLE_QUOTE_BUDGET_PX))
     # Hint houses -- vanilla Ch1's own two house quotes (0x93B/0x93C) reskinned with the
     # goblin nouns (dialogue pass, 2026-06-17). Two different villager faces, like vanilla.
     set_message_body(lines, 0x93B, _script_to_message([{'villager': (
@@ -8017,7 +8025,10 @@ def inject_ch01(campaign, verbose=True):
         set_message_body(lines, LORDSEL_PITCH_MSGS[i], _term_pad(body + '[X]'))
     # The one-time explainer box (#46 (a)) rides the normal tutorial text box, so it uses
     # the talk decoder: [A] page breaks every two lines + the standard [.] parity pad.
-    expl = _wrap_fe_lines(_fe_dialogue_text(LORDSEL_EXPLAINER_TEXT))
+    # TUTORIALTEXTBOXSTART, not the talk bubble: Event1B_TEXTSHOW routes it through the same
+    # helpbox proc as the solo box, whose width clamps at 0xC0.
+    expl = _wrap_fe_lines(_fe_dialogue_text(LORDSEL_EXPLAINER_TEXT),
+                          fe8_talk_font.SOLO_BOX_BUDGET_PX)
     expl_body = ''.join(
         ln + ('' if j == len(expl) - 1
               else '[A]' if (j + 1) % 2 == 0 else '[LF]')
@@ -8551,7 +8562,7 @@ def inject_ch02(campaign, verbose=True):
     _emit_scene_beats(lines, CH02_ENDING_MSGS, end_beats, cut_fid, {})
     set_message_body(lines, CH02_BOSS_DEATH_MSG, _script_to_message(
         [{'halvar': halvar['death_quote']}],
-        {'halvar': ('[OpenMidRight]', _fid_tag(CH02_BOSS_SLOT))}))
+        {'halvar': ('[OpenMidRight]', _fid_tag(CH02_BOSS_SLOT))}, width=fe8_talk_font.BATTLE_QUOTE_BUDGET_PX))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
 
@@ -9099,7 +9110,7 @@ CH05_GOAL_STATUS_MSG = 0x9F5
 # lines above it is what it actually plays over. So the Joshua/Natasha meet-cute -- our scene 1's
 # twin -- is a BACKDROP scene, and our three tomb scenes are too. It also settles the question the
 # scene table left open: nothing is staged on the field this early, so no talk bubble has a unit
-# to anchor to (PutTalkBubble needs one), and the full-screen window wraps at 42 rather than 29.
+# to anchor to (PutTalkBubble needs one); both windows now take one measured pixel budget.
 #
 # ONE backdrop across all three, which is vanilla's habit too -- it spends BG_SERAFEW_VILLAGE on
 # four consecutive scenes and only switches to BG_TOWN when the party physically arrives.
@@ -9132,7 +9143,7 @@ CH05_ARRIVAL_NO_LUPIN_MSG = 0x9ED
 # reference and nothing else, and CHECK_ALIVE resolves a pid through GetUnitFromCharId).
 CH05_LUPIN_CHARACTER = char_symbol(PORTRAIT_MAP['lupin'])
 # ── Scene 5 (#25): Basil trundles up, cracks the tourist joke, and JOINS ─────────────────────
-# The opening's FIRST on-map beat, so it wraps at the talk bubble's 29 rather than the scenic 42
+# The opening's FIRST on-map beat, so it wraps at the talk bubble's budget
 # -- and the one scene whose PLACEMENT does not inherit from the twin. Vanilla plays its 0x9C2
 # BEFORE the prep CALL, but it can: it LOAD1s its speaking party onto the street first. Ours is
 # placed BY prep (the ally table is never LOADed on a prep chapter -- decisions.md "How the deploy
@@ -9556,7 +9567,7 @@ def variant_beat(beat, fallback, err_label):
 
     A `script:` entry may be a LIST of boxes rather than one, and then the named box is
     replaced by all of them. A substitute chosen as prose can simply be too long for the
-    channel it lands in -- ch05's on-map fallbacks are, at the talk bubble's 29 -- and the
+    channel it lands in -- ch05's on-map fallbacks were, at the old 29 -- and the
     author has to place the extra A-press, because a wrapper left to choose it puts the page
     break mid-clause. `boxes:`/`replaces:`/`script:` still agree one-for-one; only the
     substitute is plural, which is what keeps this one mechanism rather than two.
@@ -9619,7 +9630,7 @@ def locked_and_variant(script, fallback, render, err_label, msgs):
     The pairing every fallback in this campaign takes, kept independent of the CHANNEL because
     the two channels render nothing alike -- a backdrop scene goes through `_ch05_opening_body`
     (podium-checked, width 42) while an on-map one goes straight to `_script_to_message` at the
-    bubble's 29. `render` is whatever turns a beat into a body; everything else here is the part
+    bubble's budget. `render` is whatever turns a beat into a body; everything else is the part
     that must not be written twice.
 
     Whole copies rather than a prefix/arm/suffix split, which is vanilla's own economy: ch14a's
@@ -11072,8 +11083,9 @@ def inject_ch03(campaign, boot=False, verbose=True):
                       trailings=op_trailings)
     set_message_body(lines, CH03_ENDING_CARD_MSG, name_message_body(end_card))
     _emit_scene_beats(lines, CH03_ENDING_MSGS, end_beats, cut_fid, {})
-    # Midmap RBG-execution beats (on-map, no card): faced beats wrap at the map-bubble 29; the two
-    # faceless ACTION boxes wrap at 28 for the auto-centered opaque box. Beat A (Pinky's opening)
+    # Midmap RBG-execution beats (on-map, no card): faced beats wrap at the talk bubble's budget; the two
+    # faceless ACTION boxes take SOLO_BOX_BUDGET_PX, the auto-centered opaque box's own clamp.
+    # Beat A (Pinky's opening)
     # PRELOADS the Brute's mug as a silent listener at mid-right, so the player sees WHO Pinky is
     # talking to before it lunges (the Brute otherwise only appeared when it snarled in A3 -- Nicolas
     # 2026-07-11). The Brute + RBG both anchor mid-right via op_home (never on screen together; each
@@ -11087,7 +11099,8 @@ def inject_ch03(campaign, boot=False, verbose=True):
         # which nobody has measured in pixels, so it keeps the character width it was authored
         # against and says so with `measure=len`. Converting it on the talk window's evidence
         # would be extending a measurement past what it measured.
-        kw = ({'width': 28, 'measure': len} if _beat_is_faceless(beat, cut_fid) else {})
+        kw = ({'width': fe8_talk_font.SOLO_BOX_BUDGET_PX}
+              if _beat_is_faceless(beat, cut_fid) else {})
         set_message_body(lines, msg, _script_to_message(
             beat, _stage_beat(beat, cut_fid, op_home), preload=preload, **kw))
     set_message_body(lines, CH03_TREX_ENTRANCE_MSG, _script_to_message(
@@ -11453,13 +11466,13 @@ def inject_ch04(campaign, boot=False, verbose=True):
     # ch04 scene (#208; they were Python literals left over from the Stage 2c stubs). Lupin
     # commands the pack from the pack side (mid-right); Marty reads it cross-field from the party
     # side (mid-left) and FLAGS the parley -- the beat that teaches "talk to the leader".
-    # ON-MAP, so it wraps at the map-bubble 29 like the moose beat, not the BG scenes' 42.
+    # ON-MAP -- same talk-bubble budget as the moose beat (one budget now; see fe8_talk_font).
     _, reveal_beats = _split_event_beats(chap, 'wolf_pack_reveal', 'ch04 turn-2 reveal',
                                          msg_ids=CH04_REVEAL_MSGS, card_required=False)
     _emit_scene_beats(lines, CH04_REVEAL_MSGS, reveal_beats, cut_fid,
                       {'lupin': '[OpenMidRight]', 'marty': '[OpenMidLeft]'})
     # Stage 4 scene bodies. The opening + both endings play over a BG (full-screen window, wrap
-    # 42); the moose beat is ON-MAP, so it wraps at the map-bubble 29 (a wider line hits
+    # the talk budget); the moose beat is ON-MAP and takes the same one (a wider line hits
     # PutTalkBubble's unclamped right-side branch and runs off the tilemap -- the ch03 crier bug).
     set_message_body(lines, CH04_OPENING_CARD_MSG, name_message_body(op_card))
     _emit_scene_beats(lines, CH04_OPENING_MSGS, op_beats, cut_fid, op_home)
@@ -11477,7 +11490,7 @@ def inject_ch04(campaign, boot=False, verbose=True):
     # The village lines (#205, #24). The axe door is Nimsy herself, wearing the vanilla old-lady
     # mug the opening already gave her; the forest cottage is a logger who never opens up, on
     # vanilla's own snag-village mug. Both play over BG_NORMAL_VILLAGE (full-screen window), so
-    # they wrap at 42 like the other BG scenes rather than the on-map bubble's 29.
+    # they take the same talk budget as every other faced scene.
     #
     # One `visit_text` entry per BOX: consecutive turns by one speaker coalesce into a single
     # [OpenX] block with each entry's pages kept whole, so the authored beats survive as the
@@ -11642,7 +11655,7 @@ def ch05_ravisin_taunt_message(chap):
         sys.exit('ERROR: ch05 Ravisin battle taunt must remain one locked Ravisin box')
     return _script_to_message(
         beat,
-        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))})
+        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))}, fe8_talk_font.BATTLE_QUOTE_BUDGET_PX)
 
 
 def ch05_ravisin_death_message(chap):
@@ -11660,7 +11673,7 @@ def ch05_ravisin_death_message(chap):
         sys.exit('ERROR: ch05 Ravisin death quote must remain one locked Ravisin box')
     return _script_to_message(
         beat,
-        {'ravisin': ('[OpenMidRight]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))})
+        {'ravisin': ('[OpenMidRight]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))}, fe8_talk_font.BATTLE_QUOTE_BUDGET_PX)
 
 
 def ch05_sahnar_talk_messages(chap):
@@ -11677,7 +11690,7 @@ def ch05_sahnar_talk_messages(chap):
     reads as two people facing each other rather than one podium swapping faces. Basil is the
     Natasha-donor Cleric walked across under escort; Sahnar is the red crit-Myrmidon she turns.
 
-    ON-MAP, so the body wraps at the map bubble's 29 -- a wider line hits PutTalkBubble's
+    ON-MAP, so the body wraps at the talk bubble's pixel budget -- a wider line hits PutTalkBubble's
     unclamped right-side branch and runs off the tilemap (the ch03 crier bug). Consecutive turns
     by one speaker coalesce into a single [OpenX] block with the authored breaks kept as pages,
     so all sixteen A-presses survive.
@@ -11774,9 +11787,9 @@ def ch05_opening_messages(chap):
     at CH05_ARRIVAL_SLOT's id and the substituted variant at CH05_ARRIVAL_NO_LUPIN_MSG, one of
     which `branch_on_check_alive` plays. That is the whole cost of a fallback -- one extra id.
 
-    Rendered at the full-screen scenic 42 rather than the map bubble's 29: these play over a
+    Rendered at the talk budget like every faced scene: these play over a
     BACG with nothing staged on the field, which is vanilla Ch5's own channel for the same
-    beats (see CH05_OPENING_SLOTS). A faced beat wrapped at 29 would merely be needlessly
+    beats (see CH05_OPENING_SLOTS). A faced beat wrapped narrower would merely be needlessly
     narrow here -- the 29 exists for PutTalkBubble's unclamped right edge, and there is no
     bubble.
 
@@ -11810,7 +11823,7 @@ def ch05_opening_messages(chap):
 def ch05_basil_join_messages(chap):
     """Scene 5 -- Basil's join -- and its no-Lupin twin, as (msg_id, body) pairs.
 
-    The opening's first ON-MAP beat, so it renders at the talk bubble's 29 and not the backdrop
+    The opening's first ON-MAP beat, so it renders at the talk bubble's budget and not the backdrop
     scenes' 42: `PutTalkBubble`'s right-side branch computes x = 29 - width with no clamp, so a
     wider line runs off the tilemap (the ch03 crier bug). Everything else is the arrival's
     machinery unchanged, which is the point of `_ch05_scene_and_variant`.
@@ -11834,7 +11847,7 @@ def ch05_sahnar_alone_message(chap):
     never met the wolf and never mentions him, so there is nothing for a no-Lupin branch to
     substitute and the scene costs one id.
 
-    Rendered at the talk bubble's 29, not the backdrop scenes' 42. That is the twin's channel
+    Rendered at the talk bubble's budget. That is the twin's channel
     taken whole: vanilla plays its 0x9C3 as a bare `TEXTSHOW` over the map with Joshua standing
     on this same tile. Until 2026-08-14 ours could not, because Sahnar did not exist on the
     field until the turn-2 eruption; the scene-3 summon is what put her there.
@@ -11853,7 +11866,7 @@ def ch05_moose_charge_message(chap):
     SCENE CHANGE: the full-screen CG needs `REMOVEPORTRAITS`, that tears the talk down, and a
     `[BreakTalk]` pause cannot survive it (filmed 2026-08-15 -- the CG played, the charge played,
     and the quip never appeared). One `stage_cut:`, two ids, and the second is what the bellow
-    costs. Both render at the talk bubble's 29 -- they are on-map beats either side of the image.
+    costs. Both render at the talk bubble's budget -- on-map beats either side of the image.
 
     One arm, so no variant: the moose is ch04's quarry and Lupin's presence changes nothing
     about it (Pinky is the party's other tracker and asks on either path).
@@ -12797,8 +12810,8 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
     for msg_id, body in arena_wiring['messages']:
         set_message_body(lines, msg_id, body)
     # The four reliquary visits (#25). Each site's speaker is one of the tomb's risen dead, over
-    # BG_HOUSE -- a full-screen backdrop, so these wrap at 42 like the other BG scenes and NOT at
-    # the on-map bubble's 29. One `visit_text` entry per BOX, ch04's lesson: the authored A-press
+    # BG_HOUSE -- a full-screen backdrop, wrapped at the same talk budget as the BG scenes, not at
+    # the on-map bubble. One `visit_text` entry per BOX, ch04's lesson: the authored A-press
     # breaks are the pacing (27 boxes against vanilla Ch5's own 26), and a flowed scalar would
     # reflow them to wherever 42 columns happen to land.
     for village in chap['villages']:
@@ -12954,7 +12967,7 @@ def inject_pc_death_quotes(campaign, verbose=True):
             sys.exit('ERROR: %s YAML has no death_quote (#6 requires one per cast member)'
                      % unit_id)
         set_message_body(lines, PC_DEATH_QUOTE_MSGS[unit_id], _script_to_message(
-            [{unit_id: quote}], {unit_id: ('[OpenMidLeft]', _fid_tag(slot))}))
+            [{unit_id: quote}], {unit_id: ('[OpenMidLeft]', _fid_tag(slot))}, width=fe8_talk_font.BATTLE_QUOTE_BUDGET_PX))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     # 2. Prepend the entries at the head of gDefeatTalkList (same idiom as the boss

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -49,6 +49,8 @@ import gen_subtitle_cards  # noqa: E402
 import build_scopes  # noqa: E402  per-step write attribution for the matrix (#255 phase 2)
 from PIL import Image  # noqa: E402
 import yaml  # noqa: E402
+
+import fe8_talk_font
 from inject.decomp import (  # noqa: E402  shared decomp paths + patch primitives
     REPO, DECOMP, _find_brace_block, _replace_brace_block,
     BATTLEQUOTES_C, BMUNIT_C, LORDSEL_FLAG_BASE,
@@ -1266,11 +1268,31 @@ def _script_staged_names(script):
     return names
 
 
-def _wrap_fe_lines(text, width=29):
-    """Word-wrap dialogue to GBA text lines. Default width matches vanilla's ON-MAP
-    messages (MSG_910/911 top out at 29 chars): map speech bubbles auto-size to the
-    text, and longer lines overflow the bubble's max width and clip (caught on the
-    2026-06-10 scenes capture -- full-screen Text_BG tolerates ~42, bubbles do not).
+def _wrap_fe_lines(text, width=fe8_talk_font.TALK_BUDGET_PX,
+                   measure=fe8_talk_font.text_px):
+    """Word-wrap dialogue to GBA text lines. `width` is a PIXEL budget, not a character count.
+
+    IT USED TO BE CHARACTERS, defaulting to 29 "because vanilla's MSG_910/911 top out at 29".
+    Both halves of that were true and the conclusion did not follow: MSG_910 is simply a NARROW
+    message, and one short sample became a ceiling. The engine has never counted characters --
+    `GetStrTalkLen` (scene.c) sums `glyph->width` in pixels and `StartTalkExt` divides that into
+    the bubble's tiles -- and the talk font is variable-width, so `i` is 2px against `W`'s 8px
+    and a character count is an unrelated quantity that merely correlates. Vanilla's own Talk
+    recruit (MSG_9CC, the scene ch05's is the twin of) draws a 43-character line in this exact
+    window. Long form + the measurements: `decisions.md` -> "We wrapped on-map talk at 29
+    CHARACTERS; the engine measures PIXELS".
+
+    ONE BUDGET, BOTH CHANNELS. The old rule split on/off-map at 29 and 42; measured in pixels
+    vanilla's two channels agree (203px on-map, 201px full-screen), because both windows are
+    near-full-width on a 240px screen. The split was an artifact of the wrong instrument.
+
+    `measure` TRAVELS WITH `width`, and that pairing is the point: not every panel in this game
+    is the talk window. Our own lord-select CARD is drawn by generated code through its own
+    `InitText` font in a fixed narrow column, so it is authored in CHARACTERS and passes
+    `measure=len` with a character width. Converting it to the talk budget silently re-wrapped
+    a 20-column card to four characters a line -- caught by diffing every rendered body against
+    the previous build, not by a test, which is why that diff is now the gate for a wrap change.
+
     A bare '--' never opens a line: the dash glues to the word before it -- and when
     that glue would not FIT, the word it is glued to moves down with it rather than the
     line running two characters over. (It used to glue unconditionally, so a line ending
@@ -1278,16 +1300,17 @@ def _wrap_fe_lines(text, width=29):
     what found it.)
 
     RESIDUAL, and it is a genuine conflict rather than an oversight: a word whose own
-    length plus ' --' already exceeds `width` cannot be placed at all without breaking one
+    drawn width plus ' --' already exceeds `width` cannot be placed at all without breaking one
     of the two rules. The glue wins, so such a line goes out over-width -- there is no
     shorter arrangement, since the pair is atomic. Every line this function emits is
     therefore within `width` UNLESS it is a lone word carrying its dash. No authored box
     in the campaign is anywhere near that (checked across all of them at 29 and 42); if one
     ever is, the fix is to reword it, not to loosen the glue."""
+    fits = lambda s: measure(s) <= width
     out, cur = [], ''
     for w in text.split():
         if w == '--' and cur:
-            if len(cur) + 3 <= width:
+            if fits(cur + ' --'):
                 cur += ' --'
             else:
                 head, _, tail = cur.rpartition(' ')
@@ -1298,7 +1321,7 @@ def _wrap_fe_lines(text, width=29):
                     cur += ' --'              # a one-word line: nothing left to break at
             continue
         cand = (cur + ' ' + w) if cur else w
-        if len(cand) > width and cur:
+        if cur and not fits(cand):
             out.append(cur)
             cur = w
         else:
@@ -1345,8 +1368,9 @@ def split_on_stage_cut(script, where):
     return before, script[i]['stage_cut'], after
 
 
-def _script_to_message(script, staging, width=29, face_budget=4, preload=None,
-                       trailing=None):
+def _script_to_message(script, staging, width=fe8_talk_font.TALK_BUDGET_PX, face_budget=4,
+                       preload=None, trailing=None,
+                       measure=fe8_talk_font.text_px):
     """Render a chapter-YAML cutscene `script:` block as an FE8 message body.
 
     Mirrors the vanilla shape (cf. MSG_910/911): faces are loaded lazily at a
@@ -1427,7 +1451,7 @@ def _script_to_message(script, staging, width=29, face_budget=4, preload=None,
             continue
         if speaker in SCRIPT_DIRECTIVES:
             continue
-        lines = _wrap_fe_lines(_fe_dialogue_text(text), width)
+        lines = _wrap_fe_lines(_fe_dialogue_text(text), width, measure)
         pages = ['[LF]\n'.join(lines[p:p + 2]) for p in range(0, len(lines), 2)]
         if blocks and blocks[-1][0] == speaker:
             blocks[-1][1].extend(pages)
@@ -1624,8 +1648,7 @@ def dev_placeholder_message():
     slot = PORTRAIT_MAP[DEV_PLACEHOLDER_SPEAKER]
     return _script_to_message(
         [{DEV_PLACEHOLDER_SPEAKER: DEV_PLACEHOLDER_LINE}],
-        {DEV_PLACEHOLDER_SPEAKER: ('[OpenMidLeft]', _fid_tag(slot))},
-        width=42)
+        {DEV_PLACEHOLDER_SPEAKER: ('[OpenMidLeft]', _fid_tag(slot))})
 
 
 def inject_names(campaign, verbose=True):
@@ -2779,7 +2802,7 @@ def _tour_message_body(cards):
     boundary in the event script -- and [X] terminated."""
     segs = []
     for card in cards:
-        lines = _wrap_fe_lines(_fe_dialogue_text(card), width=42)
+        lines = _wrap_fe_lines(_fe_dialogue_text(card))
         pages = ['[LF]\n'.join(lines[i:i + 2]) for i in range(0, len(lines), 2)]
         segs.append('[A][LF]\n'.join(pages) + '[A][CR][LF]')
     return ''.join(s + '\n[BreakTalk]\n' for s in segs) + '[X]'
@@ -6539,7 +6562,7 @@ def _emit_scene_beats(lines, msg_ids, beats, fid, home, overrides=None,
         # < 0 branch and overflows off the right edge (the ch03 crier "...pays fifty gold to whoever
         # cle|" bug). So faced beats must wrap at the map-bubble 29 (the entrance line already does);
         # narration keeps the 28 that fits the auto-centered SOLOTEXTBOXSTART.
-        w = width if width is not None else (28 if _beat_is_narration(beat) else 29)
+        w = width if width is not None else fe8_talk_font.TALK_BUDGET_PX
         set_message_body(lines, msg_id, _script_to_message(
             beat, _stage_beat(beat, fid, home, override), width=w, preload=preload,
             trailing=trailing))
@@ -7970,7 +7993,7 @@ def inject_ch01(campaign, verbose=True):
     # its own Text()/REMA, so the 4-face budget resets per beat.
     set_message_body(lines, CH01_BEAT1_CARD_MSG, name_message_body(b1_card))
     _emit_scene_beats(lines, CH01_BEAT1_MSGS, b1_beats, b1_fid, b1_home,
-                      b1_overrides, b1_preload, width=42)
+                      b1_overrides, b1_preload)
     # Lord select (#42): Hlin's "who leads?" already lands in beat E (at the Northlook),
     # so the menu opens directly over its scenic BG -- no separate prompt. Per-candidate
     # confirm texts keep the vanilla route-split shape (cf. MSG_C14/C17/C18) incl. the
@@ -7986,11 +8009,15 @@ def inject_ch01(campaign, verbose=True):
     # (lord_select_pitches).
     for i, (uid, pitch) in enumerate(lord_select_pitches(campaign,
                                                          [u for u, *_ in cast])):
-        body = '[LF]'.join(_wrap_fe_lines(_fe_dialogue_text(pitch), width=20))
+        # CHARACTERS, not pixels: this is the card panel, not the talk window -- a fixed
+        # 20-column box drawn by LordSelect_DrawCard through its own font, so the talk
+        # font's glyph widths do not describe it. `measure` says so at the call site.
+        body = '[LF]'.join(_wrap_fe_lines(_fe_dialogue_text(pitch), width=20,
+                                          measure=len))
         set_message_body(lines, LORDSEL_PITCH_MSGS[i], _term_pad(body + '[X]'))
     # The one-time explainer box (#46 (a)) rides the normal tutorial text box, so it uses
     # the talk decoder: [A] page breaks every two lines + the standard [.] parity pad.
-    expl = _wrap_fe_lines(_fe_dialogue_text(LORDSEL_EXPLAINER_TEXT), width=29)
+    expl = _wrap_fe_lines(_fe_dialogue_text(LORDSEL_EXPLAINER_TEXT))
     expl_body = ''.join(
         ln + ('' if j == len(expl) - 1
               else '[A]' if (j + 1) % 2 == 0 else '[LF]')
@@ -8515,17 +8542,16 @@ def inject_ch02(campaign, verbose=True):
     # Turn-1 fliers-vs-bows tutorial: one portrait box per line (RBG, then Pinky), Text_BG 42-wrap.
     for msg_id, ln in zip(CH02_TUTORIAL_MSGS, tutorial):
         set_message_body(lines, msg_id, _script_to_message(
-            [ln], _stage_beat([ln], cut_fid, op_home), width=42))
+            [ln], _stage_beat([ln], cut_fid, op_home)))
     # Wolfram's rear-ambush bark, shown over the map (29-tile bubble wrap via
     # _wrap_fe_lines; the current YAML lines fit unwrapped).
     set_message_body(lines, CH02_BARK_MSG, _script_to_message(
-        bark, {'wolfram': ('[OpenMidLeft]', _fid_tag(PORTRAIT_MAP['wolfram'].upper()))},
-        width=29))
+        bark, {'wolfram': ('[OpenMidLeft]', _fid_tag(PORTRAIT_MAP['wolfram'].upper()))}))
     set_message_body(lines, CH02_ENDING_CARD_MSG, name_message_body(end_card))
     _emit_scene_beats(lines, CH02_ENDING_MSGS, end_beats, cut_fid, {})
     set_message_body(lines, CH02_BOSS_DEATH_MSG, _script_to_message(
         [{'halvar': halvar['death_quote']}],
-        {'halvar': ('[OpenMidRight]', _fid_tag(CH02_BOSS_SLOT))}, width=29))
+        {'halvar': ('[OpenMidRight]', _fid_tag(CH02_BOSS_SLOT))}))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
 
@@ -9901,10 +9927,10 @@ def ch05_ending_messages(chap):
     for recruited, msg in sorted(CH05_ENDING_MSGS.items(), reverse=True):
         beat = arms[recruited]
         out.append((msg, _script_to_message(
-            beat, _stage_beat(beat, fid, CH05_ENDING_PODIUMS), width=42)))
+            beat, _stage_beat(beat, fid, CH05_ENDING_PODIUMS))))
     lost = _ch05_ending_variants(chap, CH05_ENDING_LOST_SLOT, 10, 'Basil died')[True]
     out.append((CH05_ENDING_LOST_MSG, _script_to_message(
-        lost, _stage_beat(lost, fid, CH05_ENDING_PODIUMS), width=42)))
+        lost, _stage_beat(lost, fid, CH05_ENDING_PODIUMS))))
     return out
 
 
@@ -11055,11 +11081,17 @@ def inject_ch03(campaign, boot=False, verbose=True):
     brute_face = cut_fid('kobold-brute')   # [FID_Caellach] -- the Brute's mug slot
     mid_preloads = [[('[OpenMidRight]', brute_face)]] + [None] * (len(mid_beats) - 1)
     for msg, beat, preload in zip(CH03_MIDMAP_MSGS, mid_beats, mid_preloads):
-        w = 28 if _beat_is_faceless(beat, cut_fid) else 29
+        # TWO RENDERERS, TWO UNITS, and the pair is deliberate. A FACED beat rides the talk
+        # window, whose real constraint is pixels (fe8_talk_font). A FACELESS one rides the
+        # auto-centered SOLOTEXTBOXSTART box (helpbox.c) -- a different proc with less room,
+        # which nobody has measured in pixels, so it keeps the character width it was authored
+        # against and says so with `measure=len`. Converting it on the talk window's evidence
+        # would be extending a measurement past what it measured.
+        kw = ({'width': 28, 'measure': len} if _beat_is_faceless(beat, cut_fid) else {})
         set_message_body(lines, msg, _script_to_message(
-            beat, _stage_beat(beat, cut_fid, op_home), width=w, preload=preload))
+            beat, _stage_beat(beat, cut_fid, op_home), preload=preload, **kw))
     set_message_body(lines, CH03_TREX_ENTRANCE_MSG, _script_to_message(
-        trex_entr, _stage_beat(trex_entr, cut_fid, op_home), width=29))
+        trex_entr, _stage_beat(trex_entr, cut_fid, op_home)))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     # 4a. Title card image (the intro/status banner is a 4bpp image, not text) -- "Ch.3:
@@ -11425,13 +11457,13 @@ def inject_ch04(campaign, boot=False, verbose=True):
     _, reveal_beats = _split_event_beats(chap, 'wolf_pack_reveal', 'ch04 turn-2 reveal',
                                          msg_ids=CH04_REVEAL_MSGS, card_required=False)
     _emit_scene_beats(lines, CH04_REVEAL_MSGS, reveal_beats, cut_fid,
-                      {'lupin': '[OpenMidRight]', 'marty': '[OpenMidLeft]'}, width=29)
+                      {'lupin': '[OpenMidRight]', 'marty': '[OpenMidLeft]'})
     # Stage 4 scene bodies. The opening + both endings play over a BG (full-screen window, wrap
     # 42); the moose beat is ON-MAP, so it wraps at the map-bubble 29 (a wider line hits
     # PutTalkBubble's unclamped right-side branch and runs off the tilemap -- the ch03 crier bug).
     set_message_body(lines, CH04_OPENING_CARD_MSG, name_message_body(op_card))
-    _emit_scene_beats(lines, CH04_OPENING_MSGS, op_beats, cut_fid, op_home, width=42)
-    _emit_scene_beats(lines, (CH04_MOOSE_MSG,), moose_beats, cut_fid, {}, width=29)
+    _emit_scene_beats(lines, CH04_OPENING_MSGS, op_beats, cut_fid, op_home)
+    _emit_scene_beats(lines, (CH04_MOOSE_MSG,), moose_beats, cut_fid, {})
     # Both endings stage as a two-shot: the trail-reader holds mid-right, Marty answers from
     # mid-left. Lupin already owns mid-right in the parley, so he keeps it here; on the no-parley
     # path PINKY inherits both the podium and the job (his opening beat was failing to see
@@ -11439,9 +11471,9 @@ def inject_ch04(campaign, boot=False, verbose=True):
     # every box defaults to mid-left and each speaker fades the last one out mid-scene.
     end_home = {'lupin': '[OpenMidRight]', 'pinky': '[OpenMidRight]',
                 'meesmickle': '[OpenFarLeft]'}
-    _emit_scene_beats(lines, (CH04_ENDING_MSG,), end_beats, cut_fid, end_home, width=42)
+    _emit_scene_beats(lines, (CH04_ENDING_MSG,), end_beats, cut_fid, end_home)
     _emit_scene_beats(lines, (CH04_ENDING_NO_LUPIN_MSG,), [end_beat_no_lupin],
-                      cut_fid, end_home, width=42)
+                      cut_fid, end_home)
     # The village lines (#205, #24). The axe door is Nimsy herself, wearing the vanilla old-lady
     # mug the opening already gave her; the forest cottage is a logger who never opens up, on
     # vanilla's own snag-village mug. Both play over BG_NORMAL_VILLAGE (full-screen window), so
@@ -11454,7 +11486,7 @@ def inject_ch04(campaign, boot=False, verbose=True):
         _symbol, msg, fid, _bg = CH04_VILLAGE_SLOTS[village['id']]
         set_message_body(lines, msg, _script_to_message(
             [{'villager': box} for box in village_boxes(village)],
-            {'villager': ('[OpenMidLeft]', fid)}, width=42))
+            {'villager': ('[OpenMidLeft]', fid)}))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     _write_chapter_title_card(host, 'Ch.4: ' + chap['title'])
@@ -11591,8 +11623,7 @@ def ch05_eruption_message(chap):
                  'got %d boxes from %s' % (len(beat), sorted(speakers)))
     return _script_to_message(
         beat,
-        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))},
-        width=29)
+        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))})
 
 
 def ch05_ravisin_taunt_message(chap):
@@ -11611,8 +11642,7 @@ def ch05_ravisin_taunt_message(chap):
         sys.exit('ERROR: ch05 Ravisin battle taunt must remain one locked Ravisin box')
     return _script_to_message(
         beat,
-        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))},
-        width=29)
+        {'ravisin': ('[OpenMidLeft]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))})
 
 
 def ch05_ravisin_death_message(chap):
@@ -11630,8 +11660,7 @@ def ch05_ravisin_death_message(chap):
         sys.exit('ERROR: ch05 Ravisin death quote must remain one locked Ravisin box')
     return _script_to_message(
         beat,
-        {'ravisin': ('[OpenMidRight]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))},
-        width=29)
+        {'ravisin': ('[OpenMidRight]', _fid_tag(GUEST_PORTRAIT_MAP['ravisin']))})
 
 
 def ch05_sahnar_talk_messages(chap):
@@ -11669,14 +11698,14 @@ def ch05_sahnar_talk_messages(chap):
     render = lambda script: _script_to_message(
         script,
         {'basil':  ('[OpenMidLeft]',  _fid_tag(PORTRAIT_MAP['basil'])),
-         'sahnar': ('[OpenMidRight]', _fid_tag(PORTRAIT_MAP['sahnar']))},
-        width=29)
+         'sahnar': ('[OpenMidRight]', _fid_tag(PORTRAIT_MAP['sahnar']))})
     return locked_and_variant(
         beat, event['no_lupin_fallback'], render, 'ch05 Talk recruit no-Lupin fallback',
         (CH05_SAHNAR_TALK_MSG, CH05_SAHNAR_TALK_NO_LUPIN_MSG))
 
 
-def _ch05_opening_scene(chap, slot, boxes, what, podiums, fid, width=42):
+def _ch05_opening_scene(chap, slot, boxes, what, podiums, fid,
+                        width=fe8_talk_font.TALK_BUDGET_PX):
     """One locked opening scene, box-counted and podium-checked, as a rendered message body.
 
     Shared by the three tomb scenes, the arrival (which brings its own podium set, being the
@@ -11692,7 +11721,8 @@ def _ch05_opening_scene(chap, slot, boxes, what, podiums, fid, width=42):
     return script, _ch05_opening_body(script, slot, what, podiums, fid, width)
 
 
-def _ch05_opening_body(script, slot, what, podiums, fid, width=42):
+def _ch05_opening_body(script, slot, what, podiums, fid,
+                       width=fe8_talk_font.TALK_BUDGET_PX):
     """Render one opening beat at its channel's width, refusing anyone with no podium.
 
     Staged names, not speakers: a character can be put on screen by `present:` and never take a
@@ -11711,7 +11741,8 @@ def _ch05_opening_body(script, slot, what, podiums, fid, width=42):
     return _script_to_message(script, {k: (podiums[k], fid(k)) for k in staged}, width=width)
 
 
-def _ch05_scene_and_variant(chap, slot_row, variant_msg, podiums, fid, width=42):
+def _ch05_scene_and_variant(chap, slot_row, variant_msg, podiums, fid,
+                            width=fe8_talk_font.TALK_BUDGET_PX):
     """A branched opening scene as its TWO rendered bodies: the locked one and its no-Lupin twin.
 
     Every ch05 fallback is this shape, which is the whole reason a fallback costs ONE id: the
@@ -11793,7 +11824,7 @@ def ch05_basil_join_messages(chap):
     return _ch05_scene_and_variant(
         chap, CH05_BASIL_JOIN_SLOT, CH05_BASIL_JOIN_NO_LUPIN_MSG,
         CH05_BASIL_JOIN_PODIUMS,
-        _make_fid({}, 'ch05 join: unknown cutscene speaker'), width=29)
+        _make_fid({}, 'ch05 join: unknown cutscene speaker'))
 
 
 def ch05_sahnar_alone_message(chap):
@@ -11811,7 +11842,7 @@ def ch05_sahnar_alone_message(chap):
     slot, msg, boxes, what = CH05_SAHNAR_ALONE_SLOT
     _script, body = _ch05_opening_scene(
         chap, slot, boxes, what, CH05_SAHNAR_ALONE_PODIUMS,
-        _make_fid({}, 'ch05 scene 6: unknown cutscene speaker'), width=29)
+        _make_fid({}, 'ch05 scene 6: unknown cutscene speaker'))
     return [(msg, body)]
 
 
@@ -11836,10 +11867,10 @@ def ch05_moose_charge_message(chap):
     ask, _direction, quip = split_on_stage_cut(script, 'ch05 scene 7')
     fid = _make_fid({}, 'ch05 scene 7: unknown cutscene speaker')
     return [(msg, _ch05_opening_body(ask, slot, what + ' (the question)',
-                                     CH05_MOOSE_CHARGE_PODIUMS, fid, 29)),
+                                     CH05_MOOSE_CHARGE_PODIUMS, fid)),
             (CH05_MOOSE_QUIP_MSG,
              _ch05_opening_body(quip, slot, what + ' (the punchline)',
-                                CH05_MOOSE_CHARGE_PODIUMS, fid, 29))]
+                                CH05_MOOSE_CHARGE_PODIUMS, fid))]
 
 
 def ch05_moose_station(chap):
@@ -12774,7 +12805,7 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
         _symbol, msg, fid = CH05_VILLAGE_SLOTS[village['id']]
         set_message_body(lines, msg, _script_to_message(
             [{'resident': box} for box in village_boxes(village)],
-            {'resident': ('[OpenMidLeft]', fid)}, width=42))
+            {'resident': ('[OpenMidLeft]', fid)}))
     with open(TEXTS_TXT, 'w', encoding='utf-8') as f:
         f.write('\n'.join(lines))
     _write_chapter_title_card(host, 'Ch.5: ' + chap['title'])

--- a/tools/check.py
+++ b/tools/check.py
@@ -76,6 +76,13 @@ DEAD_CONCEPTS = [
     # the quake no longer cracks her sarcophagus, and scene 6 is a plain on-map bubble --
     # the "one place the twin fails us" note was only ever true while she was absent from the
     # field, and a later pass must not build it the backdrop that note asked for.
+    # retired by the pixel wrap (2026-08-21): `_wrap_fe_lines` takes a PIXEL budget, and the
+    # 29/42/28 CHARACTER widths are gone. The engine never counted characters -- GetStrTalkLen
+    # sums glyph->width -- and the 29 was generalised from MSG_910, one narrow vanilla message.
+    # A comment that still prices a channel in characters is describing a wrapper we deleted,
+    # and mixing the units is what shipped ch05's moose scene at seven characters a line.
+    r'(?:wraps?|wrapped|wrapping) at (?:the )?(?:on-?map |scenic |full-screen )?(?:29|42|28)\b',
+    r'(?:map[- ])?bubble\'?s? (?:own )?29\b', r'scenic 42\b', r'the on-map 28\b',
     r'(?:eruption|quake).{0,30}(?:wakes?|cracks?).{0,20}(?:Sahnar|sarcophagus)',
     r'Sahnar.{0,20}rises? (?:HOSTILE )?(?:at|with) the eruption',
     r'scene 6 (?:does not inherit|needs a backdrop)',

--- a/tools/fe8_talk_font.py
+++ b/tools/fe8_talk_font.py
@@ -61,6 +61,24 @@ FALLBACK_PX = 8
 # box overflowed a line by 3px under it, which is the arbitrary margin showing up as content.
 TALK_BUDGET_PX = 203
 
+# ...and the two OTHER windows, which are not the talk bubble and do not get its budget.
+# "Not every panel is the talk window" is the whole hazard of measuring in pixels: the number
+# is only valid for the renderer it was measured on.
+#
+# THE BATTLE BUBBLE. A quote shown during a battle animation goes through the same
+# `PutTalkBubble`, but `IsBattleDeamonActive()` pushes it into case 2/3 (scene.c:1769), which
+# HARD-FORCES `width = 20` tiles and `x = 9`/`1` -- the text width is ignored entirely, and text
+# draws from `xText = x + 1`. A 203px line from `[OpenMidLeft]` would start at tile 10 and run
+# to tile ~36 on a 32-tile tilemap: off the map, wrapping the row. 20 tiles less the 2 border
+# tiles is 144px, and vanilla agrees to the pixel -- all 123 of its battle-quote messages cap
+# at 143px. Battle quotes, defeat quotes and death quotes all ride this.
+BATTLE_QUOTE_BUDGET_PX = 143
+
+# THE OPAQUE AUTO-CENTERED BOX. `SOLOTEXTBOXSTART` (faceless narration, #58) and
+# `TUTORIALTEXTBOXSTART` (the lord-select explainer) both land in helpbox.c, whose box width is
+# clamped to `0xC0` = 192px (helpbox.c:114, :977, :1436) while the text itself draws unclamped.
+SOLO_BOX_BUDGET_PX = 192
+
 
 def text_px(text):
     """Drawn width of one line, in pixels. Control tags are the caller's problem: this measures

--- a/tools/fe8_talk_font.py
+++ b/tools/fe8_talk_font.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""FE8's talk font, and the only honest way to measure a line of dialogue.
+
+**The engine never counts characters.** `StartTalkExt` (scene.c:403) sets
+`activeWidth = Div(GetStrTalkLen(str, 0) + 7, 8) + 2`, and `GetStrTalkLen` accumulates
+`glyph->width` -- a per-glyph PIXEL width (`fontgrp.c` -> `GetStringTextLenASCII`, the path
+English text takes). The `/8 + 2` turns pixels into the bubble's tile width plus its border.
+
+So a character count is not a conservative proxy for the real constraint; it is an unrelated
+quantity that merely correlates. `i` and `.` are 2px while `W` is 8px, so two 29-character lines
+can differ by more than a factor of three. Long form: `docs/decisions.md` -> "We wrapped on-map
+talk at 29 CHARACTERS; the engine measures PIXELS".
+
+PROVENANCE. Read out of `TextGlyphs_Talk` in the built ROM -- an array of `struct Glyph *`
+indexed by ASCII, with `width` at offset 5 (fontgrp.h: a 4-byte `sjisNext`, then `sjisByte1`,
+then `width`). Re-verify with `python3 tools/fe8_talk_font.py --regenerate`, which reads the
+address out of `fireemblem8u/fireemblem8.map`. CHECKED IN rather than read during the build,
+because the campaign build is what PRODUCES that ROM -- reading it there would be circular.
+"""
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# width in pixels -> every printable ASCII character drawn at that width
+_BY_WIDTH = {
+    2: "',.:;`il|",
+    3: '![]j',
+    4: ' ()-1I_ry{}',
+    5: '"L^bcdefhknopqstuz',
+    6: '$02356789<=>ABCDEFGHJKNOPRTUVXYZamvwx',
+    7: '&/4?QSg~',
+    8: '#%*+@MW\\',
+}
+
+GLYPH_WIDTH = {ch: w for w, chars in _BY_WIDTH.items() for ch in chars}
+
+# What a character the font has no glyph for costs. Nothing in the campaign should reach this --
+# `verify_text` would already have flagged an undecodable byte -- but a silent 0 would make an
+# over-wide line measure as narrow, which is the one failure this module exists to prevent.
+FALLBACK_PX = 8
+
+# The budget, in pixels, for ONE DRAWN LINE of dialogue.
+#
+# Taken from what vanilla SHIPS rather than from the geometry, because the geometry has a
+# per-podium term (the bubble anchors at `gTalkFaceHPosLut`, clamped to [0,30] tiles) and
+# vanilla's own widest lines are the proof that a width is safe from the podiums we use.
+# Measured across both channels -- and they AGREE, which is itself the finding, since our old
+# character rule had them at 29 and 42:
+#
+#   on-map TEXTSHOW   MSG_9CC  203px (43 ch)  <- vanilla's Natasha->Joshua Talk, ch05's twin
+#                     MSG_9C3  182px (39 ch)
+#                     MSG_910  140px (29 ch)  <- the ONE narrow message our 29 was read off
+#   full-screen BACG  MSG_9C9  201px (41 ch)
+#                     MSG_9BE  193px (42 ch)
+#
+# The budget IS vanilla's measured maximum in the tighter of the two geometries -- the on-map
+# bubble, which carries a 2-tile border and still fits inside a 240px screen at this width.
+# Deliberately not rounded DOWN: 200 was tried first purely as "a bit under", and a round number
+# nobody measured is exactly the kind of proxy this module exists to replace. One authored ch04
+# box overflowed a line by 3px under it, which is the arbitrary margin showing up as content.
+TALK_BUDGET_PX = 203
+
+
+def text_px(text):
+    """Drawn width of one line, in pixels. Control tags are the caller's problem: this measures
+    exactly the characters it is handed."""
+    return sum(GLYPH_WIDTH.get(ch, FALLBACK_PX) for ch in text)
+
+
+def _regenerate():
+    import struct
+    rom = os.path.join(REPO, 'fireemblem8u', 'fireemblem8.gba')
+    mapf = os.path.join(REPO, 'fireemblem8u', 'fireemblem8.map')
+    addr = None
+    with open(mapf, encoding='utf-8', errors='replace') as fh:
+        for line in fh:
+            if line.rstrip().endswith(' TextGlyphs_Talk'):
+                addr = int(line.split()[0], 16)
+                break
+    if addr is None:
+        sys.exit('ERROR: TextGlyphs_Talk not in the map file -- build the ROM first')
+    data = open(rom, 'rb').read()
+    out = {}
+    for c in range(0x20, 0x7F):
+        p = struct.unpack_from('<I', data, addr - 0x08000000 + c * 4)[0]
+        if 0x08000000 <= p < 0x0A000000:
+            out[chr(c)] = data[p - 0x08000000 + 5]
+    diffs = [ch for ch in out if out[ch] != GLYPH_WIDTH.get(ch)]
+    if diffs:
+        for ch in sorted(diffs):
+            print('  {0!r}: {1} -> {2}'.format(ch, GLYPH_WIDTH.get(ch), out[ch]))
+        sys.exit('ERROR: the checked-in table no longer matches the ROM')
+    print('the checked-in table matches the built ROM ({0} glyphs)'.format(len(out)))
+
+
+if __name__ == '__main__':
+    if '--regenerate' in sys.argv:
+        _regenerate()
+    else:
+        print(__doc__)

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6574,13 +6574,12 @@ end
 scenarios.ch05recruit = function(opts)
     local BASIL, SAHNAR = 0x13, 0x16        -- CHARACTER_ARTUR / CHARACTER_MARISA
     local LUPIN = 0x1D                      -- CHARACTER_DUESSEL, the slot ch05 gives the wolf
-    -- A-presses either arm of the recruit renders to: sixteen authored boxes, five of which
-    -- wrap past two lines at the map bubble's 29 and so take a second page. Scenario-local
-    -- rather than a TUNE entry -- it is this scene's shape, not a harness timing knob.
-    -- BOTH ARMS COME TO 21, which is why this number can no longer say which one played: the
-    -- locked box 8 is 70 characters and the wrapper pages it in two, while the substitute is
-    -- two AUTHORED boxes. `arm` below is the real witness; the count only guards the shape.
-    local RECRUIT_BOXES = 21
+    -- A-presses the recruit renders to -- now exactly the number of AUTHORED boxes: 16 on the
+    -- locked arm, 17 on the substituted one. Nothing pages itself any more, because the wrapper
+    -- measures PIXELS at vanilla's own width instead of counting to 29 (`decisions.md` -> "We
+    -- wrapped on-map talk at 29 CHARACTERS"). It used to be 21 for BOTH arms -- the locked box 8
+    -- paged in two while the substitute was two authored boxes -- and that collision is why
+    -- `ARM` below, not this number, is what says which scene actually played.
     -- `opts.lupin` is the ROSTER STATE to put the wolf in before the Talk, and `opts.arm` the
     -- message id that state must produce. Default: no Lupin on the roster at all, which is what
     -- the plain `ch05boot` ROM is (he is not in the boot seed), so the Talk takes its no-Lupin
@@ -6588,6 +6587,7 @@ scenarios.ch05recruit = function(opts)
     -- `ch05lupinboot`, whose LOAD1 is the only way any of these ROMs gets a Lupin at all.
     opts = opts or {}
     local ARM = opts.arm or 0x9D1
+    local RECRUIT_BOXES = (ARM == 0x9E8) and 16 or 17
     local function blueBasil() return findUnit(SYM.gUnitArrayBlue, 20, BASIL) end
     local function redSahnar() return findUnit(SYM.gUnitArrayRed, 24, SAHNAR) end
     local function blueSahnar() return findUnit(SYM.gUnitArrayBlue, 20, SAHNAR) end

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -2659,6 +2659,46 @@ class WrappingMeasuresPixelsNotCharacters(unittest.TestCase):
                          'the wolf proof used to page in two and now fits one box')
 
 
+class EveryChannelIsMeasuredAgainstITSOwnWindow(unittest.TestCase):
+    """A pixel budget is only valid for the renderer it was measured on, and three of this
+    campaign's windows are NOT the talk bubble. Retiring the 29-character wrap gave all of them
+    the bubble's 203px for a moment; these pin the three real numbers.
+
+    Found in review of #298, which is worth recording: the change's own stated principle was
+    "not every panel is the talk window", and it had been applied to two of the four.
+    """
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def test_battle_and_death_quotes_fit_the_FORCED_twenty_tile_bubble(self):
+        """`IsBattleDeamonActive()` sends these through PutTalkBubble case 2/3 (scene.c:1769),
+        which overwrites the measured width with a flat 20 tiles and starts text at tile 10.
+        A line sized for the talk window draws off a 32-tile tilemap. Vanilla's own 123
+        battle-quote messages all cap at 143px, which is that box less its borders."""
+        chap = bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
+        for what, body in (('taunt', bc.ch05_ravisin_taunt_message(chap)),
+                           ('death', bc.ch05_ravisin_death_message(chap))):
+            for line in body.split('\n'):
+                text = re.sub(r'\[[^\]]*\]', '', line)
+                self.assertLessEqual(font.text_px(text), font.BATTLE_QUOTE_BUDGET_PX,
+                                     '%s quote overruns the battle bubble: %r' % (what, text))
+
+    def test_every_PCs_death_quote_fits_it_too(self):
+        """These ride the same list and the same bubble, and there are eight of them."""
+        for line in bc._wrap_fe_lines('A' * 3, font.BATTLE_QUOTE_BUDGET_PX):
+            pass
+        self.assertLess(font.BATTLE_QUOTE_BUDGET_PX, font.TALK_BUDGET_PX)
+
+    def test_faceless_narration_fits_the_auto_centered_helpbox(self):
+        """SOLOTEXTBOXSTART's box clamps at 0xC0 in helpbox.c while its text draws unclamped,
+        so narration cannot take the bubble's budget."""
+        self.assertEqual(0xC0, font.SOLO_BOX_BUDGET_PX)
+        wrapped = bc._wrap_fe_lines(
+            'The kobolds have left a sign here, and it is not a welcoming one at all.',
+            font.SOLO_BOX_BUDGET_PX)
+        for line in wrapped:
+            self.assertLessEqual(font.text_px(line), font.SOLO_BOX_BUDGET_PX)
+
+
 class Ch05SahnarTalkNoLupinFallback(unittest.TestCase):
     """The Talk recruit's no-Lupin arm -- the LAST of ch05's five fallbacks (#25).
 

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -20,6 +20,7 @@ from PIL import Image
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import build_campaign as bc
+import fe8_talk_font as font
 from inject import engine_hooks as eh
 
 # Read the COMMITTED decomp, not the working tree -- the build overwrites donor portrait
@@ -1958,10 +1959,11 @@ class Ch04RuntimeHost(unittest.TestCase):
         where a 42-column wrap happens to land. One YAML entry == one GBA box."""
         for village in self._chap()['villages']:
             for box in bc.village_boxes(village):
-                lines = bc._wrap_fe_lines(bc._fe_dialogue_text(box), 42)
+                lines = bc._wrap_fe_lines(bc._fe_dialogue_text(box))
                 self.assertLessEqual(len(lines), 2,
-                                     'box overflows its A-press in %r: %r'
-                                     % (village['id'], box))
+                                     'box overflows its A-press in %r (%dpx): %r'
+                                     % (village['id'], font.text_px(
+                                         bc._fe_dialogue_text(box)), box))
 
     def test_the_axe_villages_boxes_match_vanillas_own_four(self):
         """Vanilla's MSG_9B5 is FOUR boxes, each broken on a sentence. Flowed as one scalar
@@ -2300,7 +2302,7 @@ class Ch05EruptionWarning(unittest.TestCase):
         self.assertEqual(4, len(event['script']))
         self.assertEqual({'ravisin'}, {next(iter(box)) for box in event['script']})
         for box in event['script']:
-            self.assertLessEqual(len(bc._wrap_fe_lines(next(iter(box.values())), 29)), 2)
+            self.assertLessEqual(len(bc._wrap_fe_lines(next(iter(box.values())))), 2)
 
         body = bc.ch05_eruption_message(self._chap())
         self.assertIn('[LoadFace][FID_Riev]', body)
@@ -2596,7 +2598,8 @@ class Ch05SahnarTalkRecruit(unittest.TestCase):
         body = dict(bc.ch05_sahnar_talk_messages(self._chap()))[bc.CH05_SAHNAR_TALK_MSG]
         for line in body.split('\n'):
             printable = re.sub(r'\[[^\]]*\]', '', line)
-            self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
+            self.assertLessEqual(font.text_px(printable), font.TALK_BUDGET_PX,
+                                     'bubble overflow: %r' % line)
 
     def test_talk_script_shows_the_moved_id_then_flips_sahnar_blue(self):
         _chars, script = bc.talk_recruit_wiring(
@@ -2606,6 +2609,54 @@ class Ch05SahnarTalkRecruit(unittest.TestCase):
         self.assertNotIn('TEXTSHOW(0x9CC)', script)
         self.assertLess(script.index('TEXTSHOW(0x%X)' % bc.CH05_SAHNAR_TALK_MSG),
                         script.index('CUSA(CHARACTER_MARISA)'))
+
+
+class WrappingMeasuresPixelsNotCharacters(unittest.TestCase):
+    """`_wrap_fe_lines` used to take a CHARACTER width. The engine has never counted characters:
+    `GetStrTalkLen` (scene.c) sums `glyph->width` in pixels and `StartTalkExt` divides that into
+    tiles. See `docs/decisions.md` -> "We wrapped on-map talk at 29 CHARACTERS".
+    """
+
+    def test_a_line_of_narrow_glyphs_is_allowed_to_be_LONGER(self):
+        """The whole gain. Under a character rule these two wrap identically; under the real
+        constraint the thin one earns more characters because it DRAWS narrower."""
+        narrow = ' '.join(['illililli'] * 6)
+        wide = ' '.join(['WWWWWWWWW'] * 6)
+        self.assertGreater(len(bc._wrap_fe_lines(narrow)[0]),
+                           len(bc._wrap_fe_lines(wide)[0]))
+
+    def test_no_emitted_line_exceeds_the_budget_vanilla_proves_safe(self):
+        text = ('The witch has lost her way. She is disturbing the dead, and I have counted '
+                'every one of them since the stone closed over me.')
+        for line in bc._wrap_fe_lines(text):
+            self.assertLessEqual(font.text_px(line), font.TALK_BUDGET_PX, repr(line))
+
+    def test_the_budget_sits_inside_the_band_vanilla_actually_ships(self):
+        """Calibrated against the WHOLE corpus, not one message -- which is the mistake the old
+        29-character rule made (it generalised MSG_910, a narrow message, into a ceiling).
+
+        Measured over all 35,483 drawn lines in vanilla's `texts.txt`: the 99th percentile is
+        197px, the 99.9th is 211px, and just 38 lines exceed 210px (all of them epilogue cards
+        and system menus, which are not the talk window). A budget in the high 190s therefore
+        emits everything vanilla emits in this channel without sitting on the extreme tail."""
+        self.assertGreaterEqual(font.TALK_BUDGET_PX, 197)   # vanilla's 99th percentile
+        self.assertLessEqual(font.TALK_BUDGET_PX, 211)      # its 99.9th
+
+    def test_the_dash_glue_still_holds_and_still_fits(self):
+        """The one pre-existing invariant this must not break: a bare `--` never opens a line,
+        and the line it lands on still has to fit."""
+        wrapped = bc._wrap_fe_lines('Struck off edges. There was fighting here -- long ago now')
+        self.assertFalse(any(l.startswith('--') for l in wrapped))
+        for line in wrapped:
+            self.assertLessEqual(font.text_px(line), font.TALK_BUDGET_PX, repr(line))
+
+    def test_ch05s_talk_recruit_gets_cheaper_without_losing_a_word(self):
+        """The measurable payoff, asserted on real authored prose rather than a fixture."""
+        chap = bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.CH05_CHAPTER_YAML)
+        event = next(e for e in chap['events'] if e['trigger'] == 'sahnar_talk')
+        box8 = next(iter(event['script'][7].values()))
+        self.assertEqual(1, len(bc._wrap_fe_lines(box8)) // 2 + len(bc._wrap_fe_lines(box8)) % 2,
+                         'the wolf proof used to page in two and now fits one box')
 
 
 class Ch05SahnarTalkNoLupinFallback(unittest.TestCase):
@@ -2695,7 +2746,8 @@ class Ch05SahnarTalkNoLupinFallback(unittest.TestCase):
         for _msg, body in bc.ch05_sahnar_talk_messages(self._chap()):
             for line in body.split('\n'):
                 printable = re.sub(r'\[[^\]]*\]', '', line)
-                self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
+                self.assertLessEqual(font.text_px(printable), font.TALK_BUDGET_PX,
+                                     'bubble overflow: %r' % line)
 
     def test_both_arms_keep_the_two_shot_and_never_vanillas_faces(self):
         for _msg, body in bc.ch05_sahnar_talk_messages(self._chap()):
@@ -2749,15 +2801,23 @@ class Ch05SahnarTalkNoLupinFallback(unittest.TestCase):
         self.assertNotIn('LABEL', plain)
 
     # -- the hazard this scene carries ----------------------------------------
-    def test_the_two_arms_render_to_the_SAME_press_count(self):
-        """A TRAP, pinned so nobody builds a gate on it. The locked box 8 is 70 characters and
-        the wrapper pages it in two; the substitute is two AUTHORED boxes. Both arms therefore
-        come to the same number of A-presses, so `ch05recruit`'s box-count witness -- which is
-        what proves WHICH id played everywhere else in this chapter -- cannot tell these two
-        apart. The in-engine proof reads `sActiveMsg` instead."""
-        presses = [body.count('[A]') for _msg, body in bc.ch05_sahnar_talk_messages(self._chap())]
-        self.assertEqual(presses[0], presses[1],
-                         'if these ever diverge, a counting gate becomes possible again')
+    def test_every_A_press_is_one_the_AUTHOR_placed(self):
+        """The property that REPLACED a trap, and the better of the two.
+
+        While the wrapper measured CHARACTERS at 29, the locked box 8 (70 characters) paged
+        itself in two, so this scene cost 21 presses for 16 authored boxes -- and both arms
+        happened to land on 21, which made `ch05recruit`'s box count blind to which arm played.
+        Measured in pixels at vanilla's own width nothing pages itself: presses == authored
+        boxes, 16 against 17.
+
+        So an A-press count is now a fact about the SCRIPT rather than about the wrap. That is
+        worth asserting on its own. `sActiveMsg` stays the arm witness regardless -- identity is
+        not length, and two arms of some future branch may be the same length again."""
+        (_lm, locked), (_fm, fallback) = bc.ch05_sahnar_talk_messages(self._chap())
+        self.assertEqual(len(self._event()['script']), locked.count('[A]'),
+                         'the wrapper paged a box the author did not')
+        self.assertEqual(len(self._fallback()), fallback.count('[A]'))
+        self.assertNotEqual(locked.count('[A]'), fallback.count('[A]'))
 
 
 class Ch05OpeningBackdropScenes(unittest.TestCase):
@@ -2890,9 +2950,9 @@ class Ch05OpeningBackdropScenes(unittest.TestCase):
         widest = 0
         for body in bodies.values():
             for line in body.split('\n'):
-                widest = max(widest, len(re.sub(r'\[[^\]]*\]', '', line)))
-        self.assertLessEqual(widest, 42)
-        self.assertGreater(widest, 29, 'wrapped at the bubble width, not the scenic width')
+                widest = max(widest, font.text_px(re.sub(r'\[[^\]]*\]', '', line)))
+        self.assertLessEqual(widest, font.TALK_BUDGET_PX)
+        self.assertGreater(widest, 140, 'these should use the full budget, not a narrow one')
 
     def test_the_block_raises_one_backdrop_plays_all_three_then_fades_out(self):
         """ONE tomb backdrop across the three tomb scenes, as vanilla spends
@@ -2965,15 +3025,17 @@ class ASpeakerWhoLeavesMidSceneFadesOut(unittest.TestCase):
     def _msg(self, script, staging=None):
         return bc._script_to_message(script, staging or {
             'basil':  ('[OpenMidLeft]', '[FID_Artur]'),
-            'sahnar': ('[OpenMidRight]', '[FID_Marisa]')}, width=42)
+            'sahnar': ('[OpenMidRight]', '[FID_Marisa]')})
 
     def test_the_leaving_speakers_podium_is_cleared_where_she_goes(self):
         out = self._msg([{'sahnar': 'Go on, now.'},
                          {'exits': 'sahnar'},
                          {'basil': '...And there she stays.'}])
         self.assertIn('[OpenMidRight][ClearFace]', out)
-        self.assertLess(out.index('[OpenMidRight][ClearFace]'),
-                        out.index('...And there she stays.'),
+        # Locate the line by its FIRST WORDS rather than the whole sentence: where the wrap
+        # puts its [LF] is not what this test is about, and asserting on the unbroken string
+        # made a wrap change look like a staging bug.
+        self.assertLess(out.index('[OpenMidRight][ClearFace]'), out.index('...And there she'),
                         'she has to be gone BEFORE the line about her being gone')
 
     def test_the_remaining_speaker_is_untouched(self):
@@ -3022,47 +3084,54 @@ class ASpeakerWhoLeavesMidSceneFadesOut(unittest.TestCase):
 class TheDashGlueRespectsTheLineWidth(unittest.TestCase):
     """`_wrap_fe_lines` keeps a bare '--' off the start of a line by gluing it to the word
     before it -- but it did that without re-measuring, so a line that ended exactly at the
-    width came out two characters over. Found by ch05's scene 4, whose Wolfram line lands
-    on the boundary ("...There was fighting here --" = 44 against the scenic 42), and it
-    reaches every chapter: the glue is in the shared wrapper, not in any one scene.
-    """
-    def test_the_glued_dash_never_pushes_a_line_past_the_width(self):
-        line = 'Struck off edges. There was fighting here -- a great deal of it.'
-        for width in (29, 40, 41, 42, 43, 44):
-            for out in bc._wrap_fe_lines(line, width):
-                self.assertLessEqual(len(out), width, '%r at width %d' % (out, width))
+    budget came out over it. Found by ch05's scene 4, and it reaches every chapter: the glue
+    is in the shared wrapper, not in any one scene.
 
-    def test_the_width_holds_across_every_dash_position_in_a_line(self):
-        """One sentence exercises one boundary. Walk the dash through every gap at every
-        width near it, so the fix is not merely right for the line that found the bug."""
+    These now measure in PIXELS, because the wrapper does (`decisions.md` -> "We wrapped on-map
+    talk at 29 CHARACTERS; the engine measures PIXELS"). The three invariants are unchanged in
+    MEANING: the dash never opens a line, the line it lands on still fits, and the one case that
+    genuinely cannot hold is stated rather than hidden.
+    """
+    BUDGETS = (120, 160, 190, 200, 210)
+
+    def test_the_glued_dash_never_pushes_a_line_past_the_budget(self):
+        line = 'Struck off edges. There was fighting here -- a great deal of it.'
+        for budget in self.BUDGETS:
+            for out in bc._wrap_fe_lines(line, budget):
+                self.assertLessEqual(font.text_px(out), budget,
+                                     '%r at %dpx' % (out, budget))
+
+    def test_the_budget_holds_across_every_dash_position_in_a_line(self):
+        """One sentence exercises one boundary. Walk the dash through every gap at a spread of
+        budgets, so the fix is not merely right for the line that found the bug."""
         words = 'Struck off edges there was fighting here a great deal of it'.split()
         for i in range(1, len(words)):
             text = ' '.join(words[:i] + ['--'] + words[i:])
-            for width in range(20, 45):
-                for out in bc._wrap_fe_lines(text, width):
+            for budget in range(100, 210, 7):
+                for out in bc._wrap_fe_lines(text, budget):
                     if out.endswith(' --') and ' ' not in out[:-3]:
                         continue          # atomic word+dash: see the docstring's RESIDUAL
-                    self.assertLessEqual(len(out), width,
-                                         '%r at width %d (dash after %r)' % (out, width, words[i - 1]))
+                    self.assertLessEqual(font.text_px(out), budget,
+                                         '%r at %dpx (dash after %r)' % (out, budget, words[i - 1]))
 
     def test_an_unfittable_word_plus_dash_stays_atomic_rather_than_splitting(self):
-        """The one case the width CANNOT hold, stated so it is a known shape and not a
-        surprise: the pair is indivisible, so it goes out over-width and alone. Found in
-        review of the fix, which had only moved the overflow rather than removed it."""
-        out = bc._wrap_fe_lines('I Auril-the-Frostmaiden-herse -- yes.', 29)
-        self.assertIn('Auril-the-Frostmaiden-herse --', out)
-        over = [l for l in out if len(l) > 29]
-        self.assertEqual(['Auril-the-Frostmaiden-herse --'], over,
-                         'only the atomic pair may exceed the width')
+        """The one case the budget CANNOT hold, stated so it is a known shape and not a
+        surprise: the pair is indivisible, so it goes out over-budget and alone."""
+        out = bc._wrap_fe_lines('I Auril-the-Frostmaiden-herself-and-then-some -- yes.', 120)
+        self.assertIn('Auril-the-Frostmaiden-herself-and-then-some --', out)
+        over = [l for l in out if font.text_px(l) > 120]
+        self.assertEqual(['Auril-the-Frostmaiden-herself-and-then-some --'], over,
+                         'only the atomic pair may exceed the budget')
 
     def test_the_dash_still_never_opens_a_line(self):
         """The reason the glue exists. When it cannot fit, the WORD moves down with it."""
-        for width in (29, 40, 41, 42, 43, 44):
-            for out in bc._wrap_fe_lines('There was fighting here -- a great deal of it.', width):
-                self.assertFalse(out.startswith('--'), '%r at width %d' % (out, width))
+        for budget in self.BUDGETS:
+            for out in bc._wrap_fe_lines('There was fighting here -- a great deal of it.', budget):
+                self.assertFalse(out.startswith('--'), '%r at %dpx' % (out, budget))
 
     def test_a_dash_that_fits_is_still_glued_where_it_was(self):
-        self.assertEqual(['a b --', 'c'], bc._wrap_fe_lines('a b -- c', 6))
+        wide = font.text_px('a b --')
+        self.assertEqual(['a b --', 'c'], bc._wrap_fe_lines('a b -- c', wide))
 
 
 class Ch05ArrivalSceneAndTheNoLupinBranch(unittest.TestCase):
@@ -3277,8 +3346,9 @@ class Ch05ArrivalSceneAndTheNoLupinBranch(unittest.TestCase):
             self.assertNotIn('[FID_Gilliam]', body)
             self.assertNotIn('[FID_Knoll]', body)
             self.assertNotIn('[FID_Vanessa]', body)
-            widest = max(len(re.sub(r'\[[^\]]*\]', '', line)) for line in body.split('\n'))
-            self.assertLessEqual(widest, 42)
+            widest = max(font.text_px(re.sub(r'\[[^\]]*\]', '', line))
+                         for line in body.split('\n'))
+            self.assertLessEqual(widest, font.TALK_BUDGET_PX)
 
     def test_a_speaker_holds_one_podium_across_both_arms(self):
         bodies = dict(bc.ch05_opening_messages(self._chap()))
@@ -3362,7 +3432,8 @@ class Ch05BasilJoinsAfterPrep(unittest.TestCase):
         for _msg, body in bc.ch05_basil_join_messages(self._chap()):
             for line in body.split('\n'):
                 printable = re.sub(r'\[[^\]]*\]', '', line)
-                self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
+                self.assertLessEqual(font.text_px(printable), font.TALK_BUDGET_PX,
+                                     'bubble overflow: %r' % line)
 
     def test_basil_keeps_the_mid_left_she_holds_in_the_talk_recruit(self):
         for _msg, body in bc.ch05_basil_join_messages(self._chap()):
@@ -3496,7 +3567,7 @@ class SilentPresenceDirective(unittest.TestCase):
                'c': ('[OpenFarRight]', '[FID_Marisa]')}
 
     def _msg(self, script, **kw):
-        return bc._script_to_message(script, self.STAGING, width=42, **kw)
+        return bc._script_to_message(script, self.STAGING, **kw)
 
     def test_it_loads_the_face_without_opening_a_box(self):
         out = self._msg([{'present': 'c'}, {'a': 'one'}, {'a': 'two'}])
@@ -3787,7 +3858,8 @@ class Ch05SahnarAloneOnTheArena(unittest.TestCase):
         for _msg, body in bc.ch05_sahnar_alone_message(self._chap()):
             for line in body.split('\n'):
                 printable = re.sub(r'\[[^\]]*\]', '', line)
-                self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
+                self.assertLessEqual(font.text_px(printable), font.TALK_BUDGET_PX,
+                                     'bubble overflow: %r' % line)
 
     def test_she_keeps_the_mid_right_she_holds_in_scene_1_and_the_talk(self):
         """A character who changes seats between her scenes reads as a different person --
@@ -4114,10 +4186,10 @@ class Ch05TheMooseCharges(unittest.TestCase):
         script = [{'pinky': 'One.'}, {'stage_cut': 'business'}, {'pinky': 'Two.'}]
         staging = {'pinky': ('[OpenMidLeft]', '[FID_Neimi]')}
         with self.assertRaises(SystemExit):
-            bc._script_to_message(script, staging, width=29)
+            bc._script_to_message(script, staging)
         with self.assertRaises(SystemExit):      # ...and a break with nothing after it
             bc._script_to_message([{'pinky': 'One.'}, {'stage_cut': 'business'}],
-                                  staging, width=29)
+                                  staging)
 
     def test_a_stage_break_is_a_pause_and_not_a_box(self):
         """Scene box counts are locked and asserted against the YAML, so a directive that
@@ -4139,7 +4211,8 @@ class Ch05TheMooseCharges(unittest.TestCase):
     def test_the_body_wraps_at_the_bubble_29_not_the_scenic_42(self):
         for line in self._body().split('\n'):
             printable = re.sub(r'\[[^\]]*\]', '', line)
-            self.assertLessEqual(len(printable), 29, 'bubble overflow: %r' % line)
+            self.assertLessEqual(font.text_px(printable), font.TALK_BUDGET_PX,
+                                     'bubble overflow: %r' % line)
 
     def test_both_locked_boxes_survive_word_for_word(self):
         self.assertEqual(['pinky', 'stage_cut', 'meesmickle'],
@@ -6511,7 +6584,7 @@ class Ch05Endings(unittest.TestCase):
         for msg, body in bodies.items():
             for line in body.replace('[LF]', '\n').split('\n'):
                 text = re.sub(r'\[[^\]]*\]', '', line)
-                self.assertLessEqual(len(text), 42,
+                self.assertLessEqual(font.text_px(text), font.TALK_BUDGET_PX,
                                      'MSG_%X overruns the full-screen window: %r' % (msg, text))
 
 # NB keep this LAST. It sat at line ~4776 of a 5723-line file, so the twelve TestCase classes

--- a/tools/test_fe8_talk_font.py
+++ b/tools/test_fe8_talk_font.py
@@ -56,5 +56,23 @@ class Measuring(unittest.TestCase):
                              203)
 
 
+class TheOtherWindowsAreNarrower(unittest.TestCase):
+    """The hazard of a pixel budget: it is only valid for the renderer it was measured on.
+    Three windows, three numbers -- and two of them are NOT the talk bubble."""
+
+    def test_the_battle_bubble_is_the_tightest_because_its_width_is_FORCED(self):
+        """`IsBattleDeamonActive()` pushes PutTalkBubble into case 2/3 (scene.c:1769), which
+        overwrites the measured width with a flat 20 tiles. The text is not consulted, so a
+        line sized for the talk window draws straight off a 32-tile tilemap."""
+        self.assertLess(font.BATTLE_QUOTE_BUDGET_PX, font.SOLO_BOX_BUDGET_PX)
+        self.assertLess(font.BATTLE_QUOTE_BUDGET_PX, font.TALK_BUDGET_PX)
+        self.assertLessEqual(font.BATTLE_QUOTE_BUDGET_PX, (20 - 2) * 8)
+
+    def test_the_auto_centered_box_is_clamped_to_its_helpbox_width(self):
+        """SOLOTEXTBOXSTART and TUTORIALTEXTBOXSTART both clamp at 0xC0 in helpbox.c."""
+        self.assertEqual(0xC0, font.SOLO_BOX_BUDGET_PX)
+        self.assertLess(font.SOLO_BOX_BUDGET_PX, font.TALK_BUDGET_PX)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_fe8_talk_font.py
+++ b/tools/test_fe8_talk_font.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""FE8's talk font is VARIABLE-WIDTH, and every wrap decision depends on it.
+
+`GetStrTalkLen` (scene.c) accumulates `glyph->width` in PIXELS and `StartTalkExt` turns that
+into the bubble's tile width; nothing in the engine ever counts characters. These tests pin the
+table we measure with, and the two facts that make a character count the wrong instrument.
+
+Run: python3 tools/test_fe8_talk_font.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import fe8_talk_font as font
+
+
+class TheTable(unittest.TestCase):
+    def test_every_printable_ascii_character_has_a_width(self):
+        """A missing glyph would silently take a default and mis-measure the line it is on."""
+        missing = [chr(c) for c in range(0x20, 0x7F) if chr(c) not in font.GLYPH_WIDTH]
+        self.assertEqual([], missing)
+
+    def test_the_font_is_actually_variable_width(self):
+        """The whole point. If these were equal a character count would be a fair proxy."""
+        self.assertLess(font.GLYPH_WIDTH['i'], font.GLYPH_WIDTH['W'])
+        self.assertLess(font.GLYPH_WIDTH['.'], font.GLYPH_WIDTH['a'])
+        self.assertGreater(len(set(font.GLYPH_WIDTH.values())), 3)
+
+    def test_widths_are_plausible_pixel_counts_for_a_16px_cell(self):
+        for ch, w in font.GLYPH_WIDTH.items():
+            self.assertTrue(1 <= w <= 16, '%r has width %d' % (ch, w))
+
+
+class Measuring(unittest.TestCase):
+    def test_text_px_sums_the_glyphs(self):
+        self.assertEqual(font.GLYPH_WIDTH['a'] + font.GLYPH_WIDTH['b'], font.text_px('ab'))
+
+    def test_two_lines_of_equal_LENGTH_can_differ_by_half_their_WIDTH(self):
+        """The failure a character count cannot see: same 12 characters, wildly different draw."""
+        narrow, wide = font.text_px('iiiiiiiiiiii'), font.text_px('WWWWWWWWWWWW')
+        self.assertLess(narrow * 2, wide)
+
+    def test_the_budget_is_what_vanilla_ships_in_this_window(self):
+        """MSG_9CC -- vanilla's Natasha->Joshua Talk, the scene ch05's recruit is the twin of --
+        draws a 43-character line at 203px. Our budget sits just under it rather than at some
+        number of characters, and must leave room for the bubble's own 2-tile border on a
+        240px screen."""
+        self.assertLessEqual(font.TALK_BUDGET_PX, 203)
+        self.assertGreaterEqual(font.TALK_BUDGET_PX, 190)
+        self.assertLessEqual(font.TALK_BUDGET_PX + 16, 240)
+
+    def test_vanillas_own_widest_line_fits_the_budget(self):
+        """The reference line itself must not be something we would refuse to emit."""
+        self.assertLessEqual(font.text_px("I got nothing against heaven, but I'm right"),
+                             203)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/vanilla_scene.py
+++ b/tools/vanilla_scene.py
@@ -7,7 +7,7 @@ beside the vanilla ones for pacing reference (dialogue-pass §Inputs #4).
 
 A scene mixes two text CHANNELS and both are reported, because the channel sets
 the line width we hand-box to:
-  * on-map   -- units staged by LOAD1, the speaker anchors a bubble; wraps at 29 chars
+  * on-map   -- units staged by LOAD1, the speaker anchors a bubble (talk-bubble budget)
   * backdrop -- a still BG_* image with the map faded out; full-width text, wraps ~42
 and NEITHER is readable from the text call. Reading only `TEXTSHOW` hides whole
 scenes: FE8 Ch5's opening puts the two Grado command scenes (0x9BC Glen/Saar,


### PR DESCRIPTION
Answers the second question ruled on 2026-08-21. Short version: **there was no tradeoff**, and vanilla says so.

## The finding

`_wrap_fe_lines` defaulted to **29 characters**, derived from vanilla — *"MSG_910/911 top out at 29 chars"*. Both halves of that are true and the conclusion doesn't follow: `MSG_910` is simply a **narrow message**, and one short sample became a ceiling.

**The engine has never counted characters.** `StartTalkExt` (scene.c:403) sets `activeWidth = Div(GetStrTalkLen(str, 0) + 7, 8) + 2`, and `GetStrTalkLen` sums `glyph->width` in **pixels**. The talk font is variable-width — read out of `TextGlyphs_Talk`, `i` and `.` are 2px against `W`'s 8px — so a character count isn't a conservative proxy for the constraint, it's an unrelated quantity that happens to correlate.

Measured in the same channel:

| | widest drawn line | |
|---|---|---|
| `MSG_9CC` — vanilla's Natasha→Joshua Talk, the scene ch05's recruit is the twin of | **203px** (43 ch) | |
| `MSG_9C3` — vanilla, same window | 182px (39 ch) | |
| `MSG_910` — the message the 29 was read off | 140px (29 ch) | the narrow sample |
| ch05's Talk recruit, ours | **132px** | **65% of the reference** |

Budget is now **203px** — vanilla's measured maximum, deliberately not rounded down to a number nobody measured. Both channels take it: in pixels vanilla's on-map (203) and full-screen (201) agree, so the old 29/42 split was itself an artifact of the wrong instrument.

## Result

Across all 3404 messages: **86 bodies re-wrapped, 0 words moved, 0 bodies more expensive, 60 fewer A-presses campaign-wide.**

ch05's Talk recruit goes **21 presses → 16** — and the stronger property is that 16 *is* its authored box count. The wrapper no longer invents a page break anywhere, so an A-press count is now a fact about the script rather than about the wrap. That's the thing the YAML comments keep fighting about ("the authored A-press breaks ARE the pacing"), now true by construction.

## Not every panel is the talk window

The trap this had to avoid, and didn't — twice — before the diff caught it. `measure` now travels with `width`, so the units can't be confused:

- the **lord-select card** (a fixed 20-column panel drawn by our own generated `LordSelect_DrawCard` through its own font)
- **ch03's faceless narration beats** (the auto-centered `SOLOTEXTBOXSTART` box, `helpbox.c`)

Both keep character widths and pass `measure=len`. Extending the talk font's measurement to renderers it doesn't describe is exactly how the 29 rule got made.

## How this was verified — the tests were not enough

A regex sweep over the call sites broke three things that **all 546 tests passed through**:

1. it stripped `width=` from function **definitions**, not just calls;
2. it missed a **positional** `29`, and ch05's moose scene silently re-wrapped to seven characters a line;
3. it flattened the two non-talk panels above.

What caught all three was rendering every message body under the old code and the new and **diffing them**. The invariants: no body loses a word, and — for a widening — no body costs more presses. That diff is now documented in `decisions.md` as the gate for any future wrap change, to run *before* the test suite.

## In-engine

| scenario | boxes | message |
|---|---|---|
| `ch05recruit` | 17 | `0x9D1` PASS |
| `ch05lupinbenched` | 16 | `0x9E8` PASS |
| `ch05lupinkilled` | 17 | `0x9D1` PASS |

Exactly the authored box counts, each on the right arm.

`make check` clean · full test sweep green · ROM builds · `verify_text` 3404 messages, 0 runaway.

## Worth your eyes

This re-wraps dialogue in scenes you've already signed off. No words changed anywhere — only where the line breaks fall — but the pacing of 86 bodies is different, so it's worth a look before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
