### PR TITLE
tooling: the drift lint could not see the docs people follow

### DIFF
--- a/.claude/skills/dialogue-pass/SKILL.md
+++ b/.claude/skills/dialogue-pass/SKILL.md
@@ -29,8 +29,8 @@ beats → lines, human curates every level). Decided 2026-06-09 (docs/decisions.
    **A chapter's messages live in TWO places and TWO channels — check both, or you will
    conclude vanilla lacks a beat it has:**
    - `*-eventscript.h` carries the scenes, in **two channels**: `TEXTSHOW` (on-map, units
-     staged by `LOAD1`, bubbles wrap at **29** chars) and `Text_BG(BG_*, id)` (a still
-     backdrop, wraps **~42**). The channel sets the width you hand-box to, and vanilla uses
+     staged by `LOAD1`, the bubble's budget is **203px**) and `Text_BG(BG_*, id)` (a still
+     backdrop, auto-centred helpbox, **192px**). The channel sets the width you hand-box to, and vanilla uses
      the backdrop for scenes that happen ELSEWHERE (Ch5's Grado command scenes) — so it also
      tells you where a scene is set. `vanilla_scene.py` prints id + channel per message
      (regression-guarded by `tools/test_vanilla_scene.py`; it once matched `TEXTSHOW` only
@@ -83,8 +83,9 @@ silently strip it. So, before locking beats:
    (e.g. "menace vs. brevity"). Nicolas picks or mixes; he owns voice.
 2. **Draft BOXED, never as prose** (2026-07-23 learning — prose-length lines read as
    wordy and hide the real A-press pacing). Write every line as GBA boxes from the first
-   pass: **2 lines per box, ~29–30 chars/line** (on-map bubbles wrap at 29; cutscene
-   Text_BG ~42), `...` holds, `--` interrupts, one A-press per box — and show it *boxed*
+   pass: **2 lines per box**, measured in PIXELS not characters (#298 — 203px talk bubble,
+   192px helpbox, 143px battle bubble; `tools/fe8_talk_font.py` owns the three budgets and
+   `make scene` renders the real wrap), `...` holds, `--` interrupts — and show it *boxed*
    to Nicolas, not as paragraphs. Stay inside the budget: boss taunt ≤ 4 lines / 1 screen;
    opening exchange ≤ ~8 boxes; ending beat ≤ ~10 lines; narration card 2–5 lines ≤ ~25
    words; quote msgs 1–2 lines. Cut before adding.
@@ -157,8 +158,8 @@ alternative lines, Nicolas decides whether the lock reopens.
   mislead -- they catch the typewriter mid-stroke. Once the feature is accepted,
   remove the review artifact before merge unless a live document links to it.
 - Message-encoding gotchas (the hard-won ones, full trace in
-  `tools/build_campaign.py` `_script_to_message`): on-map bubble lines wrap at
-  29 chars, NOT Text_BG's ~42; every non-terminal [A] must be [LF]-followed
+  `tools/build_campaign.py` `_script_to_message`): a line's budget is PIXELS —
+  203px on-map, NOT the helpbox's 192px — so character counts are not the measure; every non-terminal [A] must be [LF]-followed
   (the width measure doesn't stop at [A], and right-side bubbles have no
   position clamp -- merged turns = offscreen bubble); a boss "steps out" via a
   message SPLIT + LOAD1 between, never a lazy right-face load mid-message.

--- a/.github/ISSUE_TEMPLATE/custom_unit.md
+++ b/.github/ISSUE_TEMPLATE/custom_unit.md
@@ -7,12 +7,12 @@ labels: ["art"]
 
 End-to-end checklist for giving a unit its custom look. **The "how" lives in code + decisions, not a
 prose doc** — each step links its source of truth:
-- Anim/clone-class how → the `inject_battle_anims` docstring (`tools/build_campaign.py`)
+- Anim how (PC + enemy paths both) → the `inject_battle_anims` docstring (`tools/build_campaign.py`)
 - Platform how → the `inject_battle_platforms` docstring (`tools/build_campaign.py`)
-- Decisions/rationale (additive clone class, platform picks, scale) → `docs/decisions.md` (Art & Audio)
+- Decisions/rationale (additive binding, platform picks, scale) → `docs/decisions.md` (Art & Audio)
 - Fast iteration → `make TESTCH=1` (boots into the Ch1 sandbox) + `inject_test_chapter` docstring;
   capture via `tools/playtest/run.sh recordrbg` (fresh checkpoint)
-- **Principle that governs all of it: ADDITIVE, never global** — clone into free slots; never edit a
+- **Principle that governs all of it: ADDITIVE, never global** — bind into free slots; never edit a
   shared vanilla class/anim/terrain in place.
 
 ## Checklist
@@ -33,9 +33,12 @@ prose doc** — each step links its source of truth:
       set the chapter's `battleTileSet` (0 = Snowdrift / 0x15 = Uneven).
 - [ ] **Build + verify** — `make TESTCH=1`, then capture all THREE parts of the art in-engine:
       `PT_CHAR=<id> run.sh recordcast` (bust + map sprite, off the status screen) and
-      `PT_CHAR=<id> run.sh recordanim` (the battle anim). Confirm the unit deploys as its PLAIN
-      vanilla class (the anim rides a private per-character AnimConf) and fires on the right ground
-      (unforced).
+      `PT_CHAR=<id> run.sh recordanim` (the battle anim; `recordenemy` for a generic).
+      ⚠️ **The two halves of this template bind DIFFERENTLY.** A named PC/boss keeps its PLAIN
+      vanilla class and the anim rides a **private per-character AnimConf** (`_u25`). A generic
+      enemy has no unique character id, so an `enemy_class_reskins` entry binds at the **CLASS**
+      instead — a free `slot:` (`CLASS_BLST_*_EMPTY`, …) whose `.pBattleAnimDef` is repointed
+      (`decisions.md` #90). Confirm the unit fires on the right ground (unforced).
       ⚠️ **Film several rounds — `PT_ROUNDS=4` — not one.** FE8 resolves damage in DATA whatever the
       animation does, so a broken script still kills the foe, still shows correct frames and still
       reports PASS; a one-round capture never asks for the next input that reveals a soft-lock.

--- a/.github/ISSUE_TEMPLATE/custom_unit.md
+++ b/.github/ISSUE_TEMPLATE/custom_unit.md
@@ -20,7 +20,7 @@ prose doc** — each step links its source of truth:
       `tools/ref_to_bust.py` / `tools/portrait_tool.py`; reskin a credited FE-Repo body via
       `tools/map_sprite_editor.py`. Add `fe_name` (≤12) if the name overflows the buffer.
 - [ ] **Battle anim** — 3 hi-res poses → BOX-descale to `campaigns/.../battle_anims/<unit>/{ready,
-      windup,peak}.png`; add the `battle_anim:` YAML block with a **free** `clone_into` class slot.
+      windup,peak}.png`; add the `battle_anim:` YAML block naming its `clone_from` donor class.
       (An FE-native community anim goes through `import:` instead — the `.txt` owns the cadence,
       so do NOT hand it one of ours.)
       ⚠️ confirm `AnimConf .index == anim_id + 1` (else purple dragon).
@@ -33,8 +33,9 @@ prose doc** — each step links its source of truth:
       set the chapter's `battleTileSet` (0 = Snowdrift / 0x15 = Uneven).
 - [ ] **Build + verify** — `make TESTCH=1`, then capture all THREE parts of the art in-engine:
       `PT_CHAR=<id> run.sh recordcast` (bust + map sprite, off the status screen) and
-      `PT_CHAR=<id> run.sh recordanim` (the battle anim). Confirm the unit deploys as its clone
-      class number and fires on the right ground (unforced).
+      `PT_CHAR=<id> run.sh recordanim` (the battle anim). Confirm the unit deploys as its PLAIN
+      vanilla class (the anim rides a private per-character AnimConf) and fires on the right ground
+      (unforced).
       ⚠️ **Film several rounds — `PT_ROUNDS=4` — not one.** FE8 resolves damage in DATA whatever the
       animation does, so a broken script still kills the foe, still shows correct frames and still
       reports PASS; a one-round capture never asks for the next input that reveals a soft-lock.

--- a/tools/check.py
+++ b/tools/check.py
@@ -30,7 +30,10 @@ import tempfile
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Docs that carry prose facts (decisions.md is handled specially per-check).
-DOC_GLOBS = ['docs/**/*.md', 'CLAUDE.md', 'README.md', 'HANDOFF.md']
+DOC_GLOBS = ['docs/**/*.md', 'CLAUDE.md', 'README.md', 'HANDOFF.md',
+             '.github/**/*.md']   # issue templates are docs people follow, and they were
+                                  # unscanned until 2026-08-24 -- custom_unit.md still said
+                                  # `clone_into`, a term DEAD_CONCEPTS has listed since #65
 
 # Terms that are NEVER legitimate in vision/ops docs OR hand-written code comments:
 # abandoned tools, dead code symbols, retired implementation phrases. decisions.md

--- a/tools/check.py
+++ b/tools/check.py
@@ -30,10 +30,13 @@ import tempfile
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Docs that carry prose facts (decisions.md is handled specially per-check).
+# Every doc a HUMAN OR AGENT FOLLOWS, not just the ones under docs/. `.github/` and
+# `.claude/skills/` were unscanned until 2026-08-26 and both had already drifted:
+# `custom_unit.md` still said `clone_into` (dead since #65) and the dialogue-pass skill
+# still taught the 29/42-CHARACTER wrap that #298 replaced with pixel budgets. A doc that
+# instructs is exactly the kind this guard exists for.
 DOC_GLOBS = ['docs/**/*.md', 'CLAUDE.md', 'README.md', 'HANDOFF.md',
-             '.github/**/*.md']   # issue templates are docs people follow, and they were
-                                  # unscanned until 2026-08-24 -- custom_unit.md still said
-                                  # `clone_into`, a term DEAD_CONCEPTS has listed since #65
+             '.github/**/*.md', '.claude/skills/**/*.md']
 
 # Terms that are NEVER legitimate in vision/ops docs OR hand-written code comments:
 # abandoned tools, dead code symbols, retired implementation phrases. decisions.md

--- a/tools/test_check_comment_drift.py
+++ b/tools/test_check_comment_drift.py
@@ -76,6 +76,19 @@ class HandwrittenSourceScan(unittest.TestCase):
         self.assertIn('tools/playtest/harness.lua', sources)
         self.assertNotIn('tools/check.py', sources)   # hosts the registry; exempt
 
+    def test_the_doc_globs_cover_the_docs_people_FOLLOW(self):
+        """DOC_GLOBS silently re-narrowing is how both 2026-08-26 incidents happened:
+        `.github/ISSUE_TEMPLATE/custom_unit.md` taught the retired `clone_into` binding and
+        the dialogue-pass skill taught the retired 29/42-CHARACTER wrap, for as long as the
+        scan could not see either directory. Nothing asserted over `_docs()` before this."""
+        docs = [os.path.relpath(p, check.REPO) for p in check._docs()]
+        self.assertIn('.github/ISSUE_TEMPLATE/custom_unit.md', docs)
+        self.assertIn('.claude/skills/dialogue-pass/SKILL.md', docs)
+        self.assertIn('CLAUDE.md', docs)
+        self.assertIn('.claude/skills/dialogue-pass/references/fe8-register.md', docs)
+        # decisions.md IS globbed; its exemption is applied inside check_no_dead_concepts,
+        # not by narrowing the scan -- so do not assert its absence here.
+
     def test_the_live_repo_is_clean(self):
         fail = []
         check.check_no_dead_concepts(fail)


### PR DESCRIPTION
`DOC_GLOBS` covered `docs/`, `CLAUDE.md`, `README.md` and `HANDOFF.md` — **not `.github/`**.

So `.github/ISSUE_TEMPLATE/custom_unit.md`, which both `CLAUDE.md` and `AGENTS.md` cite as *the* checklist for adding a unit's art, still told the reader to:

- give the `battle_anim:` block "a **free** `clone_into` class slot", and
- "confirm the unit deploys as its **clone class number**".

`clone_into` has been in `DEAD_CONCEPTS` since #65. The per-character private AnimConf replaced the clone-class approach, and a unit now deploys as its **plain vanilla class** (`inject_battle_anims`: *"the earlier clone-class approach is retired"*). The one guard that exists to catch exactly this drift could not read the file.

## Changes

- **`custom_unit.md`** — says `clone_from`, and describes the private AnimConf rather than a clone class number.
- **`check.py`** — `.github/**/*.md` joins `DOC_GLOBS`, so the next one fails the build.

Scanned the rest of `.github/` (templates + workflows) against all 37 dead concepts before widening the glob — `clone_into` was the only hit, so this lands green rather than opening a backlog.

## Why it matters now

ch06 needs custom art for Messie, Grynsk and Tali, and this template is the checklist we'd have followed.

## Verification

`python3 tools/check.py` — exit 0, `drift check: clean`, with the widened glob active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
