### PR TITLE
playtest: the gate grades NORMAL by default, not Tutorial (#303)

### DIFF
--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -81,15 +81,17 @@ local CHAR_HLIN, CHAR_SCRAMSAX, CHAR_SEPHEK = 0x0D, 0x11, 0x68 -- NATASHA/KYLE/O
 -- prologue/sandbox host on chapter slot 1; a chapter load-test (e.g. --ch03-boot on slot 4)
 -- overrides via PT_HOST_CHAPTER so bootToMap/inChapter recognize the right slot.
 local HOST_CHAPTER = PLAYTEST_HOST_CHAPTER or 1
--- Which difficulty mode a run selects on the New Game menu (PT_DIFFICULTY). nil keeps the
--- old behaviour -- press A on whatever is highlighted -- which is option 0, TUTORIAL. That
--- default is why every verdict before #303 graded the easiest mode while reading as general.
+-- Which difficulty mode a run selects on the New Game menu (PT_DIFFICULTY), defaulting to
+-- NORMAL -- the mode that ships to most players and the one `difficulty.py` grades by
+-- default. It has to be a declared default rather than "whatever the menu highlights":
+-- FE8 initialises the menu to option 0 (TUTORIAL) and the harness only pressed A, so every
+-- verdict this project produced before #303 graded the EASIEST mode while reading as
+-- general. A scenario that genuinely wants another mode names it.
 -- Hung off TUNE rather than taking two top-level locals: harness.lua sits AT Lua's 200-local
 -- ceiling, and the next top-level local stops the whole chunk loading (check.py guards it).
 TUNE.difficultyWant = (function()
     local requested = (PLAYTEST_DIFFICULTY ~= nil and PLAYTEST_DIFFICULTY ~= "")
-        and PLAYTEST_DIFFICULTY or nil
-    if requested == nil then return nil end
+        and PLAYTEST_DIFFICULTY or "normal"
     local index = ({ tutorial = 0, normal = 1, difficult = 2 })[requested]
     if index == nil then
         error(string.format("PT_DIFFICULTY=%q is not one of tutorial, normal, difficult",
@@ -1735,8 +1737,9 @@ end
 -- three numbers the chapter DECLARES in its YAML `difficulty:` block. Reading the map
 -- rather than the menu is the point: the menu only proves we clicked something.
 scenarios.difficulty = function()
-    local mode = (PLAYTEST_DIFFICULTY ~= nil and PLAYTEST_DIFFICULTY ~= "")
-        and PLAYTEST_DIFFICULTY or "default"
+    -- The mode this run is SUPPOSED to be in: the resolved default, not the raw env var
+    -- (unset now means NORMAL, not "whatever the menu highlights").
+    local mode = ({ [0] = "tutorial", [1] = "normal", [2] = "difficult" })[TUNE.difficultyWant]
     if not bootToMap() then return result("FAIL", "never reached the map") end
     -- PROVE the run is in the mode it labels before recording anything under that name.
     -- A scenario that boots from a saved state never passes the difficulty menu, so it

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -89,15 +89,24 @@ local HOST_CHAPTER = PLAYTEST_HOST_CHAPTER or 1
 -- general. A scenario that genuinely wants another mode names it.
 -- Hung off TUNE rather than taking two top-level locals: harness.lua sits AT Lua's 200-local
 -- ceiling, and the next top-level local stops the whole chunk loading (check.py guards it).
+TUNE.difficultyIndex = { tutorial = 0, normal = 1, difficult = 2 }
 TUNE.difficultyWant = (function()
+    -- run.sh owns the default and always sends a value; this fallback only covers entry
+    -- points that bypass it, and must agree with run.sh (pinned by test_playtest_harness).
     local requested = (PLAYTEST_DIFFICULTY ~= nil and PLAYTEST_DIFFICULTY ~= "")
         and PLAYTEST_DIFFICULTY or "normal"
-    local index = ({ tutorial = 0, normal = 1, difficult = 2 })[requested]
+    local index = TUNE.difficultyIndex[requested]
     if index == nil then
         error(string.format("PT_DIFFICULTY=%q is not one of tutorial, normal, difficult",
                             tostring(requested)))
     end
     return index
+end)()
+-- The inverse, DERIVED so the two cannot drift apart.
+TUNE.difficultyName = (function()
+    local out = {}
+    for name, index in pairs(TUNE.difficultyIndex) do out[index] = name end
+    return out
 end)()
 -- Lord select (#42): menu order = classed cast order (build_campaign PORTRAIT_MAP);
 -- the LAST candidate (pinky, NEIMI slot) is benched by default under the 4-slot
@@ -1207,6 +1216,28 @@ local function advanceBootState(observation, state)
     return nil
 end
 
+-- The mode the ROM is ACTUALLY in, from the two bits SaveMenuWriteNewGame sets:
+--   chapterStateBits +0x14, PLAY_FLAG_HARD = 1<<6 (types.h:187,246)
+--   config +0x40, controller = bit 21 (PlaySt_OptionBits; pokeFastConfig pins the packing)
+-- TUTORIAL_MODE() is `!HARD && controller ~= 1` (eventinfo.h:107).
+INSPECT.liveDifficulty = function()
+    local hard = (ru8(SYM.gPlaySt + 0x14) & 0x40) ~= 0
+    local controller = (ru32(SYM.gPlaySt + 0x40) >> 21) & 1
+    return hard and "difficult" or (controller == 1 and "normal" or "tutorial"), hard, controller
+end
+
+-- nil when the run is in the mode it was asked for, else the failure text.
+INSPECT.difficultyMismatch = function()
+    local want = TUNE.difficultyName[TUNE.difficultyWant]
+    local actual, hard, controller = INSPECT.liveDifficulty()
+    if actual == want then return nil end
+    return string.format(
+        "difficulty mode is %s but this run wants %s (HARD=%s controller=%d) -- a save state "
+        .. "minted in another mode, or a menu selection that never committed. Set "
+        .. "PT_DIFFICULTY, or delete the checkpoint so it re-mints.",
+        actual, want, tostring(hard), controller)
+end
+
 local function bootToMap(stopAtPrep)
     log("booting to map with observed FE8 states")
     local stalled = INSPECT.watch("boot")
@@ -1222,6 +1253,14 @@ local function bootToMap(stopAtPrep)
         end
         if state == "player_map_idle" then
             if inChapter() then
+                -- Assert the MODE on every boot, not only in the difficulty probe. A
+                -- checkpoint reload or a silent revert to the menu default would otherwise
+                -- run the whole gate in a mode nobody asked for and nothing would say so.
+                local wrong = INSPECT.difficultyMismatch()
+                if wrong then
+                    result("FAIL", wrong)
+                    return false
+                end
                 log(string.format("in chapter %d turn %d", chapter(), turn()))
                 shot("map-loaded")
                 return true
@@ -1737,27 +1776,8 @@ end
 -- three numbers the chapter DECLARES in its YAML `difficulty:` block. Reading the map
 -- rather than the menu is the point: the menu only proves we clicked something.
 scenarios.difficulty = function()
-    -- The mode this run is SUPPOSED to be in: the resolved default, not the raw env var
-    -- (unset now means NORMAL, not "whatever the menu highlights").
-    local mode = ({ [0] = "tutorial", [1] = "normal", [2] = "difficult" })[TUNE.difficultyWant]
     if not bootToMap() then return result("FAIL", "never reached the map") end
-    -- PROVE the run is in the mode it labels before recording anything under that name.
-    -- A scenario that boots from a saved state never passes the difficulty menu, so it
-    -- would happily file Tutorial stats as "difficult"; a mislabeled measurement is worse
-    -- than no measurement. These are the two bits SaveMenuWriteNewGame actually sets:
-    --   chapterStateBits +0x14, PLAY_FLAG_HARD = 1<<6 (types.h:187,246)
-    --   config +0x40, controller = bit 21 (PlaySt_OptionBits; gameSpeed bit 7 and
-    --   animationType bits 17-18 in pokeFastConfig above pin the same packing)
-    -- and TUTORIAL_MODE() is `!HARD && controller ~= 1` (eventinfo.h:107).
-    local hard = (ru8(SYM.gPlaySt + 0x14) & 0x40) ~= 0
-    local controller = (ru32(SYM.gPlaySt + 0x40) >> 21) & 1
-    local actual = hard and "difficult" or (controller == 1 and "normal" or "tutorial")
-    if TUNE.difficultyWant ~= nil and actual ~= mode then
-        return result("FAIL", string.format(
-            "PT_DIFFICULTY=%s but the ROM is in %s (HARD=%s controller=%d) -- the menu "
-            .. "selection never committed, so these stats are not that mode",
-            mode, actual, tostring(hard), controller))
-    end
+    local actual, hard, controller = INSPECT.liveDifficulty()
     local total = INSPECT.difficultyProbe(actual)
     shot("difficulty-" .. actual)
     return result("PASS", string.format(

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -1028,8 +1028,14 @@ def scenario_fingerprint(scenario, rom_digest, harness_source=None, driver=None,
                      for scope in sorted(scenario_scopes(scenario, observed=observed))))
     h.update(('matrix-verdict-v1\n%s\nentry:%s\n' % (rom_part, export_env(scenario))).encode())
     for key in PLAYTEST_ENV_KEYS:
-        if env.get(key):
-            h.update(('env:%s=%s\n' % (key, env[key])).encode())
+        value = env.get(key)
+        # run.sh DEFAULTS PT_DIFFICULTY, so unset and an explicit "normal" are the same run.
+        # Normalising here keeps them on one cache key instead of paying for the same watched
+        # run twice (the other keys have no default -- absent really is a different run).
+        if key == 'PT_DIFFICULTY' and not value:
+            value = 'normal'
+        if value:
+            h.update(('env:%s=%s\n' % (key, value)).encode())
     h.update(b'driver:\n')
     h.update(driver.encode())
     h.update(b'\nshared:\n')

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -217,7 +217,7 @@ PLAYTEST_SEED = "${PT_SEED:-1}"
 PLAYTEST_CHAR = "${PT_CHAR:-}"
 PLAYTEST_ROUNDS = ${PT_ROUNDS:-1}
 PLAYTEST_HOST_CHAPTER = ${PT_HOST_CHAPTER:-${MX_HOST_CHAPTER:-1}}
-PLAYTEST_DIFFICULTY = "${PT_DIFFICULTY:-}"
+PLAYTEST_DIFFICULTY = "${PT_DIFFICULTY:-normal}"
 PLAYTEST_LLMDIR = "$LLM_DIR"
 PLAYTEST_STATE = "${PT_STATE:-}"
 PLAYTEST_TAG = "${PT_TAG:-}"
@@ -276,16 +276,21 @@ if [ -n "$MX_CHECKPOINT_DYNAMIC" ]; then
     CKPT="${PT_STATE:?$SCENARIO needs PT_STATE=<checkpoint> (e.g. PT_STATE=ch02intro)}"
     BUILDER="ckpt_${PT_STATE}"
 fi
+# A save state carries the difficulty it was MINTED in (it is in gPlaySt), so checkpoint
+# validity is (rom, mode) -- not rom alone. Keying on the hash reloaded a Tutorial state
+# under a Normal label, and a difficulty change alters no ROM bytes, so the hash could
+# never notice. Existing single-hash stamps mismatch and re-mint once, which is correct.
+CHECKPOINT_STAMP="$ROMHASH:${PT_DIFFICULTY:-normal}"
 if [ -n "$BUILDER" ]; then
-    if [ ! -f "$STATE_DIR/$CKPT.ss" ] || [ "$(cat "$STATE_DIR/$CKPT.romhash" 2>/dev/null || true)" != "$ROMHASH" ]; then
-        echo "== checkpoint '$CKPT' missing/stale -> building at top speed (240fps) =="
+    if [ ! -f "$STATE_DIR/$CKPT.ss" ] || [ "$(cat "$STATE_DIR/$CKPT.romhash" 2>/dev/null || true)" != "$CHECKPOINT_STAMP" ]; then
+        echo "== checkpoint '$CKPT' missing/stale for $CHECKPOINT_STAMP -> building at top speed (240fps) =="
         run_mgba "$BUILDER" 240 0 "$MX_CHECKPOINT_DEADLINE"  # ch02start plays the whole ch00->ch01->ch02 chain
         case "$VERDICT" in
-            *PASS*) echo "$ROMHASH" > "$STATE_DIR/$CKPT.romhash" ;;
+            *PASS*) echo "$CHECKPOINT_STAMP" > "$STATE_DIR/$CKPT.romhash" ;;
             *) echo "checkpoint build FAILED -- aborting"; exit 1 ;;
         esac
     else
-        echo "== checkpoint '$CKPT' valid for rom $ROMHASH -> loading =="
+        echo "== checkpoint '$CKPT' valid for $CHECKPOINT_STAMP -> loading =="
     fi
 fi
 

--- a/tools/playtest/test_controller.lua
+++ b/tools/playtest/test_controller.lua
@@ -810,7 +810,9 @@ local function diffObs(current, want)
 end
 
 check(action(diffObs(0, nil), "confirm_difficulty").key, "A",
-    "with no mode requested, A confirms the default as before")
+    "with no mode wanted at all, A confirms whatever is highlighted")
+check(action(diffObs(0, 1), "select_difficulty_down").key, "DOWN",
+    "the gate default is NORMAL, so a fresh run must move off option 0 (Tutorial)")
 check(action(diffObs(0, 2), "select_difficulty_down").key, "DOWN",
     "below the wanted mode, DOWN is the legal move")
 check(action(diffObs(0, 2), "confirm_difficulty"), nil,

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression coverage for state-driven playtest scenario wiring."""
 import os
+import re
 import unittest
 
 
@@ -316,16 +317,47 @@ class TestDifficultyGateDefault(unittest.TestCase):
         with open(os.path.join(here, 'playtest', 'harness.lua'), encoding='utf-8') as fh:
             return fh.read()
 
-    def test_the_default_mode_is_normal(self):
-        src = self._harness()
-        self.assertIn('or "normal"', src,
-                      'harness.lua must fall back to "normal" when PT_DIFFICULTY is unset')
-        self.assertNotIn('PLAYTEST_DIFFICULTY or nil', src)
+    def _mode_table(self, src):
+        """The one mode->menu-index table, parsed. FE8's menu order is fixed:
+        option 0 Tutorial, 1 Normal, 2 Difficult (SaveMenuWriteNewGame, savemenu.c:522)."""
+        m = re.search(r'difficultyIndex\s*=\s*\{(.*?)\}', src, re.S)
+        self.assertIsNotNone(m, 'harness.lua must expose one named mode->index table')
+        return {k: int(v) for k, v in re.findall(r'(\w+)\s*=\s*(\d+)', m.group(1))}
 
-    def test_every_mode_is_still_selectable(self):
+    def test_the_menu_indices_match_fe8s_own_order(self):
+        # Pins the MAPPING, not the spelling. Swapping tutorial/normal here would make the
+        # gate confirm Tutorial while calling it Normal -- the exact regression this PR
+        # exists to prevent, and a string-only assertion sails straight past it.
+        self.assertEqual(self._mode_table(self._harness()),
+                         {'tutorial': 0, 'normal': 1, 'difficult': 2})
+
+    def test_the_default_mode_resolves_to_normal(self):
         src = self._harness()
-        for mode in ('tutorial', 'normal', 'difficult'):
-            self.assertIn('%s = ' % mode, src, 'mode %s lost its index' % mode)
+        m = re.search(r'PLAYTEST_DIFFICULTY\s*or\s*"(\w+)"', src)
+        self.assertIsNotNone(m, 'harness.lua must name its fallback mode')
+        self.assertEqual(m.group(1), 'normal')
+        self.assertEqual(self._mode_table(src)[m.group(1)], 1,
+                         'the fallback must resolve to menu option 1 (Normal)')
+
+    def test_run_sh_and_the_harness_agree_on_the_default(self):
+        # run.sh owns the default; harness.lua's fallback only fires for entry points that
+        # bypass it. They must not be able to disagree about what "unset" means.
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, 'playtest', 'run.sh'), encoding='utf-8') as fh:
+            run = fh.read()
+        m = re.search(r'PT_DIFFICULTY:-(\w+)', run)
+        self.assertIsNotNone(m, 'run.sh must default PT_DIFFICULTY')
+        self.assertEqual(m.group(1), 'normal')
+
+    def test_the_checkpoint_stamp_includes_the_mode(self):
+        # A save state carries the difficulty it was minted in. Keying checkpoints on the
+        # ROM hash alone reloads a Tutorial state under a Normal label, and this change
+        # alters no ROM bytes -- so the hash cannot notice.
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, 'playtest', 'run.sh'), encoding='utf-8') as fh:
+            run = fh.read()
+        self.assertIn('CHECKPOINT_STAMP', run,
+                      'checkpoint validity must include the difficulty mode, not just ROMHASH')
 
 
 if __name__ == '__main__':

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -299,5 +299,34 @@ class TestPlaytestHarness(unittest.TestCase):
         self.assertIn('afterPre = pokeNormalConfig', recorder)
 
 
+class TestDifficultyGateDefault(unittest.TestCase):
+    """The playtest gate grades NORMAL unless a scenario asks otherwise (#303 follow-up).
+
+    FE8's difficulty menu initialises to option 0 (Tutorial) and the harness only ever
+    pressed A, so every verdict this project produced before #303 graded the EASIEST mode
+    while reading as general. Normal is what ships to most players and what
+    `difficulty.py` grades by default, so it is what the gate must run.
+
+    Pinned at the source, because the default is a module-level constant evaluated at load
+    and there is no way to observe it without booting mGBA.
+    """
+
+    def _harness(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(here, 'playtest', 'harness.lua'), encoding='utf-8') as fh:
+            return fh.read()
+
+    def test_the_default_mode_is_normal(self):
+        src = self._harness()
+        self.assertIn('or "normal"', src,
+                      'harness.lua must fall back to "normal" when PT_DIFFICULTY is unset')
+        self.assertNotIn('PLAYTEST_DIFFICULTY or nil', src)
+
+    def test_every_mode_is_still_selectable(self):
+        src = self._harness()
+        for mode in ('tutorial', 'normal', 'difficult'):
+            self.assertIn('%s = ' % mode, src, 'mode %s lost its index' % mode)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Follow-up to #304. **The playtest gate grades Normal by default instead of Tutorial.**

## Why

FE8's difficulty menu initialises to option 0 (Tutorial) and the harness only ever pressed A — so **every playtest verdict this project has produced graded the easiest mode** while reading as general. #304 gave scenarios a way to name a mode; this makes the unnamed case Normal, which is what ships to most players and what `difficulty.py` grades by default. The two halves of verification finally describe one configuration.

## What changed

One default, plus the scenario's label now coming from the **resolved** mode rather than the raw env var — unset means Normal, not "whatever the menu highlights". Mislabeling that would defeat the mode assertion added in #304.

Verified in-engine with `PT_DIFFICULTY` unset:

```
RESULT: PASS -- mode=normal (HARD=false controller=1) chapter=6 red maxHP total=384
```

Identical to the explicit `PT_DIFFICULTY=normal` run, and distinct from Tutorial's 362.

## ⚠️ This re-baselines every existing verdict

On Normal, enemies in ch02/ch03/ch05 arrive **two levels below** their authored table, where on Tutorial they arrived **four** below. Scenarios tuned against the old numbers may shift — particularly anything asserting on combat outcomes or unit survival.

**The full matrix re-run is deliberately not part of this PR.** It is a watched, expensive gate and belongs to you, not to me. Merging this and then running the gate is the intended order; anything that falls over is a genuine finding about content that was only ever verified on the easiest mode.

## Verification here

`test_playtest_harness` 18, `test_controller.lua` 261, `check.py` clean, one in-engine run. No ROM change — this is harness-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
