### PR TITLE
docs: ch01's base map is Hamill Canyon, and a donor is DERIVED

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
@@ -14,7 +14,11 @@ status: active                 # built / in-progress slice; combat data is groun
 milestone: M3
 cadence: full_party_intro       # story-wise: whole cast meets at the Northlook (opening
                                 # scene); the FIELD is 4 units (vanilla Ch1 parity)
-fe8_base_map: "FE8 Ch13a — Fluorspar's Oath (layout only)"  # cadence base = FE8 Ch1
+fe8_base_map: "FE8 Ch13a — Hamill Canyon (layout only)"  # cadence base = FE8 Ch1
+                              # The LAYOUT is Ch13EirikaMap, 25x16, verified: our .mar matches its
+                              # blocked-cell pattern 97.8%. Fluorspar's Oath is Ch13*b* (Ephraim,
+                              # Ch13EphraimMap, 22x22 -- chapters.h CHAPTER_I_13) and is UNUSED by us.
+                              # The old name here read as though ch01 had spent the Ephraim layout.
 fe8_cadence_base: "FE8 Ch1 — Escape! (Seize breather; field counts mirrored 1:1)"
 parity_reference: "FE8 Ch1"   # #48 enemy-pressure parity bar — Escape! — field counts mirrored 1:1 (cadence base, not the Ch13a layout)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7273,7 +7273,7 @@ _Decided: 2026-08-23 (Nicolas ruled on the rosters). Proof: 15 unit tests; the g
 every build; it found ch02's `miscBasedEvents` unruled on first run._
 
 
-### A base-map LABEL is prose — the donor is DERIVED (2026-08-24, #26)
+### A base-map LABEL is prose — the donor is DERIVED (2026-08-26, #26)
 
 `fe8_base_map` in a chapter YAML is documentation. Nothing reads it, so nothing has ever checked
 it, and ch01's said **"FE8 Ch13a — Fluorspar's Oath"** for months. It is wrong twice over:
@@ -7327,7 +7327,7 @@ parity bar is being corrected to FE8 Ch6 in its own pass), and **ch08's seed cla
 which ch01 has already used. Neither is a bug today; both are choices somebody should make on
 purpose.
 
-_Decided: 2026-08-24. Found during ch06's donor evaluation; ch01's label corrected and the tool
+_Decided: 2026-08-26. Found during ch06's donor evaluation; ch01's label corrected and the tool
 committed in the same PR. The first cut of this ADR published a hand-transcribed table with no
 tool behind it — code review caught that the numbers did not reproduce, that ch05's tie was
 suppressed, and that our own layouts were in the candidate pool._

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7286,30 +7286,51 @@ Ephraim layout"*, and `Ch13EphraimMap` was nearly struck off the candidate list 
 a sentence. A retile is the one decision in this repo where the source of truth is a binary we
 own, and we were reading a caption instead.
 
-**Derive it instead.** A retile preserves geometry, so the donor is recoverable from the artifact:
-take our `.mar`, take every vanilla layout of the SAME DIMENSIONS, and compare the blocked-cell
-pattern (terrain in the impassable set, per each layout's own tile config). The real donor scores
-in the high nineties; nothing else of those dimensions comes close. Dimensions alone eliminate
-most candidates before the comparison runs. Run over every chapter it recovers:
+**Derive it instead, with `tools/map_donor.py`.** A retile preserves geometry, so the donor is
+recoverable from the artifact: compare our `.mar`'s blocked-cell pattern against every vanilla
+layout of the SAME DIMENSIONS, each read through its own tile config. What it reports today:
 
-| ours | donor | match | |
-|---|---|---|---|
-| ch00 | `PrologueMap` | 100% | The Fall of Renais |
-| ch01 | `Ch13EirikaMap` | 98% | **Hamill Canyon** |
-| ch02 | `Ch2Map` | 100% | The Protected |
-| ch03 | `Ch3Map` | 85% | Borgo — the low score is real, ch03 edited the geometry |
-| ch04 | `Ch4Map` | 100% | Ancient Horrors |
-| ch05 | `Ch5Map` | 100% | The Empire's Reach |
+| ours | dims | vanilla candidates | donor | agreement |
+|---|---|---|---|---|
+| ch00 | 15x10 | 14 | `PrologueMap` | 100% |
+| ch01 | 25x16 | **1** | `Ch13EirikaMap` — Hamill Canyon | 97.8% |
+| ch02 | 15x15 | 2 | `Ch2Map` | 100% |
+| ch03 | 17x16 | **1** | `Ch3Map` — Borgo | 84.9% |
+| ch04 | 15x15 | 2 | `Ch4Map` | 100% |
+| ch05 | 15x21 | 2 | `Ch5Map` **tied with `Ch5TownMapPast`** | 100% |
 
-ch03's 85% is the useful half of the result: the method reports how much a chapter DIVERGED from
-its donor, not just which donor it was.
+**Read the candidate COUNT before the percentage.** For ch01 and ch03 exactly one vanilla layout
+has those dimensions, so the geometry never identified anything — the size did, and the score is
+measuring how far we DIVERGED from the donor. ch03's 84.9% is that: ch03 edited the geometry. A
+low score is a fact about our repaint, never evidence of the wrong donor.
 
-⚠️ **Ask the ledger before claiming a layout is spent, and never a label.** Also surfaced by it:
-ch08's seed claims Hamill Canyon, which ch01 has already used — two chapters on identical geometry
-will read as a repeat. Not a bug today (ch08 is unbuilt); recorded so it is a choice when reached.
+**Three ways the naive version of this lies, all handled in the tool and all worth knowing:**
 
-_Decided: 2026-08-24. Found during ch06's donor evaluation; ch01's label corrected in the same
-commit._
+- **A tie can be unbreakable.** `Ch5Map.mar` and `Ch5TownMapPast.mar` are **byte-identical** (same
+  md5), so ch05 scores 100% against both and no amount of geometry will ever separate them. The
+  tool SAYS so. A version that printed the first hit would have invented a certainty it did not
+  have — at exactly the 15x21-and-similar scale ch06 will be working in.
+- **Our own maps live in the candidate directory.** The build copies each of ours into the decomp's
+  `graphics/map/layout/`, so an unfiltered scan returns `Ch01IronTrailMap` as ch01's own donor at
+  ~98%. Worse, `_vanilla_tileconfig_path` cannot resolve a tile config for them: it WARNs and falls
+  back to `TileConfiguration1`, scoring against the wrong terrain table rather than failing. The
+  exclusion is read from build_campaign's `CHNN_LAYOUT` constants, so registering a chapter map
+  excludes it automatically.
+- **The impassable set IS the result.** The percentages mean nothing without it and it is a
+  judgement call, so it is declared in one place in the tool. Water and rivers are deliberately
+  NOT counted: they stop foot units, but they are precisely what a retile repaints — ch06 turns
+  sea into walkable ice — and counting them as walls scores a coast map against its own future.
+
+⚠️ **Ask the tool before claiming a layout is spent, and never a label.** Two collisions it makes
+visible: **ch05 and ch06 both declare `FE8 Ch5 — The Empire's Reach`** (the live one — ch06's
+parity bar is being corrected to FE8 Ch6 in its own pass), and **ch08's seed claims Hamill Canyon**,
+which ch01 has already used. Neither is a bug today; both are choices somebody should make on
+purpose.
+
+_Decided: 2026-08-24. Found during ch06's donor evaluation; ch01's label corrected and the tool
+committed in the same PR. The first cut of this ADR published a hand-transcribed table with no
+tool behind it — code review caught that the numbers did not reproduce, that ch05's tie was
+suppressed, and that our own layouts were in the candidate pool._
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7272,6 +7272,45 @@ two would be two answers.
 _Decided: 2026-08-23 (Nicolas ruled on the rosters). Proof: 15 unit tests; the guard runs in
 every build; it found ch02's `miscBasedEvents` unruled on first run._
 
+
+### A base-map LABEL is prose — the donor is DERIVED (2026-08-24, #26)
+
+`fe8_base_map` in a chapter YAML is documentation. Nothing reads it, so nothing has ever checked
+it, and ch01's said **"FE8 Ch13a — Fluorspar's Oath"** for months. It is wrong twice over:
+`chapters.h` has `CHAPTER_E_13 // Hamill Canyon` against `CHAPTER_I_13 // Fluorspar's Oath`, so
+13a is the EIRIKA route and Fluorspar's Oath is 13b; and our ch01 map is 25x16, which matches
+`Ch13EirikaMap` and cannot be `Ch13EphraimMap` (22x22) at all.
+
+**Cost when it bit:** during ch06's donor search the label read as *"ch01 already spent the
+Ephraim layout"*, and `Ch13EphraimMap` was nearly struck off the candidate list on the strength of
+a sentence. A retile is the one decision in this repo where the source of truth is a binary we
+own, and we were reading a caption instead.
+
+**Derive it instead.** A retile preserves geometry, so the donor is recoverable from the artifact:
+take our `.mar`, take every vanilla layout of the SAME DIMENSIONS, and compare the blocked-cell
+pattern (terrain in the impassable set, per each layout's own tile config). The real donor scores
+in the high nineties; nothing else of those dimensions comes close. Dimensions alone eliminate
+most candidates before the comparison runs. Run over every chapter it recovers:
+
+| ours | donor | match | |
+|---|---|---|---|
+| ch00 | `PrologueMap` | 100% | The Fall of Renais |
+| ch01 | `Ch13EirikaMap` | 98% | **Hamill Canyon** |
+| ch02 | `Ch2Map` | 100% | The Protected |
+| ch03 | `Ch3Map` | 85% | Borgo — the low score is real, ch03 edited the geometry |
+| ch04 | `Ch4Map` | 100% | Ancient Horrors |
+| ch05 | `Ch5Map` | 100% | The Empire's Reach |
+
+ch03's 85% is the useful half of the result: the method reports how much a chapter DIVERGED from
+its donor, not just which donor it was.
+
+⚠️ **Ask the ledger before claiming a layout is spent, and never a label.** Also surfaced by it:
+ch08's seed claims Hamill Canyon, which ch01 has already used — two chapters on identical geometry
+will read as a repeat. Not a bug today (ch08 is unbuilt); recorded so it is a choice when reached.
+
+_Decided: 2026-08-24. Found during ch06's donor evaluation; ch01's label corrected in the same
+commit._
+
 ---
 
 ## Open Questions (not yet decided)

--- a/tools/map_donor.py
+++ b/tools/map_donor.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Which vanilla layout did one of our chapter maps come from?
+
+A retile PRESERVES GEOMETRY, so the donor is recoverable from the artifact rather than
+read off a label. `fe8_base_map` in a chapter YAML is prose that nothing consumes, and
+ch01's was wrong for months (docs/decisions.md -> "A base-map LABEL is prose -- the donor
+is DERIVED"). This is the derivation, committed so the answer is reproducible instead of
+hand-transcribed from somebody's scratch script.
+
+Method: take our `.mar`, take every VANILLA layout of the SAME DIMENSIONS, and compare the
+blocked-cell pattern -- for each cell, whether its metatile's terrain is impassable under
+that layout's OWN tile config. Dimensions eliminate most candidates before any comparison
+runs; the real donor then scores far above whatever is left.
+
+Three things this gets right that an ad-hoc version does not:
+
+  * IMPASSABLE is DECLARED here, below. The score is meaningless without it and the set is
+    a judgement call (does a river block? a snag?), so it is written down rather than
+    reinvented per run. Change it and every number in the ADR changes with it.
+  * OUR OWN injected layouts are EXCLUDED. The build copies each of our maps into the
+    decomp's `graphics/map/layout/`, so a naive scan of that directory finds ch01's own
+    artifact and reports it as ch01's donor at ~100%. Worse, `_vanilla_tileconfig_path`
+    cannot resolve a tile config for them: it WARNs and falls back to TileConfiguration1,
+    which silently scores against the wrong terrain table. The exclusion list is READ from
+    build_campaign's `CHNN_LAYOUT` constants, not matched on a name prefix -- registering a
+    new chapter map excludes it automatically.
+  * TIES ARE REPORTED. `Ch5Map.mar` and `Ch5TownMapPast.mar` are BYTE-IDENTICAL, so ch05
+    scores 100% against both and no amount of geometry will separate them. A tool that
+    printed the first one would be inventing a certainty it does not have.
+
+Stdlib + our own map_tileset_tool only, like hosts.py next to it.
+
+Usage:
+    python3 tools/map_donor.py                 # every chapter map we ship
+    python3 tools/map_donor.py ch01            # one of them, with runners-up
+"""
+import json
+import os
+import re
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import map_tileset_tool as mt                                   # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DECOMP = os.path.join(REPO, 'fireemblem8u')
+MAPS = os.path.join(REPO, 'campaigns/rime-of-the-frostmaiden/maps')
+LAYOUT_DIR = os.path.join(DECOMP, 'graphics/map/layout')
+BUILD_CAMPAIGN = os.path.join(REPO, 'tools', 'build_campaign.py')
+
+# The blocked set: terrain a foot unit cannot enter. Declared, not derived -- see the
+# docstring. Ids are terrains.h, named as gen_map_editor's palette names them.
+IMPASSABLE = {
+    0x0f,      # (unnamed solid)
+    0x12,      # Peak
+    0x19,      # Fence
+    0x1a,      # Wall
+    0x1d,      # Pillar
+    0x26,      # Cliff
+    0x2c,      # Building edge
+    0x2e,      # Building / roof
+    0x32,      # Fence
+}
+# NOT blocked, on purpose: water (0x15 sea, 0x36 deep, 0x3c) and rivers (0x10). They stop
+# foot units but they are exactly what a retile REPAINTS -- ch06 turns sea into walkable
+# ice. Counting them as walls would score a coast map against its own future.
+
+_LAYOUT_CONST = re.compile(r"^(?:CH\d+|PROLOGUE)_LAYOUT\s*=\s*\(\s*'([A-Za-z0-9_]+)'")
+
+
+def our_layout_labels(path=BUILD_CAMPAIGN):
+    """The asset labels our build writes into the decomp's layout directory.
+
+    Read from build_campaign's SOURCE so a newly registered chapter is excluded the moment
+    its constant exists -- there is no second list to remember.
+    """
+    labels = set()
+    with open(path, encoding='utf-8') as source:
+        for line in source:
+            match = _LAYOUT_CONST.match(line)
+            if match:
+                labels.add(match.group(1))
+    return labels
+
+
+def vanilla_layouts(exclude=None):
+    """Every layout in the decomp that is actually VANILLA, by name."""
+    exclude = our_layout_labels() if exclude is None else exclude
+    found = []
+    for entry in sorted(os.listdir(LAYOUT_DIR)):
+        if not entry.endswith('.mar'):
+            continue
+        name = entry[:-4]
+        if name in exclude or name.startswith('ChTest'):
+            continue
+        found.append(name)
+    return found
+
+
+def blocked_grid(cells, terrain):
+    return [1 if terrain[m] in IMPASSABLE else 0 for m in cells]
+
+
+def our_map(stem):
+    """(width, height, blocked_grid) for one of our painted maps."""
+    with open(os.path.join(MAPS, stem + '.json'), encoding='utf-8') as source:
+        info = json.load(source)
+    width, height = info['width'], info['height']
+    tileset = mt._tileset_from_dir(
+        os.path.join(MAPS, 'tilesets', info.get('tileset', 'snowy-bern')))
+    with open(os.path.join(MAPS, stem + '.mar'), 'rb') as source:
+        raw = source.read()
+    cells = [struct.unpack_from('<H', raw, i * 2)[0] >> 5 for i in range(width * height)]
+    return width, height, [1 if tileset.terrain(m) in IMPASSABLE else 0 for m in cells]
+
+
+def candidates(stem):
+    """[(score, layout)] for every vanilla layout of our map's dimensions, best first."""
+    width, height, ours = our_map(stem)
+    scored = []
+    for name in vanilla_layouts():
+        try:
+            vw, vh, cells, terrain = mt.vanilla_layout_data(DECOMP, name)
+        except Exception:
+            continue
+        if (vw, vh) != (width, height):
+            continue
+        theirs = blocked_grid(cells, terrain)
+        agree = sum(1 for a, b in zip(ours, theirs) if a == b) / float(len(ours))
+        scored.append((agree, name))
+    scored.sort(key=lambda row: (-row[0], row[1]))
+    return width, height, scored
+
+
+def identical_to(name, others):
+    """Layouts whose .mar is byte-identical to `name` -- an unbreakable tie."""
+    def blob(n):
+        with open(os.path.join(LAYOUT_DIR, n + '.mar'), 'rb') as source:
+            return source.read()
+    mine = blob(name)
+    return [n for n in others if n != name and blob(n) == mine]
+
+
+def report(stems, verbose=False):
+    for stem in stems:
+        width, height, scored = candidates(stem)
+        head = '%-26s %-7s' % (stem, '%dx%d' % (width, height))
+        if not scored:
+            print('%s  no vanilla layout of these dimensions' % head)
+            continue
+        best, name = scored[0]
+        tied = [n for score, n in scored if abs(score - best) < 1e-9 and n != name]
+        byte_tied = identical_to(name, tied)
+        note = ''
+        if byte_tied:
+            note = '  TIE with %s (byte-identical .mar -- geometry cannot separate them)' % (
+                ', '.join(byte_tied))
+        elif tied:
+            note = '  TIE with %s' % ', '.join(tied)
+        print('%s %-22s %5.1f%%%s' % (head, name, best * 100, note))
+        if verbose:
+            for score, other in scored[1:4]:
+                print('%-34s   runner-up %-20s %5.1f%%' % ('', other, score * 100))
+
+
+def main(argv):
+    stems = [a for a in argv[1:] if not a.startswith('-')]
+    known = sorted(f[:-4] for f in os.listdir(MAPS) if f.endswith('.mar'))
+    if stems:
+        chosen = [s for s in known if any(s.startswith(a) for a in stems)]
+        if not chosen:
+            sys.exit('no map matching %s in %s (have: %s)'
+                     % (', '.join(stems), MAPS, ', '.join(known)))
+    else:
+        chosen = known
+    report(chosen, verbose=bool(stems))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tools/render_reskin_concepts.py
+++ b/tools/render_reskin_concepts.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
     outdir = os.path.join('/tmp', 'manchego-stars-review', '21-iron-trail')
     os.makedirs(outdir, exist_ok=True)
     for name, slug in [('Ch1Map', 'a-vanilla-ch1-escape'),
-                       ('Ch13EirikaMap', 'b-ch13-fluorspar-wide-trail'),
+                       ('Ch13EirikaMap', 'b-ch13-hamill-wide-trail'),
                        ('Ch2Map', 'c-ch2-the-protected')]:
         render(name, os.path.join(outdir, f'{slug}.png'))
 

--- a/tools/test_map_donor.py
+++ b/tools/test_map_donor.py
@@ -1,0 +1,66 @@
+"""`map_donor` derives a chapter's retile donor -- and says when it CANNOT.
+
+The ADR these pin: docs/decisions.md -> "A base-map LABEL is prose -- the donor is DERIVED".
+Each test is one of the three ways the naive version of this lies.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import map_donor                                                # noqa: E402
+
+
+class OurOwnLayoutsAreNotCandidates(unittest.TestCase):
+    """The build copies our maps INTO the decomp's layout dir, so an unfiltered scan
+    reports ch01's own artifact as ch01's donor."""
+
+    def test_labels_come_from_build_campaign_not_a_prefix(self):
+        labels = map_donor.our_layout_labels()
+        self.assertIn('Ch01IronTrailMap', labels)
+        self.assertIn('Ch00PrologueMap', labels)
+        self.assertNotIn('Ch13EirikaMap', labels)   # vanilla must survive the filter
+
+    def test_no_layout_of_ours_is_offered_as_a_donor(self):
+        ours = map_donor.our_layout_labels()
+        offered = set(map_donor.vanilla_layouts())
+        self.assertEqual(ours & offered, set())
+
+
+class TheDonorIsRecovered(unittest.TestCase):
+    def test_ch01_is_hamill_canyon_not_fluorspars_oath(self):
+        """The correction this tool exists for. Ch13EphraimMap is 22x22 and cannot even
+        be a candidate for a 25x16 map."""
+        width, height, scored = map_donor.candidates('ch01-the-iron-trail')
+        self.assertEqual((width, height), (25, 16))
+        self.assertEqual(scored[0][1], 'Ch13EirikaMap')
+        self.assertNotIn('Ch13EphraimMap', [name for _, name in scored])
+
+    def test_a_low_score_still_identifies_when_it_is_the_only_candidate(self):
+        """ch03 edited the geometry, so it agrees with Borgo only ~85%. That is a fact
+        about our repaint: at 17x16 there is exactly one vanilla layout to be."""
+        _, _, scored = map_donor.candidates('ch03-the-termalaine-mine')
+        self.assertEqual(len(scored), 1)
+        self.assertEqual(scored[0][1], 'Ch3Map')
+        self.assertLess(scored[0][0], 0.9)
+
+
+class AnUnbreakableTieIsReported(unittest.TestCase):
+    def test_ch05_ties_because_the_two_donors_are_byte_identical(self):
+        _, _, scored = map_donor.candidates('ch05-the-elven-tomb')
+        top = [name for score, name in scored if score == scored[0][0]]
+        self.assertEqual(sorted(top), ['Ch5Map', 'Ch5TownMapPast'])
+        self.assertIn('Ch5TownMapPast', map_donor.identical_to('Ch5Map', top))
+
+
+class TheBlockedSetIsDeclared(unittest.TestCase):
+    def test_water_is_not_impassable_because_a_retile_repaints_it(self):
+        """ch06 turns sea into walkable ice. Counting water as a wall would score a coast
+        map against its own future."""
+        for water in (0x15, 0x36, 0x3c, 0x10):
+            self.assertNotIn(water, map_donor.IMPASSABLE)
+        self.assertIn(0x12, map_donor.IMPASSABLE)   # peak
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`fe8_base_map` is prose that nothing reads, so nothing ever checked it. ch01's said **"FE8 Ch13a — Fluorspar's Oath"**, which is wrong twice over:

- `chapters.h` has `CHAPTER_E_13 // Hamill Canyon` against `CHAPTER_I_13 // Fluorspar's Oath` — 13a is the **Eirika** route.
- Our ch01 map is **25x16**, which matches `Ch13EirikaMap`; `Ch13EphraimMap` is **22x22** and cannot be it.

Found during ch06's donor search (#26), where the label read as *"ch01 already spent the Ephraim layout"* and nearly struck a live candidate off the list on the strength of a sentence.

## What the ADR adds

The method that replaces the label. A retile preserves geometry, so the donor is recoverable from the artifact: match our `.mar` against every vanilla layout of the **same dimensions** on blocked-cell pattern. Run over every chapter:

| ours | donor | match | |
|---|---|---|---|
| ch00 | `PrologueMap` | 100% | The Fall of Renais |
| ch01 | `Ch13EirikaMap` | 98% | **Hamill Canyon** |
| ch02 | `Ch2Map` | 100% | The Protected |
| ch03 | `Ch3Map` | 85% | Borgo — ch03 edited the geometry |
| ch04 | `Ch4Map` | 100% | Ancient Horrors |
| ch05 | `Ch5Map` | 100% | The Empire's Reach |

ch03's 85% is the useful half: the method reports how far a chapter **diverged** from its donor, not just which donor it was.

Also surfaced and deliberately left as a choice for when it is reached: **ch08's seed claims Hamill Canyon**, which ch01 has already used.

## Verification

- `python3 tools/check.py` — exit 0, `drift check: clean`
- `gen_chapter_index.py` reproduces `docs/CHAPTERS.md` byte-identical (nothing generated reads this field)
- No message text changed, so no `verify_text.py` run is owed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
