### PR TITLE
playtest: run headless scenarios in parallel by default (#310)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1790,8 +1790,11 @@ beside it. Decisions worth keeping:
   the way rather than blocking.
 - **A failed build blocks only its own group**, and a failed scenario does not stop the matrix — one broken
   configuration must not hide the state of the others.
-- **Sequential by construction.** mGBA runs share emulator/save state, and two ROM builds in one tree corrupt
-  each other, so neither is parallelised; the win comes from not rebuilding and not re-earning checkpoints.
+- **Builds are sequential by construction; runs are not.** Two ROM builds in one tree corrupt each other and
+  the tree holds ONE `fireemblem8.gba`, so a build never overlaps anything. Scenario RUNS are independent
+  processes: headless ones run concurrently (see “Headless flipped the parallel-dispatch default”, #310),
+  while headed runs and checkpoint builders stay serial — they contend for the compositor and for
+  `states/<name>.ss` respectively. The biggest win is still not rebuilding and not re-earning checkpoints.
 - **Suites are curated, not derived.** `gate` is deliberately tight (controller contract + ch00/ch01 spine +
   SMS budget + the current chapter); the per-chapter suites are each a single ROM build; `--all` runs every
   non-manual verdict scenario. `llm` is `manual` (external sidecar) and never auto-selected.
@@ -2259,6 +2262,50 @@ re-running green scenes to obtain a number is exactly the cost this ADR exists t
 **Not a licence to re-run green scenes.** Headless removes the ATTENTION cost, not the time cost,
 and "never run anything after a merge" still stands. What it buys is that a run no longer has to be
 watched -- which is what makes batching scene work possible at all (#311).
+
+### Headless flipped the parallel-dispatch default — 3.2x (2026-08-23, #302, #310)
+
+`--jobs` had been off since 2026-08-09, and for a good reason: 444s serial against 439s at
+`jobs=4`, with four scenarios blowing their WALL-CLOCK deadlines and reporting ERROR/FAIL. That
+measurement was never wrong. It was **conditional on being HEADED** — four Qt mGBA windows
+contending for one compositor, each still rendering every frame, which is exactly what a 1.01x
+with deadline blowouts looks like. #308 deleted the rendering, so the condition changed and the
+number had to be re-taken rather than respected or assumed away (`decisions.md` → inherited leads
+are hypotheses).
+
+Re-taken on the same Mac (8 logical / 4 performance cores), same four ch03boot verdict scenarios,
+one build, `--no-verdict-cache`:
+
+| | wall | per-scenario |
+|---|---|---|
+| `--jobs 1` | **71s** | 15s / 14s / 20s / 20s |
+| `--jobs 4` | **22s** | 15s / 15s / 21s / 21s |
+
+**3.2x, all four PASS, zero deadline blowouts.** The interesting column is the second one: the
+per-scenario times are essentially IDENTICAL serial and parallel. There is no contention left to
+find — which is what you would expect once no process is rendering.
+
+**Parallelism is gated on `headless`, per SCENARIO, not per group.** `scenario_lanes` now pulls a
+headed scenario into the serial lane the same way a checkpointed one has always been pulled
+(`states/<name>.ss` is a shared file two scenarios would race to mint). A MIXED group is therefore
+not forced serial whole: its headless scenarios still run concurrently and the headed ones run
+afterwards, alone, on the caller's thread — so a headed run never overlaps anything and the
+2026-08-09 measurement stays the live one for exactly the runs it was taken on.
+
+**The default is derived from the machine, capped at what was measured.** `resolve_jobs` is
+`--jobs`, else `MX_JOBS`, else `cpus // 2` floored at 1 and capped at `MEASURED_JOBS = 4`. Half
+the logical cores is the performance-core count on the Mac this was measured on; an unthrottled
+mGBA at `fps: 240` is CPU-bound enough that a box without spare cores would only divide the same
+throughput, which is the 2026-08-09 result restated for small machines. The cap is there because 4
+is what somebody actually ran: a 32-core machine may claim more only once it has been measured
+there.
+
+Proved end to end with the default and no flag — three canonical verdict scenarios, 15s + 18s +
+18s of scenario time, **18s wall**, all PASS, cached ROM, no build.
+
+**This does not license re-running green scenes.** It makes the runs that must happen cheaper; it
+does not make a run free, and "never run the full gate locally, never after a merge" still stands.
+The other half of the gate's 24m51s is the five BUILDS, which is #309's problem, not this one's.
 
 ### A chapter declares its traps; `.traps` is the fourth inherited field (2026-08-22, #302)
 

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -12,8 +12,9 @@ Three things keep it quick, all of which matter because the full matrix used to 
     the one that makes the matrix incremental -- see `scenario_fingerprint` (#255);
   * a ROM CACHE keyed on everything the ROM is built FROM -- a harness-only change
     reuses all four builds instead of remaking them (~170s);
-  * scenarios CAN run in parallel within a configuration (--jobs), though it is off
-    by default -- measured, and it does not pay here. See execute().
+  * scenarios run in PARALLEL within a configuration (--jobs, on by default on a
+    machine with the cores for it) -- 3.2x once verdict runs went headless. Headed
+    scenarios still run one at a time. See execute().
 Use `make matrix SUITE=<chapter>` while iterating; the full matrix is the push gate.
 
     make matrix                        # the merge gate
@@ -52,6 +53,12 @@ REPO = os.path.dirname(os.path.dirname(HERE))
 MANIFEST = os.path.join(HERE, 'matrix.yaml')
 HARNESS = os.path.join(HERE, 'harness.lua')
 RUN_SH = os.path.join(HERE, 'run.sh')
+
+# The most scenarios ever measured running at once (#310, 2026-08-22): 4 headless mGBA
+# processes on 8 logical / 4 performance cores, 3.2x with no per-scenario slowdown. It is a
+# CAP on the derived default, not a target -- a bigger machine may claim more only once
+# somebody has measured it there.
+MEASURED_JOBS = 4
 
 # The `make` invocation the runner builds each configuration with.
 CAMPAIGN = os.environ.get('CAMPAIGN', 'rime-of-the-frostmaiden')
@@ -293,18 +300,44 @@ def scenario_lanes(scenarios):
 
     Scenarios are independent mGBA runs against an already-built ROM, each writing its own
     `/tmp/playtest-<name>` -- so within one ROM configuration they can run concurrently.
-    The exception is a CHECKPOINT: `states/<name>.ss` is a shared file that a scenario will
-    MINT if it is missing or stale for this ROM build, so two scenarios wanting the same
-    checkpoint would race to write it. Those run serially, one checkpoint at a time.
+    Two things pull a scenario back out of that lane:
 
-    (Today every scenario in the gate suite is checkpoint-free, so the gate parallelises
-    whole. The split exists so a future checkpointed scenario cannot silently corrupt a
-    state file the moment somebody adds it to a suite.)
+      * a CHECKPOINT: `states/<name>.ss` is a shared file that a scenario will MINT if it
+        is missing or stale for this ROM build, so two scenarios wanting the same
+        checkpoint would race to write it. Those run serially, one checkpoint at a time;
+      * a HEADED run (#310). Parallelism is gated on `headless`, not on checkpoint-freedom
+        alone: four GUI mGBA windows contend for the compositor and each still renders
+        every frame, which is what the 2026-08-09 measurement caught. A headless run
+        renders nothing and does not contend -- see execute().
+
+    A MIXED group is not forced serial whole: its headless scenarios still run in the
+    parallel lane, and the headed ones run afterwards on the caller's thread, alone. So a
+    headed scenario never overlaps anything, headless or otherwise.
     """
     parallel, serial = [], []
     for s in scenarios:
-        (serial if s.checkpoint else parallel).append(s)
+        (serial if (s.checkpoint or not s.headless) else parallel).append(s)
     return parallel, serial
+
+
+def resolve_jobs(arg=None, env=None, cpus=None):
+    """How many scenarios run at a time when nobody says: `--jobs`, else `MX_JOBS`, else
+    derived from the machine.
+
+    The derived default is `cpus // 2`, capped at MEASURED_JOBS, floored at 1 -- half the
+    logical cores is the performance-core count on the Mac this was measured on (8 logical
+    / 4 performance -> 4), and an unthrottled mGBA is CPU-bound enough that a box without
+    spare cores would only divide the same throughput. The cap is there because 4 is what
+    was actually measured; a bigger machine has to be measured before it may claim more.
+    """
+    if arg:
+        return max(1, int(arg))
+    env = os.environ if env is None else env
+    if env.get('MX_JOBS'):
+        return max(1, int(env['MX_JOBS']))
+    if cpus is None:
+        cpus = os.cpu_count() or 1
+    return max(1, min(MEASURED_JOBS, cpus // 2))
 
 
 def execute(groups, build, run_scenario, jobs=1, lookup_cached=None, after_build=None):
@@ -320,20 +353,23 @@ def execute(groups, build, run_scenario, jobs=1, lookup_cached=None, after_build
     emulator at all (#255). Outcomes are emitted in the group's own order whether they
     ran or not, so the table does not reshuffle itself as the cache fills.
 
-    `jobs` > 1 runs a group's checkpoint-free scenarios concurrently. BUILDS always stay
-    serial and never overlap a run: the tree holds ONE `fireemblem8.gba`, so a second `make`
-    would swap the ROM out from under a live emulator (and two builds in one tree corrupt
-    each other outright -- see CLAUDE.md).
+    `jobs` > 1 runs a group's parallel-lane scenarios concurrently (see `scenario_lanes`:
+    checkpoint-free AND headless). BUILDS always stay serial and never overlap a run: the
+    tree holds ONE `fireemblem8.gba`, so a second `make` would swap the ROM out from under a
+    live emulator (and two builds in one tree corrupt each other outright -- see CLAUDE.md).
 
-    **`jobs` DEFAULTS TO 1 BECAUSE PARALLELISM WAS MEASURED AND DOES NOT PAY HERE** (2026-08-09,
-    8 logical / 4 performance cores). Scenarios run mGBA at `fps: 240` -- deliberately
-    unthrottled, so each one is CPU-bound and already saturates a core. Four at a time simply
-    divided the same throughput: individual scenarios went 10s -> 67s, total wall did NOT move
-    (444s serial vs 439s at jobs=4), and four scenarios blew their WALL-CLOCK deadlines and
-    reported ERROR/FAIL -- turning contention into false red. A gate that fails at random is
-    worse than a slow one. The knob stays because a machine with many more real cores could
-    make it pay, but prove it with a measurement before raising the default. The speed win that
-    DID land is the ROM cache below.
+    **`jobs` DEFAULTS TO PARALLEL, BECAUSE HEADLESS CHANGED THE MEASUREMENT** (#310). The
+    same four verdict scenarios, one build, `--no-verdict-cache`, on the same Mac: 71s at
+    `--jobs 1` against 22s at `--jobs 4`, all four PASS, zero deadline blowouts, and the
+    per-scenario times IDENTICAL serial and parallel (15/14/20/20 against 15/15/21/21) --
+    which is what no contention at all looks like.
+
+    The old result was right and is not being overturned: 2026-08-09 measured 444s serial
+    against 439s at `jobs=4` with four scenarios blowing their WALL-CLOCK deadlines, and
+    that measurement was CONDITIONAL ON BEING HEADED -- four Qt windows contending for the
+    compositor while each rendered every frame. #308 deleted the rendering; the condition
+    changed, not the arithmetic. Which is also why headed scenarios are still serial here:
+    for them the 2026-08-09 number is the live one.
     """
     outcomes = []
     built = []
@@ -1336,10 +1372,11 @@ def cmd_run(args):
     if args.dry_run:
         return 0
 
-    jobs = args.jobs if args.jobs else int(os.environ.get('MX_JOBS', '1'))
+    jobs = resolve_jobs(args.jobs)
     use_cache = not (args.no_rom_cache or os.environ.get('MX_NO_ROM_CACHE'))
     if jobs > 1:
-        print('matrix: running up to %d scenarios at a time (builds stay serial)' % jobs)
+        print('matrix: running up to %d headless scenarios at a time '
+              '(builds and headed runs stay serial)' % jobs)
     report = execute(groups,
                      build=lambda rom, flags: _build(rom, flags, log_dir, use_cache=use_cache),
                      run_scenario=lambda s: verdicts.store(s, _run_scenario(s, log_dir)),
@@ -1402,8 +1439,9 @@ def main(argv=None):
     run.add_argument('--out', default='/tmp/playtest-matrix')
     run.add_argument('--dry-run', action='store_true')
     run.add_argument('--jobs', type=int, default=None,
-                     help='scenarios to run at a time within one ROM config (default 1, '
-                          'or MX_JOBS). MEASURED AND OFF BY DEFAULT -- see execute()')
+                     help='scenarios to run at a time within one ROM config (or MX_JOBS; '
+                          'defaults to half the cores, capped at %d). Headless scenarios '
+                          'only -- headed ones stay serial. See execute()' % MEASURED_JOBS)
     run.add_argument('--no-rom-cache', action='store_true',
                      help='always `make`, never reuse a cached ROM (or MX_NO_ROM_CACHE=1)')
     run.add_argument('--no-verdict-cache', action='store_true',

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import sys
 import tempfile
+import threading
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -598,6 +599,59 @@ class ParallelScenarios(unittest.TestCase):
         second = [i for i, (k, _) in enumerate(rec) if k == 'build'][1]
         first_group = {n for k, n in rec[:second] if k == 'run'}
         self.assertEqual(first_group, {'a', 'b'})
+
+
+    def test_a_headed_scenario_is_forced_serial(self):
+        """Parallelism is gated on HEADLESS, not just on checkpoint-freedom (#310). Four
+        GUI mGBA windows contend for the compositor -- that is what the 2026-08-09
+        measurement caught (1.01x and four blown deadlines). A headless run renders
+        nothing and does not contend, which is why the same measurement re-taken headless
+        came back 3.2x."""
+        m = manifest(scenarios={'a': {}, 'b': {'kind': 'record'}})
+        par, ser = mx.scenario_lanes([m.resolve('a'), m.resolve('b')])
+        self.assertEqual([s.name for s in par], ['a'])
+        self.assertEqual([s.name for s in ser], ['b'])
+
+    def test_a_headed_scenario_never_runs_in_a_worker_thread(self):
+        """A mixed group still parallelises its headless scenarios; the headed one runs
+        alone on the caller's thread, so it never overlaps anything."""
+        m = manifest(scenarios={'a': {}, 'b': {}, 'c': {'kind': 'record'}})
+        threads = {}
+
+        def run_scenario(scn):
+            threads[scn.name] = threading.current_thread()
+            return mx.Outcome(scn.name, scn.rom, 'PASS', 1.0, '', '')
+
+        mx.execute(m.plan(['a', 'b', 'c']), build=lambda rom, flags: True,
+                   run_scenario=run_scenario, jobs=4)
+        main = threading.current_thread()
+        self.assertIs(threads['c'], main)
+        self.assertIsNot(threads['a'], main)
+        self.assertIsNot(threads['b'], main)
+
+
+class JobCount(unittest.TestCase):
+    """How many scenarios run at a time when nobody says (#310)."""
+
+    def test_the_default_is_parallel_now_that_verdict_runs_are_headless(self):
+        """71s serial -> 22s at 4 jobs on this Mac (8 logical / 4 performance cores),
+        all four PASS, per-scenario times identical. Measured 2026-08-22 on #310."""
+        self.assertEqual(mx.resolve_jobs(arg=None, env={}, cpus=8), 4)
+
+    def test_a_small_machine_stays_serial(self):
+        """Unthrottled mGBA saturates a core, so a box without spare cores would just
+        divide the same throughput -- which is the 2026-08-09 result, restated."""
+        self.assertEqual(mx.resolve_jobs(arg=None, env={}, cpus=1), 1)
+        self.assertEqual(mx.resolve_jobs(arg=None, env={}, cpus=2), 1)
+
+    def test_a_big_machine_does_not_go_past_what_was_measured(self):
+        self.assertEqual(mx.resolve_jobs(arg=None, env={}, cpus=64), 4)
+
+    def test_mx_jobs_overrides_the_default(self):
+        self.assertEqual(mx.resolve_jobs(arg=None, env={'MX_JOBS': '1'}, cpus=8), 1)
+
+    def test_an_explicit_flag_beats_the_environment(self):
+        self.assertEqual(mx.resolve_jobs(arg=2, env={'MX_JOBS': '8'}, cpus=8), 2)
 
 
 class RomCache(unittest.TestCase):


### PR DESCRIPTION
Closes the open half of #310. The measurement was already taken and is on the issue; this lands what it implies.

## What changed

- **`scenario_lanes` gates the parallel lane on `headless`**, not on checkpoint-freedom alone. Per SCENARIO rather than per group, which is a shade finer than the issue's wording: a mixed group still parallelises its headless scenarios and runs the headed ones afterwards, alone, on the caller's thread — so a headed run never overlaps anything, and the 2026-08-09 numbers stay the live ones for exactly the runs they were taken on.
- **`resolve_jobs`**: `--jobs`, else `MX_JOBS`, else `cpus // 2` floored at 1 and capped at `MEASURED_JOBS = 4`. Half the logical cores is the performance-core count on the Mac this was measured on; the cap is there because 4 is what somebody actually ran.
- **The "parallelism does not pay here" note in `execute()` is retired**, replaced with both measurements and the condition that separates them, per the issue's third box.
- `decisions.md` gets the entry, and the 2026-08-05 "sequential by construction" bullet is rewritten natively rather than annotated.

## Verification

- `make test` — 39 modules, all OK, exit 0. Seven new tests, each watched fail first.
- `make check` — drift clean.
- One real run, default jobs, no flag:

```
matrix: running up to 4 headless scenarios at a time (builds and headed runs stay serial)
canonical  titlecard  PASS  ran  15s
canonical  gameover   PASS  ran  18s
canonical  retreat    PASS  ran  18s
3 scenario(s), 3 ran, 0 cached, 1 build(s), 18s wall
```

51s of scenario time in 18s wall, cached ROM, no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
