### PR TITLE
playtest: verify the checkpoint path for real, and fix what that found (#308)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2213,6 +2213,31 @@ re-running green scenes to obtain a number is exactly the cost this ADR exists t
    a missing binary must REFUSE, never fall back to headed: which engine ran is not in the verdict
    key, so a silent fallback serves a headed PASS for a headless run.
 
+6. **A verdict glob on the bare word matched a FAIL, and that is how the stamp got written.**
+   `run.sh` classified every verdict with `case "$VERDICT" in *PASS*)`, and `VERDICT` is the whole
+   `RESULT: ...` LINE -- reason text included. The first guard message said "refusing to let a
+   checkpoint build report PASS with no state written", so the FAIL it produced *matched the PASS
+   arm*: run.sh stamped `prep.romhash` valid off a build that had written 397312 bytes of zeros.
+   Four globs were fragile, and the last one is the EXIT CODE line, so a failure could have exited
+   0. All four now match `*"RESULT: PASS"*`, and the guard message no longer contains the word.
+   **This was found only by RUNNING the negative case** -- forcing a checkpoint builder headless
+   and watching what it wrote. Reading the code proved the guard fired; it did not prove what the
+   caller then did with that verdict. A failed build now also deletes its partial `.ss`, because a
+   397KB file in `states/` reads as a real checkpoint to whoever looks next.
+
+   Proof, both directions, on the canonical ROM (2026-08-23):
+
+   ```
+   builder forced headless:  engine: headless -> saveState prep -> false
+                             RESULT: FAIL ... -> checkpoint build FAILED -- aborting
+                             states/: no .romhash written, partial .ss removed
+   normal (ch02, headless):  engine: headed (mGBA)      -> saveState ch02start -> true  -> PASS
+                             engine: headless           -> ch02 PASS
+   ```
+
+   A real state is ~105-129KB at 99.4-99.5% non-zero; the broken one is exactly 397312 bytes of
+   zeros. That size is the tell.
+
 **Not a licence to re-run green scenes.** Headless removes the ATTENTION cost, not the time cost,
 and "never run anything after a merge" still stands. What it buys is that a run no longer has to be
 watched -- which is what makes batching scene work possible at all (#311).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2238,6 +2238,24 @@ re-running green scenes to obtain a number is exactly the cost this ADR exists t
    A real state is ~105-129KB at 99.4-99.5% non-zero; the broken one is exactly 397312 bytes of
    zeros. That size is the tell.
 
+7. **Classify a verdict in ONE place.** The glob above was four copies, so when it was wrong it
+   was wrong four times -- including on the exit-code line. It is now a single `verdict_passed()`
+   helper. The instance was the bug; the duplication was the class.
+
+8. **A failed rebuild must not delete a checkpoint it did not write.** Most builder failures never
+   reach `saveState()` at all -- the builder gives up, the deadline expires, mGBA exits early -- so
+   an unconditional cleanup would destroy the good state belonging to the PREVIOUS stamp whenever a
+   rebuild was triggered by a stamp change alone (`PT_DIFFICULTY=difficult` and back). run.sh
+   compares the state's mtime across the build and removes it only if THIS run wrote it. Proved
+   both ways: a 5s builder deadline leaves the good state byte-identical, while a headless builder
+   (which really does overwrite it with zeros before failing) removes it.
+
+9. **The checkpoint abort has to evict the verdict cache too.** `exit 1` in the checkpoint block
+   skipped the eviction at the foot of `run.sh`, so a direct `run.sh <scenario>` whose checkpoint
+   build failed left a stored green that the next `make matrix` would serve without running
+   anything -- while the same failure UNDER matrix.py did evict. Proved by planting a fake cache
+   entry and watching the abort path remove it.
+
 **Not a licence to re-run green scenes.** Headless removes the ATTENTION cost, not the time cost,
 and "never run anything after a merge" still stands. What it buys is that a run no longer has to be
 watched -- which is what makes batching scene work possible at all (#311).

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -297,8 +297,9 @@ local function saveState(name)
     -- (returns false, writes 397312 bytes of zeros), which is why run.sh keeps checkpoint
     -- builders headed -- but the guard belongs here too, where the failure is visible.
     if not ok then
-        controllerFault = "saveStateFile failed for '" .. name .. "' -- refusing to let a "
-            .. "checkpoint build report PASS with no state written"
+        -- Deliberately does NOT contain the word "pass": run.sh classifies a verdict by
+        -- matching the RESULT line, and this message travels inside it.
+        controllerFault = "saveStateFile failed for '" .. name .. "' -- no state was written"
     end
     return ok
 end

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -245,6 +245,11 @@ run_mgba() {
     local scen=$1 fps=$2 vsync=$3 deadline=$4 mode=${5:-headed}
     local app hl=0
     if [ "$mode" = "headless" ]; then app="$HEADLESS_APP"; hl=1; else app="$HEADED_APP"; ensure_headed_app; fi
+    # Say which engine ran, every time. Which binary served an invocation decides whether
+    # screenshots and saveStateFile work at all, and it was previously invisible -- the
+    # checkpoint builder silently inheriting the headless engine is exactly the bug this
+    # line makes impossible to miss (#308).
+    echo "engine: $mode ($(basename "$app"))"
     local out="/tmp/playtest-$scen" log
     log="$out/playtest.log"
     rm -rf "$out" && mkdir -p "$out"
@@ -303,7 +308,7 @@ EOF
     # of #236 was that the next question after a FAIL should be "which proc do I classify",
     # not "which hypothesis do I rebuild" (#241).
     case "$VERDICT" in
-        *PASS*) ;;
+        *"RESULT: PASS"*) ;;
         *) if grep -q '"event":"inspect"\|"event": "inspect"' "$log" 2>/dev/null; then
                echo "---------------- inspector ----------------"
                python3 "$HERE/inspect_state.py" render "$log" || true
@@ -333,8 +338,12 @@ if [ -n "$BUILDER" ]; then
         # broken under mgba-headless (see the engine-selection note above). ch02start
         # replays the whole ch00->ch01->ch02 chain.
         case "$VERDICT" in
-            *PASS*) echo "$CHECKPOINT_STAMP" > "$STATE_DIR/$CKPT.romhash" ;;
-            *) echo "checkpoint build FAILED -- aborting"; exit 1 ;;
+            *"RESULT: PASS"*) echo "$CHECKPOINT_STAMP" > "$STATE_DIR/$CKPT.romhash" ;;
+            *) # Remove the partial state too. Without its .romhash the next run would
+               # rebuild anyway, but a 397KB file of zeros sitting in states/ reads as a
+               # real checkpoint to anyone looking, and that is how a dead one gets trusted.
+               rm -f "$STATE_DIR/$CKPT.ss"
+               echo "checkpoint build FAILED -- aborting"; exit 1 ;;
         esac
     else
         echo "== checkpoint '$CKPT' valid for $CHECKPOINT_STAMP -> loading =="
@@ -359,7 +368,11 @@ if [ "$SCENARIO" = "llm" ]; then touch "$LLM_DIR/stop"; fi
 # passes through it, and the next `make matrix` would go on reporting the stale PASS for a
 # scenario that is red right now. Nothing else here reads the cache; this only invalidates.
 case "$VERDICT" in
-    *PASS*) ;;
+    *"RESULT: PASS"*) ;;
     *) rm -rf "$REPO/.matrix-verdictcache/$SCENARIO-"* 2>/dev/null || true ;;
 esac
-case "$VERDICT" in *PASS*) exit 0 ;; *) exit 1 ;; esac
+# Match the VERDICT LINE, not the bare word. VERDICT holds the whole `RESULT: ...` line, so
+# a glob on the word alone also matched a FAIL whose REASON happened to contain it -- which
+# stamped a checkpoint VALID off a failed build, and here would have exited 0 on a failure.
+# Caught by forcing a checkpoint builder headless and watching it stamp anyway (#308).
+case "$VERDICT" in *"RESULT: PASS"*) exit 0 ;; *) exit 1 ;; esac

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -238,6 +238,13 @@ python3 "$HERE/gen_symbols.py"
 pkill -9 -i mgba 2>/dev/null || true
 ROMHASH=$(shasum "$ROM" | cut -c1-12)
 
+# Did the last run_mgba PASS? Classify in ONE place. This was four copies of a glob, and
+# when the glob was wrong it was wrong four times -- including on the exit-code line, where a
+# FAIL could have exited 0. Match the whole `RESULT: ...` line, never the bare word: VERDICT
+# carries the failure REASON too, and a guard message that merely CONTAINED the word made a
+# FAIL classify as a pass (#308).
+verdict_passed() { case "$VERDICT" in *"RESULT: PASS"*) return 0 ;; *) return 1 ;; esac; }
+
 # run_mgba <scenario> <fps> <vsync> <deadline_s> [headless|headed]
 #   -> echoes log, sets global VERDICT. The engine is an ARGUMENT because a checkpoint
 #      builder must stay headed even when the scenario that needs it is headless.
@@ -307,13 +314,12 @@ EOF
     # JSON, but reading it meant knowing to run inspect_state.py by hand -- and the point
     # of #236 was that the next question after a FAIL should be "which proc do I classify",
     # not "which hypothesis do I rebuild" (#241).
-    case "$VERDICT" in
-        *"RESULT: PASS"*) ;;
-        *) if grep -q '"event":"inspect"\|"event": "inspect"' "$log" 2>/dev/null; then
-               echo "---------------- inspector ----------------"
-               python3 "$HERE/inspect_state.py" render "$log" || true
-           fi ;;
-    esac
+    if ! verdict_passed; then
+        if grep -q '"event":"inspect"\|"event": "inspect"' "$log" 2>/dev/null; then
+            echo "---------------- inspector ----------------"
+            python3 "$HERE/inspect_state.py" render "$log" || true
+        fi
+    fi
     echo "artifacts: $out"
 }
 
@@ -334,17 +340,35 @@ CHECKPOINT_STAMP="$ROMHASH:${PT_DIFFICULTY:-normal}"
 if [ -n "$BUILDER" ]; then
     if [ ! -f "$STATE_DIR/$CKPT.ss" ] || [ "$(cat "$STATE_DIR/$CKPT.romhash" 2>/dev/null || true)" != "$CHECKPOINT_STAMP" ]; then
         echo "== checkpoint '$CKPT' missing/stale for $CHECKPOINT_STAMP -> building at top speed (240fps) =="
+        # Note what the state file looked like BEFORE the build. Most builder failures never
+        # reach saveState() at all (the builder gives up, the deadline expires, mGBA exits
+        # early), so they write nothing -- and a rebuild triggered only by a STAMP change
+        # (PT_DIFFICULTY=difficult, say) would otherwise delete the perfectly good state
+        # belonging to the previous stamp and force a full re-mint when you switch back.
+        _ss_before=$(stat -f%m "$STATE_DIR/$CKPT.ss" 2>/dev/null || echo none)
         run_mgba "$BUILDER" 240 0 "$MX_CHECKPOINT_DEADLINE" headed  # HEADED always: saveStateFile is
         # broken under mgba-headless (see the engine-selection note above). ch02start
         # replays the whole ch00->ch01->ch02 chain.
-        case "$VERDICT" in
-            *"RESULT: PASS"*) echo "$CHECKPOINT_STAMP" > "$STATE_DIR/$CKPT.romhash" ;;
-            *) # Remove the partial state too. Without its .romhash the next run would
-               # rebuild anyway, but a 397KB file of zeros sitting in states/ reads as a
-               # real checkpoint to anyone looking, and that is how a dead one gets trusted.
-               rm -f "$STATE_DIR/$CKPT.ss"
-               echo "checkpoint build FAILED -- aborting"; exit 1 ;;
-        esac
+        if verdict_passed; then
+            echo "$CHECKPOINT_STAMP" > "$STATE_DIR/$CKPT.romhash"
+        else
+            _ss_after=$(stat -f%m "$STATE_DIR/$CKPT.ss" 2>/dev/null || echo none)
+            if [ "$_ss_after" != "$_ss_before" ]; then
+                # THIS run wrote it and then failed, so what is on disk is partial or dead
+                # (mgba-headless writes 397312 bytes of zeros). Without its .romhash the next
+                # run rebuilds anyway, but a file that size reads as a real checkpoint to
+                # whoever looks next, and that is how a dead one gets trusted.
+                echo "removing the partial '$CKPT' state this run wrote"
+                rm -f "$STATE_DIR/$CKPT.ss"
+            fi
+            # Evict the scenario's stored green before leaving. `exit 1` here skips the
+            # eviction at the bottom of this file, so a direct `run.sh ch02` whose checkpoint
+            # build failed would leave a stale PASS that the next `make matrix` serves without
+            # running anything -- while the same failure UNDER matrix.py does evict. The two
+            # paths have to agree.
+            rm -rf "$REPO/.matrix-verdictcache/$SCENARIO-"* 2>/dev/null || true
+            echo "checkpoint build FAILED -- aborting"; exit 1
+        fi
     else
         echo "== checkpoint '$CKPT' valid for $CHECKPOINT_STAMP -> loading =="
     fi
@@ -367,12 +391,5 @@ if [ "$SCENARIO" = "llm" ]; then touch "$LLM_DIR/stop"; fi
 # it sees a failure, but a scenario run DIRECTLY -- which is how debugging happens -- never
 # passes through it, and the next `make matrix` would go on reporting the stale PASS for a
 # scenario that is red right now. Nothing else here reads the cache; this only invalidates.
-case "$VERDICT" in
-    *"RESULT: PASS"*) ;;
-    *) rm -rf "$REPO/.matrix-verdictcache/$SCENARIO-"* 2>/dev/null || true ;;
-esac
-# Match the VERDICT LINE, not the bare word. VERDICT holds the whole `RESULT: ...` line, so
-# a glob on the word alone also matched a FAIL whose REASON happened to contain it -- which
-# stamped a checkpoint VALID off a failed build, and here would have exited 0 on a failure.
-# Caught by forcing a checkpoint builder headless and watching it stamp anyway (#308).
-case "$VERDICT" in *"RESULT: PASS"*) exit 0 ;; *) exit 1 ;; esac
+verdict_passed || rm -rf "$REPO/.matrix-verdictcache/$SCENARIO-"* 2>/dev/null || true
+verdict_passed && exit 0 || exit 1


### PR DESCRIPTION
Refs #308. You asked me to actually verify the checkpoint path instead of asserting it was "proven by construction." Doing that found a second bug the first fix did not close.

## What the verification found

`run.sh` classified every verdict with `case "$VERDICT" in *PASS*)` — and `VERDICT` is the whole `RESULT: ...` **line**, reason text included. The guard message I added in 2c6167b read:

> refusing to let a checkpoint build report **PASS** with no state written

So the FAIL it produced **matched the PASS arm.** `run.sh` stamped `prep.romhash` valid off a build that had just written 397,312 bytes of zeros — exactly the poisoning the guard existed to prevent, reached by a different route.

All four globs were fragile, and the last one is the **exit-code line**, so a failure whose reason mentioned the word could have made `run.sh` exit 0.

Reading the code proved the guard fired. It did not prove what the *caller* then did with that verdict. Only running the negative case showed that.

## Fixes

- All four globs match `*"RESULT: PASS"*`; the guard message no longer contains the word.
- A failed checkpoint build removes its partial `.ss`. Without the stamp the next run rebuilds anyway, but a 397KB file in `states/` reads as a real checkpoint to whoever looks next.
- `run_mgba` announces which engine served each invocation. That choice decides whether screenshots and `saveStateFile` work at all, and it was invisible before — it is what made both bugs observable.

## Verified live, both directions, on the canonical ROM

**Negative** — builder forced headless:
```
engine: headless (mgba-headless)
saveState prep -> false
RESULT: FAIL -- ... no state was written
checkpoint build FAILED -- aborting
states/: no .romhash written, partial .ss removed
```

**Positive** — `ch02`, which is headless and depends on `ch02start`:
```
engine: headed (mGBA)            <- the builder, as required
saveState ch02start -> true
RESULT: PASS -- ch02start checkpoint saved

engine: headless (mgba-headless) <- ch02 itself
RESULT: PASS -- ch02 entered: 3 chwinga green, 5 deployed, archer + boss present
```

A real state is 105–129KB at ~99.4% non-zero; the broken one is exactly **397,312 zero bytes**. That size is the tell, and it is recorded in `decisions.md`.

`make check` clean.

## Note on the tree

Verifying this required the **canonical** ROM (all six checkpoint builders run on it), so the tree now holds canonical rather than ch03boot — ROM, ELF and `.build-config.json` all restored from the same cache entry, with symbols regenerated. `states/` now has valid `prep` and `ch02start`, which four scenarios needed and which was empty before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
