### PR TITLE
playtest: report each scenario as it finishes (#310)

### DIFF
--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -1305,6 +1305,15 @@ def parse_verdict(text, returncode):
     return verdict
 
 
+def progress_line(outcome):
+    """What a scenario prints when it FINISHES. Dispatch lines alone stopped being progress
+    the moment four scenarios started at once (#310): they all appear immediately and then
+    nothing moves until the table. This is the other half -- name, verdict and time, in the
+    order they actually complete."""
+    return '   %-8s %-24s %s' % (outcome.verdict, outcome.scenario,
+                                 human_duration(outcome.seconds))
+
+
 def _run_scenario(scenario, log_dir):
     env = dict(os.environ)
     env['PT_HOST_CHAPTER'] = str(scenario.host_chapter)
@@ -1318,8 +1327,10 @@ def _run_scenario(scenario, log_dir):
         fh.write(text)
     verdict = parse_verdict(text, proc.returncode)
     tail = '' if verdict == 'PASS' else '\n'.join(text.strip().splitlines()[-12:])
-    return Outcome(scenario.name, scenario.rom, verdict, seconds,
-                   '/tmp/playtest-%s' % scenario.name, tail)
+    outcome = Outcome(scenario.name, scenario.rom, verdict, seconds,
+                      '/tmp/playtest-%s' % scenario.name, tail)
+    print(progress_line(outcome))
+    return outcome
 
 
 RESULTS_NAME = 'results.json'

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -654,6 +654,27 @@ class JobCount(unittest.TestCase):
         self.assertEqual(mx.resolve_jobs(arg=2, env={'MX_JOBS': '8'}, cpus=8), 2)
 
 
+class LiveProgress(unittest.TestCase):
+    """With four scenarios dispatched at once, a START line no longer tells you what is
+    still running (#310). Each one reports again when it finishes."""
+
+    def _finished(self, verdict, seconds=15.4):
+        return mx.Outcome('titlecard', 'canonical', verdict, seconds, '/tmp/playtest-titlecard', '')
+
+    def test_a_finished_scenario_reports_its_name_verdict_and_time(self):
+        line = mx.progress_line(self._finished('PASS'))
+        self.assertIn('titlecard', line)
+        self.assertIn('PASS', line)
+        self.assertIn('15s', line)
+
+    def test_a_failure_is_visible_without_waiting_for_the_table(self):
+        self.assertIn('FAIL', mx.progress_line(self._finished('FAIL')))
+
+    def test_the_finish_line_is_distinguishable_from_the_start_line(self):
+        """Both scroll past interleaved; if they read alike, neither is progress."""
+        self.assertNotEqual(mx.progress_line(self._finished('PASS')).split()[0], '--')
+
+
 class RomCache(unittest.TestCase):
     """A harness-only change must not pay for four rebuilds."""
 


### PR DESCRIPTION
The last box on #310 — hydra's live-progress idea, at the size this runner needs it.

Parallel dispatch made the existing `-- name [rom]` lines stop being progress: with four scenarios started at once they all print immediately and nothing moves until the table. Each scenario now prints again when it finishes, in completion order, so a failure is visible while the rest are still running.

```
matrix: running up to 4 headless scenarios at a time (builds and headed runs stay serial)
== canonical: cached ROM reused (no ROM input changed)
-- titlecard [canonical]
-- gameover [canonical]
-- retreat [canonical]
   PASS     titlecard                15s
   PASS     retreat                  18s
   PASS     gameover                 18s
```

What hydra parses a line protocol for is a supervisor aggregating many workers; what this needs is which scenario ended and how, so `progress_line` is a pure formatter and the table stays the summary.

## Verification

- `make test` — exit 0. Three new tests, watched fail first (`module 'matrix' has no attribute 'progress_line'`).
- `make check` — drift clean.
- The output above is a real run, default jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
