### PR TITLE
build: cache the config-invariant injection steps (#309)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,8 @@ campaigns/*/battle_anims/*/.paint/
 # matrix verdict cache (earned PASS verdicts + their artifacts, keyed by input fingerprint)
 .matrix-verdictcache/
 
+# injection step cache (what a config-invariant injection step wrote, keyed on its inputs)
+.injectcache/
+
 # matrix build-scope manifest (what each injection step wrote; describes the build, not the source)
 .build-scopes.json

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2307,6 +2307,73 @@ Proved end to end with the default and no flag — three canonical verdict scena
 does not make a run free, and "never run the full gate locally, never after a merge" still stands.
 The other half of the gate's 24m51s is the five BUILDS, which is #309's problem, not this one's.
 
+### A build is 50 seconds, and 26 of them were the same battle anims every time (2026-08-23, #302, #309)
+
+#309 was written as *"switch ROM configurations by PATCHING the linked ELF, not by rebuilding"*,
+borrowed from pokeemerald-expansion, on the premise that the gate's five builds were half of its
+24m51s. The premise was inherited, so it was measured first (`decisions.md` → inherited leads are
+hypotheses). On this Mac, `-j8`:
+
+| | injector | `make -C fireemblem8u` | total |
+|---|---|---|---|
+| same-config rebuild | 35.8s | 23.9s | **59.7s** (ROM byte-identical) |
+| config switch → `ch04boot` | 34.9s | 14.1s | **49.0s** |
+
+A config switch recompiles ten `.c` files and relinks — it was already incremental. And
+`cProfile` on the injector says where the rest goes: **`inject_enemy_class_battle_anims` 17.1s +
+`inject_battle_anims` 8.5s = 26 of the ~35 injector seconds**, with every other step under 1.8s.
+Neither can see a boot flag — both are called with `campaign` alone, and both run before the first
+flag-dependent step — so all twelve `rom_configs` pay 26 seconds to produce byte-identical anim
+data. **ELF patching aims at the 14s; the 26s was the number worth taking.**
+
+**So a step whose inputs have not moved now restores what it wrote** (`tools/inject/step_cache.py`)
+— the same bargain the ROM cache and the verdict cache already make one level up, with the STEP as
+the unit. A config switch went **49.0s → 25.2s**, and a same-config rebuild 59.7s → 25.5s.
+
+**What makes a restore sound, and what enforces it:**
+
+- The key is everything the ROM is built from EXCEPT the boot flags, plus the decomp revision.
+  That is exactly the claim being made — these steps cannot see a flag, so two configurations of
+  the same source owe the same anim data. `build_scopes.fingerprint_paths` is now the ONE
+  implementation of "have the inputs moved", shared with `matrix.rom_input_hash`: two caches
+  answering that question differently would mean one of them is wrong.
+- The key is the argument; the `pre`/`post` map is the CHECK on it, because a key that silently
+  misses an input is the failure this repo cannot see — the ROM would be wrong and everything
+  would still be green. Every file the step wrote must be sitting at the digest it had BEFORE the
+  recorded run, or at the one that run left. **Both are needed**: `pre` is what makes "not yet
+  applied" distinguishable from "already applied" for a step that APPENDS (banim tables are
+  additive donor-prime, #65), and `post` is the state a real tree is actually in, because nothing
+  wipes the decomp between builds. A `pre`-only rule looked right and would have hit exactly never
+  — a test caught it, not a build.
+- Two of the seven source files those steps write (`src/data_characters.c`, `src/data_classes.c`)
+  are also written by EARLIER steps. Restoring is equivalent only because those earlier steps are
+  themselves config-invariant, which is a property of main()'s ORDER — so
+  `check.py check_cached_steps_are_config_invariant` holds it, reading the flag list out of
+  main()'s own `_requested_flags` table so adding a flag cannot quietly widen the gap.
+- Which paths to hash is DERIVED (what the step wrote last time), never declared. `roots` is a
+  cost hint for the first entry only; a write outside it records an `unknown` pre-state, which
+  forces a miss and fixes itself.
+- `NO_INJECT_CACHE=1` resolves to a cache that always runs the step, so the call site has one
+  shape and no branch.
+
+**Proved by output, not by tests passing**: canonical built with the cache cold is
+`a44afcc2…`, byte-identical to the ROM built before any of this existed; `ch04boot` built with 639
+files restored instead of computed is `5fa10577…`, byte-identical to the `ch04boot` ROM built the
+old way half an hour earlier. Two configurations, two matching ROMs.
+
+⚠️ **A wrapped step drops out of `check_injection_order` unless the parser is told.** `_scopes.run`
+had already taught this once and the docstring said so; `_anims.run` broke it again the same day it
+was added, and the unit tests were green — `test_repo_main_satisfies_all_constraints` was the one
+that caught it. The parser now sees through any `_x.run(step, ...)` wrapper.
+
+**Phase 2 (ELF patching) is not dead, it is priced.** The boot TARGET really is patchable — a
+hardcoded immediate `_redirect_new_game` writes into `StartBattleMap`. But each `--chNN-boot` also
+LOADs an armed party seed table so a cold New Game has a party to field, and that must not execute
+on the real chain where the party persists; patching means runtime-gating the seed first. And
+`testch`, `lordboot`, `ch05lupinboot`, `montage` and the ch05 debug boots all inject DATA and can
+never be patched. Best case for the gate is **2 of 5 builds**, to be decided against the
+post-phase-1 numbers.
+
 ### A chapter declares its traps; `.traps` is the fourth inherited field (2026-08-22, #302)
 
 `.traps` is a **ChapterEventGroup** field (chapterdata.h:32), not a `chapter_settings` one. Our

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -56,6 +56,7 @@ from inject.decomp import (  # noqa: E402  shared decomp paths + patch primitive
     BATTLEQUOTES_C, BMUNIT_C, LORDSEL_FLAG_BASE,
     WEAPON_ITEM_ENUM, fe_item_enum)  # shared weapon<->ITEM map (used by inject_prologue)
 from inject import engine_hooks  # noqa: E402  campaign-agnostic engine C-source hooks
+from inject import step_cache  # noqa: E402  restore a config-invariant step (#309)
 
 # PyYAML's pure-Python scanner walks a document one character at a time through a chain of
 # Python calls, which made YAML parsing ~22s of a 51s injection (6M reader.forward calls) for
@@ -640,6 +641,42 @@ BUILD_STAMP = os.path.join(REPO, '.build-config.json')
 # which scenarios a change can possibly have affected (#255 phase 2). Gitignored for the
 # same reason as the build stamp: it describes this tree's build, not the source.
 BUILD_SCOPES_PATH = os.path.join(REPO, '.build-scopes.json')
+# Where a config-invariant injection step's output is kept between builds (#309). Gitignored
+# for the same reason as the two above: it describes builds, not source. `NO_INJECT_CACHE=1`
+# turns it off, the way `MX_NO_ROM_CACHE` turns off the matrix's ROM cache.
+INJECT_CACHE_DIR = os.path.join(REPO, '.injectcache')
+# Where the battle-anim steps write, used ONLY to bootstrap the first entry's pre-state hashes
+# (step_cache derives the real path list from what the step actually wrote). `src` and
+# `include` are in it because both steps also touch a handful of shared tables there.
+BANIM_ROOTS = ('data/banim', 'graphics/banim', 'src', 'include')
+
+
+def _anim_step_cache(campaign, verbose=True):
+    """The cache the two battle-anim steps run through (#309).
+
+    Keyed on everything the ROM is built from EXCEPT the boot flags -- which is precisely the
+    claim being made: these steps cannot see a flag, so two configurations of the same source
+    must produce the same anim data. The decomp revision is in the key too, because a submodule
+    bump moves the tables they append to.
+
+    Falls back to running the steps outright when the key cannot be pinned (no git) or when
+    `NO_INJECT_CACHE=1` says to -- the same escape hatch shape as `MX_NO_ROM_CACHE`.
+    """
+    if os.environ.get('NO_INJECT_CACHE'):
+        if verbose:
+            print('  (NO_INJECT_CACHE=1 -- battle anims will be re-injected)')
+        return step_cache.disabled()
+    h = hashlib.sha256()
+    h.update(('campaign:' + campaign + '\n').encode())
+    try:
+        head = subprocess.check_output(['git', '-C', DECOMP, 'rev-parse', 'HEAD'],
+                                       stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, OSError):
+        return step_cache.disabled()   # cannot pin the decomp -> recompute rather than guess
+    h.update(b'decomp:' + head)
+    build_scopes.fingerprint_paths(REPO, build_scopes.ROM_INPUT_PATHS, into=h)
+    return step_cache.StepCache(DECOMP, INJECT_CACHE_DIR, h.hexdigest()[:32],
+                                roots=BANIM_ROOTS, verbose=verbose)
 
 
 def _stamp_build_config(campaign, flags):
@@ -13714,6 +13751,7 @@ def main():
     # every scenario depends on, so the conservative answer is also the default one.
     _scopes = build_scopes.BuildScopes(
         DECOMP, previous=build_scopes.load_manifest(BUILD_SCOPES_PATH))
+    _anims = _anim_step_cache(args.campaign)
     print('portraits:')
     inject_portraits(args.campaign)
     inject_arena_attendant_portraits(args.campaign)
@@ -13769,10 +13807,15 @@ def main():
         print('enemy class reskins (#21):')
         inject_enemy_class_reskins(args.campaign)  # after map sprites (SMS ids), before ch01
         sms_alloc_report()
+        # The two most expensive steps in the build (17.1s + 8.5s of a ~50s `make`, measured
+        # 2026-08-23) and the two that NO boot flag reaches -- every ROM configuration pays
+        # them to produce byte-identical data, and the matrix builds five for one gate. So
+        # they are cached on their inputs (#309). Both run BEFORE the first flag-dependent
+        # step, which is what makes them config-invariant; `check.py` holds that ordering.
         print('enemy class battle anims (#90):')
-        inject_enemy_class_battle_anims(args.campaign)  # after reskins (binds the clone class)
+        _anims.run(inject_enemy_class_battle_anims, args.campaign)  # after reskins (binds the clone)
         print('battle anims (#65):')
-        inject_battle_anims(args.campaign)
+        _anims.run(inject_battle_anims, args.campaign)
         print('winter tileset:')
         inject_winter_tileset(args.campaign)
         print('battle platforms (#65):')

--- a/tools/build_scopes.py
+++ b/tools/build_scopes.py
@@ -39,6 +39,49 @@ SCOPE_ROOTS = ('src', 'data', 'include', 'graphics', 'scripts')
 _CHAPTER = re.compile(r'ch\d\d')
 
 
+# Everything the ROM is built FROM. Lives here rather than in the playtest runner because
+# both caches key on it: the matrix's ROM cache (can this whole BUILD be restored) and
+# inject.step_cache (can this one injection STEP be).
+ROM_INPUT_PATHS = ('campaigns', 'engine', 'tools/inject', 'tools/build_campaign.py',
+                   'tools/portrait_tool.py', 'tools/feditor_to_banim.py', 'Makefile')
+
+
+def fingerprint_paths(root, paths, into=None):
+    """Fold (relpath, size, mtime_ns) for every file under `paths` into a hash.
+
+    Shared by the two caches that ask "have the ROM's inputs moved" -- `matrix.rom_input_hash`
+    (which decides whether a whole BUILD can be restored) and `inject.step_cache` (whether one
+    injection STEP can be). They must answer that question the same way or one of them is
+    wrong; this is the one implementation.
+
+    Files are fingerprinted by stat rather than by content deliberately: hashing the whole
+    campaign tree on every build would cost more than it saves, and the failure mode is the
+    safe one -- a touched-but-identical file forces a needless recompute, never a stale
+    artifact.
+    """
+    h = into if into is not None else hashlib.sha256()
+    for rel in paths:
+        path = os.path.join(root, rel)
+        if os.path.isfile(path):
+            files = [path]
+        elif os.path.isdir(path):
+            files = [os.path.join(dirpath, name)
+                     for dirpath, dirs, names in os.walk(path)
+                     for name in names
+                     if not name.startswith('.')
+                     and not any(d in dirpath for d in ('__pycache__', '.git'))]
+        else:
+            continue
+        for f in sorted(files):
+            try:
+                st = os.stat(f)
+            except OSError:
+                continue
+            h.update(('%s|%d|%d\n' % (os.path.relpath(f, root), st.st_size,
+                                      st.st_mtime_ns)).encode())
+    return h
+
+
 def scope_of_step(name):
     """The scope a step's writes belong to, read off the step's own function name.
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -536,12 +536,13 @@ def _injection_call_sequence(text):
     hoists one earlier).
 
     A step wrapped for build-scope attribution (`_scopes.run(inject_ch05, ...)`, #255
-    phase 2) is the same step in the same place, so it counts as a call to itself --
-    otherwise every wrapped chapter injector silently drops out of this gate."""
+    phase 2) or for injection caching (`_anims.run(inject_battle_anims, ...)`, #309) is the
+    same step in the same place, so it counts as a call to itself -- otherwise every wrapped
+    injector silently drops out of this gate, taking its ordering constraints with it."""
     m = re.search(r'\ndef main\(\):.*', text, re.S)
     if not m:
         return []
-    names = re.findall(r'^\s+(?:engine_hooks\.)?(?:_scopes\.run\()?(\w+)[(,]',
+    names = re.findall(r'^\s+(?:engine_hooks\.)?(?:_\w+\.run\()?(\w+)[(,]',
                        m.group(0), re.M)
     seen, order = set(), []
     for n in names:
@@ -564,6 +565,50 @@ def _injection_order_violations(order):
             msgs.append('build_campaign.main(): %s must run before %s -- %s'
                         % (before, after, why))
     return msgs
+
+
+def _cached_step_violations(text):
+    """A cached injection step must run before anything that reads a boot flag (#309).
+
+    The injection cache restores a step's output ACROSS ROM configurations, which is only
+    sound while nothing configuration-dependent has run yet. That is a property of main()'s
+    ORDER, so it is checked against main()'s order rather than trusted to a comment.
+
+    The flag names are read out of main()'s own `_requested_flags` table -- the one place
+    that already lists every boot flag -- so adding a flag cannot quietly widen the gap.
+    """
+    m = re.search(r'\ndef main\(\):.*', text, re.S)
+    if not m:
+        return []
+    body = m.group(0).splitlines()
+    flags = set(re.findall(r'args\.(\w+)',
+                           re.search(r'_requested_flags = \{.*?\}', m.group(0), re.S).group(0)
+                           if re.search(r'_requested_flags = \{.*?\}', m.group(0), re.S) else ''))
+    if not flags:
+        return ['build_campaign.main() has no _requested_flags table to read boot flags from']
+    call = re.compile(r'^\s+(?:_\w+\.run\()?((?:inject|_configure|chain)\w*)[(,]')
+    flagged = []          # (line no, step) for every injector that reads a boot flag
+    problems = []
+    for i, line in enumerate(body):
+        hit = call.match(line)
+        if not hit:
+            continue
+        step = hit.group(1)
+        if '_anims.run(' in line:
+            for at, earlier in flagged:
+                problems.append(
+                    'injection cache: %s (line %d of main) is cached across ROM configurations, '
+                    'but %s reads a boot flag at line %d and runs FIRST -- a restored output '
+                    'would then depend on which config built it (#309)' % (step, i, earlier, at))
+        elif any(('args.' + f) in line for f in flags):
+            flagged.append((i, step))
+    return problems
+
+
+def check_cached_steps_are_config_invariant(fail):
+    """The ordering the injection cache's soundness rests on (#309)."""
+    path = os.path.join(REPO, 'tools', 'build_campaign.py')
+    fail.extend(_cached_step_violations(open(path, encoding='utf-8').read()))
 
 
 def check_injection_order(fail):
@@ -1515,7 +1560,8 @@ def main():
                   check_tests_pass, check_yaml_parses,
                   check_chapter_status, check_chapter_deployment_schema,
                   check_personal_line_injection_routes,
-                  check_injection_order, check_playtest_matrix,
+                  check_injection_order, check_cached_steps_are_config_invariant,
+                  check_playtest_matrix,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,
                   check_tool_refs_exist, check_no_dead_concepts,

--- a/tools/inject/step_cache.py
+++ b/tools/inject/step_cache.py
@@ -1,0 +1,221 @@
+"""Restore an injection step's output instead of recomputing it (#309).
+
+A `make` costs ~50s, and **26 of them are battle-anim injection** (`inject_enemy_class_battle_anims`
+17.1s + `inject_battle_anims` 8.5s, measured 2026-08-23) -- two steps that no boot flag reaches,
+producing byte-identical data for all twelve `rom_configs`. The matrix builds five configurations
+for one gate, so those 26 seconds are paid five times over for nothing.
+
+This is the same bargain the ROM cache and the verdict cache already make one level up: when the
+inputs have not moved, restore what was produced last time. Here the unit is one injection STEP.
+
+WHAT MAKES A RESTORE SOUND. A step's output is a function of (a) the inputs in the cache key --
+campaign data, the injector's own source, the decomp revision -- and (b) the state of the tree
+when it runs, which earlier steps produced from those same inputs. Equal key therefore implies
+equal output. The key is the argument; the `pre` map below is the CHECK on that argument, and it
+exists because a key that silently misses an input is exactly the failure this repo cannot see:
+the ROM would be wrong and everything would still be green.
+
+`pre` records, for every file the step wrote, the digest that file had BEFORE it ran, and `post`
+what the step left there. A restore requires every one of those files to be sitting at one of
+those two digests right now: at `pre`, meaning this build has reached exactly the state the
+recorded run started from, or at `post`, meaning an identical run already left its output there
+and the tree was never rewound. Restoring writes the same bytes either way.
+
+Anything else is a MISS -- and the case that matters is an earlier step writing something ELSE
+into a file this step overwrites (`src/data_characters.c` and `src/data_classes.c` are both
+written by earlier passes), which is caught even when the key says hit. Both digests are needed
+because a step may APPEND: for those, `pre` is what makes "already applied" distinguishable from
+"not yet applied", and getting that backwards would double the rows.
+
+Which paths to hash is DERIVED, never declared: they are the paths the step wrote last time. The
+first run for a step has no such list, so it hashes `roots` outright to bootstrap one. `roots` is
+therefore a cost hint, not a correctness boundary -- a write outside it is recorded with an
+`unknown` pre-state, which forces a miss on the next build and fixes itself on the one after.
+"""
+import hashlib
+import json
+import os
+import shutil
+import time
+
+# The decomp subtrees a step can write into. Same roots as build_scopes, and for the same
+# reason: build OUTPUTS live elsewhere and are not sources.
+SCOPE_ROOTS = ('src', 'data', 'include', 'graphics', 'scripts')
+
+MISSING = 'missing'     # the file did not exist before the step ran
+UNKNOWN = 'unknown'     # it did, but nothing had told us to hash it -- never restorable
+
+
+def digest_file(path):
+    try:
+        with open(path, 'rb') as fh:
+            return hashlib.sha256(fh.read()).hexdigest()[:16]
+    except OSError:
+        return MISSING
+
+
+def snapshot(root, roots=SCOPE_ROOTS):
+    """{abs path: mtime_ns} over the watched roots -- how a write is detected.
+
+    Same mechanism as `build_scopes.BuildScopes`: `stat` is cheap enough to do this around
+    every step, and only files that actually moved are ever hashed.
+    """
+    seen = {}
+    for rel in roots:
+        base = os.path.join(root, rel)
+        for dirpath, dirnames, names in os.walk(base):
+            dirnames[:] = [d for d in dirnames if not d.startswith('.')]
+            for name in names:
+                path = os.path.join(dirpath, name)
+                try:
+                    seen[path] = os.stat(path).st_mtime_ns
+                except OSError:
+                    pass
+    return seen
+
+
+class Outcome(object):
+    """What one `run` did, so the build log can say whether the cache is working."""
+
+    def __init__(self, step, hit, paths, seconds, recorded_seconds):
+        self.step = step
+        self.hit = hit
+        self.paths = list(paths)
+        self.seconds = seconds                    # what this call cost
+        self.recorded_seconds = recorded_seconds  # what the cached run cost when it ran
+
+    @property
+    def saved(self):
+        """Seconds this restore bought. Zero on a miss -- a miss saves nothing."""
+        return self.recorded_seconds if self.hit else 0.0
+
+    def __repr__(self):
+        return '<Outcome %s %s %.1fs>' % (self.step, 'hit' if self.hit else 'miss', self.seconds)
+
+
+def disabled():
+    """A cache that always runs the step. `NO_INJECT_CACHE=1` resolves to one of these so the
+    build has a single call shape and no branch at the call site."""
+    return NullCache()
+
+
+class NullCache(object):
+
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
+    def run(self, fn, *args, **kwargs):
+        step = kwargs.pop('name', None) or getattr(fn, '__name__', '')
+        started = time.time()
+        fn(*args, **kwargs)
+        return Outcome(step, False, (), time.time() - started, 0.0)
+
+
+class StepCache(object):
+    """Cache of what injection steps wrote, keyed on everything they read."""
+
+    def __init__(self, root, store, key, roots=SCOPE_ROOTS, scope_roots=None, verbose=False):
+        self.root = root
+        self.store = store
+        self.key = key
+        self.roots = tuple(roots)                                  # bootstrap hashing only
+        self.scope_roots = tuple(scope_roots or SCOPE_ROOTS)       # write detection
+        # A cache nobody can see working is a cache nobody trusts, and the number it prints is
+        # what the next measurement argues with. The REPORT lives here rather than at the call
+        # site so a cached step reads as a plain call to itself -- which is also what keeps it
+        # visible to check.py's injection-order gate.
+        self.verbose = verbose
+
+    # -- entries ------------------------------------------------------------
+
+    def _entry_dir(self, step):
+        return os.path.join(self.store, step)
+
+    def _meta_path(self, step):
+        return os.path.join(self._entry_dir(step), 'entry.json')
+
+    def _load(self, step):
+        try:
+            with open(self._meta_path(step)) as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            return None
+
+    # -- the check ----------------------------------------------------------
+
+    def _hash_paths(self, rels):
+        return dict((rel, digest_file(os.path.join(self.root, rel))) for rel in rels)
+
+    def _restorable(self, entry, now):
+        """A hit needs the same key AND every recorded file sitting at its `pre` or `post`
+        digest -- the two states from which restoring writes the right bytes."""
+        if not entry or entry.get('key') != self.key:
+            return False
+        pre, post = entry.get('pre') or {}, entry.get('post') or {}
+        if not pre or UNKNOWN in pre.values():
+            return False
+        return all(now.get(rel) in (was, post.get(rel)) for rel, was in pre.items())
+
+    # -- running ------------------------------------------------------------
+
+    def run(self, fn, *args, **kwargs):
+        """Restore `fn`'s recorded output, or run it and record what it wrote."""
+        step = kwargs.pop('name', None) or getattr(fn, '__name__', '')
+        entry = self._load(step)
+        started = time.time()
+        pre_now = self._hash_paths(entry.get('paths', ())) if entry else self._bootstrap()
+
+        if self._restorable(entry, pre_now):
+            self._restore(step, entry)
+            outcome = Outcome(step, True, entry['paths'], time.time() - started,
+                              entry.get('seconds', 0.0))
+            if self.verbose:
+                print('  %s: restored from cache -- %d files, %.1fs saved'
+                      % (outcome.step, len(outcome.paths), outcome.saved))
+            return outcome
+
+        before = snapshot(self.root, self.scope_roots)
+        ran = time.time()
+        fn(*args, **kwargs)
+        # A step that raises records NOTHING: half a step's writes stored as a whole step is a
+        # poisoned entry that would restore forever.
+        seconds = time.time() - ran
+        after = snapshot(self.root, self.scope_roots)
+        moved = sorted(os.path.relpath(path, self.root) for path, mtime in after.items()
+                       if before.get(path) != mtime)
+        self._record(step, moved, pre_now, before, seconds)
+        return Outcome(step, False, moved, time.time() - started, seconds)
+
+    def _bootstrap(self):
+        """No entry yet, so nothing knows which paths to hash: hash `roots` outright, once."""
+        return dict((os.path.relpath(path, self.root), digest_file(path))
+                    for path in snapshot(self.root, self.roots))
+
+    def _record(self, step, moved, pre_now, before, seconds):
+        entry_dir = self._entry_dir(step)
+        shutil.rmtree(entry_dir, ignore_errors=True)
+        pre = {}
+        for rel in moved:
+            if rel in pre_now:
+                pre[rel] = pre_now[rel]
+            elif os.path.join(self.root, rel) not in before:
+                pre[rel] = MISSING          # the step created it; absence is a state
+            else:
+                pre[rel] = UNKNOWN          # it existed and went unhashed -> never restorable
+            src = os.path.join(self.root, rel)
+            dst = os.path.join(entry_dir, 'files', rel)
+            if not os.path.isdir(os.path.dirname(dst)):
+                os.makedirs(os.path.dirname(dst))
+            shutil.copyfile(src, dst)
+        post = self._hash_paths(moved)
+        with open(self._meta_path(step), 'w') as fh:
+            json.dump({'key': self.key, 'step': step, 'paths': moved, 'pre': pre,
+                       'post': post, 'seconds': round(seconds, 2)}, fh, indent=1)
+
+    def _restore(self, step, entry):
+        files = os.path.join(self._entry_dir(step), 'files')
+        for rel in entry['paths']:
+            dst = os.path.join(self.root, rel)
+            if not os.path.isdir(os.path.dirname(dst)):
+                os.makedirs(os.path.dirname(dst))
+            shutil.copyfile(os.path.join(files, rel), dst)

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -50,6 +50,9 @@ import yaml
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 REPO = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, os.path.join(REPO, 'tools'))     # build_scopes, inject.hosts
+import build_scopes                                 # noqa: E402  the build's own bookkeeping
+
 MANIFEST = os.path.join(HERE, 'matrix.yaml')
 HARNESS = os.path.join(HERE, 'harness.lua')
 RUN_SH = os.path.join(HERE, 'run.sh')
@@ -675,18 +678,14 @@ STAMP_PATH = os.path.join(REPO, '.build-config.json')
 # What build_campaign.py recorded each injection step as having written (#255 phase 2).
 SCOPES_PATH = os.path.join(REPO, '.build-scopes.json')
 ROM_CACHE_DIR = os.path.join(REPO, '.matrix-romcache')
-ROM_INPUT_PATHS = ('campaigns', 'engine', 'tools/inject', 'tools/build_campaign.py',
-                   'tools/portrait_tool.py', 'tools/feditor_to_banim.py', 'Makefile')
+ROM_INPUT_PATHS = build_scopes.ROM_INPUT_PATHS
 
 
 def rom_input_hash(make_flags, paths=None):
     """A digest of everything the ROM is built from, for cache keying.
 
-    Files are fingerprinted by (path, size, mtime_ns) rather than content: hashing the whole
-    campaign tree on every run would cost more than it saves, and the failure mode is the safe
-    one -- a touched-but-identical file forces a needless REBUILD, never a stale ROM. The
-    unsafe direction (edited content landing on a byte-identical size AND timestamp) does not
-    happen with real editors or with git.
+    The file fingerprint itself is `build_scopes.fingerprint_paths` -- shared with the
+    injection step cache (#309), because "have the inputs moved" must have one answer.
     """
     h = hashlib.sha256()
     h.update(('flags:' + ' '.join(make_flags) + '|campaign:' + CAMPAIGN + '\n').encode())
@@ -696,25 +695,7 @@ def rom_input_hash(make_flags, paths=None):
         h.update(b'decomp:' + head)
     except (subprocess.CalledProcessError, OSError):
         return None             # cannot pin the decomp -> refuse to cache rather than guess
-    for rel in (ROM_INPUT_PATHS if paths is None else paths):
-        path = os.path.join(REPO, rel)
-        if os.path.isfile(path):
-            files = [path]
-        elif os.path.isdir(path):
-            files = [os.path.join(root, name)
-                     for root, dirs, names in os.walk(path)
-                     for name in names
-                     if not name.startswith('.')
-                     and not any(d in root for d in ('__pycache__', '.git'))]
-        else:
-            continue
-        for f in sorted(files):
-            try:
-                st = os.stat(f)
-            except OSError:
-                continue
-            h.update(('%s|%d|%d\n' % (os.path.relpath(f, REPO), st.st_size,
-                                      st.st_mtime_ns)).encode())
+    build_scopes.fingerprint_paths(REPO, ROM_INPUT_PATHS if paths is None else paths, into=h)
     return h.hexdigest()[:32]
 
 
@@ -945,9 +926,6 @@ PLAYTEST_ENV_KEYS = ('PT_SEED', 'PT_CHAR', 'PT_ROUNDS', 'PT_STATE', 'PT_TAG', 'P
 #
 # Slot numbers come from `tools/inject/hosts.py`, the file that ENROLS a chapter, so adding
 # ch06 is one line there and nothing here.
-sys.path.insert(0, os.path.join(REPO, 'tools'))     # build_scopes, inject.hosts
-
-
 def _host_slots():
     """{host slot -> build scope}, read from the injector's own enrolment constants."""
     from inject import hosts
@@ -1245,7 +1223,6 @@ class VerdictCache(object):
 
     def _scope_manifest(self, rom, digest, fresh=False):
         """The build's own account of what it wrote, or None (fall back to the ROM key)."""
-        import build_scopes
         if fresh:
             return build_scopes.load_manifest(SCOPES_PATH)
         if digest is None:

--- a/tools/test_check_inject_order.py
+++ b/tools/test_check_inject_order.py
@@ -24,7 +24,7 @@ def main():
     engine_hooks._inject_lord_floor_engine()
     inject_map_sprites(c)
     inject_enemy_class_reskins(c)
-    inject_enemy_class_battle_anims(c)
+    _anims.run(inject_enemy_class_battle_anims, c)
     inject_winter_tileset(c)
     inject_ch01(c)
     inject_ch03(c)
@@ -42,6 +42,15 @@ class TestCallSequence(unittest.TestCase):
         order = check._injection_call_sequence(GOOD)
         self.assertLess(order.index('inject_ch01'), order.index('inject_prologue'))
         self.assertIn('_inject_lord_select_engine', order)   # engine_hooks. prefix stripped
+
+    def test_a_cached_step_still_counts_as_itself(self):
+        """A step run through the injection cache (`_anims.run(inject_x, ...)`, #309) is the
+        same step in the same place -- exactly like `_scopes.run`. If the parser missed it,
+        the step would silently drop out of this gate and its ordering constraints with it."""
+        order = check._injection_call_sequence(GOOD)
+        self.assertIn('inject_enemy_class_battle_anims', order)
+        self.assertLess(order.index('inject_enemy_class_reskins'),
+                        order.index('inject_enemy_class_battle_anims'))
 
     def test_ignores_calls_outside_main(self):
         # helper()'s inject_prologue must not count as the first call.
@@ -90,6 +99,46 @@ class TestRealBuildCampaign(unittest.TestCase):
         check.check_injection_order(fail)
         self.assertEqual(fail, [])
 
+
+
+CACHED_GOOD = """
+def main():
+    _requested_flags = {'TESTCH': args.test_chapter, 'CH05BOOT': args.ch05_boot}
+    if args.ch05_moose and not args.ch05_boot:
+        sys.exit('--ch05-moose needs --ch05-boot')
+    _anims.run(inject_enemy_class_battle_anims, args.campaign)
+    _anims.run(inject_battle_anims, args.campaign)
+    _scopes.run(inject_ch05, args.campaign, boot=args.ch05_boot)
+    if args.ch05_boot:
+        _configure_boot(CH05_HOST_INDEX)
+"""
+
+CACHED_BAD = """
+def main():
+    _requested_flags = {'TESTCH': args.test_chapter, 'CH05BOOT': args.ch05_boot}
+    _scopes.run(inject_ch05, args.campaign, boot=args.ch05_boot)
+    _anims.run(inject_battle_anims, args.campaign)
+"""
+
+
+class TestCachedStepsAreConfigInvariant(unittest.TestCase):
+    """A cached step's output is restored across ROM configurations, so nothing that reads a
+    boot flag may run before it (#309). Ordering is what makes the cache sound; a comment
+    saying so is not."""
+
+    def test_a_cached_step_ahead_of_every_flagged_injector_passes(self):
+        self.assertEqual(check._cached_step_violations(CACHED_GOOD), [])
+
+    def test_a_flagged_injector_ahead_of_a_cached_step_is_a_violation(self):
+        msgs = check._cached_step_violations(CACHED_BAD)
+        self.assertEqual(len(msgs), 1, msgs)
+        self.assertIn('inject_battle_anims', msgs[0])
+        self.assertIn('inject_ch05', msgs[0])
+
+    def test_the_real_build_campaign_satisfies_it(self):
+        fail = []
+        check.check_cached_steps_are_config_invariant(fail)
+        self.assertEqual(fail, [])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_step_cache.py
+++ b/tools/test_step_cache.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Tests for tools/inject/step_cache.py -- the config-invariant injection cache (#309).
+
+Every test runs a real step against a real temp tree: the unit under test is "what
+happened to the files", and a mock cannot tell you that.
+
+Run:
+
+    python3 tools/test_step_cache.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from inject import step_cache as sc
+
+
+def read(path):
+    with open(path, 'rb') as fh:
+        return fh.read()
+
+
+def write(path, data):
+    if not os.path.isdir(os.path.dirname(path)):
+        os.makedirs(os.path.dirname(path))
+    with open(path, 'wb') as fh:
+        fh.write(data if isinstance(data, bytes) else data.encode())
+
+
+class StepCacheTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.tree = os.path.join(self.tmp, 'tree')
+        self.store = os.path.join(self.tmp, 'store')
+        os.makedirs(os.path.join(self.tree, 'data'))
+        # a file the step OVERWRITES (an earlier step wrote it) and one it CREATES
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+        self.runs = []
+
+    def cache(self, key='k1'):
+        return sc.StepCache(self.tree, self.store, key, roots=('data',))
+
+    def step(self, payload='anim rows\n'):
+        """A stand-in for an injection step: overwrites one file, creates another."""
+        def inject_battle_anims():
+            self.runs.append(payload)
+            write(os.path.join(self.tree, 'data', 'shared.c'), 'anims bound\n')
+            write(os.path.join(self.tree, 'data', 'banim', 'rows.s'), payload)
+        return inject_battle_anims
+
+    # -- miss ---------------------------------------------------------------
+
+    def test_a_cold_step_runs_and_is_recorded(self):
+        outcome = self.cache().run(self.step())
+        self.assertEqual(self.runs, ['anim rows\n'])
+        self.assertFalse(outcome.hit)
+        self.assertEqual(sorted(outcome.paths), ['data/banim/rows.s', 'data/shared.c'])
+
+    # -- hit ----------------------------------------------------------------
+
+    def test_a_second_run_restores_instead_of_running(self):
+        self.cache().run(self.step())
+        os.remove(os.path.join(self.tree, 'data', 'banim', 'rows.s'))
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+
+        outcome = self.cache().run(self.step())
+
+        self.assertEqual(len(self.runs), 1, 'the step must not have run a second time')
+        self.assertTrue(outcome.hit)
+        self.assertEqual(read(os.path.join(self.tree, 'data', 'banim', 'rows.s')),
+                         b'anim rows\n')
+        self.assertEqual(read(os.path.join(self.tree, 'data', 'shared.c')), b'anims bound\n')
+
+    def test_a_created_file_comes_back_even_though_it_was_absent_before(self):
+        """The pre-state of a CREATED file is 'missing', which is a state like any other."""
+        self.cache().run(self.step())
+        shutil.rmtree(os.path.join(self.tree, 'data', 'banim'))
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+
+        self.cache().run(self.step())
+
+        self.assertTrue(os.path.isfile(os.path.join(self.tree, 'data', 'banim', 'rows.s')))
+
+    # -- what makes a hit unsound -------------------------------------------
+
+    def test_a_different_key_does_not_hit(self):
+        self.cache('k1').run(self.step())
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+        self.cache('k2').run(self.step('other rows\n'))
+        self.assertEqual(len(self.runs), 2)
+
+    def test_a_moved_pre_state_does_not_hit_even_on_the_same_key(self):
+        """The licence to restore is that everything the step READS is unchanged. A file it
+        overwrites is one of those reads, and an earlier step having written something else
+        into it means this step's recorded output answers a question nobody asked."""
+        self.cache().run(self.step())
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'an EARLIER STEP MOVED\n')
+
+        outcome = self.cache().run(self.step())
+
+        self.assertFalse(outcome.hit)
+        self.assertEqual(len(self.runs), 2, 'the step must re-run when its input moved')
+
+    def test_a_step_that_raises_records_nothing(self):
+        """Half a step's writes cached as a whole step is a poisoned entry that would
+        restore forever."""
+        def explodes():
+            write(os.path.join(self.tree, 'data', 'banim', 'rows.s'), 'half\n')
+            raise RuntimeError('injection failed')
+
+        with self.assertRaises(RuntimeError):
+            self.cache().run(explodes)
+
+        outcome = self.cache().run(self.step())
+        self.assertFalse(outcome.hit)
+        self.assertEqual(len(self.runs), 1)
+
+    def test_one_step_s_entry_does_not_answer_for_another(self):
+        self.cache().run(self.step())
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+
+        def inject_map_sprites():
+            self.runs.append('sprites')
+            write(os.path.join(self.tree, 'data', 'sprites.s'), 'sprite rows\n')
+
+        outcome = self.cache().run(inject_map_sprites)
+        self.assertFalse(outcome.hit)
+
+    def test_a_tree_still_holding_last_build_s_output_hits(self):
+        """The real case: nothing wipes the decomp between builds, so on the next build every
+        file this step wrote is still sitting at its OUTPUT. That is a state restoring is
+        correct from -- it writes the same bytes -- and treating it as a miss would mean the
+        cache never hit in the tree it was built for."""
+        self.cache().run(self.step())          # leaves data/banim/rows.s at its output
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+
+        outcome = self.cache().run(self.step())
+
+        self.assertTrue(outcome.hit)
+        self.assertEqual(len(self.runs), 1)
+
+    def test_an_appending_step_is_not_applied_twice(self):
+        """A banim table is APPENDED to (additive donor-prime, #65). Restoring the recorded
+        output is what keeps that idempotent -- re-running it over its own output would double
+        the rows, which is why a hit restores rather than re-runs."""
+        table = os.path.join(self.tree, 'data', 'table.s')
+        write(table, 'vanilla rows\n')
+
+        def inject_battle_anims():
+            self.runs.append('append')
+            with open(table, 'a') as fh:
+                fh.write('our rows\n')
+
+        self.cache().run(inject_battle_anims)
+        self.assertEqual(read(table), b'vanilla rows\nour rows\n')
+
+        outcome = self.cache().run(inject_battle_anims)
+
+        self.assertTrue(outcome.hit)
+        self.assertEqual(read(table), b'vanilla rows\nour rows\n')
+
+    def test_a_verbose_cache_says_what_it_restored(self):
+        """The build log is where a cache is seen working; the call site should not have to
+        wrap every step to get that line."""
+        import contextlib, io as _io
+        sc.StepCache(self.tree, self.store, 'k1', roots=('data',), verbose=True).run(self.step())
+        buf = _io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            sc.StepCache(self.tree, self.store, 'k1', roots=('data',),
+                         verbose=True).run(self.step())
+        self.assertIn('restored', buf.getvalue())
+        self.assertIn('inject_battle_anims', buf.getvalue())
+
+    def test_a_quiet_cache_says_nothing(self):
+        import contextlib, io as _io
+        buf = _io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.cache().run(self.step())
+            self.cache().run(self.step())
+        self.assertEqual(buf.getvalue(), '')
+
+    # -- reporting ----------------------------------------------------------
+
+    def test_a_miss_saves_nothing_and_a_hit_saves_what_the_step_cost(self):
+        """The build log has to be able to say what the cache saved, or nobody can tell
+        whether it is working."""
+        import json
+        cold = self.cache().run(self.step())
+        write(os.path.join(self.tree, 'data', 'shared.c'), 'from an earlier step\n')
+        warm = self.cache().run(self.step())
+
+        self.assertEqual(cold.saved, 0.0)
+        recorded = json.load(open(os.path.join(
+            self.store, 'inject_battle_anims', 'entry.json')))['seconds']
+        self.assertTrue(warm.hit)
+        self.assertEqual(warm.saved, recorded)
+
+
+class DisabledCache(unittest.TestCase):
+    """`NO_INJECT_CACHE=1` has to mean the step runs, not that the caller branches."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.runs = []
+
+    def test_a_disabled_cache_always_runs_the_step_and_stores_nothing(self):
+        cache = sc.disabled()
+
+        def inject_battle_anims():
+            self.runs.append(1)
+
+        first = cache.run(inject_battle_anims)
+        second = cache.run(inject_battle_anims)
+
+        self.assertEqual(len(self.runs), 2)
+        self.assertFalse(first.hit)
+        self.assertFalse(second.hit)
+        self.assertEqual(os.listdir(self.tmp), [], 'a disabled cache writes nothing')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Phase 1 of the re-scoped #309. The issue asked to patch the linked ELF instead of rebuilding; measuring the build first moved the target, and the [measurement is on the issue](https://github.com/NicoviGH/manchego-stars/issues/309#issuecomment-5387546205).

## Why this and not the ELF patch

| | injector | `make -C fireemblem8u` | total |
|---|---|---|---|
| same-config rebuild | 35.8s | 23.9s | 59.7s |
| config switch → `ch04boot` | 34.9s | 14.1s | 49.0s |

A config switch already recompiles only ten `.c` files. `cProfile` on the injector: `inject_enemy_class_battle_anims` 17.1s + `inject_battle_anims` 8.5s = **26 of the ~35 injector seconds**, and no boot flag reaches either — all twelve `rom_configs` pay it for byte-identical anim data. ELF patching aims at the 14s and can serve at most 2 of the gate's 5 builds; this aims at the 26s and serves all five.

## What landed

- **`tools/inject/step_cache.py`** — a step whose inputs have not moved restores what it wrote. Keyed on everything the ROM is built from *except* the boot flags, which is the claim being made.
- **The `pre`/`post` guard.** The key is the argument; the digest map is the check on it, because a key that silently misses an input is the failure this repo can't see — the ROM would be wrong and everything would still be green. Every file the step wrote must sit at the digest it had before the recorded run, or the one that run left. Both are needed: `pre` distinguishes "not yet applied" from "already applied" for a step that APPENDS (banim tables are additive), `post` is the state a real tree is actually in. **A `pre`-only rule looked right and would have hit exactly never — a test caught it, not a build.**
- **`build_scopes.fingerprint_paths`** is now the one implementation of "have the inputs moved", shared with `matrix.rom_input_hash`; `ROM_INPUT_PATHS` moves to the same owner.
- **`check.py check_cached_steps_are_config_invariant`** holds the ordering the soundness rests on, reading the flag list out of `main()`'s own `_requested_flags` table so adding a flag can't quietly widen the gap.
- **A fix that fell out**: `check_injection_order` had silently dropped both wrapped steps. Its parser now sees through any `_x.run(step, ...)` wrapper — which its own docstring already said it must do for `_scopes.run`.

## Verification

- **Byte-identical ROMs, two configurations.** `canonical` built with the cache cold is `a44afcc2…`, the same ROM as before any of this existed. `ch04boot` built with 639 files restored instead of computed is `5fa10577…`, the same ROM as the one built the old way half an hour earlier.
- Config switch **49.0s → 25.2s**; same-config rebuild **59.7s → 25.5s**.
- `make test` exit 0 (40 modules), `make check` drift clean. 16 new tests, each watched fail first.

Phase 2 (ELF patching) stays open on the issue, priced: the boot target is genuinely patchable, but each `--chNN-boot` also LOADs an armed party seed that must not run on the real chain, so it needs runtime-gating first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
