### PR TITLE
tooling: register the press-count claim #311 retired

### DIFF
--- a/tools/check.py
+++ b/tools/check.py
@@ -58,6 +58,12 @@ DEAD_CONCEPTS = [
     r'gen-chapter-index\.rb', r'gen-class-index\.rb',  # ported to Python 2026-06-09
     # retired by the 2026-07-02 comment sweep:
     r'clone_into',                     # #65 clone-class approach -> per-character _u25
+    # retired by #311 (2026-08-23): the wrapper DOES page a turn at two lines and each page is
+    # its own [A], so a press count is a fact about the WRAP, read off the rendered body. The
+    # false claim had been written down THREE times -- #311's own scope, a decisions.md
+    # postscript, and HANDOFF's #298 entry, which survived the correction because nothing
+    # scanned for it. Registering it is what the ADR log calls registry discipline.
+    r'presses? ==\s*authored boxes', r'wrapper never invents a page break',
     r'tileset_stem\s*=',               # _register_chapter_map reads the layout's stamp
     r'BATTLE_FOLLOWUP_THRESHOLD',      # misnomer; real: BATTLE_FOLLOWUP_SPEED_THRESHOLD
     # Marty's "spore covenant" (2026-07-29): a ch05 villain-foil thread we drifted away


### PR DESCRIPTION
`presses == authored boxes, the wrapper never invents a page break` is **false**. `_script_to_message` pages a turn at two lines and each page is its own `[A]`, so ch05 scene 1 is 19 authored boxes and costs 23 presses.

#311 corrected it, and its ADR (*"A scene is readable without a ROM, and a press count is read off the BODY"*) notes the claim had been written down **twice** — in #311's own scope and in a `decisions.md` postscript.

It was written down **three** times. The third copy was `HANDOFF.md`'s #298 entry, still asserting it as a settled fact a week later. It survived the correction because nothing scanned for the phrase.

`DEAD_CONCEPTS` is exactly the mechanism for this, and the ADR log's own **registry discipline** says a change that retires a term adds its key phrases *in the same commit*. That step was skipped when #311 landed. This adds it:

```python
r'presses? ==\s*authored boxes', r'wrapper never invents a page break',
```

The HANDOFF copy itself is removed in the trim commit on `main` (`9e58460`), which is where that file has to be authored.

## Verification

`python3 tools/check.py` — exit 0, `drift check: clean`, with both new patterns active against the whole repo (so no fourth copy is hiding anywhere else).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
