### PR TITLE
playtest: a chapter DECLARES its scenarios, and its Lua gets its own chunk (#314)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The data is the doc — facts live in exactly one place, and indexes are generat
 | Adding a unit's art / battle anim / platform | the **`inject_battle_anims` / `inject_battle_platforms` docstrings** (how) + `decisions.md` Art & Audio (why) + the **`custom_unit` issue template** (checklist) |
 | Borrowable enemy reskin art (what the FE-Repo has) | **`docs/fe-repo-scouting.md`** (scouting log) + per-unit `skin:` fields in chapter YAML + `campaign.yaml` `enemy_class_reskins` |
 | Hosting a new chapter (map → slot → deploy → win → boot) | **`docs/adding-a-chapter.md`** (the repeatable runbook) + `inject_ch03` (lean reference impl) |
-| What a playtest scenario needs (ROM flag, host chapter, checkpoint, timing) | **`tools/playtest/matrix.yaml`** — the single source; `harness.lua` comments say what a scenario *proves*, not what it needs |
+| What a playtest scenario needs (ROM flag, host chapter, checkpoint, timing) | A hosted chapter's scenarios are DECLARED in its own YAML under `playtest:` and their rows + chapter suite are derived (`tools/playtest/declared.py`, #314). Everything a chapter does not own — the spine, chapter-generic probes, checkpoint builders, ROM configs, timing classes, `gate` — stays in **`tools/playtest/matrix.yaml`**. A name in both RAISES. |
 | Prep screen / deploy cap / force-deployment | `decisions.md` → "How the deploy cap + prep screen are actually wired" + `inject_ch01`'s docstring. **Prep from ch01 on is standing protocol — the CAP is the parity, Pick Units only chooses which PCs fill it. Never re-derive this from the decomp, and never from `hasPrepScreen` (dead FE7 leftover, false everywhere).** |
 | FE8 cadence/reward grounding | `docs/fe8-pacing-reference.md` |
 | Post-MVP (Act II–V) plan | `docs/roadmap.md` |
@@ -123,7 +123,10 @@ Rationale + long form: `docs/decisions.md` → Coordination model. The operating
 Long form + examples: `docs/decisions.md` → Coordination model. In brief (Cockburn): push each line
 to the desk that owns it; talk over interfaces, never reach into another module's private state; judge
 a boundary by which *named* future changes it makes cheap (don't refactor for futures you can't name —
-e.g. `harness.lua` stays whole; its only likely change is "add a scenario").
+e.g. a chapter's Lua lives in its OWN chunk, because the named future is "add a chapter" and
+it costs top-level `local` slots against a 200-per-chunk ceiling — see `decisions.md` → "A
+CHAPTER costs local slots"; the earlier reading of this same test named "add a scenario",
+which is free, and got the boundary wrong).
 **Code-review rule:** a change that reaches into another desk's cabinet or scatters one decision
 across desks is rejected; localize the decision first.
 

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
@@ -606,9 +606,7 @@ playtest:
       proves: the Lonelywood village hands over its Iron Axe
       given: [on_map]
       when:
-        - visit: {x: 8, y: 2}    # villages -> lonelywood
-      then:
-        - gained_item: 0x1F      # ITEM_AXE_IRON
+        - visit: {x: 8, y: 2, gains: 0x1F}     # lonelywood -> ITEM_AXE_IRON
 
     # Still hand-written Lua. ch04cottage asserts on TERRAIN rather than an item (the
     # forest cottage's gift is the scene, not a reward), which the v1 vocabulary has no

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
@@ -596,3 +596,33 @@ design_notes: >
   gimmick wants — as the FOG SCOUT: a Thief sees +5 tiles in fog (GetUnitFogViewRange),
   so Trex is the one who actually spots the moose and the wolves. Villain thread:
   Ravisin awakened the wolves, the moose, and Messie.
+
+# What this chapter's playtest scenarios PROVE (#314) -- see ch05's block for the shape and
+# tools/playtest/declared.py for what is derived from it.
+playtest:
+  boot: ch04boot                 # CH04BOOT=1; host slot 5 comes from inject/hosts.py
+  cases:
+    - name: ch04village
+      proves: the Lonelywood village hands over its Iron Axe
+      given: [on_map]
+      when:
+        - visit: {x: 8, y: 2}    # villages -> lonelywood
+      then:
+        - gained_item: 0x1F      # ITEM_AXE_IRON
+
+    # Still hand-written Lua. ch04cottage asserts on TERRAIN rather than an item (the
+    # forest cottage's gift is the scene, not a reward), which the v1 vocabulary has no
+    # word for yet.
+    - {name: ch04cottage,        proves: the forest cottage speaks and closes behind you, lua: ch04cottage}
+    - {name: ch04moose,          proves: the White Moose reaches its pen and the hunt fires, lua: ch04moose}
+    - {name: ch04packmath,       proves: the wolf pack's converted count matches the roster, lua: ch04packmath}
+    - {name: ch04snag,           proves: felling the snag turns the river row into a crossing, lua: ch04snag}
+    - {name: clear_ch04_parley,  proves: the parley route clears the chapter, lua: clear_ch04_parley}
+    - {name: smoke_ch04,         proves: ch04 boots and survives a long soak, lua: smoke_ch04}
+    - {name: clear_ch04,         proves: ch04 routs via real combat, lua: clear_ch04}
+    - {name: recordch04parley,   proves: the pack converts in place, lua: recordch04parley}
+    - {name: ch04sprites,        proves: the ch04 map sprites read on the winter tileset, lua: ch04sprites, kind: diagnostic}
+    - {name: recordch04moose,    proves: the moose charge in motion, lua: recordch04moose, kind: record}
+    - {name: recordch04open,     proves: the two-BG Lonelywood opening in motion, lua: recordch04open, kind: record}
+    - {name: recordch04reveal,   proves: the moose reveal in motion, lua: recordch04reveal, kind: record}
+    - {name: recordch04cottage,  proves: the cottage scene in motion, lua: recordch04cottage, kind: record}

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -1933,3 +1933,73 @@ design_notes: >
   `skin:` names the intended FE-Repo asset (sword/bow guardians = real skeleton anims; lance/axe/
   armor = frost palette-swaps) for the build-slice art track. The wolf ANIMS I scouted (Gwyllgi
   repals, Hellhounds) are logged for CH04's beast pack — see issue #24.
+
+# ---------------------------------------------------------------------------------------
+# What this chapter's playtest scenarios PROVE (#314). Everything mechanical about them --
+# the ROM configuration, PT_HOST_CHAPTER, the `matrix.yaml` row, membership of `SUITE=ch05`
+# -- is DERIVED from this block by tools/playtest/declared.py. Nothing here is restated in
+# matrix.yaml, and a name declared in both files is a check_playtest_matrix failure.
+#
+# A case is EITHER declared (given/when/then, run by tools/playtest/cases.lua) OR `lua:`
+# naming a function in harness.lua. Only the BODY opts out: a `lua:` case still derives its
+# row and its suite membership here, so a chapter declares everything it owns.
+playtest:
+  boot: ch05boot                 # CH05BOOT=1; host slot 6 comes from inject/hosts.py
+  cases:
+    - name: ch05village
+      proves: the south reliquary hands over its Dracoshield
+      given: [on_map]
+      when:
+        - visit: {x: 12, y: 19}  # villages -> reliquary-south
+      then:
+        - gained_item: 0x60      # ITEM_DRACOSHIELD
+
+    - name: ch05reliquaries
+      proves: all four reliquaries speak and hand over their OWN gift
+      # `spoke` is not decoration: a wired-but-empty message would hand the gift over in
+      # silence and every item check here would still pass.
+      given: [on_map]
+      when:
+        - visit: {x: 5,  y: 1}   # reliquary-north
+        - visit: {x: 5,  y: 6}   # reliquary-west
+        - visit: {x: 12, y: 10}  # reliquary-east
+        - visit: {x: 12, y: 19}  # reliquary-south
+      # Assertions are order-free and evaluated against the WHOLE case, never paired
+      # positionally with a step: `gained_item` means the party gained that item at some
+      # point in this case, `spoke` means EVERY visit raised a text box. Positional pairing
+      # would make inserting a step silently re-target every assertion after it.
+      then:
+        - gained_item: 0x70      # ITEM_TORCH
+        - gained_item: 0x5D      # ITEM_SECRETBOOK
+        - gained_item: 0x0E      # ITEM_SWORD_ARMORSLAYER
+        - gained_item: 0x60      # ITEM_DRACOSHIELD
+        - spoke: true
+
+    # Still hand-written Lua. Each names WHY it is the exception rather than the default.
+    - {name: ch05arena,        proves: the arena tutorial is one-shot on EVFLAG_TMP(13),        lua: ch05arena}
+    - {name: ch05recruit,      proves: the Talk recruit converts Sahnar on both CHECK_ALIVE arms, lua: ch05recruit}
+    - {name: ch05lupinbenched, proves: the recruit's no-Lupin arm plays with Lupin BENCHED,     lua: ch05lupinbenched, boot: ch05lupinboot}
+    - {name: ch05lupinkilled,  proves: the recruit's no-Lupin arm plays with Lupin DEAD,        lua: ch05lupinkilled,  boot: ch05lupinboot}
+    - {name: ch05raid,         proves: a raider can SACK a reliquary -- terrain flips to ruins and its event id stays unset, lua: ch05raid}
+    - {name: ch05crest,        proves: saving all four reliquaries pays out the Guiding Ring,   lua: ch05crest}
+
+    # The capture scenarios. `kind: record` because their output IS the picture -- they
+    # stay headed and produce no verdict, so they are not in SUITE=ch05 (matrix_suites
+    # takes verdict cases only). Boots differ: the ending arms and the moose beat each
+    # ride a DEBUG boot that lands New Game straight on the beat, rather than replaying
+    # ~52 approved A-presses to reach ten seconds of footage.
+    - {name: recordch05opening,        proves: the four-scene opening in motion,               lua: recordch05opening,        kind: record}
+    - {name: recordch05openinglupin,   proves: the opening on Lupin's arm,                     lua: recordch05openinglupin,   kind: record, boot: ch05lupinboot}
+    - {name: recordch05join,           proves: "scene 5, the join, after Preparations",          lua: recordch05join,           kind: record}
+    - {name: recordch05joinlupin,      proves: the join on Lupin's arm,                        lua: recordch05joinlupin,      kind: record, boot: ch05lupinboot}
+    - {name: recordch05moose,          proves: "scene 7 alone, the moose charge",                lua: recordch05moose,          kind: record, boot: ch05mooseboot}
+    - {name: recordch05recruit,        proves: the Talk recruit in motion,                     lua: recordch05recruit,        kind: record}
+    - {name: recordch05eruption,       proves: the turn-2 eruption warning in motion,          lua: recordch05eruption,       kind: record}
+    - {name: recordch05combatquotes,   proves: scenes 12 and 13 in one fight,                  lua: recordch05combatquotes,   kind: record}
+    - {name: recordch05ravisindeath,   proves: Ravisin's death quote in motion,                lua: recordch05ravisindeath,   kind: record}
+    - {name: recordch05platform,       proves: "what the cast stand on, on road",                lua: recordch05platform,       kind: record}
+    - {name: recordch05ending,         proves: "scene 16 A+B+C -- Basil alive, Sahnar recruited", lua: recordch05ending,        kind: record, boot: ch05endingboot}
+    - {name: recordch05endingnosahnar, proves: the ending with Sahnar never recruited,         lua: recordch05endingnosahnar, kind: record, boot: ch05endingnosahnar}
+    - {name: recordch05endingbasildied, proves: scene 17 -- the ending over Basil's body,      lua: recordch05endingbasildied, kind: record, boot: ch05endingbasildied}
+    - {name: recordravisin,            proves: Ravisin's battle anim and map sprite,           lua: recordravisin,            kind: record}
+    - {name: mapfullch05,              proves: sixteen risen tomb-guard on the real winter map, lua: mapfullch05,             kind: record}

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -1950,29 +1950,29 @@ playtest:
       proves: the south reliquary hands over its Dracoshield
       given: [on_map]
       when:
-        - visit: {x: 12, y: 19}  # villages -> reliquary-south
-      then:
-        - gained_item: 0x60      # ITEM_DRACOSHIELD
+        - visit: {x: 12, y: 19, gains: 0x60}   # reliquary-south -> ITEM_DRACOSHIELD
 
     - name: ch05reliquaries
       proves: all four reliquaries speak and hand over their OWN gift
       # `spoke` is not decoration: a wired-but-empty message would hand the gift over in
       # silence and every item check here would still pass.
+      # `gains` rides the STEP, so each door is pinned to ITS OWN gift causally. The
+      # gifts are per-tile on purpose (vanilla's placement, richest where the eruption
+      # races), so "some item arrived" is not the assertion -- the RIGHT item is, from the
+      # RIGHT door. A whole-case `gained_item` list would pass on four doors handing over
+      # each other's gifts, which is the defect this scenario exists to catch.
+      #
+      # It is still not POSITIONAL: the assertion is inside the step it belongs to, so
+      # inserting a door cannot silently re-target another door's assertion. That was the
+      # flaw in pairing a `then` list against a `when` list by index.
       given: [on_map]
       when:
-        - visit: {x: 5,  y: 1}   # reliquary-north
-        - visit: {x: 5,  y: 6}   # reliquary-west
-        - visit: {x: 12, y: 10}  # reliquary-east
-        - visit: {x: 12, y: 19}  # reliquary-south
-      # Assertions are order-free and evaluated against the WHOLE case, never paired
-      # positionally with a step: `gained_item` means the party gained that item at some
-      # point in this case, `spoke` means EVERY visit raised a text box. Positional pairing
-      # would make inserting a step silently re-target every assertion after it.
+        - visit: {x: 5,  y: 1,  gains: 0x70}   # reliquary-north -> ITEM_TORCH
+        - visit: {x: 5,  y: 6,  gains: 0x5D}   # reliquary-west  -> ITEM_SECRETBOOK
+        - visit: {x: 12, y: 10, gains: 0x0E}   # reliquary-east  -> ITEM_SWORD_ARMORSLAYER
+        - visit: {x: 12, y: 19, gains: 0x60}   # reliquary-south -> ITEM_DRACOSHIELD
+      # Whole-case assertions only: `spoke` is a fact about EVERY visit, not about one.
       then:
-        - gained_item: 0x70      # ITEM_TORCH
-        - gained_item: 0x5D      # ITEM_SECRETBOOK
-        - gained_item: 0x0E      # ITEM_SWORD_ARMORSLAYER
-        - gained_item: 0x60      # ITEM_DRACOSHIELD
         - spoke: true
 
     # Still hand-written Lua. Each names WHY it is the exception rather than the default.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5185,9 +5185,9 @@ he does not exist. The run says our build reads the roster, not the map — whic
 
 **Both rode the existing scenario rather than new ones.** `ch05recruit` is parameterised over the
 wolf's roster state and the expected arm; the two states are four-line callers. That also keeps
-`harness.lua` at its 2 free top-level local slots — the ceiling that, hit, stops the whole chunk
-loading (`check.py` says so on every run, and names the escape hatch: hang the helper off an
-existing table). `INSPECT.activeMsg` went on `INSPECT` for exactly that reason.
+`harness.lua` off the 200-local ceiling that, hit, stops the whole chunk loading — a margin
+`check.py` MEASURES on every run rather than one anybody writes down, which is the rule this
+sentence used to break by naming a number. `INSPECT.activeMsg` went on `INSPECT` for exactly that reason.
 
 Not covered, and not pretended otherwise: the poke reproduces the STATE a benched unit is in, not
 the route by which a player gets there. The real ch04 → ch05 chain remains the only thing that
@@ -5450,16 +5450,90 @@ intent; only the generated artifact proves the wiring.
 
 _Recorded: 2026-08-11 (migrated out of HANDOFF 2026-08-20)._
 
-### `harness.lua` is ONE Lua chunk, at the 200-local ceiling (2026-08, #25)
+### A CHAPTER costs local slots, so a chapter gets its own chunk (2026-08-24, #314)
 
-Lua allows 200 locals per chunk and the harness is a single one, sitting at the limit — `check.py`
-prints the remaining slots on every run, so the live number never needs writing down anywhere.
+Lua allocates one VM register per local and caps it at **200 per function**. A `.lua` file compiles
+as one function, so every top-level `local` in `harness.lua` — all 9,000+ lines of it — competes for
+the same 200 slots. `check_lua_local_headroom` measures the margin by appending probe locals until
+the chunk stops compiling, and fails at zero; the number is never written down, because the version
+that was written down was wrong in three files at once.
 
-Hang a new helper off an existing table (`INSPECT`, `TUNE`) or declare it INSIDE the scenario that
-needs it. Never add a top-level `local`. A scenario-local table costs nothing against this budget,
-which is why `RESKIN_ENEMY_CLASS` and the raw-pid map live inside `recordenemy` rather than beside it.
+**Adding a scenario is free. Adding a CHAPTER is not.** `scenarios.ch05village = function()` is a
+table field and costs nothing. Of the harness's 198 top-level locals, **32 are chapter- or
+cast-scoped** (`CH02_CHWINGA_PIDS`, `CHAR_BRAULO`, `reachCh02Map`, `clearCh04`) — roughly **6–7 per
+chapter across the five built**. Measured against the growth curve (116 locals in June, 148 in July,
+198 in August) and thirteen chapters still to build, the harness runs out during **ch06**, not at
+ch18.
 
-_Recorded: 2026-08 (migrated out of HANDOFF 2026-08-20)._
+It had not broken yet because the pressure was venting as **duplication** rather than as a compile
+error. The old rule here — *"declare it INSIDE the scenario that needs it"* — is what produced that:
+**94 constant declarations inside scenario bodies, 67 distinct names, 24 of them re-typed across two
+or three scenarios.** `VILLAGE_X`/`VILLAGE_Y` in two, the four reliquary `SITES` typed once in
+`ch05reliquaries` and again in `ch05crest`, `PEN_X`/`PEN_Y`/`RUN_X`/`RUN_Y` in two. A ceiling that
+converts itself into duplication is worse than one that fails, because nothing reports it.
+
+**So chapter-scoped Lua lives in its own chunk, with its own fresh 200** — `tools/playtest/ch05.lua`,
+returning a table the scenarios that need it `dofile`. `LUA_CHUNKS` is globbed, so a new chunk is
+covered by `check_lua_chunks_load` the day it exists. `harness.lua` keeps the engine primitives and
+the scenario table; what is *about a chapter* leaves.
+
+**What this corrects.** The previous version of this entry said the harness stays whole and a new
+helper should be declared inside the scenario that needs it. That was a sound call against the
+future it could name — *"its only likely change is add a scenario"* — and it named the wrong one.
+The recurring change is *add a chapter*, and it costs slots. The placement test in `CLAUDE.md` cited
+this file as its own example and has been rewritten with it.
+
+_Recorded: 2026-08-24 (#314). Supersedes the 2026-08 entry, which was measured against scenario
+count rather than chapter count._
+
+### A scenario is DECLARED by the chapter it tests (2026-08-24, #314)
+
+A chapter YAML declares what its scenarios PROVE; everything mechanical is derived. The ROM comes
+from the chapter's `boot`, `PT_HOST_CHAPTER` from `inject/hosts.py`, the `matrix.yaml` row and the
+chapter suite from `tools/playtest/declared.py`. A name declared in both a chapter YAML and
+`matrix.yaml` **raises** — letting one copy win would recreate the hand-sync this replaced, with the
+added twist that which body ran would depend on merge order.
+
+**A case is EITHER declared or `lua:`, never both and never neither.** Both means two descriptions of
+one scenario. Neither means a row that dispatches to the driver, finds no steps and **passes
+vacuously** — a green scenario that asserts nothing is worse than a missing one, because it reports
+coverage. The driver refuses an empty `then` for the same reason.
+
+**Only the BODY opts out.** A `lua:` case still derives its row and its suite membership from the
+chapter, so a chapter declares everything it owns. That is the DECORATE lesson kept intact: code is
+the exception you NAME, not the default you copy.
+
+Four things paid for while building it:
+
+**`kind` is declared and never inferred from the name, even though timing still globs on it.**
+`matrix.yaml`'s classes match `record*`/`smoke*` to set fps and deadlines, and that is fine — timing
+may be guessed from a name. What a scenario ASSERTS may not: `recordsupply` and `recordunitlist` are
+verdict scenarios despite the prefix, and `kind` drives both the headless split and
+`check_verdict_scenarios_are_guarded`.
+
+**Assertions are ORDER-FREE and evaluated against the whole case.** The first draft interleaved
+`then` with `when` so each assertion paired positionally with a step. Inserting a step would then
+silently re-target every assertion after it. `gained_item` now means *the party gained this during
+the case* and `spoke` means *every visit raised a box*.
+
+**`gained_item` counts copies; it does not check presence.** A presence check passes on a reliquary
+that hands over nothing whenever anyone in the party already happens to be carrying one — which is
+exactly the blind spot `ch04village` was written to close (#205).
+
+**A `visit` step's tile is checked against the chapter's own `villages:` block.** The coordinates
+were a third copy: the chapter YAML declares `reliquary-south tile=[12,19]`, the Lua had `12, 19`,
+and `matrix.yaml` had the row. `check_declared_cases` proves a case only visits tiles the chapter
+declares a village at. Resolving the tile FROM the village id is the obvious next step and was not
+taken here: item ids resolve through `build_campaign.py`, which imports Pillow, and CI's lightweight
+`checks` job cannot import it. That wants an item-id registry that does not drag the art pipeline.
+
+**How the port was gated**, and both gates were required. First, free: all **111 scenario rows
+resolved byte-identical** before and after, so the derivation reproduces the hand-written table
+rather than merely resembling it. Second, real: the three ported scenarios ran in mGBA and **every
+guarded input was identical** — 26, 92 and 155 actions, same input, result, state and cursor tile,
+in the same order. A matching PASS would not have been evidence; a matching input sequence is.
+
+_Recorded: 2026-08-24 (#314)._
 
 ### A scenario written against the old design will FAIL ON SUCCESS (2026-08-14, #25)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5511,13 +5511,25 @@ may be guessed from a name. What a scenario ASSERTS may not: `recordsupply` and 
 verdict scenarios despite the prefix, and `kind` drives both the headless split and
 `check_verdict_scenarios_are_guarded`.
 
-**Assertions are ORDER-FREE and evaluated against the whole case.** The first draft interleaved
-`then` with `when` so each assertion paired positionally with a step. Inserting a step would then
-silently re-target every assertion after it. `gained_item` now means *the party gained this during
-the case* and `spoke` means *every visit raised a box*.
+**An assertion lives where its subject does, and getting this wrong cost two drafts.** The first
+draft interleaved `then` with `when`, pairing each assertion to a step *by index* — so inserting a
+step silently re-targets every assertion after it. The fix for that made assertions order-free and
+whole-case, and **that was worse**: `ch05reliquaries` stopped asserting that each door hands over
+*its own* gift and only checked that four ids arrived. Rotating the four gifts passed. That is
+exactly the defect the scenario exists to catch — the gifts are per-tile on purpose, richest where
+the eruption races — and it was caught in review, not by the suite.
 
-**`gained_item` counts copies; it does not check presence.** A presence check passes on a reliquary
-that hands over nothing whenever anyone in the party already happens to be carrying one — which is
+So: an assertion about ONE STEP rides that step (`visit: {x, y, gains}`), and `then` holds only
+assertions about the WHOLE case (`spoke`, `event_flag`). Not positional, and not detached from its
+subject. **The general lesson is that weakening an assertion is invisible to every gate we have** —
+the scenario still passes, the diff looks like a simplification, and the coverage is gone.
+
+`declared.py subsumed` depends on this placement directly: it compares `when` and `then` as
+independent multisets, which is sound *only* because a per-step assertion cannot be in `then`. Move
+one back and A silently "covers" B while asserting nothing about what B pinned.
+
+**A gift assertion counts copies; it does not check presence.** A presence check passes on a
+reliquary that hands over nothing whenever anyone in the party already happens to be carrying one —
 exactly the blind spot `ch04village` was written to close (#205).
 
 **A `visit` step's tile is checked against the chapter's own `villages:` block.** The coordinates

--- a/tools/check.py
+++ b/tools/check.py
@@ -862,7 +862,8 @@ def check_verdict_scenarios_are_guarded(fail):
             # A chapter-declared case has no function here on purpose (#314). It cannot hold
             # a raw press() at all: cases.lua drives the game only through the `api` table,
             # and every input primitive on it is a guarded one. That is asserted directly
-            # below rather than assumed -- see check_declared_cases_are_guarded.
+            # below rather than assumed -- see check_declared_cases, which checks cases.lua
+            # AND the api adapter in harness.lua that it drives the game through.
             if name in declared_bodies:
                 continue
             fail.append('verdict scenario %s has no function in harness.lua, so the '
@@ -892,6 +893,10 @@ def _declared_case_violations(cases, villages, harness_src):
             key, arg = list(entry.items())[0]
             if key != 'visit':
                 continue
+            if not isinstance(arg, dict):
+                problems.append('%s case %s: `visit` takes a mapping with x and y, got %r'
+                                % (short, case['name'], arg))
+                continue
             tile = [arg.get('x'), arg.get('y')]
             if tile not in villages.get(short, []):
                 problems.append(
@@ -899,14 +904,39 @@ def _declared_case_violations(cases, villages, harness_src):
                     'chapter YAML owns that map data, and a case coordinate that drifts '
                     'from it asserts against a tile the chapter does not have'
                     % (short, case['name'], tile[0], tile[1], short))
+        for i, entry in enumerate(case.get('then') or ()):
+            if not isinstance(entry, dict) or len(entry) != 1:
+                problems.append(
+                    '%s case %s: assertion %d is not a single-key mapping (`- spoke: true`, '
+                    'not `- spoke`)' % (short, case['name'], i))
     # cases.lua reaches the game ONLY through the api table it is handed, so it cannot hold
     # a raw press(). Asserting it rather than trusting it: this is the file every future
     # declared case runs through, so one blind press here would un-guard all of them at once
     # (decisions.md -> "A verdict scenario may not drive the UI with a raw press()").
-    if re.search(r'\bpress\(', harness_src):
-        problems.append('tools/playtest/cases.lua drives the UI with a raw press() -- the '
-                        'declared driver may only reach the game through its `api` table')
+    for label, src in sorted(harness_src.items()):
+        if re.search(r'\bpress\(', src):
+            problems.append(
+                '%s drives the UI with a raw press() -- every declared case reaches the game '
+                'through it, so one blind press here un-guards ALL of them at once rather '
+                'than one (decisions.md -> a verdict scenario may not drive the UI with a '
+                'raw press())' % label)
     return problems
+
+
+def _declared_api_adapter(harness):
+    """The `api` table harness.lua hands to cases.lua.
+
+    It is declared INSIDE the runner coroutine so it costs no top-level local slot, which
+    also means `harness_functions` attributes it to whatever scenario precedes it -- a
+    `record` one, which check_verdict_scenarios_are_guarded skips. So it is carved out by
+    name here and checked directly; otherwise the one piece of code every declared case
+    drives the game through is the one piece nothing reviews.
+    """
+    start = harness.find('local function runDeclaredCase')
+    if start < 0:
+        return None
+    end = harness.find('log("scenario: "', start)
+    return harness[start:end if end > start else len(harness)]
 
 
 def check_declared_cases(fail):
@@ -930,8 +960,15 @@ def check_declared_cases(fail):
         short = str(d.get('id', '')).split('-')[0]
         villages[short] = [list(v['tile']) for v in (d.get('villages') or []) if v.get('tile')]
     with open(os.path.join(REPO, 'tools/playtest/cases.lua'), encoding='utf-8') as fh:
-        src = fh.read()
-    fail.extend(_declared_case_violations(cases, villages, src))
+        sources = {'tools/playtest/cases.lua': fh.read()}
+    with open(os.path.join(REPO, 'tools/playtest/harness.lua'), encoding='utf-8') as fh:
+        adapter = _declared_api_adapter(fh.read())
+    if adapter is None:
+        fail.append('harness.lua no longer defines runDeclaredCase, so the api table every '
+                    'declared case drives the game through cannot be reviewed')
+    else:
+        sources["harness.lua's declared-case api adapter"] = adapter
+    fail.extend(_declared_case_violations(cases, villages, sources))
 
 
 # GBA address space. 0x04-0x07 are ARCHITECTURAL (MMIO, palette, VRAM, OAM) -- fixed by the

--- a/tools/check.py
+++ b/tools/check.py
@@ -729,11 +729,29 @@ def check_playtest_matrix(fail):
         fail.append('tools/playtest/matrix.yaml does not load (%s)' % exc)
         return
 
+    # A chapter-declared case (#314) has NO function in harness.lua by design: its body is
+    # the chapter YAML's given/when/then and cases.lua runs it. A `lua:` case is the
+    # exception and still must resolve to a real function -- that is the half of the old
+    # pairing check worth keeping, and it now covers the chapter YAML too.
+    try:
+        sys.path.insert(0, os.path.join(REPO, 'tools', 'playtest'))
+        import declared
+        bodies = {c['name']: c for _s, c in declared.cases()}
+    except Exception as exc:                      # noqa: BLE001 -- report, don't crash the lint
+        fail.append('chapter-declared playtest cases do not load (%s)' % exc)
+        bodies = {}
+    declared_bodies = {n for n, c in bodies.items() if 'lua' not in c}
+
     harness = mx.harness_scenarios()
     for name in sorted(harness - set(m.scenarios)):
         fail.append('harness.lua defines scenario %s with no matrix.yaml row' % name)
-    for name in sorted(set(m.scenarios) - harness):
-        fail.append('matrix.yaml has a row for %s, which harness.lua no longer defines' % name)
+    for name in sorted(set(m.scenarios) - harness - declared_bodies):
+        if name in bodies:
+            fail.append('%s: the chapter YAML names `lua: %s`, which harness.lua no longer '
+                        'defines' % (name, bodies[name]['lua']))
+        else:
+            fail.append('matrix.yaml has a row for %s, which harness.lua no longer defines'
+                        % name)
 
     for name in m.scenarios:
         if name not in harness:
@@ -823,6 +841,12 @@ def check_verdict_scenarios_are_guarded(fail):
         return
     with open(os.path.join(REPO, 'tools/playtest/harness.lua'), encoding='utf-8') as fh:
         funcs = mx.harness_functions(fh.read())
+    try:
+        sys.path.insert(0, os.path.join(REPO, 'tools', 'playtest'))
+        import declared
+        declared_bodies = {c['name'] for _s, c in declared.cases() if 'lua' not in c}
+    except Exception:                             # noqa: BLE001 -- check_playtest_matrix reports it
+        declared_bodies = set()
 
     for name in sorted(m.scenarios):
         try:
@@ -835,6 +859,12 @@ def check_verdict_scenarios_are_guarded(fail):
         # again. check_playtest_matrix reports the pairing separately; this refuses to pretend
         # it reviewed something it could not find.
         if name not in funcs:
+            # A chapter-declared case has no function here on purpose (#314). It cannot hold
+            # a raw press() at all: cases.lua drives the game only through the `api` table,
+            # and every input primitive on it is a guarded one. That is asserted directly
+            # below rather than assumed -- see check_declared_cases_are_guarded.
+            if name in declared_bodies:
+                continue
             fail.append('verdict scenario %s has no function in harness.lua, so the '
                         'blind-press gate cannot review it (#238)' % name)
             continue
@@ -848,6 +878,60 @@ def check_verdict_scenarios_are_guarded(fail):
                     'verdict scenario %s drives the UI with %d raw press() call(s) in %s -- '
                     'use guardedInput/selectSemantic, or classify the state it needs (#238)'
                     % (name, count, where))
+
+
+def _declared_case_violations(cases, villages, harness_src):
+    """Pure half of the two declared-case guards (unit-tested in test_check_declared.py)."""
+    problems = []
+    for short, case in cases:
+        for i, entry in enumerate(case.get('when') or ()):
+            if not isinstance(entry, dict) or len(entry) != 1:
+                problems.append('%s case %s: step %d is not a single-key mapping'
+                                % (short, case['name'], i))
+                continue
+            key, arg = list(entry.items())[0]
+            if key != 'visit':
+                continue
+            tile = [arg.get('x'), arg.get('y')]
+            if tile not in villages.get(short, []):
+                problems.append(
+                    '%s case %s visits (%s,%s), which %s declares no village at -- the '
+                    'chapter YAML owns that map data, and a case coordinate that drifts '
+                    'from it asserts against a tile the chapter does not have'
+                    % (short, case['name'], tile[0], tile[1], short))
+    # cases.lua reaches the game ONLY through the api table it is handed, so it cannot hold
+    # a raw press(). Asserting it rather than trusting it: this is the file every future
+    # declared case runs through, so one blind press here would un-guard all of them at once
+    # (decisions.md -> "A verdict scenario may not drive the UI with a raw press()").
+    if re.search(r'\bpress\(', harness_src):
+        problems.append('tools/playtest/cases.lua drives the UI with a raw press() -- the '
+                        'declared driver may only reach the game through its `api` table')
+    return problems
+
+
+def check_declared_cases(fail):
+    """Chapter-declared playtest cases describe the chapter they live in (#314).
+
+    Two things nothing else can catch. A `visit` step carries a tile, and the chapter YAML
+    already declares its villages with their tiles -- so a coordinate typo produces a case
+    that runs, walks a unit to empty ground, and FAILs blaming the chapter. And cases.lua is
+    the one body every declared case shares, so a raw press() in it would defeat the
+    blind-press contract for every case at once rather than for one.
+    """
+    sys.path.insert(0, os.path.join(REPO, 'tools', 'playtest'))
+    try:
+        import declared
+        cases = declared.cases()
+    except Exception as exc:                      # noqa: BLE001 -- report, don't crash the lint
+        fail.append('chapter-declared playtest cases do not load (%s)' % exc)
+        return
+    villages = {}
+    for rel, d in _chapters():
+        short = str(d.get('id', '')).split('-')[0]
+        villages[short] = [list(v['tile']) for v in (d.get('villages') or []) if v.get('tile')]
+    with open(os.path.join(REPO, 'tools/playtest/cases.lua'), encoding='utf-8') as fh:
+        src = fh.read()
+    fail.extend(_declared_case_violations(cases, villages, src))
 
 
 # GBA address space. 0x04-0x07 are ARCHITECTURAL (MMIO, palette, VRAM, OAM) -- fixed by the
@@ -1623,6 +1707,7 @@ def main():
                   check_personal_line_injection_routes,
                   check_injection_order, check_cached_steps_are_config_invariant,
                   check_playtest_matrix, check_gate_chapter_window,
+                  check_declared_cases,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,
                   check_tool_refs_exist, check_no_dead_concepts,

--- a/tools/playtest/cases.lua
+++ b/tools/playtest/cases.lua
@@ -1,0 +1,190 @@
+-- cases.lua -- the driver for DECLARED playtest cases (#314).
+--
+-- A chapter YAML declares what its scenarios prove; `tools/playtest/declared.py` emits one
+-- case as a Lua table and this runs it. The vocabulary is deliberately small: it covers the
+-- shape 15 of the harness's scenarios already share (boot -> settle -> drive -> read
+-- memory), and anything outside it stays hand-written Lua behind the chapter's `lua:` key.
+-- Code is the exception you NAME, not the default you copy.
+--
+-- WHY THIS IS ITS OWN CHUNK. Lua allows 200 locals per chunk and `harness.lua` is one chunk
+-- sitting at that ceiling with 2 slots left (`check_lua_local_headroom` measures it). Of its
+-- 198 top-level locals, 32 are chapter- or cast-scoped, so a chapter costs ~6-7 -- which
+-- means the harness runs out during ch06, not at ch18. A chapter's Lua lives in its own
+-- chunk with its own budget now; see decisions.md -> "A chapter costs local slots".
+--
+-- The driver never touches `emu`, `SYM` or any harness global: everything the game can do
+-- arrives on the `api` table. That is what lets `test_cases.lua` be a complete test double,
+-- and it is the interface the placement test asks for -- cases.lua talks over it and never
+-- reaches into the harness's cabinet.
+--
+-- Assertions are ORDER-FREE and evaluated against the whole case, never paired positionally
+-- with a step: inserting a step must not silently re-target every assertion after it.
+local M = {}
+
+-- ---------------------------------------------------------------- given
+-- Preconditions. `on_map` is the four-line preamble 15 scenarios open with, named once.
+M.GIVEN = {}
+
+M.GIVEN.on_map = function(api, state)
+    if not api.bootToMap() then
+        return false, "never reached the map"
+    end
+    api.fastConfig()
+    -- The WEAK settle: player faction, no menu, no std_event. Deliberately not the idle
+    -- one -- that is what every hand-written preamble waits on after a boot, and demanding
+    -- `player_map_idle` here would be a stricter precondition than any of them proved.
+    if not api.settle(false) then
+        return false, "booted, but the map never returned to player control"
+    end
+    state.itemsAtStart = M.tally(api.collectedItems())
+    return true
+end
+
+-- ---------------------------------------------------------------- when
+-- Steps. Each returns ok, why.
+M.WHEN = {}
+
+M.WHEN.visit = function(api, arg, state)
+    -- Settle FIRST. A location event's tail (give-item, MapChange, EVBIT_T, ENDA) is still
+    -- running when the item lands, and walking to the next door while std_event holds the
+    -- controller is an illegal input that dies as "cursor could not reach" -- which reads
+    -- like a map problem and is an impatience problem.
+    if not api.settle(true) then
+        return false, string.format(
+            "the map never returned to player control before (%d,%d)", arg.x, arg.y)
+    end
+    local ok, why, spoke = api.visitVillage(arg.x, arg.y)
+    if not ok then
+        return false, string.format("(%d,%d): %s", arg.x, arg.y, tostring(why))
+    end
+    api.shot("visit")
+    state.visits = state.visits + 1
+    if not spoke then
+        state.silent[#state.silent + 1] = string.format("(%d,%d)", arg.x, arg.y)
+    end
+    return true
+end
+
+-- ---------------------------------------------------------------- then
+-- Assertions. Each returns ok, why.
+M.THEN = {}
+
+-- The party GAINED this item during the case -- counted, not merely present. A presence
+-- check would pass on a reliquary that hands over nothing whenever anyone in the party
+-- already happens to be carrying one.
+M.THEN.gained_item = function(api, id, state)
+    local now = M.tally(api.collectedItems())
+    local before, after = state.itemsAtStart[id] or 0, now[id] or 0
+    if after > before then
+        return true
+    end
+    return false, string.format(
+        "item 0x%02X never arrived (%d in the party before, %d after) -- the site was "
+        .. "visited, the give-item tail did not run", id, before, after)
+end
+
+-- Every visit raised a text box. A wired-but-empty message would hand its gift over in
+-- silence and every item assertion would still pass.
+M.THEN.spoke = function(api, want, state)
+    if want == false then
+        return true
+    end
+    if #state.silent > 0 then
+        return false, "these visits paid out in SILENCE (no text box): "
+            .. table.concat(state.silent, ", ")
+    end
+    return true
+end
+
+M.THEN.event_flag = function(api, id, state)
+    if api.eventFlag(id) then
+        return true
+    end
+    return false, string.format(
+        "event id %d never set -- the location's Village macro is still on flag 0, so "
+        .. "nothing can count it toward a save-all payout", id)
+end
+
+-- ---------------------------------------------------------------- driver
+
+function M.tally(list)
+    local n = {}
+    for _, id in ipairs(list or {}) do n[id] = (n[id] or 0) + 1 end
+    return n
+end
+
+-- One-key table -> key, value. A `when`/`then` entry is a single-pair mapping in YAML.
+function M.pair(entry)
+    local k, v
+    for key, value in pairs(entry) do
+        if k ~= nil then return nil, nil, "entry declares more than one key" end
+        k, v = key, value
+    end
+    if k == nil then return nil, nil, "empty entry" end
+    return k, v
+end
+
+function M.run(case, api)
+    local state = {visits = 0, silent = {}, itemsAtStart = {}}
+    local name = case.name or "?"
+
+    for _, want in ipairs(case.given or {}) do
+        local fn = M.GIVEN[want]
+        if not fn then
+            return api.result("ERROR", string.format(
+                "%s: unknown `given` %q -- the vocabulary is in cases.lua", name, tostring(want)))
+        end
+        local ok, why = fn(api, state)
+        if not ok then
+            return api.result("FAIL", string.format("%s: %s", name, why))
+        end
+    end
+
+    for i, entry in ipairs(case["when"] or {}) do
+        local key, arg, err = M.pair(entry)
+        if err then
+            return api.result("ERROR", string.format("%s: step %d: %s", name, i, err))
+        end
+        local fn = M.WHEN[key]
+        if not fn then
+            return api.result("ERROR", string.format(
+                "%s: unknown step %q -- the vocabulary is in cases.lua, and a case outside "
+                .. "it belongs behind the chapter's `lua:` key", name, key))
+        end
+        local ok, why = fn(api, arg, state)
+        if not ok then
+            return api.result("FAIL", string.format("%s: %s", name, why))
+        end
+    end
+
+    -- A case that asserts nothing must not report green. It would be counted as coverage by
+    -- `make chapter`, by the chapter suite and by the gate, and it proves nothing at all.
+    local asserts = case["then"] or {}
+    if #asserts == 0 then
+        return api.result("ERROR", string.format(
+            "%s: declares no `then` assertions, so a PASS would mean nothing", name))
+    end
+
+    local proved = {}
+    for i, entry in ipairs(asserts) do
+        local key, arg, err = M.pair(entry)
+        if err then
+            return api.result("ERROR", string.format("%s: assertion %d: %s", name, i, err))
+        end
+        local fn = M.THEN[key]
+        if not fn then
+            return api.result("ERROR", string.format(
+                "%s: unknown assertion %q -- the vocabulary is in cases.lua", name, key))
+        end
+        local ok, why = fn(api, arg, state)
+        if not ok then
+            return api.result("FAIL", string.format("%s: %s", name, why))
+        end
+        proved[#proved + 1] = key
+    end
+
+    return api.result("PASS", string.format("%s: %s (%d assertion(s) over %d visit(s))",
+        name, case.proves or "declared case", #proved, state.visits))
+end
+
+return M

--- a/tools/playtest/cases.lua
+++ b/tools/playtest/cases.lua
@@ -17,8 +17,11 @@
 -- and it is the interface the placement test asks for -- cases.lua talks over it and never
 -- reaches into the harness's cabinet.
 --
--- Assertions are ORDER-FREE and evaluated against the whole case, never paired positionally
--- with a step: inserting a step must not silently re-target every assertion after it.
+-- WHERE AN ASSERTION LIVES. An assertion about ONE STEP rides that step (`visit: {x, y,
+-- gains}`); `then` holds only assertions about the WHOLE case (`spoke`, `event_flag`).
+-- Neither is paired positionally, and both are needed. A whole-case list alone passes on
+-- four doors handing over each other's gifts; a `then` list paired against `when` by INDEX
+-- means inserting a step silently re-targets every assertion after it.
 local M = {}
 
 -- ---------------------------------------------------------------- given
@@ -44,7 +47,15 @@ end
 -- Steps. Each returns ok, why.
 M.WHEN = {}
 
+-- `arg.gains` is an item id this door must hand over. It rides the STEP because the gift is
+-- per-tile: a whole-case "these ids arrived" list passes on four doors swapping each other's
+-- gifts, which is exactly the defect ch05reliquaries exists to catch. It is still not
+-- positional -- the assertion lives INSIDE the step it belongs to, so inserting a door cannot
+-- re-target another door's assertion.
 M.WHEN.visit = function(api, arg, state)
+    if type(arg) ~= "table" or type(arg.x) ~= "number" or type(arg.y) ~= "number" then
+        return false, "a `visit` step needs a table with numeric x and y"
+    end
     -- Settle FIRST. A location event's tail (give-item, MapChange, EVBIT_T, ENDA) is still
     -- running when the item lands, and walking to the next door while std_event holds the
     -- controller is an illegal input that dies as "cursor could not reach" -- which reads
@@ -53,12 +64,23 @@ M.WHEN.visit = function(api, arg, state)
         return false, string.format(
             "the map never returned to player control before (%d,%d)", arg.x, arg.y)
     end
+    local before = M.tally(api.collectedItems())
     local ok, why, spoke = api.visitVillage(arg.x, arg.y)
     if not ok then
         return false, string.format("(%d,%d): %s", arg.x, arg.y, tostring(why))
     end
     api.shot("visit")
     state.visits = state.visits + 1
+    if arg.gains ~= nil then
+        state.asserted = state.asserted + 1
+        local after = M.tally(api.collectedItems())
+        if (after[arg.gains] or 0) <= (before[arg.gains] or 0) then
+            return false, string.format(
+                "(%d,%d) was visited but did not hand over item 0x%02X -- this door's OWN "
+                .. "gift. Another door's gift arriving instead still fails here, on purpose",
+                arg.x, arg.y, arg.gains)
+        end
+    end
     if not spoke then
         state.silent[#state.silent + 1] = string.format("(%d,%d)", arg.x, arg.y)
     end
@@ -115,6 +137,11 @@ end
 
 -- One-key table -> key, value. A `when`/`then` entry is a single-pair mapping in YAML.
 function M.pair(entry)
+    if type(entry) ~= "table" then
+        return nil, nil, string.format(
+            "is %s, not a single-key mapping (write `- spoke: true`, not `- spoke`)",
+            type(entry))
+    end
     local k, v
     for key, value in pairs(entry) do
         if k ~= nil then return nil, nil, "entry declares more than one key" end
@@ -125,7 +152,7 @@ function M.pair(entry)
 end
 
 function M.run(case, api)
-    local state = {visits = 0, silent = {}, itemsAtStart = {}}
+    local state = {visits = 0, silent = {}, itemsAtStart = {}, asserted = 0}
     local name = case.name or "?"
 
     for _, want in ipairs(case.given or {}) do
@@ -160,9 +187,10 @@ function M.run(case, api)
     -- A case that asserts nothing must not report green. It would be counted as coverage by
     -- `make chapter`, by the chapter suite and by the gate, and it proves nothing at all.
     local asserts = case["then"] or {}
-    if #asserts == 0 then
+    if #asserts == 0 and state.asserted == 0 then
         return api.result("ERROR", string.format(
-            "%s: declares no `then` assertions, so a PASS would mean nothing", name))
+            "%s: asserts nothing -- no `then` entry and no step carrying its own assertion, "
+            .. "so a PASS would mean nothing", name))
     end
 
     local proved = {}
@@ -184,7 +212,7 @@ function M.run(case, api)
     end
 
     return api.result("PASS", string.format("%s: %s (%d assertion(s) over %d visit(s))",
-        name, case.proves or "declared case", #proved, state.visits))
+        name, case.proves or "declared case", #proved + state.asserted, state.visits))
 end
 
 return M

--- a/tools/playtest/ch05.lua
+++ b/tools/playtest/ch05.lua
@@ -1,0 +1,56 @@
+-- ch05.lua -- ch05's chapter-scoped playtest facts, in ITS OWN chunk (#314).
+--
+-- WHY THIS FILE EXISTS. Lua caps locals at 200 per chunk and `harness.lua` is one chunk at
+-- that ceiling. Of its 198 top-level locals, 32 are chapter- or cast-scoped -- ~6-7 per
+-- chapter over the five built -- so a shared budget runs out during ch06, not at ch18. The
+-- old escape hatch ("declare it inside the scenario that needs it") kept the harness
+-- compiling by converting the ceiling into DUPLICATION instead: 94 constant declarations
+-- inside scenario bodies, 24 names re-typed across two or three scenarios. Basil's pid was
+-- typed in three places, Ravisin's in two.
+--
+-- So a chapter's facts live in a chapter chunk with its own fresh 200. `LUA_CHUNKS` is
+-- globbed, so `check_lua_chunks_load` covers this file the day it exists.
+--
+-- HOW TO USE IT. `dofile` it INSIDE the scenario that needs it -- function-scoped, so it
+-- still costs harness.lua no top-level slot:
+--
+--     scenarios.ch05crest = function()
+--         local CH05 = dofile(PLAYTEST_DIR .. "/ch05.lua")
+--         ... CH05.PID.RAVISIN ...
+--
+-- WHAT BELONGS HERE: facts about ch05 that more than one scenario reads -- cast pids, the
+-- reliquary table, message ids a branch turns on. What does NOT: engine constants (terrain
+-- ids, item ids that are FE8's rather than ours) and anything a single scenario uses once.
+-- ch06 starts here by default rather than by exception.
+return {
+    -- Cast, by the vanilla character slot each unit occupies.
+    PID = {
+        BASIL   = 0x13,     -- CHARACTER_ARTUR
+        SAHNAR  = 0x16,     -- CHARACTER_MARISA
+        RAVISIN = 0xb8,     -- the chapter boss
+        MOOSE   = 0xb9,     -- the White Moose, ch04's payoff charging through scene 7
+        LUPIN   = 0x1D,     -- CHARACTER_DUESSEL, the slot ch05 gives the wolf
+    },
+
+    -- The four reliquary doors: where they are, what each hands over, and the event id its
+    -- Village macro sets. The tiles are the chapter YAML's `villages:` block
+    -- (`check_declared_cases` proves a declared case cannot drift from it); the flags are
+    -- CH05_VILLAGE_FLAGS in build_campaign, and they are what the save-all payout counts.
+    RELIQUARIES = {
+        { name = "north", x = 5,  y = 1,  item = 0x70, flag = 12 },   -- Torch
+        { name = "west",  x = 5,  y = 6,  item = 0x5D, flag = 11 },   -- Secret Book
+        { name = "east",  x = 12, y = 10, item = 0x0E, flag = 9  },   -- Armorslayer
+        { name = "south", x = 12, y = 19, item = 0x60, flag = 10 },   -- Dracoshield
+    },
+
+    -- The save-all reward, paid only when all four flags above are set.
+    REWARD = { GUIDING_RING = 0x68 },
+
+    -- Message ids a BRANCH turns on. Box count cannot witness which arm played -- the Talk
+    -- recruit's two arms are both 21 A-presses -- so a scenario asserts the id via
+    -- INSPECT.activeMsg() instead (decisions.md -> "box count is no longer a witness").
+    MSG = {
+        RECRUIT_NO_LUPIN = 0x9D1,   -- the fallback arm: the wolf is absent, benched or dead
+        ENDING_FULL      = 0x9C9,   -- Basil alive + Sahnar recruited
+    },
+}

--- a/tools/playtest/declared.py
+++ b/tools/playtest/declared.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Chapter-declared playtest cases: the reader, and the matrix rows derived from them (#314).
+
+A chapter YAML declares what its scenarios PROVE; everything mechanical about them is
+derived here rather than hand-written a second time in `matrix.yaml`:
+
+    playtest:
+      boot: ch05boot                 # the ROM configuration the chapter boots on
+      cases:
+        - name: ch05village
+          proves: the south reliquary hands over its Dracoshield
+          given: [on_map]
+          when:  [{visit: {x: 12, y: 19}}]
+          then:  [{gained_item: 0x60}]
+
+        - name: ch05arena
+          proves: the arena tutorial is one-shot on EVFLAG_TMP(13)
+          lua: ch05arena             # the escape hatch: only the BODY opts out
+
+`host_chapter` comes from `inject/hosts.py` -- the host-slot registry, which is already the
+single declaration of which vanilla slot a chapter rides. Deriving it from the chapter
+NUMBER instead would be right up to ch04 and wrong forever after: from slot 6 on, vanilla's
+slot index leads the chapter number by one (FE8 inserts chapter 5X at slot 5), so ch05's
+cases would boot ch04's slot and assert against the wrong map while looking well-formed.
+
+`kind` is DECLARED and never inferred from the case NAME, even though `matrix.yaml`'s
+timing classes still glob on it. That is `decisions.md` -> "A verdict scenario needs no
+pixels": recordsupply and recordunitlist are verdict scenarios despite the prefix, and
+`kind` drives both the headless split and `check_verdict_scenarios_are_guarded`. Timing may
+be inferred from a name; what a scenario ASSERTS may not.
+
+Stdlib + pyyaml only, so CI's lightweight `checks` job can import it -- same constraint as
+`campaign_chapters` and `inject/hosts`, and for the same reason.
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_TOOLS = os.path.dirname(_HERE)
+if _TOOLS not in sys.path:
+    sys.path.insert(0, _TOOLS)
+
+import campaign_chapters                               # noqa: E402
+from inject import hosts                               # noqa: E402
+
+
+class CaseError(Exception):
+    """A chapter's `playtest:` block does not describe a runnable case."""
+
+
+# The keys a case may carry. Anything else is a typo, and a typo that resolved to a default
+# would produce a case that runs and asserts something other than what was written.
+CASE_KEYS = frozenset(('name', 'proves', 'boot', 'kind', 'headless', 'deadline',
+                       'checkpoint', 'manual', 'given', 'when', 'then', 'lua'))
+
+# What a case may carry INSTEAD of `lua`. A case is one or the other, never both and never
+# neither -- see _body_kind.
+BODY_KEYS = ('given', 'when', 'then')
+
+
+def host_slots(campaign=campaign_chapters.CAMPAIGN):
+    """{short chapter id: host slot index}, from the host registry."""
+    return dict((h.name, h.host_index) for h in hosts.hosted_chapters())
+
+
+def _body_kind(case, where):
+    """'lua' or 'declared' -- and never both, never neither.
+
+    Both would mean two descriptions of one scenario, which is the hand-sync this issue
+    exists to delete. Neither would mean a row in the matrix with nothing to run: it would
+    dispatch to the declared driver, find no steps, and PASS vacuously -- a green scenario
+    that asserts nothing is worse than a missing one, because it reports coverage.
+    """
+    has_lua = 'lua' in case
+    has_body = any(k in case for k in BODY_KEYS)
+    if has_lua and has_body:
+        raise CaseError('%s: declares both `lua` and %s -- a case is one or the other'
+                        % (where, '/'.join(k for k in BODY_KEYS if k in case)))
+    if not has_lua and not has_body:
+        raise CaseError('%s: declares neither `lua` nor any of %s, so there is nothing to '
+                        'run (a case with no steps PASSES vacuously)'
+                        % (where, '/'.join(BODY_KEYS)))
+    return 'lua' if has_lua else 'declared'
+
+
+def cases(docs=None, slots=None, campaign=campaign_chapters.CAMPAIGN):
+    """Every declared case, validated, as (short chapter id, case dict) pairs."""
+    docs = campaign_chapters.load_all(campaign) if docs is None else docs
+    slots = host_slots(campaign) if slots is None else slots
+    out = []
+    for doc in docs:
+        block = (doc or {}).get('playtest')
+        if not block:
+            continue
+        short = campaign_chapters.short_id(doc)
+        if short not in slots:
+            raise CaseError(
+                '%s declares playtest cases but is not hosted -- no slot in inject/hosts.py, '
+                'so every case would inherit host_chapter 1 and assert against the prologue'
+                % short)
+        for i, case in enumerate(block.get('cases') or ()):
+            where = '%s case %d' % (short, i)
+            if not isinstance(case, dict):
+                raise CaseError('%s: not a mapping' % where)
+            name = case.get('name')
+            if not name:
+                raise CaseError('%s: has no `name`' % where)
+            where = '%s case %s' % (short, name)
+            unknown = set(case) - CASE_KEYS
+            if unknown:
+                raise CaseError('%s: unknown key(s) %s' % (where, ', '.join(sorted(unknown))))
+            if not case.get('proves'):
+                raise CaseError('%s: has no `proves` -- what a case proves is the one thing '
+                                'nothing else can derive' % where)
+            _body_kind(case, where)
+            if not (case.get('boot') or block.get('boot')):
+                raise CaseError('%s: no `boot`, and %s declares no chapter-wide one'
+                                % (where, short))
+            out.append((short, case))
+    names = [c['name'] for _, c in out]
+    dupes = sorted(set(n for n in names if names.count(n) > 1))
+    if dupes:
+        raise CaseError('declared twice: %s' % ', '.join(dupes))
+    return out
+
+
+def matrix_rows(docs=None, slots=None, campaign=campaign_chapters.CAMPAIGN):
+    """{scenario name: matrix.yaml row} for every chapter-declared case.
+
+    The row is emitted in `matrix.yaml`'s own vocabulary and resolved through the same
+    defaults and timing classes, so a derived scenario and a hand-written one are the same
+    kind of thing to every consumer downstream.
+    """
+    slots = host_slots(campaign) if slots is None else slots
+    rows = {}
+    for short, case in cases(docs, slots, campaign):
+        row = {
+            'rom': case.get('boot') or _block(docs, short, campaign)['boot'],
+            'host_chapter': slots[short],
+            'kind': case.get('kind', 'verdict'),
+        }
+        for optional in ('headless', 'deadline', 'checkpoint', 'manual'):
+            if optional in case:
+                row[optional] = case[optional]
+        rows[case['name']] = row
+    return rows
+
+
+def _block(docs, short, campaign):
+    docs = campaign_chapters.load_all(campaign) if docs is None else docs
+    for doc in docs:
+        if campaign_chapters.short_id(doc) == short:
+            return doc['playtest']
+    raise CaseError('no chapter %s' % short)
+
+
+def matrix_suites(docs=None, slots=None, campaign=campaign_chapters.CAMPAIGN):
+    """{short chapter id: [verdict case names]} -- the chapter suite, derived.
+
+    Only VERDICT cases: a suite is what you run to know a chapter is sound, and a `record`
+    capture has no verdict to be sound. `record`/`diagnostic` cases still resolve, still
+    run by name, and still appear in `make chapter` -- they are simply not what a suite is.
+    """
+    suites = {}
+    for short, case in cases(docs, slots, campaign):
+        if case.get('kind', 'verdict') != 'verdict':
+            continue
+        suites.setdefault(short, []).append(case['name'])
+    return suites
+
+
+# -- emitting a case for the Lua driver ---------------------------------------------------
+
+def _lua(value, indent=1):
+    """A Python value as a Lua literal. Only the shapes a case can hold."""
+    pad = '    ' * indent
+    if value is True:
+        return 'true'
+    if value is False:
+        return 'false'
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return '"%s"' % value.replace('\\', '\\\\').replace('"', '\\"')
+    if isinstance(value, list):
+        if not value:
+            return '{}'
+        return '{\n%s%s,\n%s}' % (pad, (',\n' + pad).join(
+            _lua(v, indent + 1) for v in value), '    ' * (indent - 1))
+    if isinstance(value, dict):
+        # `when`/`then` keys include Lua keywords (`then`), so every key is bracketed.
+        return '{%s}' % ', '.join('["%s"] = %s' % (k, _lua(v, indent + 1))
+                                  for k, v in sorted(value.items()))
+    raise CaseError('cannot express %r as a Lua literal' % (value,))
+
+
+def lua_case(name, docs=None, slots=None, campaign=campaign_chapters.CAMPAIGN):
+    """One declared case as a Lua chunk returning its table.
+
+    Emitted to the scenario's own run directory rather than committed: a generated file in
+    the tree is a second copy of the chapter YAML that can be stale, which is the failure
+    this issue exists to delete.
+    """
+    for _short, case in cases(docs, slots, campaign):
+        if case['name'] != name:
+            continue
+        if 'lua' in case:
+            raise CaseError('%s is a `lua:` case -- it has no declared body' % name)
+        # Emitted key by key rather than as one nested literal: this file is what a human
+        # opens when a declared case misbehaves, and `proves` is the first thing they want.
+        out = ['-- GENERATED from the chapter YAML by tools/playtest/declared.py (#314).',
+               '-- Do not edit: the chapter declares this case, and this file is rebuilt',
+               '-- for every run.',
+               'return {',
+               '    ["name"]   = %s,' % _lua(name),
+               '    ["proves"] = %s,' % _lua(campaign_chapters.squish(case['proves'])),
+               '    ["given"]  = %s,' % _lua(case.get('given') or [], 2)]
+        for key in ('when', 'then'):
+            out.append('    ["%s"]%s = %s,' % (key, ' ' * (6 - len(key)),
+                                               _lua(case.get(key) or [], 2)))
+        out.append('}')
+        return '\n'.join(out) + '\n'
+    raise CaseError('no declared case %r (a `lua:` case is not one)' % name)
+
+
+def is_declared(name, docs=None, slots=None, campaign=campaign_chapters.CAMPAIGN):
+    """True if `name` is a chapter-declared case with a BODY (not a `lua:` one)."""
+    return any(c['name'] == name and 'lua' not in c
+               for _s, c in cases(docs, slots, campaign))
+
+
+# -- subsumption ---------------------------------------------------------------------------
+
+def _entries(case, key):
+    """A case's `when`/`then` list as comparable (key, value) pairs."""
+    out = []
+    for entry in case.get(key) or ():
+        if isinstance(entry, dict) and len(entry) == 1:
+            k, v = list(entry.items())[0]
+            out.append((k, repr(v) if isinstance(v, (dict, list)) else v))
+    return out
+
+
+def subsumes(a, b):
+    """True if running case `a` proves everything case `b` does.
+
+    Only DECLARED cases can be compared -- a `lua:` case is opaque, and guessing at what an
+    opaque body covers is exactly the kind of derived claim that should not be made. Both
+    must boot the same ROM, `a` must do at least everything `b` does, and `a` must assert at
+    least everything `b` asserts.
+
+    Coverage, not diagnosis. A subsumed case is often the better ISOLATOR: ch05reliquaries
+    visits four doors in sequence, so a broken north door fails it before south is ever
+    reached, where ch05village would have named south exactly. That is why this is a REPORT
+    and not an automatic gate edit -- the gate only needs coverage, but which scenario a
+    chapter suite keeps for diagnosis is a human call.
+    """
+    if 'lua' in a or 'lua' in b or a['name'] == b['name']:
+        return False
+    if (a.get('boot'), a.get('kind', 'verdict')) != (b.get('boot'), b.get('kind', 'verdict')):
+        return False
+    if not set(b.get('given') or ()) <= set(a.get('given') or ()):
+        return False
+    for key in ('when', 'then'):
+        big, small = _entries(a, key), _entries(b, key)
+        for item in small:
+            if big.count(item) < small.count(item):
+                return False
+    return True
+
+
+def subsumed_pairs(docs=None, slots=None, campaign=campaign_chapters.CAMPAIGN):
+    """[(covering case, subsumed case, chapter)] over every declared case."""
+    everything = cases(docs, slots, campaign)
+    out = []
+    for short_a, a in everything:
+        for short_b, b in everything:
+            if short_a == short_b and subsumes(a, b):
+                out.append((a['name'], b['name'], short_a))
+    return out
+
+
+def main(argv):
+    import argparse
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    e = sub.add_parser('emit', help='print one declared case as a Lua chunk')
+    e.add_argument('name')
+    sub.add_parser('list', help='every declared case, with what it proves')
+    sub.add_parser('subsumed', help='cases another case already fully covers')
+    args = ap.parse_args(argv)
+    if args.cmd == 'emit':
+        sys.stdout.write(lua_case(args.name))
+        return 0
+    if args.cmd == 'subsumed':
+        pairs = subsumed_pairs()
+        if not pairs:
+            print('nothing subsumed: every declared case proves something no other one does')
+            return 0
+        print('These cases are fully covered by another case in the same chapter. Coverage '
+              'only --\nthe subsumed one may still be the better ISOLATOR, so this is a '
+              'report, not an edit.\n')
+        for covering, subsumed, short in pairs:
+            print('  %-10s %s  is fully covered by  %s' % (short, subsumed, covering))
+        return 0
+    for short, case in cases():
+        how = 'lua:%s' % case['lua'] if 'lua' in case else 'declared'
+        print('%-10s %-28s %-14s %s' % (short, case['name'], how,
+                                        campaign_chapters.squish(case['proves'])))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tools/playtest/declared.py
+++ b/tools/playtest/declared.py
@@ -249,6 +249,14 @@ def subsumes(a, b):
     must boot the same ROM, `a` must do at least everything `b` does, and `a` must assert at
     least everything `b` asserts.
 
+    WHY THE COMPARISON IS SOUND, and what makes it unsound. It compares `when` and `then`
+    as independent multisets, which is only valid because of where assertions live: an
+    assertion ABOUT ONE STEP rides that step (`visit: {x, y, gains}`), and `then` holds only
+    assertions about the WHOLE case (`spoke`, `event_flag`). So if b's steps are a subset of
+    a's and b's whole-case assertions are a subset of a's, a really does prove everything b
+    does. Move a per-step assertion back into `then` and this claim silently breaks -- a
+    would then "cover" b while asserting nothing about the step b pinned.
+
     Coverage, not diagnosis. A subsumed case is often the better ISOLATOR: ch05reliquaries
     visits four doors in sequence, so a broken north door fails it before south is ever
     reached, where ch05village would have named south exactly. That is why this is a REPORT

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -6575,8 +6575,8 @@ end
 -- would have failed on 0 eruption boxes and blamed the warning.
 -- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05recruit (needs a CH05BOOT=1 ROM).
 scenarios.ch05recruit = function(opts)
-    local BASIL, SAHNAR = 0x13, 0x16        -- CHARACTER_ARTUR / CHARACTER_MARISA
-    local LUPIN = 0x1D                      -- CHARACTER_DUESSEL, the slot ch05 gives the wolf
+    local CH05 = dofile(PLAYTEST_DIR .. "/ch05.lua")     -- ch05's shared facts (#314)
+    local BASIL, SAHNAR, LUPIN = CH05.PID.BASIL, CH05.PID.SAHNAR, CH05.PID.LUPIN
     -- A-presses the recruit renders to -- now exactly the number of AUTHORED boxes: 16 on the
     -- locked arm, 17 on the substituted one. Nothing pages itself any more, because the wrapper
     -- measures PIXELS at vanilla's own width instead of counting to 29 (`decisions.md` -> "We
@@ -6589,7 +6589,7 @@ scenarios.ch05recruit = function(opts)
     -- arm. The two named states are #25's last two owed CHECK_ALIVE cases and ride
     -- `ch05lupinboot`, whose LOAD1 is the only way any of these ROMs gets a Lupin at all.
     opts = opts or {}
-    local ARM = opts.arm or 0x9D1
+    local ARM = opts.arm or CH05.MSG.RECRUIT_NO_LUPIN
     local RECRUIT_BOXES = (ARM == 0x9E8) and 16 or 17
     local function blueBasil() return findUnit(SYM.gUnitArrayBlue, 20, BASIL) end
     local function redSahnar() return findUnit(SYM.gUnitArrayRed, 24, SAHNAR) end
@@ -6916,117 +6916,6 @@ local function visitVillage(x, y, done, onBox)
     return true, nil, spoke
 end
 
--- ch04village (#205): does the Lonelywood village actually hand over its Iron Axe?
--- It did not, for the whole slice, and NOTHING looked wrong: the map drew a cottage, the chapter
--- compiled and played. FE8 gates the Visit menu item on the TERRAIN under the unit (bmmenu.c:735)
--- before it ever consults the location event, and the snowy reskin had mapped vanilla's village
--- metatile onto ruins. So this checks the two halves that must BOTH hold -- a visitable tile and a
--- wired Village() entry -- by the only evidence that settles it: the axe is in the party's hands
--- afterwards and was not before.
--- Run: PT_HOST_CHAPTER=5 tools/playtest/run.sh ch04village (needs a CH04BOOT=1 ROM).
-scenarios.ch04village = function()
-    local VILLAGE_X, VILLAGE_Y, IRON_AXE = 8, 2, 0x1F
-    if not bootToMap() then return result("FAIL", "never reached the ch04 map") end
-    pokeFastConfig()
-    waitFor(function() return faction() == 0 and not menuOpen()
-        and not procActive(SYM.ProcScr_StdEventEngine) end, 6000, true)
-    local function axes()
-        local n = 0
-        for _, id in ipairs(collectedItems()) do if id == IRON_AXE then n = n + 1 end end
-        return n
-    end
-    local before = axes()
-    log(string.format("ch04village: %d Iron Axe(s) in the party before visiting", before))
-    local ok, why = visitVillage(VILLAGE_X, VILLAGE_Y, function() return axes() > before end)
-    if not ok then return result("FAIL", why) end
-    shot("ch04village")
-    local after = axes()
-    if after <= before then
-        return result("FAIL", string.format(
-            "visited (%d,%d) but the party still holds %d Iron Axe(s) -- the village handed over "
-            .. "nothing (check the tile's terrain AND the Village() entry)",
-            VILLAGE_X, VILLAGE_Y, after))
-    end
-    return result("PASS", string.format(
-        "the Lonelywood village handed over its Iron Axe: %d -> %d in the party", before, after))
-end
-
--- ch05reliquaries (#25): all FOUR reliquary doors -- each one speaks, and each hands over ITS
--- OWN gift. ch05village covers the south door alone, and a scenario's verdict only covers what
--- it actually reads: three doors, three faces and three of the four authored lines had no
--- witness at all, which is the same blind spot that let ch05village pass for months while
--- proving nothing about the recruit. The gifts are per-tile on purpose (vanilla's placement,
--- richest where the eruption races), so "some item arrived" is not the assertion -- the RIGHT
--- item is. `spoke` is checked too: a wired-but-empty message would hand the gift over in
--- silence and every item check would still pass.
--- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05reliquaries (needs a CH05BOOT=1 ROM).
-scenarios.ch05reliquaries = function()
-    local SITES = {
-        {name = "north  Torch",       x = 5,  y = 1,  item = 0x70},
-        {name = "west   Secret Book", x = 5,  y = 6,  item = 0x5D},
-        {name = "east   Armorslayer", x = 12, y = 10, item = 0x0E},
-        {name = "south  Dracoshield", x = 12, y = 19, item = 0x60},
-    }
-    if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
-    pokeFastConfig()
-    waitFor(function() return faction() == 0 and not menuOpen()
-        and not procActive(SYM.ProcScr_StdEventEngine) end, 6000, true)
-    local function held(id)
-        local n = 0
-        for _, got in ipairs(collectedItems()) do if got == id then n = n + 1 end end
-        return n
-    end
-    -- The visit's `done` fires the moment the ITEM lands, but the location event is still
-    -- running behind it (give-item tail, the door's MapChange, EVBIT_T, ENDA). Walking to the
-    -- next door while std_event holds the controller is an illegal input, and the run dies on
-    -- "cursor could not reach" -- which reads like a map problem and is really an impatience
-    -- problem. Settle back to player-idle between doors.
-    local function settle()
-        return waitFor(function()
-            return faction() == 0 and not menuOpen()
-                and not procActive(SYM.ProcScr_StdEventEngine)
-                and controllerState() == "player_map_idle"
-        end, 3000, true)
-    end
-    local silent = {}
-    for _, site in ipairs(SITES) do
-        if not settle() then
-            return result("FAIL", string.format(
-                "the map never returned to player control before %s (%d,%d)",
-                site.name, site.x, site.y))
-        end
-        local before = held(site.item)
-        -- One shot per door by default (enough to prove the face and the first line). Set
-        -- PT_RECORD_BOXES=1 for a full review capture: every box of every door, which is what
-        -- you want when the question is "read the whole scene", not "did it fire".
-        local shown = false
-        local ok, why, spoke = visitVillage(site.x, site.y, function()
-            return held(site.item) > before
-        end, function()
-            if os.getenv("PT_RECORD_BOXES") then
-                shot("box")
-            elseif not shown then
-                shot("reliquary"); shown = true
-            end
-        end)
-        if not ok then
-            return result("FAIL", string.format("%s (%d,%d): %s", site.name, site.x, site.y, why))
-        end
-        if held(site.item) <= before then
-            return result("FAIL", string.format(
-                "%s (%d,%d) was visited but its gift never arrived -- the door ran, the "
-                .. "give-item tail did not", site.name, site.x, site.y))
-        end
-        if not spoke then silent[#silent + 1] = site.name end
-        log(string.format("ch05reliquaries: %s handed over its gift", site.name))
-    end
-    if #silent > 0 then
-        return result("FAIL", "these doors paid out in SILENCE (no text box): "
-            .. table.concat(silent, ", "))
-    end
-    return result("PASS", "all four reliquaries spoke and handed over their own gift")
-end
-
 -- ch05arena (#264): the active onboarding ledger claims a tutorial on the real arena tile.
 -- Park the leader one step away, take the engine's real move+Wait path onto (12,6), and count
 -- the six authored pages. Then step off and back on during the same turn (manually clearing its
@@ -7329,42 +7218,6 @@ scenarios.ch05arena = function()
         wager))
 end
 
--- ch05village (#25): does the SOUTH reliquary at (12,19) actually hand over its Dracoshield?
--- Two things this pins, both of which shipped wrong once. First the same failure ch04village
--- exists for: ch05's Location list was EMPTY, so four villages plus an armory and a vendor sat on
--- intact tiles that nothing pointed at -- a finished-looking map with unreachable rewards.
--- Second, WHICH gift: (12,19) is the south-east site and the turn-2 eruption pair spawns beside
--- it, so vanilla puts its richest gift here and its cheapest at (5,1); ours had them swapped,
--- which no other gate can see (same item set, same total, parity still reads PARITY). Checking
--- the Dracoshield specifically -- not "some item" -- is what makes that visible here too.
--- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05village (needs a CH05BOOT=1 ROM).
-scenarios.ch05village = function()
-    local VILLAGE_X, VILLAGE_Y, DRACOSHIELD = 12, 19, 0x60
-    if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
-    pokeFastConfig()
-    waitFor(function() return faction() == 0 and not menuOpen()
-        and not procActive(SYM.ProcScr_StdEventEngine) end, 6000, true)
-    local function shields()
-        local n = 0
-        for _, id in ipairs(collectedItems()) do if id == DRACOSHIELD then n = n + 1 end end
-        return n
-    end
-    local before = shields()
-    log(string.format("ch05village: %d Dracoshield(s) in the party before visiting", before))
-    local ok, why = visitVillage(VILLAGE_X, VILLAGE_Y, function() return shields() > before end)
-    if not ok then return result("FAIL", why) end
-    shot("ch05village")
-    local after = shields()
-    if after <= before then
-        return result("FAIL", string.format(
-            "visited (%d,%d) but the party still holds %d Dracoshield(s) -- the reliquary handed "
-            .. "over nothing (check the tile's terrain AND the Village() entry)",
-            VILLAGE_X, VILLAGE_Y, after))
-    end
-    return result("PASS", string.format(
-        "the south reliquary handed over its Dracoshield: %d -> %d in the party", before, after))
-end
-
 -- ch05raid (#25): can the party LOSE a reliquary? The chapter has declared a village-raid race
 -- since #196 -- "the eruption's dead race the party for the spread reward-sites" -- and for that
 -- whole time nothing on the map could reach one: every wave was `aggressive`, no site carried an
@@ -7378,9 +7231,14 @@ end
 -- nothing (eventinfo.c), which is exactly why a sacked site cannot count toward the save-all.
 -- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05raid (needs a CH05BOOT=1 ROM).
 scenarios.ch05raid = function()
-    local SITE_X, SITE_Y = 12, 19          -- reliquary-south: vanilla's turn-2 pair spawns beside it
-    local VILLAGE_REGULAR, RUINS, DRACOSHIELD = 0x03, 0x25, 0x60
-    local SITE_FLAG = 10                   -- CH05_VILLAGE_FLAGS['reliquary-south']
+    -- reliquary-south, from the chapter chunk: its tile, its gift and its event id were
+    -- three literals here and three more in ch05crest (#314). VILLAGE_REGULAR and RUINS
+    -- stay literals -- they are FE8's terrain ids, not ch05's.
+    local CH05 = dofile(PLAYTEST_DIR .. "/ch05.lua")
+    local SOUTH = CH05.RELIQUARIES[4]
+    local SITE_X, SITE_Y = SOUTH.x, SOUTH.y
+    local VILLAGE_REGULAR, RUINS, DRACOSHIELD = 0x03, 0x25, SOUTH.item
+    local SITE_FLAG = SOUTH.flag
     if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
     pokeFastConfig()
     waitFor(function() return faction() == 0 and not menuOpen()
@@ -7451,13 +7309,12 @@ end
 -- is about the PAYOUT wiring, not about whether the fight is winnable.
 -- Run: PT_HOST_CHAPTER=6 tools/playtest/run.sh ch05crest (needs a CH05BOOT=1 ROM).
 scenarios.ch05crest = function()
-    local SITES = {
-        { name = "north", x = 5,  y = 1,  item = 0x70, flag = 12 },
-        { name = "west",  x = 5,  y = 6,  item = 0x5D, flag = 11 },
-        { name = "east",  x = 12, y = 10, item = 0x0E, flag = 9  },
-        { name = "south", x = 12, y = 19, item = 0x60, flag = 10 },
-    }
-    local RAVISIN, GUIDING_RING = 0xb8, 0x68
+    -- ch05's shared facts, from the chapter's own chunk (#314). Function-scoped, so it
+    -- costs harness.lua no top-level local slot. The four sites were typed here AND in
+    -- ch05reliquaries before the chapter owned them.
+    local CH05 = dofile(PLAYTEST_DIR .. "/ch05.lua")
+    local SITES = CH05.RELIQUARIES
+    local RAVISIN, GUIDING_RING = CH05.PID.RAVISIN, CH05.REWARD.GUIDING_RING
     if not bootToMap() then return result("FAIL", "never reached the ch05 map") end
     pokeFastConfig()
     -- Take the tomb's teeth out for the duration. Saving all four sites scatters four units to
@@ -9183,10 +9040,63 @@ scenarios.recordch02ending = function()
 end
 
 -- ---------------------------------------------------------------- runner
+-- A DECLARED case (#314) has no function here: its chapter YAML declares what it proves,
+-- `declared.py` emits it as a Lua table into the run directory, and cases.lua runs it. The
+-- api table below is the whole interface -- cases.lua never touches emu, SYM or any global
+-- in this chunk, which is what lets test_cases.lua drive it with a fake.
+--
+-- Declared INSIDE the runner coroutine, not beside it: `harness.lua` is one Lua chunk at
+-- Lua's 200-local ceiling, and a top-level `local function` here would spend one of the two
+-- remaining slots on the very mechanism that exists to stop chapters spending them.
 local co = coroutine.create(function()
+  local function runDeclaredCase(path)
+    local api = {
+        bootToMap = bootToMap,
+        fastConfig = pokeFastConfig,
+        collectedItems = collectedItems,
+        eventFlag = eventFlag,
+        result = result,
+        log = log,
+        shot = shot,
+        -- Weak (post-boot) and strong (pre-visit) settle, matching what the hand-written
+        -- preambles actually waited on. The strong one adds `player_map_idle`, which is the
+        -- lesson ch05reliquaries paid for: a location event's tail still holds the
+        -- controller when the item lands, and moving then dies as "cursor could not reach".
+        settle = function(strong)
+            return waitFor(function()
+                return faction() == 0 and not menuOpen()
+                    and not procActive(SYM.ProcScr_StdEventEngine)
+                    and (not strong or controllerState() == "player_map_idle")
+            end, strong and 3000 or 6000, true)
+        end,
+        -- `done` is generic here where a hand-written scenario passed its own item test: the
+        -- step does not know what the case asserts (assertions are order-free), so it stops
+        -- on ANY item arriving and lets the `gained_item` assertion decide whether it was
+        -- the right one. A site that hands over the WRONG item now reads as a wrong item
+        -- rather than as a timeout.
+        visitVillage = function(x, y)
+            local before = 0
+            for _ in ipairs(collectedItems()) do before = before + 1 end
+            return visitVillage(x, y, function()
+                local now = 0
+                for _ in ipairs(collectedItems()) do now = now + 1 end
+                return now ~= before
+            end)
+        end,
+    }
+    return dofile(PLAYTEST_DIR .. "/cases.lua").run(dofile(path), api)
+  end
+
     log("scenario: " .. PLAYTEST_SCENARIO)
     local fn = scenarios[PLAYTEST_SCENARIO]
-    if not fn then return result("ERROR", "unknown scenario " .. tostring(PLAYTEST_SCENARIO)) end
+    if not fn then
+        if PLAYTEST_CASE ~= nil and PLAYTEST_CASE ~= "" then
+            runDeclaredCase(PLAYTEST_CASE)
+            log("declared case returned")
+            return
+        end
+        return result("ERROR", "unknown scenario " .. tostring(PLAYTEST_SCENARIO))
+    end
     fn()
     log("scenario function returned")
 end)

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -143,6 +143,28 @@ class Group(object):
         return '<Group %s x%d>' % (self.rom, len(self.scenarios))
 
 
+def merge_declared(data):
+    """Fold chapter-declared rows and suites into a parsed `matrix.yaml` document."""
+    import declared
+
+    rows, suites = declared.matrix_rows(), declared.matrix_suites()
+    clash = sorted(set(rows) & set(data['scenarios'] or {}))
+    if clash:
+        raise ManifestError(
+            'declared in BOTH a chapter YAML and matrix.yaml: %s -- delete the matrix.yaml '
+            'row, the chapter owns it now (#314)' % ', '.join(clash))
+    data['scenarios'] = dict(data['scenarios'] or {}, **rows)
+    have = data.get('suites') or {}
+    clash = sorted(set(suites) & set(have))
+    if clash:
+        raise ManifestError(
+            'suite(s) %s are DERIVED from the chapter YAML now -- delete the matrix.yaml '
+            'copy, which can only fall behind (#314)' % ', '.join(clash))
+    have.update(suites)
+    data['suites'] = have
+    return data
+
+
 class Manifest(object):
     def __init__(self, data):
         self.defaults = data['defaults']
@@ -154,8 +176,20 @@ class Manifest(object):
 
     @classmethod
     def load(cls, path=None):
+        """The manifest as shipped, PLUS every chapter-declared case (#314).
+
+        A chapter YAML's `playtest:` block derives its own rows and its own suite, so
+        `matrix.yaml` no longer carries a hand-written copy of them. Merging here rather
+        than in `__init__` keeps the synthetic manifests the pure tests build from reaching
+        into the campaign.
+
+        A name in both files RAISES. Silently letting one win would recreate exactly the
+        hand-sync this replaced, with the added twist that which copy ran would depend on
+        merge order -- so the scenario could differ from the one someone was reading.
+        """
         with open(path or MANIFEST) as fh:
-            return cls(yaml.safe_load(fh))
+            data = yaml.safe_load(fh)
+        return cls(merge_declared(data))
 
     # -- resolution ---------------------------------------------------------
 

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -1,11 +1,20 @@
-# The playtest matrix manifest (#231) -- what every scenario in harness.lua needs.
+# The playtest matrix manifest (#231) -- what a scenario needs to run.
 #
 # This is the SINGLE SOURCE of the scenario -> ROM-configuration / host-chapter /
 # checkpoint / timing table. Both consumers read it:
 #   * tools/playtest/run.sh          (one scenario, via `matrix.py resolve`)
 #   * tools/playtest/matrix.py run   (the grouped matrix)
-# `check.py check_playtest_matrix` proves it still describes harness.lua, so a new
-# scenario without a row here is a drift failure, not a silent default.
+# `check.py check_playtest_matrix` proves it still describes what exists, so a new
+# scenario without a row is a drift failure, not a silent default.
+#
+# WHAT IS NOT HERE (#314). A hosted chapter DECLARES its own scenarios, in its own YAML
+# under `playtest:`, and `tools/playtest/declared.py` derives their rows and their chapter
+# suite from that -- the ROM from the chapter's boot, PT_HOST_CHAPTER from the host-slot
+# registry. Those rows are merged in at load time and are deliberately absent from this
+# file: a name declared in both places RAISES rather than letting one copy quietly win.
+# What stays here is everything a chapter does not own -- the spine, the chapter-generic
+# probes, the checkpoint builders, the ROM configurations, the timing classes, and `gate`
+# (which spans chapters by definition, and is bounded by check_gate_chapter_window).
 #
 # Resolution order:  defaults  <  classes (in order, key by key)  <  the scenario's row.
 # That is a direct port of run.sh's `case "$SCENARIO"` statements, including the fact
@@ -171,19 +180,6 @@ scenarios:
     rom: ch03boot
     host_chapter: 4
     kind: record
-  # The same chapter-generic pan, on ch05 -- the review shot for its enemy reskins (#25):
-  # sixteen risen tomb-guard on the real map, which is the only place the four skeleton
-  # sprites can be judged against each other and against the winter tileset.
-  #
-  # `ch05boot`, the same ROM every other ch05 scenario boots, and the scenario pokes FAST
-  # config before booting -- which is what the two timeouts were about. The opening is 52
-  # boxes; at normal text speed that is past the deadline, and `--ch05-moose` was the wrong
-  # answer to it (bootToMap is documented as the wrong driver on that ROM, since there the
-  # beginning script IS the beat).
-  mapfullch05:
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
   recordopening:
     rom: montage
     kind: record
@@ -249,9 +245,6 @@ scenarios:
   smoke_ch03:
     rom: ch03boot
     host_chapter: 4
-  smoke_ch04:
-    rom: ch04boot
-    host_chapter: 5
   ch02:
     checkpoint: ch02start
   smoke_ch02:
@@ -274,137 +267,10 @@ scenarios:
     rom: ch03boot
     host_chapter: 4
     kind: record
-  recordch04moose:
-    rom: ch04boot
-    host_chapter: 5
-    kind: record
-  ch04moose:
-    rom: ch04boot
-    host_chapter: 5
-  ch04sprites:
-    rom: ch04boot
-    host_chapter: 5
-    kind: diagnostic
-  recordch04parley:                                    # asserts the pack converts in place
-    rom: ch04boot
-    host_chapter: 5
-  ch04packmath:
-    rom: ch04boot
-    host_chapter: 5
-  ch04village:
-    rom: ch04boot
-    host_chapter: 5
-  ch04cottage:
-    rom: ch04boot
-    host_chapter: 5
-  recordch04cottage:
-    rom: ch04boot
-    host_chapter: 5
-    kind: record
-  ch05village:
-    rom: ch05boot
-    host_chapter: 6
-  ch05reliquaries:
-    rom: ch05boot
-    host_chapter: 6
-  ch05arena:
-    rom: ch05boot
-    host_chapter: 6
-  ch05recruit:
-    rom: ch05boot
-    host_chapter: 6
-  # The two CHECK_ALIVE states the Talk recruit's no-Lupin branch turns on, and the only two
-  # #25 still owed. Both ride `ch05lupinboot` -- the ONLY ROM with Lupin on the roster at all --
-  # and differ solely in what the harness does to him before the Talk.
-  ch05lupinbenched:
-    rom: ch05lupinboot
-    host_chapter: 6
-  ch05lupinkilled:
-    rom: ch05lupinboot
-    host_chapter: 6
-  ch05raid:
-    rom: ch05boot
-    host_chapter: 6
-  ch05crest:
-    rom: ch05boot
-    host_chapter: 6
-  recordravisin:
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05eruption:
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05ravisindeath:
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05combatquotes:                              # scenes 12 + 13 in one fight (#25)
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05platform:                                  # what they STAND on, on road (#65)
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05recruit:
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05opening:
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05openinglupin:                              # the same film, Lupin's arm (#25)
-    rom: ch05lupinboot
-    host_chapter: 6
-    kind: record
-  recordch05join:                                      # scene 5, AFTER prep (#25)
-    rom: ch05boot
-    host_chapter: 6
-    kind: record
-  recordch05moose:                                     # scene 7 ALONE, on the debug boot (#25)
-    rom: ch05mooseboot
-    host_chapter: 6
-    kind: record
-  recordch05joinlupin:                                 # the same film, Lupin's arm (#25)
-    rom: ch05lupinboot
-    host_chapter: 6
-    kind: record
-  recordch05ending:                                    # scenes 16 A+B+C, on the debug boot (#25)
-    rom: ch05endingboot
-    host_chapter: 6
-    kind: record
-  recordch05endingnosahnar:                            # the same ending, Sahnar never recruited
-    rom: ch05endingnosahnar
-    host_chapter: 6
-    kind: record
-  recordch05endingbasildied:                           # scene 17 -- the ending over Basil's body
-    rom: ch05endingbasildied
-    host_chapter: 6
-    kind: record
-  ch04snag:
-    rom: ch04boot
-    host_chapter: 5
   attackprobe:                                         # reads whatever map it lands on
     rom: any
     host_chapter: null
     kind: diagnostic
-  clear_ch04:
-    rom: ch04boot
-    host_chapter: 5
-  clear_ch04_parley:
-    rom: ch04boot
-    host_chapter: 5
-  recordch04open:
-    rom: ch04boot
-    host_chapter: 5
-    kind: record
-  recordch04reveal:
-    rom: ch04boot
-    host_chapter: 5
-    kind: record
   recordch03talk:
     rom: ch03boot
     host_chapter: 4
@@ -499,28 +365,7 @@ suites:
     - ch03midmap
     - smoke_ch03
 
-  ch04:
-    - ch04moose
-    - ch04packmath
-    - ch04village
-    - ch04cottage
-    - ch04snag
-    - recordch04parley
-    - smoke_ch04
-    - clear_ch04
-    - clear_ch04_parley
 
-  # Was `ch05village` alone -- the chapter suite never picked up the scenarios that landed in
-  # `gate` after it, so "the one you run while working ch05" was the weakest of the five.
-  ch05:
-    - ch05village
-    - ch05reliquaries
-    - ch05arena
-    - ch05recruit
-    - ch05lupinbenched
-    - ch05lupinkilled
-    - ch05raid
-    - ch05crest
 
   sandbox:
     - recordunitlist

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -267,6 +267,17 @@ run_mgba() {
     local out="/tmp/playtest-$scen" log
     log="$out/playtest.log"
     rm -rf "$out" && mkdir -p "$out"
+    # A DECLARED case (#314) has no function in harness.lua: its chapter YAML declares what
+    # it proves and declared.py emits it here, fresh, for every run. Generated into the run
+    # directory rather than committed -- a generated file in the tree is a second copy of the
+    # chapter YAML, and a second copy can be stale.
+    local case=""
+    if python3 "$HERE/declared.py" emit "$scen" > "$out/case.lua" 2>"$out/case.err"; then
+        case="$out/case.lua"
+        echo "case: declared (from the chapter YAML)"
+    else
+        rm -f "$out/case.lua"
+    fi
     local wrapper="$out/wrapper.lua"
     cat > "$wrapper" <<EOF
 PLAYTEST_DIR = "$HERE"
@@ -288,6 +299,7 @@ PLAYTEST_MAXFRAMES = "${PT_MAXFRAMES:-}"
 PLAYTEST_PRESSEVERY = "${PT_PRESSEVERY:-}"
 PLAYTEST_SHOTEVERY = "${PT_SHOTEVERY:-}"
 PLAYTEST_HEADLESS = "$hl"
+PLAYTEST_CASE = "$case"
 dofile("$HERE/harness.lua")
 EOF
     rm -f "$REPO/fireemblem8u/fireemblem8.sav"   # fresh save: New Game is the default path

--- a/tools/playtest/test_cases.lua
+++ b/tools/playtest/test_cases.lua
@@ -27,13 +27,13 @@ local function fakeApi(opts)
     opts = opts or {}
     local items = {}
     for _, id in ipairs(opts.items or {}) do items[#items + 1] = id end
-    local a = {verdict = nil, reason = nil, log = {}, visits = {}, booted = false, settled = 0}
+    local a = {verdict = nil, reason = nil, logged = {}, visits = {}, booted = false, settled = 0}
     a.bootToMap = function() a.booted = true; return opts.boot ~= false end
     a.fastConfig = function() a.fast = true end
     a.settle = function() a.settled = a.settled + 1; return opts.settle ~= false end
     a.collectedItems = function() return items end
     a.eventFlag = function(id) return (opts.flags or {})[id] == true end
-    a.log = function(s) a.log[#a.log + 1] = s end
+    a.log = function(s) a.logged[#a.logged + 1] = s end
     a.shot = function() end
     a.result = function(v, why) a.verdict, a.reason = v, why; return v end
     a.visitVillage = function(x, y)
@@ -175,6 +175,71 @@ do
            ["then"] = {{gained_item = 1}}}, api)
     check(api.verdict, "FAIL", "a map that never settles FAILs")
     contains(api.reason, "player control", "the reason blames the settle, not the visit")
+end
+
+-- A door that hands over ANOTHER door's gift must FAIL. This is the whole reason the gift
+-- rides the step: the gifts are per-tile on purpose, so "some item arrived" is not the
+-- assertion. Rotating the four gifts passed under a whole-case `gained_item` list -- every
+-- id still arrived, just from the wrong door -- which is the defect ch05reliquaries was
+-- written to catch in the first place.
+do
+    local api = fakeApi({visits = {{gives = 0x5D}, {gives = 0x0E}, {gives = 0x60}, {gives = 0x70}}})
+    C.run({name = "ch05reliquaries", given = {"on_map"},
+           ["when"] = {{visit = {x = 5, y = 1, gains = 0x70}},
+                       {visit = {x = 5, y = 6, gains = 0x5D}},
+                       {visit = {x = 12, y = 10, gains = 0x0E}},
+                       {visit = {x = 12, y = 19, gains = 0x60}}},
+           ["then"] = {{spoke = true}}}, api)
+    check(api.verdict, "FAIL", "four doors handing over each other's gifts FAILs")
+    contains(api.reason, "(5,1)", "the reason names the FIRST door that gave the wrong gift")
+    contains(api.reason, "0x70", "the reason names the gift that door owed")
+end
+
+-- The matching happy path: each door gives its own.
+do
+    local api = fakeApi({visits = {{gives = 0x70}, {gives = 0x5D}, {gives = 0x0E}, {gives = 0x60}}})
+    C.run({name = "ch05reliquaries", given = {"on_map"},
+           ["when"] = {{visit = {x = 5, y = 1, gains = 0x70}},
+                       {visit = {x = 5, y = 6, gains = 0x5D}},
+                       {visit = {x = 12, y = 10, gains = 0x0E}},
+                       {visit = {x = 12, y = 19, gains = 0x60}}},
+           ["then"] = {{spoke = true}}}, api)
+    check(api.verdict, "PASS", "each door handing over its own gift PASSes")
+end
+
+-- A step-borne assertion COUNTS as an assertion: a case with `gains` and no `then` is not
+-- the vacuous case the ERROR is for.
+do
+    local api = fakeApi({visits = {{gives = 0x60}}})
+    C.run({name = "ch05village", given = {"on_map"},
+           ["when"] = {{visit = {x = 12, y = 19, gains = 0x60}}}, ["then"] = {}}, api)
+    check(api.verdict, "PASS", "a `gains` step is an assertion, so `then` may be empty")
+end
+
+-- ...but a case with neither still cannot pass.
+do
+    local api = fakeApi({visits = {{gives = 0x60}}})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 1, y = 1}}},
+           ["then"] = {}}, api)
+    check(api.verdict, "ERROR", "no `then` and no step assertion is still an ERROR")
+end
+
+-- A malformed entry is an ERROR with a readable reason, not an uncaught Lua error inside
+-- pairs(). `- spoke` instead of `- spoke: true` is the typo this catches.
+do
+    local api = fakeApi({visits = {{gives = 1}}})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 1, y = 1, gains = 1}}},
+           ["then"] = {"spoke"}}, api)
+    check(api.verdict, "ERROR", "a bare string in `then` is an ERROR verdict, not a crash")
+    contains(api.reason, "single-key mapping", "the reason explains the shape it wanted")
+end
+
+-- A `visit` whose argument is not a coordinate table fails cleanly too.
+do
+    local api = fakeApi({})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = "south"}},
+           ["then"] = {{spoke = true}}}, api)
+    check(api.verdict, "FAIL", "a non-table visit argument FAILs rather than crashing")
 end
 
 print(string.format("%d checks, %d failures", tests, fails))

--- a/tools/playtest/test_cases.lua
+++ b/tools/playtest/test_cases.lua
@@ -1,0 +1,181 @@
+-- Tests for cases.lua -- the declarative playtest case driver (#314, no emulator).
+-- The driver is pure with respect to the game: everything it touches arrives on the `api`
+-- table, so a fake api is a complete test double.
+-- Run: lua tools/playtest/test_cases.lua
+local here = (arg[0]:match("(.*/)")) or "./"
+local C = dofile(here .. "cases.lua")
+
+local tests, fails = 0, 0
+local function check(got, want, msg)
+    tests = tests + 1
+    if got ~= want then
+        fails = fails + 1
+        print(string.format("FAIL: %s\n  got  %s\n  want %s", msg, tostring(got), tostring(want)))
+    end
+end
+local function contains(hay, needle, msg)
+    tests = tests + 1
+    if not tostring(hay):find(needle, 1, true) then
+        fails = fails + 1
+        print(string.format("FAIL: %s\n  %q does not contain %q", msg, tostring(hay), needle))
+    end
+end
+
+-- A fake api. `script` decides what each visit does: it returns ok, why, spoke and may add
+-- items to the party, exactly as visitVillage does against the real engine.
+local function fakeApi(opts)
+    opts = opts or {}
+    local items = {}
+    for _, id in ipairs(opts.items or {}) do items[#items + 1] = id end
+    local a = {verdict = nil, reason = nil, log = {}, visits = {}, booted = false, settled = 0}
+    a.bootToMap = function() a.booted = true; return opts.boot ~= false end
+    a.fastConfig = function() a.fast = true end
+    a.settle = function() a.settled = a.settled + 1; return opts.settle ~= false end
+    a.collectedItems = function() return items end
+    a.eventFlag = function(id) return (opts.flags or {})[id] == true end
+    a.log = function(s) a.log[#a.log + 1] = s end
+    a.shot = function() end
+    a.result = function(v, why) a.verdict, a.reason = v, why; return v end
+    a.visitVillage = function(x, y)
+        a.visits[#a.visits + 1] = {x = x, y = y}
+        local step = (opts.visits or {})[#a.visits] or {}
+        if step.gives then items[#items + 1] = step.gives end
+        return step.ok ~= false, step.why or "refused", step.spoke ~= false
+    end
+    return a
+end
+
+-- The happy path: ch05village's shape end to end.
+do
+    local api = fakeApi({visits = {{gives = 0x60}}})
+    local case = {name = "ch05village", given = {"on_map"},
+                  ["when"] = {{visit = {x = 12, y = 19}}},
+                  ["then"] = {{gained_item = 0x60}}}
+    C.run(case, api)
+    check(api.verdict, "PASS", "a satisfied case PASSes")
+    check(api.booted, true, "`on_map` boots to the map")
+    check(api.fast, true, "`on_map` pokes fast text")
+    check(#api.visits, 1, "one visit step ran")
+    check(api.visits[1].x, 12, "the visit used the declared x")
+    check(api.visits[1].y, 19, "the visit used the declared y")
+end
+
+-- The item never arrives: the case must FAIL, and say which item.
+do
+    local api = fakeApi({visits = {{}}})       -- visit succeeds, hands over nothing
+    C.run({name = "ch05village", given = {"on_map"}, ["when"] = {{visit = {x = 12, y = 19}}},
+           ["then"] = {{gained_item = 0x60}}}, api)
+    check(api.verdict, "FAIL", "an unmet gained_item FAILs")
+    contains(api.reason, "0x60", "the reason names the item that never arrived")
+end
+
+-- An item the party ALREADY held does not count: the assertion is that the case GAINED it.
+-- Without this, ch05village would pass on a chapter whose reliquary hands over nothing at
+-- all, so long as anyone in the party happened to be carrying a Dracoshield.
+do
+    local api = fakeApi({items = {0x60}, visits = {{}}})
+    C.run({name = "ch05village", given = {"on_map"}, ["when"] = {{visit = {x = 12, y = 19}}},
+           ["then"] = {{gained_item = 0x60}}}, api)
+    check(api.verdict, "FAIL", "an item held BEFORE the case does not satisfy gained_item")
+end
+
+-- A second copy of an item the party already held DOES count.
+do
+    local api = fakeApi({items = {0x60}, visits = {{gives = 0x60}}})
+    C.run({name = "ch05village", given = {"on_map"}, ["when"] = {{visit = {x = 12, y = 19}}},
+           ["then"] = {{gained_item = 0x60}}}, api)
+    check(api.verdict, "PASS", "gained_item counts copies, not presence")
+end
+
+-- ch05reliquaries: four visits, four items, and `spoke` covering all of them.
+do
+    local api = fakeApi({visits = {{gives = 0x70}, {gives = 0x5D}, {gives = 0x0E}, {gives = 0x60}}})
+    C.run({name = "ch05reliquaries", given = {"on_map"},
+           ["when"] = {{visit = {x = 5, y = 1}}, {visit = {x = 5, y = 6}},
+                       {visit = {x = 12, y = 10}}, {visit = {x = 12, y = 19}}},
+           ["then"] = {{gained_item = 0x70}, {gained_item = 0x5D}, {gained_item = 0x0E},
+                       {gained_item = 0x60}, {spoke = true}}}, api)
+    check(api.verdict, "PASS", "all four reliquaries satisfied")
+    check(#api.visits, 4, "four visit steps ran")
+    -- 5, not 4: `on_map` settles once after the boot, and each visit settles again
+    -- before it moves. That is exactly what the hand-written ch05reliquaries does.
+    check(api.settled, 5, "the map settles after the boot and before every visit")
+end
+
+-- A door that pays out in SILENCE fails `spoke`, and the reason names which one.
+do
+    local api = fakeApi({visits = {{gives = 0x70}, {gives = 0x5D, spoke = false},
+                                   {gives = 0x0E}, {gives = 0x60}}})
+    C.run({name = "ch05reliquaries", given = {"on_map"},
+           ["when"] = {{visit = {x = 5, y = 1}}, {visit = {x = 5, y = 6}},
+                       {visit = {x = 12, y = 10}}, {visit = {x = 12, y = 19}}},
+           ["then"] = {{gained_item = 0x70}, {spoke = true}}}, api)
+    check(api.verdict, "FAIL", "a silent payout FAILs")
+    contains(api.reason, "(5,6)", "the reason names the silent door's tile")
+end
+
+-- Boot failure is a FAIL with a reason about the BOOT, not a confusing assertion error.
+do
+    local api = fakeApi({boot = false})
+    C.run({name = "ch05village", given = {"on_map"}, ["when"] = {{visit = {x = 1, y = 1}}},
+           ["then"] = {{gained_item = 0x60}}}, api)
+    check(api.verdict, "FAIL", "a failed boot FAILs")
+    contains(api.reason, "never reached", "the reason blames the boot")
+    check(#api.visits, 0, "no step runs after a failed boot")
+end
+
+-- An unknown step or assertion is an ERROR, never a skip. A case that silently ignored a
+-- word it did not know would report coverage it does not have -- the same failure class as
+-- a case with no steps passing vacuously.
+do
+    local api = fakeApi({})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{teleport = {x = 1}}},
+           ["then"] = {{gained_item = 1}}}, api)
+    check(api.verdict, "ERROR", "an unknown step is an ERROR")
+    contains(api.reason, "teleport", "the reason names the unknown step")
+end
+do
+    local api = fakeApi({visits = {{gives = 1}}})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 1, y = 1}}},
+           ["then"] = {{unit_is_purple = true}}}, api)
+    check(api.verdict, "ERROR", "an unknown assertion is an ERROR")
+    contains(api.reason, "unit_is_purple", "the reason names the unknown assertion")
+end
+do
+    local api = fakeApi({})
+    C.run({name = "x", given = {"levitate"}, ["when"] = {}, ["then"] = {}}, api)
+    check(api.verdict, "ERROR", "an unknown given is an ERROR")
+end
+
+-- A case with no assertions cannot PASS. Vacuous green is worse than red: it reports
+-- coverage that does not exist.
+do
+    local api = fakeApi({visits = {{gives = 1}}})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 1, y = 1}}},
+           ["then"] = {}}, api)
+    check(api.verdict, "ERROR", "a case asserting nothing is an ERROR, not a PASS")
+end
+
+-- event_flag, for the save-all payout shape (ch05crest's half that is declarable).
+do
+    local api = fakeApi({visits = {{gives = 1}}, flags = {[12] = true}})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 5, y = 1}}},
+           ["then"] = {{event_flag = 12}}}, api)
+    check(api.verdict, "PASS", "a set event flag satisfies event_flag")
+    api = fakeApi({visits = {{gives = 1}}, flags = {}})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 5, y = 1}}},
+           ["then"] = {{event_flag = 12}}}, api)
+    check(api.verdict, "FAIL", "an unset event flag FAILs")
+end
+
+-- The map failing to return to player control before a visit is its own reason.
+do
+    local api = fakeApi({settle = false})
+    C.run({name = "x", given = {"on_map"}, ["when"] = {{visit = {x = 5, y = 1}}},
+           ["then"] = {{gained_item = 1}}}, api)
+    check(api.verdict, "FAIL", "a map that never settles FAILs")
+    contains(api.reason, "player control", "the reason blames the settle, not the visit")
+end
+
+print(string.format("%d checks, %d failures", tests, fails))
+os.exit(fails == 0 and 0 or 1)

--- a/tools/test_check_declared.py
+++ b/tools/test_check_declared.py
@@ -15,7 +15,9 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import check                                            # noqa: E402
 
-CLEAN_LUA = 'local M = {}\nM.WHEN.visit = function(api, arg) return api.visitVillage(arg.x) end\n'
+CLEAN = {'tools/playtest/cases.lua':
+         'local M = {}\nM.WHEN.visit = function(api, arg) return api.visitVillage(arg.x) end\n',
+         "harness.lua's declared-case api adapter": 'local api = {shot = shot}\n'}
 VILLAGES = {'ch05': [[5, 1], [5, 6], [12, 10], [12, 19]]}
 
 
@@ -28,40 +30,74 @@ def case(**over):
 
 class TestVisitTilesMatchTheChapter(unittest.TestCase):
     def test_a_declared_village_tile_is_clean(self):
-        self.assertEqual(check._declared_case_violations(case(), VILLAGES, CLEAN_LUA), [])
+        self.assertEqual(check._declared_case_violations(case(), VILLAGES, CLEAN), [])
 
     def test_a_tile_the_chapter_declares_no_village_at_is_reported(self):
         bad = case(when=[{'visit': {'x': 12, 'y': 18}}])      # off by one row
-        found = check._declared_case_violations(bad, VILLAGES, CLEAN_LUA)
+        found = check._declared_case_violations(bad, VILLAGES, CLEAN)
         self.assertEqual(len(found), 1, found)
         self.assertIn('(12,18)', found[0])
 
     def test_every_bad_step_is_reported_not_just_the_first(self):
         bad = case(when=[{'visit': {'x': 0, 'y': 0}}, {'visit': {'x': 1, 'y': 1}}])
-        self.assertEqual(len(check._declared_case_violations(bad, VILLAGES, CLEAN_LUA)), 2)
+        self.assertEqual(len(check._declared_case_violations(bad, VILLAGES, CLEAN)), 2)
 
     def test_a_non_visit_step_is_not_checked_against_villages(self):
         self.assertEqual(
-            check._declared_case_violations(case(when=[{'end_turn': True}]), VILLAGES, CLEAN_LUA),
+            check._declared_case_violations(case(when=[{'end_turn': True}]), VILLAGES, CLEAN),
             [])
 
     def test_a_malformed_step_is_reported_rather_than_crashing(self):
         bad = case(when=[{'visit': {'x': 1}, 'spoke': True}])   # two keys
-        found = check._declared_case_violations(bad, VILLAGES, CLEAN_LUA)
+        found = check._declared_case_violations(bad, VILLAGES, CLEAN)
         self.assertEqual(len(found), 1, found)
         self.assertIn('single-key', found[0])
+
+    def test_a_non_mapping_visit_argument_does_not_abort_the_whole_lint(self):
+        # `- visit: south` reached arg.get() and raised AttributeError. main() calls the
+        # checks unguarded, so one typo aborted the drift gate and every check after this
+        # one never ran -- a lint that fails OPEN.
+        found = check._declared_case_violations(case(when=[{'visit': 'south'}]), VILLAGES, CLEAN)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('mapping with x and y', found[0])
+
+    def test_a_malformed_then_entry_is_reported(self):
+        # `- spoke` instead of `- spoke: true` linted clean and then died inside mGBA.
+        found = check._declared_case_violations(case(then=['spoke']), VILLAGES, CLEAN)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('single-key mapping', found[0])
 
 
 class TestTheDriverStaysGuarded(unittest.TestCase):
     def test_a_clean_driver_is_clean(self):
-        self.assertEqual(check._declared_case_violations(case(), VILLAGES, CLEAN_LUA), [])
+        self.assertEqual(check._declared_case_violations(case(), VILLAGES, CLEAN), [])
 
     def test_a_raw_press_in_the_driver_is_reported(self):
         # One blind press here un-guards EVERY declared case at once, not one of them.
-        dirty = CLEAN_LUA + 'M.WHEN.mash = function(api) press(api.K.A, 4) end\n'
+        dirty = dict(CLEAN)
+        dirty['tools/playtest/cases.lua'] += 'M.WHEN.mash = function(api) press(1, 4) end\n'
         found = check._declared_case_violations(case(), VILLAGES, dirty)
         self.assertEqual(len(found), 1, found)
         self.assertIn('raw press()', found[0])
+
+    def test_a_raw_press_in_the_API_ADAPTER_is_reported(self):
+        """The adapter lives inside harness.lua's runner coroutine, so `harness_functions`
+        attributes it to the preceding `record` scenario and the blind-press gate skips it.
+        It is every declared case's only route to the game, so it gets checked by name."""
+        dirty = dict(CLEAN)
+        dirty["harness.lua's declared-case api adapter"] += 'press(1, 4)\n'
+        found = check._declared_case_violations(case(), VILLAGES, dirty)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('api adapter', found[0])
+
+    def test_the_adapter_is_actually_found_in_the_live_harness(self):
+        """If the carve-out stops matching, the check silently reviews nothing."""
+        import os
+        with open(os.path.join(check.REPO, 'tools/playtest/harness.lua'), encoding='utf-8') as fh:
+            adapter = check._declared_api_adapter(fh.read())
+        self.assertIsNotNone(adapter)
+        self.assertIn('visitVillage', adapter, 'the carve-out must cover the real api table')
+        self.assertLess(len(adapter), 4000, 'the carve-out has run past the adapter')
 
 
 class TestTheShippedCasesAreClean(unittest.TestCase):

--- a/tools/test_check_declared.py
+++ b/tools/test_check_declared.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for check.py's chapter-declared playtest case guards (#314).
+
+The pure half (`_declared_case_violations`) is tested here against synthetic inputs, the
+same split test_check_chapter_schema.py uses. A guard is asserted in BOTH directions --
+clean input produces nothing, bad input produces the finding -- because a guard that cannot
+fail is not a guard, and this repo has shipped one of those before.
+
+Run: python3 tools/test_check_declared.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check                                            # noqa: E402
+
+CLEAN_LUA = 'local M = {}\nM.WHEN.visit = function(api, arg) return api.visitVillage(arg.x) end\n'
+VILLAGES = {'ch05': [[5, 1], [5, 6], [12, 10], [12, 19]]}
+
+
+def case(**over):
+    c = {'name': 'ch05village', 'proves': 'x',
+         'when': [{'visit': {'x': 12, 'y': 19}}], 'then': [{'gained_item': 0x60}]}
+    c.update(over)
+    return [('ch05', c)]
+
+
+class TestVisitTilesMatchTheChapter(unittest.TestCase):
+    def test_a_declared_village_tile_is_clean(self):
+        self.assertEqual(check._declared_case_violations(case(), VILLAGES, CLEAN_LUA), [])
+
+    def test_a_tile_the_chapter_declares_no_village_at_is_reported(self):
+        bad = case(when=[{'visit': {'x': 12, 'y': 18}}])      # off by one row
+        found = check._declared_case_violations(bad, VILLAGES, CLEAN_LUA)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('(12,18)', found[0])
+
+    def test_every_bad_step_is_reported_not_just_the_first(self):
+        bad = case(when=[{'visit': {'x': 0, 'y': 0}}, {'visit': {'x': 1, 'y': 1}}])
+        self.assertEqual(len(check._declared_case_violations(bad, VILLAGES, CLEAN_LUA)), 2)
+
+    def test_a_non_visit_step_is_not_checked_against_villages(self):
+        self.assertEqual(
+            check._declared_case_violations(case(when=[{'end_turn': True}]), VILLAGES, CLEAN_LUA),
+            [])
+
+    def test_a_malformed_step_is_reported_rather_than_crashing(self):
+        bad = case(when=[{'visit': {'x': 1}, 'spoke': True}])   # two keys
+        found = check._declared_case_violations(bad, VILLAGES, CLEAN_LUA)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('single-key', found[0])
+
+
+class TestTheDriverStaysGuarded(unittest.TestCase):
+    def test_a_clean_driver_is_clean(self):
+        self.assertEqual(check._declared_case_violations(case(), VILLAGES, CLEAN_LUA), [])
+
+    def test_a_raw_press_in_the_driver_is_reported(self):
+        # One blind press here un-guards EVERY declared case at once, not one of them.
+        dirty = CLEAN_LUA + 'M.WHEN.mash = function(api) press(api.K.A, 4) end\n'
+        found = check._declared_case_violations(case(), VILLAGES, dirty)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('raw press()', found[0])
+
+
+class TestTheShippedCasesAreClean(unittest.TestCase):
+    def test_the_real_chapter_yaml_passes_both_guards(self):
+        fail = []
+        check.check_declared_cases(fail)
+        self.assertEqual(fail, [])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tools/test_playtest_declared.py
+++ b/tools/test_playtest_declared.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Tests for tools/playtest/declared.py -- chapter-declared playtest cases (#314).
+
+Two layers, the same split test_playtest_matrix.py uses:
+
+  * the PURE layer runs against synthetic chapter documents, so a test never reads the
+    campaign, builds a ROM or launches mGBA;
+  * the REAL-DATA layer asserts the shipped chapter YAML derives rows byte-identical to
+    the hand-written `matrix.yaml` rows they replaced. That oracle is the whole proof
+    that this is a DERIVATION and not a rewrite -- see PORTED_ORACLE below.
+
+Run:
+
+    python3 tools/test_playtest_declared.py
+"""
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, 'playtest'))
+import declared                                        # noqa: E402
+
+
+def chapter(**over):
+    """A minimal chapter document carrying a `playtest:` block."""
+    doc = {
+        'id': 'ch05-the-elven-tomb',
+        'chapter_number': 5,
+        'playtest': {
+            'boot': 'ch05boot',
+            'cases': [{
+                'name': 'ch05village',
+                'proves': 'the south reliquary hands over its Dracoshield',
+                'given': ['on_map'],
+                'when': [{'visit': {'x': 12, 'y': 19}}],
+                'then': [{'gained_item': 0x60}],
+            }],
+        },
+    }
+    doc.update(over)
+    return doc
+
+
+class TestRowDerivation(unittest.TestCase):
+    """A case declares WHAT IT PROVES; every mechanical field is derived."""
+
+    def test_rom_comes_from_the_chapter_boot(self):
+        rows = declared.matrix_rows([chapter()], slots={'ch05': 6})
+        self.assertEqual(rows['ch05village']['rom'], 'ch05boot')
+
+    def test_host_chapter_comes_from_the_host_registry_not_the_chapter_number(self):
+        # ch05 is chapter 5 and rides host slot 6. Deriving PT_HOST_CHAPTER from the
+        # chapter NUMBER would boot slot 5 -- ch04's -- and every ch05 case would assert
+        # against the wrong map while looking perfectly well-formed (inject/hosts.py:
+        # from slot 6 on, vanilla's slot index leads the chapter number by one).
+        rows = declared.matrix_rows([chapter()], slots={'ch05': 6})
+        self.assertEqual(rows['ch05village']['host_chapter'], 6)
+
+    def test_kind_defaults_to_verdict_and_is_declarable(self):
+        rows = declared.matrix_rows([chapter()], slots={'ch05': 6})
+        self.assertEqual(rows['ch05village']['kind'], 'verdict')
+        doc = chapter()
+        doc['playtest']['cases'][0]['kind'] = 'record'
+        rows = declared.matrix_rows([doc], slots={'ch05': 6})
+        self.assertEqual(rows['ch05village']['kind'], 'record')
+
+    def test_a_case_may_override_the_chapter_boot(self):
+        # ch05lupinbenched rides ch05lupinboot -- the only ROM with Lupin on the roster.
+        doc = chapter()
+        doc['playtest']['cases'][0]['boot'] = 'ch05lupinboot'
+        rows = declared.matrix_rows([doc], slots={'ch05': 6})
+        self.assertEqual(rows['ch05village']['rom'], 'ch05lupinboot')
+
+    def test_a_case_with_no_name_is_an_error_not_a_silent_skip(self):
+        doc = chapter()
+        del doc['playtest']['cases'][0]['name']
+        with self.assertRaises(declared.CaseError):
+            declared.matrix_rows([doc], slots={'ch05': 6})
+
+    def test_an_unhosted_chapter_is_an_error(self):
+        # A chapter with no slot in inject/hosts.py cannot be booted at all, so a case on
+        # it would inherit host_chapter 1 and silently assert against the prologue.
+        with self.assertRaises(declared.CaseError):
+            declared.matrix_rows([chapter()], slots={})
+
+    def test_a_chapter_with_no_playtest_block_declares_nothing(self):
+        self.assertEqual(declared.matrix_rows([{'id': 'ch09-x', 'chapter_number': 9}],
+                                              slots={'ch09': 10}), {})
+
+
+class TestSuiteDerivation(unittest.TestCase):
+    """The chapter suite stops being hand-kept.
+
+    HANDOFF recorded ch05's suite as "the weakest of the five" because scenarios landed in
+    `gate` and nobody back-filled `suites: ch05`. A derived suite cannot fall behind.
+    """
+
+    def test_the_chapter_suite_is_every_declared_verdict_case(self):
+        doc = chapter()
+        doc['playtest']['cases'].append({
+            'name': 'recordch05opening', 'proves': 'x', 'kind': 'record', 'lua': 'recordch05opening'})
+        suites = declared.matrix_suites([doc], slots={'ch05': 6})
+        self.assertEqual(suites['ch05'], ['ch05village'])
+
+
+class TestEscapeHatch(unittest.TestCase):
+    """Code is the exception you NAME, not the default you copy (the DECORATE lesson)."""
+
+    def test_a_lua_case_still_derives_every_mechanical_field(self):
+        doc = chapter()
+        doc['playtest']['cases'] = [{'name': 'ch05arena', 'proves': 'the arena is one-shot',
+                                     'lua': 'ch05arena'}]
+        rows = declared.matrix_rows([doc], slots={'ch05': 6})
+        self.assertEqual(rows['ch05arena']['rom'], 'ch05boot')
+        self.assertEqual(rows['ch05arena']['host_chapter'], 6)
+
+    def test_a_case_may_not_be_both_declared_and_lua(self):
+        doc = chapter()
+        doc['playtest']['cases'][0]['lua'] = 'ch05village'
+        with self.assertRaises(declared.CaseError):
+            declared.matrix_rows([doc], slots={'ch05': 6})
+
+    def test_a_case_must_be_one_or_the_other(self):
+        doc = chapter()
+        doc['playtest']['cases'] = [{'name': 'ch05village', 'proves': 'x'}]
+        with self.assertRaises(declared.CaseError):
+            declared.matrix_rows([doc], slots={'ch05': 6})
+
+
+class TestSubsumption(unittest.TestCase):
+    """"Is A already covered by B" becomes computable once a case is DATA (#302 gate work).
+
+    It was previously answerable only by a human reading two Lua functions, which is how
+    ch05village sat in the merge gate fully covered by ch05reliquaries.
+    """
+
+    BIG = {'name': 'big', 'proves': 'x', 'boot': 'ch05boot', 'given': ['on_map'],
+           'when': [{'visit': {'x': 5, 'y': 1}}, {'visit': {'x': 12, 'y': 19}}],
+           'then': [{'gained_item': 0x70}, {'gained_item': 0x60}]}
+    SMALL = {'name': 'small', 'proves': 'x', 'boot': 'ch05boot', 'given': ['on_map'],
+             'when': [{'visit': {'x': 12, 'y': 19}}], 'then': [{'gained_item': 0x60}]}
+
+    def test_a_superset_subsumes_a_subset(self):
+        self.assertTrue(declared.subsumes(self.BIG, self.SMALL))
+
+    def test_a_subset_does_not_subsume_its_superset(self):
+        self.assertFalse(declared.subsumes(self.SMALL, self.BIG))
+
+    def test_a_case_does_not_subsume_itself(self):
+        self.assertFalse(declared.subsumes(self.BIG, self.BIG))
+
+    def test_a_different_boot_is_never_subsumed(self):
+        # ch05lupinbenched and ch05recruit walk the same tiles on DIFFERENT ROMs -- the
+        # whole point of the pair. Ignoring the boot would delete the only run that ever
+        # walks the Lupin arm.
+        other = dict(self.SMALL, boot='ch05lupinboot')
+        self.assertFalse(declared.subsumes(self.BIG, other))
+
+    def test_an_assertion_the_bigger_case_does_not_make_blocks_it(self):
+        other = dict(self.SMALL, then=[{'gained_item': 0x60}, {'spoke': True}])
+        self.assertFalse(declared.subsumes(self.BIG, other))
+
+    def test_an_opaque_lua_case_is_never_compared(self):
+        # Guessing what a hand-written body covers is exactly the derived claim not to make.
+        self.assertFalse(declared.subsumes(self.BIG, {'name': 'l', 'proves': 'x',
+                                                      'boot': 'ch05boot', 'lua': 'l'}))
+        self.assertFalse(declared.subsumes({'name': 'l', 'proves': 'x', 'boot': 'ch05boot',
+                                            'lua': 'l'}, self.SMALL))
+
+    def test_repeated_steps_are_counted_not_merely_present(self):
+        twice = dict(self.SMALL, when=[{'visit': {'x': 12, 'y': 19}},
+                                       {'visit': {'x': 12, 'y': 19}}])
+        self.assertFalse(declared.subsumes(self.BIG, twice),
+                         'one visit cannot cover two')
+
+    def test_the_shipped_campaign_reports_the_known_redundancy(self):
+        pairs = declared.subsumed_pairs()
+        self.assertIn(('ch05reliquaries', 'ch05village', 'ch05'), pairs)
+
+
+# What the three ported scenarios resolved to BEFORE the port, read off the shipped
+# matrix.yaml at d4aeafc. The derivation has to reproduce these exactly: that is gate one
+# of the two the port is held to (the other is a real mGBA run, diffed against its
+# pre-port log). A hand-written oracle rather than a captured snapshot, so a wrong
+# derivation cannot quietly re-bless itself.
+PORTED_ORACLE = {
+    'ch04village':     {'rom': 'ch04boot', 'host_chapter': 5, 'kind': 'verdict'},
+    'ch05village':     {'rom': 'ch05boot', 'host_chapter': 6, 'kind': 'verdict'},
+    'ch05reliquaries': {'rom': 'ch05boot', 'host_chapter': 6, 'kind': 'verdict'},
+}
+
+
+class TestPortedScenariosResolveIdentically(unittest.TestCase):
+    def test_the_derivation_reproduces_the_hand_written_rows(self):
+        rows = declared.matrix_rows()
+        for name, want in sorted(PORTED_ORACLE.items()):
+            self.assertIn(name, rows, '%s is no longer chapter-declared' % name)
+            for field, value in sorted(want.items()):
+                self.assertEqual(rows[name][field], value,
+                                 '%s.%s drifted from the row it replaced' % (name, field))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tools/test_playtest_harness.py
+++ b/tools/test_playtest_harness.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression coverage for state-driven playtest scenario wiring."""
 import os
+import sys
 import re
 import unittest
 
@@ -184,7 +185,7 @@ class TestPlaytestHarness(unittest.TestCase):
 
     def test_ch05arena_proves_the_loaded_winter_palette_and_skeleton_face(self):
         harness = _read_harness()
-        body = _block(harness, 'scenarios.ch05arena = function()', '\n-- ch05village')
+        body = _block(harness, 'scenarios.ch05arena = function()', '\nend')
         self.assertIn('SYM.gFaces', body)
         self.assertIn('ru16(face + 0x3E) == 0x4B', body,
                       'the live Arena face proc must carry the chapter-selected Glen FID')
@@ -267,13 +268,13 @@ class TestPlaytestHarness(unittest.TestCase):
         self.assertIn('boxes == 1', body,
                       'the focused proof must require exactly the one locked death box')
 
-        matrix = os.path.join(REPO, 'tools/playtest/matrix.yaml')
-        with open(matrix, encoding='utf-8') as source:
-            registry = source.read()
-        self.assertIn('  recordch05ravisindeath:\n'
-                      '    rom: ch05boot\n'
-                      '    host_chapter: 6\n'
-                      '    kind: record\n', registry)
+        # The row is DERIVED from ch05's chapter YAML now (#314), so this asserts the
+        # resolved row rather than matrix.yaml's text: it checks the value the runner
+        # actually uses, and it keeps holding wherever the declaration lives.
+        sys.path.insert(0, os.path.join(REPO, 'tools', 'playtest'))
+        import matrix as mx
+        row = mx.Manifest.load().resolve('recordch05ravisindeath')
+        self.assertEqual((row.rom, row.host_chapter, row.kind), ('ch05boot', 6, 'record'))
 
     def test_ch04snag_accepts_the_native_fallen_snag_crossing(self):
         harness = _read_harness()

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -448,8 +448,29 @@ class RealManifest(unittest.TestCase):
                       'the gate must walk the arm ch05recruit cannot reach')
 
     def test_every_manifest_row_still_exists_in_harness(self):
-        stale = sorted(set(self.m.scenarios) - self.harness)
-        self.assertEqual(stale, [], 'matrix.yaml rows for scenarios harness.lua no longer defines')
+        """Every row still names something runnable -- a harness function, or a chapter-
+        declared case (#314).
+
+        A chapter-declared case has no function in harness.lua by design: its body is the
+        chapter YAML's given/when/then and cases.lua runs it. The guard keeps its teeth for
+        everything else, including a `lua:` case whose named function has been deleted --
+        that one IS stale, and it is the failure this test was written for.
+        """
+        import declared
+        bodies = {c['name'] for _s, c in declared.cases() if 'lua' not in c}
+        stale = sorted(set(self.m.scenarios) - self.harness - bodies)
+        self.assertEqual(stale, [], 'matrix rows naming nothing runnable')
+
+    def test_a_declared_case_body_is_the_chapter_yaml_not_a_dead_row(self):
+        """The complement: the three ported cases resolve, and harness.lua does NOT define
+        them. Without this, deleting the derivation would make the test above vacuous."""
+        import declared
+        bodies = {c['name'] for _s, c in declared.cases() if 'lua' not in c}
+        for name in ('ch04village', 'ch05village', 'ch05reliquaries'):
+            self.assertIn(name, bodies, '%s is no longer chapter-declared' % name)
+            self.assertNotIn(name, self.harness,
+                             '%s is declared AND hand-written -- two bodies, one name' % name)
+            self.m.resolve(name)
 
     def test_every_scenario_resolves(self):
         for name in self.m.scenarios:


### PR DESCRIPTION
Child of #302 — the keystone one. Closes #314.

## What changed

A chapter YAML declares what its scenarios **prove**; everything mechanical is derived (`tools/playtest/declared.py`). **37 rows and two hand-written suites left `matrix.yaml`.** A name declared in both files **raises** rather than letting one copy quietly win.

```yaml
playtest:
  boot: ch05boot                 # host slot 6 comes from inject/hosts.py
  cases:
    - name: ch05village
      proves: the south reliquary hands over its Dracoshield
      given: [on_map]
      when:  [{visit: {x: 12, y: 19}}]
      then:  [{gained_item: 0x60}]

    - {name: ch05arena, proves: the arena tutorial is one-shot, lua: ch05arena}
```

Three scenarios are **ported off Lua entirely** (144 lines deleted) and run through `cases.lua`. Everything else stays hand-written behind `lua:` and still derives its row there — code is the exception you NAME, not the default you copy.

## Both gates the port was held to

| | result |
|---|---|
| **Free** — all 111 scenario rows resolved before vs after | **byte-identical** |
| **Real** — the three ran in mGBA, guarded inputs diffed | **26 / 92 / 155 actions identical** — same input, result, state, cursor tile, order |

A matching PASS would not have been evidence. A matching input sequence is.

## A CHAPTER costs local slots

`harness.lua` is one chunk at Lua's **200-local ceiling with 2 slots free**. 32 of its 198 top-level locals are chapter- or cast-scoped — ~6–7 per chapter over five built. On the measured curve (116 locals in June → 148 → 198) it runs out during **ch06**, not at ch18.

It hadn't broken because the old rule — *declare it inside the scenario* — converted the ceiling into **duplication**: 94 constant declarations inside scenario bodies, **24 names re-typed across two or three scenarios**. `ch05.lua` now owns the cast pids, the reliquary table and the branch message ids. All five affected scenarios PASS in-engine.

## Gate efficiency, now derivable

`declared.py subsumed` computes that **`ch05village` is fully covered by `ch05reliquaries`** — both in the merge gate, **41.4s / 5.0%** of its emulator work for no additional coverage. Shipped as a **report, not an automatic gate edit**: the subsumed case is often the better *isolator* (reliquaries visits four doors in sequence, so a broken north door fails before south is reached).

## Guards

- `check_declared_cases` — a `visit` step may only land on a tile the chapter's own `villages:` block declares (those coordinates were a third copy), and `cases.lua` may hold no raw `press()`: one there would un-guard *every* declared case at once.
- `check_playtest_matrix` / `check_verdict_scenarios_are_guarded` keep their teeth for hand-written rows and for a `lua:` case whose function has been deleted.
- Both new guards are tested in **both directions** — clean input produces nothing, bad input produces the finding.

## Docs

`decisions.md`'s *"harness.lua is ONE Lua chunk"* is **rewritten, not banner-patched** — it was measured against scenario count, and the cost is per chapter. `CLAUDE.md`'s placement test cited it as its own example and is rewritten with it.

## Not taken, and why

Resolving a visit's tile **from the village id** it already names. Item ids resolve through `build_campaign.py`, which imports Pillow, and CI's lightweight `checks` job cannot import it. That wants an item-id registry that doesn't drag the art pipeline.

## Verification

- `make check` green (headroom still 2), `make test` green (46 suites + 28 Lua checks)
- 8 mGBA scenarios run, **8 PASS**: ch04village, ch05village, ch05reliquaries (the ports) + ch05crest, ch05raid, ch05recruit, ch05lupinbenched, ch05lupinkilled (the chunk migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)