### PR TITLE
tooling: mine fireemblemwiki for the how-it-is-played half of parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,5 @@ campaigns/*/battle_anims/*/.paint/
 # matrix build-scope manifest (what each injection step wrote; describes the build, not the source)
 .build-scopes.json
 
-# fireemblemwod HTML cache (third-party pages; only the derived digest is committed)
+# fireemblemwiki HTML cache (third-party pages; only the derived digest is committed)
 .fe8-guide-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ campaigns/*/battle_anims/*/.paint/
 
 # matrix build-scope manifest (what each injection step wrote; describes the build, not the source)
 .build-scopes.json
+
+# fireemblemwod HTML cache (third-party pages; only the derived digest is committed)
+.fe8-guide-cache/

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -112,6 +112,15 @@ whose `RearUp`/`Attack`/`Charge` supply the three poses `inject_battle_anims` ne
 ## Campaign source material (Wizards of the Coast)
 - ***Icewind Dale: Rime of the Frostmaiden*** © Wizards of the Coast — the campaign this hack adapts (privately, for its own players). Book art reused in-ROM: the ch1 opener aurora-township painting (lore-crawl mural), the regional Icewind Dale map (basis/reference for the world-tour backdrops), and the **axe-beak illustration** (the reference for Baxby's portrait — see AI-generated art below).
 
+## Reference material (documentation, not shipped assets)
+- **Fire Emblem Wiki** (<https://fireemblemwiki.org>), the independent community wiki. Mined by
+  `tools/fe8_guide_mine.py` into the generated digest `docs/fe8-guide.md`, which is the *how a chapter
+  is meant to be won* half of our parity work &mdash; the decomp only answers what a chapter contains.
+  **Only game FACTS are committed** (objectives, deploy caps, per-difficulty enemy tables); the wiki's
+  Strategy prose is its own authorship and is deliberately not reproduced in-repo &mdash; the
+  `Shape`/`Pressure`/`Teaches`/`Playstyle` lines are ours, written from it. Fetched HTML lives in the
+  gitignored `.fe8-guide-cache/` and is never redistributed.
+
 ## AI-generated art (disclose)
 - **PC/cast portraits** are AI-generated (Google **Gemini / "Nano Banana"**) from reference art, then hand-fitted and indexed into FE8 portraits via our bust pipeline (`tools/ref_to_bust.py`, `tools/portrait_tool.py`). To be disclosed as AI-assisted per community norms.
 - **Baxby the axe-beak portrait** — the reference is the **axe-beak illustration from *Rime of the Frostmaiden*** (© Wizards of the Coast), modified with Google **Gemini** (prompt-run by Nicolas), then fitted/indexed via the bust pipeline (`tools/ref_to_bust.py --crop 780,18,1920,940 --flip-h --zoom 0.88`). Disclose as both AI-assisted and WotC-derived.

--- a/docs/fe8-guide-glosses.json
+++ b/docs/fe8-guide-glosses.json
@@ -1,0 +1,24 @@
+{
+  "_README": "The guide's strategy section digested into OUR design vocabulary, keyed by the slug in tools/fe8_guide_mine.py CHAPTERS. Written by hand -- a machine translation would give a paraphrase of tactics when what donor selection needs is the SHAPE of the level. 'shape' and 'pressure' feed the donor-selection index at the top of docs/fe8-guide.md; keep them to one scannable line each. An absent key means 'not digested yet', not an error.",
+
+  "ch1": {
+    "shape": "Tutorial seize with a rearward ambush",
+    "pressure": "A midline tripwire — crossing it drops 2 Fighters and a Soldier on your own start tile",
+    "teaches": "Trading weapons between units; allied reinforcements arriving on green tiles; effective weapons (the rapier against an armoured boss)",
+    "playstyle": "Barely harder than the prologue. Hand Seth's sword to Eirika first so the rapier is not wasted on ordinary infantry. Franz and Gilliam arrive turn 2 on the green tiles. Feed Eirika the Fighters and Franz or Gilliam the Soldiers if you intend to keep using them. The one trap: crossing the map's midline spawns two Fighters and a Soldier back where Seth and Eirika started, so do not leave your rear empty. Breguet is a Knight with Def 9 and Res 0 — the rapier cuts him, or lances do it the slow way. 5,000 gold on completion."
+  },
+
+  "ch6": {
+    "shape": "Rescue on a clock, run blind under fog",
+    "pressure": "Fog — the guide says it is the ONLY thing making the map hard — plus a 7-turn hostage timer, and Hard-only turn-4 cavalry spawning behind you",
+    "teaches": "Fog of war; enemies that heal; magic and poison at scale; effective weapons aimed at the player",
+    "playstyle": "The fog is the entire difficulty; strip it out and this is a walkover. Vision is a purchase, not a stat — buy torches from the PREVIOUS chapter's shop and lead with the thief for his sight radius. Then it is a race: Novala is holding hostages, reach them in under 7 turns with a flier, and the guide advises sending her from turn 1 to be safe. Saving all of them pays an Orion's Bolt, the biggest reward on the map. Only then go for the boss, who is a Shaman with Def 5 — 'a very easy boss, throw physical units at him'. Tank with your one overpowered unit, park in the forests on the right to evade, and watch your rear for the Hard-mode cavalry."
+  },
+
+  "ch7": {
+    "shape": "Seize across open ground, past fixed ranged emplacements",
+    "pressure": "Ballistae covering the approach — a positional hazard you route around rather than fight, and lethal to fliers",
+    "teaches": "Ballistae; stealing",
+    "playstyle": "A simple map by the guide's own account: beat the boss, take the castle. The single real hazard is the ballistae — keep fliers entirely outside their range, or walk an armour knight into it deliberately to break the machine. Bring the thief; there is an Energy Ring to steal. Push south behind a defensive front line. Murray is another pushover and can be safely chipped from range."
+  }
+}

--- a/docs/fe8-guide.md
+++ b/docs/fe8-guide.md
@@ -16,11 +16,11 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 
 | Chapter | Objective | Enemies (N) | Shape | Pressure comes from |
 |---|---|---|---|---|
-| [Prologue](#prologue) | Defeat O'Neill | 3 | — | — |
-| [Chapter 1](#chapter-1) | Seize the castle | 10 | Tutorial seize with a rearward ambush | A midline tripwire — crossing it drops 2 Fighters and a Soldier on your own start tile |
+| [Prologue](#prologue) | Defeat O'Neill | 3 <sub>(Easy/Normal)</sub> | — | — |
+| [Chapter 1](#chapter-1) | Seize the castle | 10 <sub>(Easy/Normal)</sub> | Tutorial seize with a rearward ambush | A midline tripwire — crossing it drops 2 Fighters and a Soldier on your own start tile |
 | [Chapter 2](#chapter-2) | Defeat all bandits | 8 | — | — |
 | [Chapter 3](#chapter-3) | Seize the throne | 10 | — | — |
-| [Chapter 4](#chapter-4) | Defeat all monsters | 22 | — | — |
+| [Chapter 4](#chapter-4) | Defeat all monsters | 22 <sub>(Easy/Normal)</sub> | — | — |
 | [Chapter 5](#chapter-5) | Defeat Saar | 23 | — | — |
 | [Chapter 5x](#chapter-5x) | Seize the throne | 31 | — | — |
 | [Chapter 6](#chapter-6) | Defeat Novala | 24 | Rescue on a clock, run blind under fog | Fog — the guide says it is the ONLY thing making the map hard — plus a 7-turn hostage timer, and Hard-only turn-4 cavalry spawning behind you |
@@ -38,8 +38,8 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 | [Chapter 12 (Ephraim)](#chapter-12-ephraim) | Defeat boss | 51 | — | — |
 | [Chapter 13 (Ephraim)](#chapter-13-ephraim) | Defeat all enemies | 58 | — | — |
 | [Chapter 14 (Ephraim)](#chapter-14-ephraim) | Seize the throne | 71 | — | — |
-| [Chapter 15](#chapter-15) | Defeat all enemies | 77 | — | — |
-| [Chapter 16](#chapter-16) | Seize the throne | 41 | — | — |
+| [Chapter 15](#chapter-15) | Defeat all enemies | 77 <sub>(Eirika Normal)</sub> | — | — |
+| [Chapter 16](#chapter-16) | Seize the throne | 41 <sub>(Eirika Normal)</sub> | — | — |
 | [Chapter 17](#chapter-17) | Defeat Lyon | 64 | — | — |
 | [Chapter 18](#chapter-18) | Defeat all enemies | 46 | — | — |
 | [Chapter 19](#chapter-19) | Protect Mansel for 13 turns or defeat Riev | 97 | — | — |
@@ -50,12 +50,14 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 ## Prologue
 
 - **Objective**: Defeat O'Neill  ·  **Lose**: Eirika dies
+- **Easy/Normal**: 3 enemies · avg L2.3 — 3× Fighter
 - **Difficult**: 3 enemies · avg L2.3 — 3× Fighter
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy prologue`*
 
 ## Chapter 1
 
 - **Objective**: Seize the castle  ·  **Lose**: Eirika dies
+- **Easy/Normal**: 10 enemies · avg L2.1 — 5× Fighter, 4× Soldier, 1× Knight
 - **Difficult**: 10 enemies · avg L2.1 — 5× Fighter, 4× Soldier, 1× Knight
 - **Shape**: Tutorial seize with a rearward ambush
 - **Pressure**: A midline tripwire — crossing it drops 2 Fighters and a Soldier on your own start tile
@@ -82,6 +84,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 
 - **Objective**: Defeat all monsters  ·  **Lose**: Eirika dies
 - **Deploy**: 2–9
+- **Easy/Normal**: 22 enemies · avg L1.8 — 12× Revenant, 6× Bonewalker, 3× Mogall, 1× Entombed
 - **Difficult**: 22 enemies · avg L1.8 — 12× Revenant, 6× Bonewalker, 3× Mogall, 1× Entombed
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch4`*
 
@@ -109,7 +112,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 24 enemies · avg L6.2 — 6× Soldier, 3× Fighter, 3× Knight, 3× Cavalier, 2× Mercenary, 2× Shaman
 - **Normal**: 24 enemies · avg L6.2 — 6× Soldier, 3× Fighter, 3× Knight, 3× Cavalier, 2× Mercenary, 2× Shaman
 - **Difficult**: 27 enemies · avg L6.2 — 6× Soldier, 6× Cavalier, 3× Fighter, 3× Knight, 2× Mercenary, 2× Shaman
-- **Hard-mode delta**: {'Cavalier': 3} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Cavalier': 3} — a UNIT change, not a level shift
 - **Shape**: Rescue on a clock, run blind under fog
 - **Pressure**: Fog — the guide says it is the ONLY thing making the map hard — plus a 7-turn hostage timer, and Hard-only turn-4 cavalry spawning behind you
 - **Teaches**: Fog of war; enemies that heal; magic and poison at scale; effective weapons aimed at the player
@@ -134,7 +137,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 33 enemies · avg L7.2 — 9× Knight, 6× Soldier, 5× Archer, 3× Mage, 3× Cavalier, 2× Mercenary
 - **Normal**: 33 enemies · avg L7.2 — 9× Knight, 6× Soldier, 5× Archer, 3× Mage, 3× Cavalier, 2× Mercenary
 - **Difficult**: 38 enemies · avg L7.2 — 9× Knight, 6× Soldier, 5× Archer, 5× Mage, 3× Mercenary, 3× Shaman
-- **Hard-mode delta**: {'Mercenary': 1, 'Shaman': 1, 'Mage': 2, 'Fighter': 1} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Fighter': 1, 'Mage': 2, 'Mercenary': 1, 'Shaman': 1} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch8`*
 
 ## Chapter 9 (Eirika)
@@ -144,7 +147,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 38 enemies · avg L8.1 — 10× Mercenary, 8× Soldier, 5× Archer, 4× Fighter, 3× Pirate, 3× Mage
 - **Normal**: 38 enemies · avg L8.1 — 10× Mercenary, 8× Soldier, 5× Archer, 4× Fighter, 3× Pirate, 3× Mage
 - **Difficult**: 46 enemies · avg L8.3 — 10× Mercenary, 8× Soldier, 7× Archer, 7× Pirate, 6× Fighter, 3× Mage
-- **Hard-mode delta**: {'Fighter': 2, 'Archer': 2, 'Pirate': 4} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Fighter': 2, 'Pirate': 4, 'Archer': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika9`*
 
 ## Chapter 10 (Eirika)
@@ -154,7 +157,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 51 enemies · avg L9.5 — 11× Brigand, 8× Myrmidon, 7× Soldier, 5× Mercenary, 4× Archer, 4× Pegasus Knight
 - **Normal**: 51 enemies · avg L9.5 — 11× Brigand, 8× Myrmidon, 7× Soldier, 5× Mercenary, 4× Archer, 4× Pegasus Knight
 - **Difficult**: 60 enemies · avg L9.6 — 11× Brigand, 8× Soldier, 8× Myrmidon, 7× Mercenary, 7× Pegasus Knight, 6× Archer
-- **Hard-mode delta**: {'Archer': 2, 'Soldier': 1, 'Mercenary': 2, 'Fighter': 1, 'Pegasus Knight': 3} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Fighter': 1, 'Pegasus Knight': 3, 'Mercenary': 2, 'Archer': 2, 'Soldier': 1} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika10`*
 
 ## Chapter 11 (Eirika)
@@ -163,7 +166,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 42 enemies · avg L8.6 — 24× Bonewalker, 4× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
 - **Normal**: 42 enemies · avg L8.6 — 24× Bonewalker, 4× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
 - **Difficult**: 54 enemies · avg L8.9 — 30× Bonewalker, 10× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
-- **Hard-mode delta**: {'Revenant': 6, 'Bonewalker': 6} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Revenant': 6, 'Bonewalker': 6} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika11`*
 
 ## Chapter 12 (Eirika)
@@ -172,7 +175,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 44 enemies · avg L9.1 — 15× Gargoyle, 8× Bael, 8× Mauthe Doog, 4× Mogall, 3× Revenant, 2× Bonewalker
 - **Normal**: 44 enemies · avg L9.1 — 15× Gargoyle, 8× Bael, 8× Mauthe Doog, 4× Mogall, 3× Revenant, 2× Bonewalker
 - **Difficult**: 53 enemies · avg L9.1 — 19× Gargoyle, 9× Mauthe Doog, 8× Bael, 5× Mogall, 5× Revenant, 3× Bonewalker
-- **Hard-mode delta**: {'Gargoyle': 4, 'Mauthe Doog': 1, 'Mogall': 1, 'Bonewalker': 1, 'Revenant': 2} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Gargoyle': 4, 'Revenant': 2, 'Mogall': 1, 'Bonewalker': 1, 'Mauthe Doog': 1} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika12`*
 
 ## Chapter 13 (Eirika)
@@ -182,7 +185,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 58 enemies · avg L10.8 — 19× Cavalier, 6× Mercenary, 4× Archer, 4× Knight, 4× Fighter, 4× Brigand
 - **Normal**: 58 enemies · avg L10.8 — 19× Cavalier, 6× Mercenary, 4× Archer, 4× Knight, 4× Fighter, 4× Brigand
 - **Difficult**: 66 enemies · avg L10.9 — 21× Cavalier, 7× Mercenary, 6× Archer, 6× Soldier, 4× Knight, 4× Fighter
-- **Hard-mode delta**: {'Archer': 2, 'Cavalier': 2, 'Soldier': 3, 'Mercenary': 1} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Mercenary': 1, 'Archer': 2, 'Cavalier': 2, 'Soldier': 3} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika13`*
 
 ## Chapter 14 (Eirika)
@@ -201,7 +204,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 46 enemies · avg L8.8 — 12× Cavalier, 6× Archer, 6× Knight, 5× Soldier, 4× Mage, 4× Mercenary
 - **Normal**: 46 enemies · avg L8.8 — 12× Cavalier, 6× Archer, 6× Knight, 5× Soldier, 4× Mage, 4× Mercenary
 - **Difficult**: 59 enemies · avg L8.9 — 23× Cavalier, 6× Archer, 6× Knight, 5× Soldier, 4× Mage, 4× Mercenary
-- **Hard-mode delta**: {'Cavalier': 11, 'Shaman': 2} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Cavalier': 11, 'Shaman': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim9`*
 
 ## Chapter 10 (Ephraim)
@@ -210,7 +213,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 43 enemies · avg L9.6 — 16× Mercenary, 7× Cavalier, 3× Pirate, 3× Fighter, 3× Wyvern Rider, 2× Soldier
 - **Normal**: 43 enemies · avg L9.6 — 16× Mercenary, 7× Cavalier, 3× Pirate, 3× Fighter, 3× Wyvern Rider, 2× Soldier
 - **Difficult**: 49 enemies · avg L9.6 — 16× Mercenary, 9× Cavalier, 6× Pirate, 4× Fighter, 3× Wyvern Rider, 2× Soldier
-- **Hard-mode delta**: {'Pirate': 3, 'Cavalier': 2, 'Fighter': 1} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Fighter': 1, 'Pirate': 3, 'Cavalier': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim10`*
 
 ## Chapter 11 (Ephraim)
@@ -220,7 +223,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 48 enemies · avg L8.1 — 18× Bonewalker, 10× Mogall, 10× Gargoyle, 6× Revenant, 2× Entombed, 1× Wight
 - **Normal**: 48 enemies · avg L8.1 — 18× Bonewalker, 10× Mogall, 10× Gargoyle, 6× Revenant, 2× Entombed, 1× Wight
 - **Difficult**: 54 enemies · avg L8.2 — 18× Bonewalker, 14× Mogall, 12× Gargoyle, 6× Revenant, 2× Entombed, 1× Wight
-- **Hard-mode delta**: {'Mogall': 4, 'Gargoyle': 2} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Gargoyle': 2, 'Mogall': 4} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim11`*
 
 ## Chapter 12 (Ephraim)
@@ -230,7 +233,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 51 enemies · avg L10.4 — 10× Shaman, 7× Cavalier, 5× Mage, 5× Bonewalker, 4× Fighter, 4× Archer
 - **Normal**: 51 enemies · avg L10.4 — 10× Shaman, 7× Cavalier, 5× Mage, 5× Bonewalker, 4× Fighter, 4× Archer
 - **Difficult**: 67 enemies · avg L10.3 — 11× Bonewalker, 10× Shaman, 8× Bael, 7× Cavalier, 6× Archer, 5× Mage
-- **Hard-mode delta**: {'Archer': 2, 'Mercenary': 2, 'Bonewalker': 6, 'Bael': 6} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Bael': 6, 'Bonewalker': 6, 'Mercenary': 2, 'Archer': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim12`*
 
 ## Chapter 13 (Ephraim)
@@ -248,17 +251,30 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 71 enemies · avg L12.2 — 15× Knight, 14× Shaman, 8× Fighter, 7× Mage, 6× Myrmidon, 6× Soldier
 - **Normal**: 71 enemies · avg L12.2 — 15× Knight, 14× Shaman, 8× Fighter, 7× Mage, 6× Myrmidon, 6× Soldier
 - **Difficult**: 81 enemies · avg L12.3 — 20× Shaman, 15× Knight, 9× Mage, 8× Fighter, 6× Myrmidon, 6× Soldier
-- **Hard-mode delta**: {'Shaman': 6, 'Mage': 2, 'Priest': 2} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Mage': 2, 'Shaman': 6, 'Priest': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim14`*
 
 ## Chapter 15
 
 - **Objective**: Defeat all enemies  ·  **Lose**: Eirika or Ephraim dies
+- **Eirika Easy**: 77 enemies · avg L12.1 — 11× Wyvern Rider, 10× Cavalier, 10× Mercenary, 10× Pegasus Knight, 8× Shaman, 7× Fighter
+- **Eirika Normal**: 77 enemies · avg L12.1 — 11× Wyvern Rider, 10× Cavalier, 10× Mercenary, 10× Pegasus Knight, 8× Shaman, 7× Fighter
+- **Eirika Difficult**: 77 enemies · avg L12.1 — 11× Wyvern Rider, 10× Cavalier, 10× Mercenary, 10× Pegasus Knight, 8× Shaman, 7× Fighter
+- **Ephraim Easy**: 76 enemies · avg L12.1 — 11× Wyvern Rider, 10× Cavalier, 10× Fighter, 10× Pegasus Knight, 9× Mage, 7× Shaman
+- **Ephraim Normal**: 76 enemies · avg L12.1 — 11× Wyvern Rider, 10× Cavalier, 10× Fighter, 10× Pegasus Knight, 9× Mage, 7× Shaman
+- **Ephraim Difficult**: 76 enemies · avg L12.1 — 11× Wyvern Rider, 10× Cavalier, 10× Fighter, 10× Pegasus Knight, 9× Mage, 7× Shaman
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch15`*
 
 ## Chapter 16
 
 - **Objective**: Seize the throne  ·  **Lose**: Eirika or Ephraim dies
+- **Eirika Easy**: 41 enemies · avg L9.7 — 6× Great Knight, 5× Warrior, 4× Shaman, 4× Cavalier, 3× Hero, 3× Knight
+- **Eirika Normal**: 41 enemies · avg L9.7 — 6× Great Knight, 5× Warrior, 4× Shaman, 4× Cavalier, 3× Hero, 3× Knight
+- **Eirika Difficult**: 50 enemies · avg L9.7 — 8× Knight, 6× Great Knight, 5× Warrior, 5× Druid, 4× Shaman, 4× Cavalier
+- **Ephraim Easy**: 52 enemies · avg L11.7 — 6× Druid, 6× Cavalier, 5× Knight, 4× Mercenary, 4× Monk, 4× Fighter
+- **Ephraim Normal**: 52 enemies · avg L11.7 — 6× Druid, 6× Cavalier, 5× Knight, 4× Mercenary, 4× Monk, 4× Fighter
+- **Ephraim Difficult**: 57 enemies · avg L11.4 — 7× Knight, 6× Druid, 6× Cavalier, 4× Mercenary, 4× Shaman, 4× Monk
+- **Delta Eirika Normal → Eirika Difficult**: {'Swordmaster': 1, 'Druid': 3, 'Knight': 5} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch16`*
 
 ## Chapter 17
@@ -276,7 +292,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 46 enemies · avg L6.1 — 21× Gorgon, 18× Gorgon Egg, 4× Mogall, 3× Gargoyle
 - **Normal**: 46 enemies · avg L6.1 — 21× Gorgon, 18× Gorgon Egg, 4× Mogall, 3× Gargoyle
 - **Difficult**: 69 enemies · avg L7.4 — 27× Gorgon, 24× Gorgon Egg, 9× Bael, 5× Gargoyle, 4× Mogall
-- **Hard-mode delta**: {'Gorgon': 6, 'Gorgon Egg': 6, 'Gargoyle': 2, 'Bael': 9} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Gargoyle': 2, 'Bael': 9, 'Gorgon': 6, 'Gorgon Egg': 6} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch18`*
 
 ## Chapter 19
@@ -295,6 +311,6 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 122 enemies · avg L6.3 — 30× Deathgoyle, 22× Wight, 20× Mogall, 16× Maelduin, 15× Elder Bael, 9× Cyclops
 - **Normal**: 122 enemies · avg L6.3 — 30× Deathgoyle, 22× Wight, 20× Mogall, 16× Maelduin, 15× Elder Bael, 9× Cyclops
 - **Difficult**: 157 enemies · avg L6.3 — 33× Deathgoyle, 22× Wight, 20× Mogall, 20× Elder Bael, 19× Maelduin, 15× Gwyllgi
-- **Hard-mode delta**: {'Maelduin': 3, 'Gargoyle': 6, 'Arch Mogall': 3, 'Deathgoyle': 3, 'Elder Bael': 5, 'Gwyllgi': 15} — a UNIT change, not just a level shift
+- **Delta Normal → Difficult**: {'Deathgoyle': 3, 'Gwyllgi': 15, 'Arch Mogall': 3, 'Gargoyle': 6, 'Elder Bael': 5, 'Maelduin': 3} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch20`*
 

--- a/docs/fe8-guide.md
+++ b/docs/fe8-guide.md
@@ -1,0 +1,300 @@
+# FE8 chapter guide — parity and playstyle reference
+
+**Generated** by `tools/fe8_guide_mine.py`. Do not hand-edit; re-run the tool.
+
+Source: **Fire Emblem Wiki** (<https://fireemblemwiki.org>), the independent wiki. Credited in `CREDITS.md`.
+
+**Vanilla FE8 only.** This is the *how is it played* half of parity — the decomp already answers *what it contains*. Facts about OUR chapters live in `campaigns/<id>/chapters/*.yaml`; never source a claim about our design from here.
+
+Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level shift* (`chapter_settings`: easyMalus/normalMalus/difficultBonus), not a different force — so a tier that adds or removes UNITS is a real design signal and is called out.
+
+**Shape / Pressure / Teaches** digest each chapter's Strategy section into design vocabulary, from `docs/fe8-guide-glosses.json`. The index below is the donor-selection view.
+
+---
+
+## Donor-selection index
+
+| Chapter | Objective | Enemies (N) | Shape | Pressure comes from |
+|---|---|---|---|---|
+| [Prologue](#prologue) | Defeat O'Neill | 3 | — | — |
+| [Chapter 1](#chapter-1) | Seize the castle | 10 | Tutorial seize with a rearward ambush | A midline tripwire — crossing it drops 2 Fighters and a Soldier on your own start tile |
+| [Chapter 2](#chapter-2) | Defeat all bandits | 8 | — | — |
+| [Chapter 3](#chapter-3) | Seize the throne | 10 | — | — |
+| [Chapter 4](#chapter-4) | Defeat all monsters | 22 | — | — |
+| [Chapter 5](#chapter-5) | Defeat Saar | 23 | — | — |
+| [Chapter 5x](#chapter-5x) | Seize the throne | 31 | — | — |
+| [Chapter 6](#chapter-6) | Defeat Novala | 24 | Rescue on a clock, run blind under fog | Fog — the guide says it is the ONLY thing making the map hard — plus a 7-turn hostage timer, and Hard-only turn-4 cavalry spawning behind you |
+| [Chapter 7](#chapter-7) | Seize the gate | 19 | Seize across open ground, past fixed ranged emplacements | Ballistae covering the approach — a positional hazard you route around rather than fight, and lethal to fliers |
+| [Chapter 8](#chapter-8) | Seize the throne | 33 | — | — |
+| [Chapter 9 (Eirika)](#chapter-9-eirika) | Defeat all enemies | 38 | — | — |
+| [Chapter 10 (Eirika)](#chapter-10-eirika) | Seize the gate | 51 | — | — |
+| [Chapter 11 (Eirika)](#chapter-11-eirika) | Defeat all enemies | 42 | — | — |
+| [Chapter 12 (Eirika)](#chapter-12-eirika) | Defeat all enemies | 44 | — | — |
+| [Chapter 13 (Eirika)](#chapter-13-eirika) | Survive 11 turns or defeat Aias | 58 | — | — |
+| [Chapter 14 (Eirika)](#chapter-14-eirika) | Seize the throne | 68 | — | — |
+| [Chapter 9 (Ephraim)](#chapter-9-ephraim) | Seize the throne | 46 | — | — |
+| [Chapter 10 (Ephraim)](#chapter-10-ephraim) | Protect Duessel for 10 turns or defeat Beran | 43 | — | — |
+| [Chapter 11 (Ephraim)](#chapter-11-ephraim) | Defeat all enemies | 48 | — | — |
+| [Chapter 12 (Ephraim)](#chapter-12-ephraim) | Defeat boss | 51 | — | — |
+| [Chapter 13 (Ephraim)](#chapter-13-ephraim) | Defeat all enemies | 58 | — | — |
+| [Chapter 14 (Ephraim)](#chapter-14-ephraim) | Seize the throne | 71 | — | — |
+| [Chapter 15](#chapter-15) | Defeat all enemies | 77 | — | — |
+| [Chapter 16](#chapter-16) | Seize the throne | 41 | — | — |
+| [Chapter 17](#chapter-17) | Defeat Lyon | 64 | — | — |
+| [Chapter 18](#chapter-18) | Defeat all enemies | 46 | — | — |
+| [Chapter 19](#chapter-19) | Protect Mansel for 13 turns or defeat Riev | 97 | — | — |
+| [Chapter 20](#chapter-20) | Seize the gate | 122 | — | — |
+
+---
+
+## Prologue
+
+- **Objective**: Defeat O'Neill  ·  **Lose**: Eirika dies
+- **Difficult**: 3 enemies · avg L2.3 — 3× Fighter
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy prologue`*
+
+## Chapter 1
+
+- **Objective**: Seize the castle  ·  **Lose**: Eirika dies
+- **Difficult**: 10 enemies · avg L2.1 — 5× Fighter, 4× Soldier, 1× Knight
+- **Shape**: Tutorial seize with a rearward ambush
+- **Pressure**: A midline tripwire — crossing it drops 2 Fighters and a Soldier on your own start tile
+- **Teaches**: Trading weapons between units; allied reinforcements arriving on green tiles; effective weapons (the rapier against an armoured boss)
+- **Playstyle**: Barely harder than the prologue. Hand Seth's sword to Eirika first so the rapier is not wasted on ordinary infantry. Franz and Gilliam arrive turn 2 on the green tiles. Feed Eirika the Fighters and Franz or Gilliam the Soldiers if you intend to keep using them. The one trap: crossing the map's midline spawns two Fighters and a Soldier back where Seth and Eirika started, so do not leave your rear empty. Breguet is a Knight with Def 9 and Res 0 — the rapier cuts him, or lances do it the slow way. 5,000 gold on completion.
+
+## Chapter 2
+
+- **Objective**: Defeat all bandits  ·  **Lose**: Eirika dies
+- **Easy**: 8 enemies · avg L2.6 — 7× Brigand, 1× Archer
+- **Normal**: 8 enemies · avg L2.6 — 7× Brigand, 1× Archer
+- **Difficult**: 8 enemies · avg L2.6 — 7× Brigand, 1× Archer
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch2`*
+
+## Chapter 3
+
+- **Objective**: Seize the throne  ·  **Lose**: Eirika dies
+- **Easy**: 10 enemies · avg L3.4 — 7× Brigand, 1× Mercenary, 1× Archer, 1× Thief
+- **Normal**: 10 enemies · avg L3.4 — 7× Brigand, 1× Mercenary, 1× Archer, 1× Thief
+- **Difficult**: 10 enemies · avg L3.4 — 7× Brigand, 1× Mercenary, 1× Archer, 1× Thief
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch3`*
+
+## Chapter 4
+
+- **Objective**: Defeat all monsters  ·  **Lose**: Eirika dies
+- **Deploy**: 2–9
+- **Difficult**: 22 enemies · avg L1.8 — 12× Revenant, 6× Bonewalker, 3× Mogall, 1× Entombed
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch4`*
+
+## Chapter 5
+
+- **Objective**: Defeat Saar  ·  **Lose**: Eirika dies
+- **Deploy**: 2–9
+- **Easy**: 23 enemies · avg L5.2 — 6× Soldier, 6× Brigand, 5× Fighter, 3× Archer, 1× Knight, 1× Mercenary
+- **Normal**: 23 enemies · avg L5.2 — 6× Soldier, 6× Brigand, 5× Fighter, 3× Archer, 1× Knight, 1× Mercenary
+- **Difficult**: 23 enemies · avg L5.2 — 6× Soldier, 6× Brigand, 5× Fighter, 3× Archer, 1× Knight, 1× Mercenary
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch5`*
+
+## Chapter 5x
+
+- **Objective**: Seize the throne  ·  **Lose**: Ephraim dies
+- **Easy**: 31 enemies · avg L4.5 — 9× Soldier, 5× Fighter, 4× Archer, 3× Knight, 3× Cavalier, 2× Mercenary
+- **Normal**: 31 enemies · avg L4.5 — 9× Soldier, 5× Fighter, 4× Archer, 3× Knight, 3× Cavalier, 2× Mercenary
+- **Difficult**: 31 enemies · avg L4.5 — 9× Soldier, 5× Fighter, 4× Archer, 3× Knight, 3× Cavalier, 2× Mercenary
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch5x`*
+
+## Chapter 6
+
+- **Objective**: Defeat Novala  ·  **Lose**: Eirika dies
+- **Deploy**: 1–10
+- **Easy**: 24 enemies · avg L6.2 — 6× Soldier, 3× Fighter, 3× Knight, 3× Cavalier, 2× Mercenary, 2× Shaman
+- **Normal**: 24 enemies · avg L6.2 — 6× Soldier, 3× Fighter, 3× Knight, 3× Cavalier, 2× Mercenary, 2× Shaman
+- **Difficult**: 27 enemies · avg L6.2 — 6× Soldier, 6× Cavalier, 3× Fighter, 3× Knight, 2× Mercenary, 2× Shaman
+- **Hard-mode delta**: {'Cavalier': 3} — a UNIT change, not just a level shift
+- **Shape**: Rescue on a clock, run blind under fog
+- **Pressure**: Fog — the guide says it is the ONLY thing making the map hard — plus a 7-turn hostage timer, and Hard-only turn-4 cavalry spawning behind you
+- **Teaches**: Fog of war; enemies that heal; magic and poison at scale; effective weapons aimed at the player
+- **Playstyle**: The fog is the entire difficulty; strip it out and this is a walkover. Vision is a purchase, not a stat — buy torches from the PREVIOUS chapter's shop and lead with the thief for his sight radius. Then it is a race: Novala is holding hostages, reach them in under 7 turns with a flier, and the guide advises sending her from turn 1 to be safe. Saving all of them pays an Orion's Bolt, the biggest reward on the map. Only then go for the boss, who is a Shaman with Def 5 — 'a very easy boss, throw physical units at him'. Tank with your one overpowered unit, park in the forests on the right to evade, and watch your rear for the Hard-mode cavalry.
+
+## Chapter 7
+
+- **Objective**: Seize the gate  ·  **Lose**: Eirika dies
+- **Deploy**: 1–10
+- **Easy**: 19 enemies · avg L7.3 — 5× Fighter, 4× Soldier, 4× Archer, 3× Mage, 2× Mercenary, 1× Cavalier
+- **Normal**: 19 enemies · avg L7.3 — 5× Fighter, 4× Soldier, 4× Archer, 3× Mage, 2× Mercenary, 1× Cavalier
+- **Difficult**: 19 enemies · avg L7.3 — 5× Fighter, 4× Soldier, 4× Archer, 3× Mage, 2× Mercenary, 1× Cavalier
+- **Shape**: Seize across open ground, past fixed ranged emplacements
+- **Pressure**: Ballistae covering the approach — a positional hazard you route around rather than fight, and lethal to fliers
+- **Teaches**: Ballistae; stealing
+- **Playstyle**: A simple map by the guide's own account: beat the boss, take the castle. The single real hazard is the ballistae — keep fliers entirely outside their range, or walk an armour knight into it deliberately to break the machine. Bring the thief; there is an Energy Ring to steal. Push south behind a defensive front line. Murray is another pushover and can be safely chipped from range.
+
+## Chapter 8
+
+- **Objective**: Seize the throne  ·  **Lose**: Eirika or Ephraim dies
+- **Deploy**: 1–9
+- **Easy**: 33 enemies · avg L7.2 — 9× Knight, 6× Soldier, 5× Archer, 3× Mage, 3× Cavalier, 2× Mercenary
+- **Normal**: 33 enemies · avg L7.2 — 9× Knight, 6× Soldier, 5× Archer, 3× Mage, 3× Cavalier, 2× Mercenary
+- **Difficult**: 38 enemies · avg L7.2 — 9× Knight, 6× Soldier, 5× Archer, 5× Mage, 3× Mercenary, 3× Shaman
+- **Hard-mode delta**: {'Mercenary': 1, 'Shaman': 1, 'Mage': 2, 'Fighter': 1} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch8`*
+
+## Chapter 9 (Eirika)
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Eirika dies
+- **Deploy**: 2–11
+- **Easy**: 38 enemies · avg L8.1 — 10× Mercenary, 8× Soldier, 5× Archer, 4× Fighter, 3× Pirate, 3× Mage
+- **Normal**: 38 enemies · avg L8.1 — 10× Mercenary, 8× Soldier, 5× Archer, 4× Fighter, 3× Pirate, 3× Mage
+- **Difficult**: 46 enemies · avg L8.3 — 10× Mercenary, 8× Soldier, 7× Archer, 7× Pirate, 6× Fighter, 3× Mage
+- **Hard-mode delta**: {'Fighter': 2, 'Archer': 2, 'Pirate': 4} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika9`*
+
+## Chapter 10 (Eirika)
+
+- **Objective**: Seize the gate  ·  **Lose**: Eirika dies
+- **Deploy**: 1–12
+- **Easy**: 51 enemies · avg L9.5 — 11× Brigand, 8× Myrmidon, 7× Soldier, 5× Mercenary, 4× Archer, 4× Pegasus Knight
+- **Normal**: 51 enemies · avg L9.5 — 11× Brigand, 8× Myrmidon, 7× Soldier, 5× Mercenary, 4× Archer, 4× Pegasus Knight
+- **Difficult**: 60 enemies · avg L9.6 — 11× Brigand, 8× Soldier, 8× Myrmidon, 7× Mercenary, 7× Pegasus Knight, 6× Archer
+- **Hard-mode delta**: {'Archer': 2, 'Soldier': 1, 'Mercenary': 2, 'Fighter': 1, 'Pegasus Knight': 3} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika10`*
+
+## Chapter 11 (Eirika)
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Eirika dies
+- **Easy**: 42 enemies · avg L8.6 — 24× Bonewalker, 4× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
+- **Normal**: 42 enemies · avg L8.6 — 24× Bonewalker, 4× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
+- **Difficult**: 54 enemies · avg L8.9 — 30× Bonewalker, 10× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
+- **Hard-mode delta**: {'Revenant': 6, 'Bonewalker': 6} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika11`*
+
+## Chapter 12 (Eirika)
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Eirika dies
+- **Easy**: 44 enemies · avg L9.1 — 15× Gargoyle, 8× Bael, 8× Mauthe Doog, 4× Mogall, 3× Revenant, 2× Bonewalker
+- **Normal**: 44 enemies · avg L9.1 — 15× Gargoyle, 8× Bael, 8× Mauthe Doog, 4× Mogall, 3× Revenant, 2× Bonewalker
+- **Difficult**: 53 enemies · avg L9.1 — 19× Gargoyle, 9× Mauthe Doog, 8× Bael, 5× Mogall, 5× Revenant, 3× Bonewalker
+- **Hard-mode delta**: {'Gargoyle': 4, 'Mauthe Doog': 1, 'Mogall': 1, 'Bonewalker': 1, 'Revenant': 2} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika12`*
+
+## Chapter 13 (Eirika)
+
+- **Objective**: Survive 11 turns or defeat Aias  ·  **Lose**: Eirika dies
+- **Deploy**: 1–12
+- **Easy**: 58 enemies · avg L10.8 — 19× Cavalier, 6× Mercenary, 4× Archer, 4× Knight, 4× Fighter, 4× Brigand
+- **Normal**: 58 enemies · avg L10.8 — 19× Cavalier, 6× Mercenary, 4× Archer, 4× Knight, 4× Fighter, 4× Brigand
+- **Difficult**: 66 enemies · avg L10.9 — 21× Cavalier, 7× Mercenary, 6× Archer, 6× Soldier, 4× Knight, 4× Fighter
+- **Hard-mode delta**: {'Archer': 2, 'Cavalier': 2, 'Soldier': 3, 'Mercenary': 1} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika13`*
+
+## Chapter 14 (Eirika)
+
+- **Objective**: Seize the throne  ·  **Lose**: Eirika dies
+- **Deploy**: 1–12
+- **Easy**: 68 enemies · avg L12.2 — 16× Knight, 12× Shaman, 9× Archer, 9× Cavalier, 7× Fighter, 4× Mercenary
+- **Normal**: 68 enemies · avg L12.2 — 16× Knight, 12× Shaman, 9× Archer, 9× Cavalier, 7× Fighter, 4× Mercenary
+- **Difficult**: 68 enemies · avg L12.2 — 16× Knight, 12× Shaman, 9× Archer, 9× Cavalier, 7× Fighter, 4× Mercenary
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika14`*
+
+## Chapter 9 (Ephraim)
+
+- **Objective**: Seize the throne  ·  **Lose**: Ephraim dies
+- **Deploy**: 1–11
+- **Easy**: 46 enemies · avg L8.8 — 12× Cavalier, 6× Archer, 6× Knight, 5× Soldier, 4× Mage, 4× Mercenary
+- **Normal**: 46 enemies · avg L8.8 — 12× Cavalier, 6× Archer, 6× Knight, 5× Soldier, 4× Mage, 4× Mercenary
+- **Difficult**: 59 enemies · avg L8.9 — 23× Cavalier, 6× Archer, 6× Knight, 5× Soldier, 4× Mage, 4× Mercenary
+- **Hard-mode delta**: {'Cavalier': 11, 'Shaman': 2} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim9`*
+
+## Chapter 10 (Ephraim)
+
+- **Objective**: Protect Duessel for 10 turns or defeat Beran  ·  **Lose**: Ephraim or Duessel dies
+- **Easy**: 43 enemies · avg L9.6 — 16× Mercenary, 7× Cavalier, 3× Pirate, 3× Fighter, 3× Wyvern Rider, 2× Soldier
+- **Normal**: 43 enemies · avg L9.6 — 16× Mercenary, 7× Cavalier, 3× Pirate, 3× Fighter, 3× Wyvern Rider, 2× Soldier
+- **Difficult**: 49 enemies · avg L9.6 — 16× Mercenary, 9× Cavalier, 6× Pirate, 4× Fighter, 3× Wyvern Rider, 2× Soldier
+- **Hard-mode delta**: {'Pirate': 3, 'Cavalier': 2, 'Fighter': 1} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim10`*
+
+## Chapter 11 (Ephraim)
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Ephraim dies
+- **Deploy**: 1–11
+- **Easy**: 48 enemies · avg L8.1 — 18× Bonewalker, 10× Mogall, 10× Gargoyle, 6× Revenant, 2× Entombed, 1× Wight
+- **Normal**: 48 enemies · avg L8.1 — 18× Bonewalker, 10× Mogall, 10× Gargoyle, 6× Revenant, 2× Entombed, 1× Wight
+- **Difficult**: 54 enemies · avg L8.2 — 18× Bonewalker, 14× Mogall, 12× Gargoyle, 6× Revenant, 2× Entombed, 1× Wight
+- **Hard-mode delta**: {'Mogall': 4, 'Gargoyle': 2} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim11`*
+
+## Chapter 12 (Ephraim)
+
+- **Objective**: Defeat boss  ·  **Lose**: Ephraim dies
+- **Deploy**: 1–12
+- **Easy**: 51 enemies · avg L10.4 — 10× Shaman, 7× Cavalier, 5× Mage, 5× Bonewalker, 4× Fighter, 4× Archer
+- **Normal**: 51 enemies · avg L10.4 — 10× Shaman, 7× Cavalier, 5× Mage, 5× Bonewalker, 4× Fighter, 4× Archer
+- **Difficult**: 67 enemies · avg L10.3 — 11× Bonewalker, 10× Shaman, 8× Bael, 7× Cavalier, 6× Archer, 5× Mage
+- **Hard-mode delta**: {'Archer': 2, 'Mercenary': 2, 'Bonewalker': 6, 'Bael': 6} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim12`*
+
+## Chapter 13 (Ephraim)
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Ephraim dies
+- **Easy**: 58 enemies · avg L11.5 — 20× Cavalier, 10× Pegasus Knight, 6× Fighter, 3× Archer, 3× Mage, 3× Shaman
+- **Normal**: 58 enemies · avg L11.5 — 20× Cavalier, 10× Pegasus Knight, 6× Fighter, 3× Archer, 3× Mage, 3× Shaman
+- **Difficult**: 58 enemies · avg L11.5 — 20× Cavalier, 10× Pegasus Knight, 6× Fighter, 3× Archer, 3× Mage, 3× Shaman
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim13`*
+
+## Chapter 14 (Ephraim)
+
+- **Objective**: Seize the throne  ·  **Lose**: Ephraim dies
+- **Deploy**: 1–12
+- **Easy**: 71 enemies · avg L12.2 — 15× Knight, 14× Shaman, 8× Fighter, 7× Mage, 6× Myrmidon, 6× Soldier
+- **Normal**: 71 enemies · avg L12.2 — 15× Knight, 14× Shaman, 8× Fighter, 7× Mage, 6× Myrmidon, 6× Soldier
+- **Difficult**: 81 enemies · avg L12.3 — 20× Shaman, 15× Knight, 9× Mage, 8× Fighter, 6× Myrmidon, 6× Soldier
+- **Hard-mode delta**: {'Shaman': 6, 'Mage': 2, 'Priest': 2} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim14`*
+
+## Chapter 15
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Eirika or Ephraim dies
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch15`*
+
+## Chapter 16
+
+- **Objective**: Seize the throne  ·  **Lose**: Eirika or Ephraim dies
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch16`*
+
+## Chapter 17
+
+- **Objective**: Defeat Lyon  ·  **Lose**: Eirika or Ephraim dies
+- **Deploy**: 1–12
+- **Easy**: 64 enemies · avg L8.6 — 15× Wyvern Rider, 12× Druid, 10× Warrior, 6× Cavalier, 4× Paladin, 4× Hero
+- **Normal**: 64 enemies · avg L8.6 — 15× Wyvern Rider, 12× Druid, 10× Warrior, 6× Cavalier, 4× Paladin, 4× Hero
+- **Difficult**: 64 enemies · avg L8.6 — 15× Wyvern Rider, 12× Druid, 10× Warrior, 6× Cavalier, 4× Paladin, 4× Hero
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch17`*
+
+## Chapter 18
+
+- **Objective**: Defeat all enemies  ·  **Lose**: Eirika or Ephraim dies
+- **Easy**: 46 enemies · avg L6.1 — 21× Gorgon, 18× Gorgon Egg, 4× Mogall, 3× Gargoyle
+- **Normal**: 46 enemies · avg L6.1 — 21× Gorgon, 18× Gorgon Egg, 4× Mogall, 3× Gargoyle
+- **Difficult**: 69 enemies · avg L7.4 — 27× Gorgon, 24× Gorgon Egg, 9× Bael, 5× Gargoyle, 4× Mogall
+- **Hard-mode delta**: {'Gorgon': 6, 'Gorgon Egg': 6, 'Gargoyle': 2, 'Bael': 9} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch18`*
+
+## Chapter 19
+
+- **Objective**: Protect Mansel for 13 turns or defeat Riev  ·  **Lose**: Eirika , Ephraim , or Mansel dies
+- **Deploy**: 1–17
+- **Easy**: 97 enemies · avg L6.9 — 16× Swordmaster, 16× Warrior, 9× Hero, 7× Great Knight, 7× Mage Knight, 7× Paladin
+- **Normal**: 97 enemies · avg L6.9 — 16× Swordmaster, 16× Warrior, 9× Hero, 7× Great Knight, 7× Mage Knight, 7× Paladin
+- **Difficult**: 97 enemies · avg L6.9 — 16× Swordmaster, 16× Warrior, 9× Hero, 7× Great Knight, 7× Mage Knight, 7× Paladin
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch19`*
+
+## Chapter 20
+
+- **Objective**: Seize the gate  ·  **Lose**: Eirika or Ephraim dies
+- **Deploy**: 1–18
+- **Easy**: 122 enemies · avg L6.3 — 30× Deathgoyle, 22× Wight, 20× Mogall, 16× Maelduin, 15× Elder Bael, 9× Cyclops
+- **Normal**: 122 enemies · avg L6.3 — 30× Deathgoyle, 22× Wight, 20× Mogall, 16× Maelduin, 15× Elder Bael, 9× Cyclops
+- **Difficult**: 157 enemies · avg L6.3 — 33× Deathgoyle, 22× Wight, 20× Mogall, 20× Elder Bael, 19× Maelduin, 15× Gwyllgi
+- **Hard-mode delta**: {'Maelduin': 3, 'Gargoyle': 6, 'Arch Mogall': 3, 'Deathgoyle': 3, 'Elder Bael': 5, 'Gwyllgi': 15} — a UNIT change, not just a level shift
+- **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch20`*
+

--- a/tools/fe8_guide_mine.py
+++ b/tools/fe8_guide_mine.py
@@ -102,10 +102,18 @@ def fetch(slug, title, delay=4.0):
     if os.path.exists(dest) and os.path.getsize(dest) > 20000:
         return "cached"
     url = BASE + title.replace(" ", "_").replace("'", "%27")
-    p = subprocess.run(["curl", "-sS", "--compressed", "-A", UA,
-                        "-w", "%{http_code}", "-o", dest, url],
-                       capture_output=True, text=True, timeout=60)
-    code = (p.stdout or "").strip()[-3:]
+    try:
+        p = subprocess.run(["curl", "-sS", "--compressed", "-A", UA,
+                            "-w", "%{http_code}", "-o", dest, url],
+                           capture_output=True, text=True, timeout=60)
+        code = (p.stdout or "").strip()[-3:]
+    except subprocess.TimeoutExpired:
+        # a partial body left behind can be big enough to pass the size check and
+        # then be trusted forever, so drop it here rather than let the loop die
+        if os.path.exists(dest):
+            os.remove(dest)
+        time.sleep(delay)
+        return "TIMEOUT"
     size = os.path.getsize(dest) if os.path.exists(dest) else 0
     ok = code == "200" and size > 20000
     if not ok and os.path.exists(dest):
@@ -119,7 +127,7 @@ def fetch_all(delay=4.0):
     bad = 0
     for slug, title, _ in CHAPTERS:
         r = fetch(slug, title, delay)
-        failed = r.startswith("HTTP")
+        failed = r.startswith(("HTTP", "TIMEOUT"))
         bad += failed
         print(f"  {'FAIL' if failed else 'ok  '} {slug:12s} {title:24s} {r}", flush=True)
     print(f"\n{len(CHAPTERS)-bad} cached, {bad} failed. Re-run to retry only the failures.")
@@ -137,6 +145,16 @@ def _section(page, sect, nxt):
     i = page.find(f'id="{sect}"')
     j = page.find(f'id="{nxt}"')
     return page[i:j if j > i else len(page)] if i >= 0 else ""
+
+
+def _section_until(page, sect, followers):
+    """Slice from `sect` to whichever of `followers` appears first after it."""
+    i = page.find(f'id="{sect}"')
+    if i < 0:
+        return ""
+    ends = [page.find(f'id="{f}"', i) for f in followers]
+    ends = [e for e in ends if e > i]
+    return page[i:min(ends)] if ends else page[i:]
 
 
 def _tab_panes(chunk):
@@ -198,15 +216,36 @@ def parse(path):
         if rows:
             d["tiers"][label] = rows
 
-    boss = _text(_section(page, "Boss_data", "Strategy"))
-    d["boss"] = boss[:400]
+    # `_section` runs to end-of-page when the named next-section is absent, so an
+    # `or` chain never reaches its fallback -- it just dumps the page tail. Cut at
+    # whichever known follower appears FIRST instead.
+    d["strategy"] = _text(_section_until(page, "Strategy",
+                                         ("Trivia", "Etymology", "Gallery",
+                                          "Navigation", "References")))
 
-    strat = _section(page, "Strategy", "Trivia") or _section(page, "Strategy", "Etymology")
-    d["strategy"] = _text(strat).replace("Strategy ", "", 1)
-
-    items = _text(_section(page, "Item_data", "Enemy_data"))
-    d["items"] = items[:400]
     return d
+
+
+def playable_tiers(tiers):
+    """Every scraped tier except the Japanese columns, in page order.
+
+    Tier labels are NOT a fixed set. Observed on the wiki: plain `Normal`, a
+    COMBINED `Easy/Normal` (prologue, Ch1, Ch4), and ROUTE-SPLIT `Eirika Normal` /
+    `Ephraim Normal` (Ch15, Ch16, which are route-shared chapters). Hardcoding
+    ("Easy","Normal","Difficult") silently rendered NOTHING for the route-split
+    chapters while the index still counted them -- so match by substring, and
+    never drop a tier just because its label is unfamiliar.
+    """
+    return [(k, v) for k, v in tiers.items() if "(Japan)" not in k]
+
+
+def tier_like(tiers, want):
+    """The tier whose label mentions `want` (so `Easy/Normal` answers to both).
+    Returns (label, rows) or (None, None)."""
+    for k, v in playable_tiers(tiers):
+        if want.lower() in k.lower():
+            return k, v
+    return None, None
 
 
 def summarize(tier_rows):
@@ -240,10 +279,16 @@ def render(records, glosses):
         g = glosses.get(slug) or {}
         if isinstance(g, str):
             g = {"playstyle": g}
-        normal = d["tiers"].get("Normal") or next(iter(d["tiers"].values()), [])
-        tot, avg, _ = summarize(normal) if normal else (0, 0, {})
+        lab, rows = tier_like(d["tiers"], "Normal")
+        if rows:
+            tot = summarize(rows)[0]
+            # say WHICH tier when it is not a plain "Normal" -- a route-split or
+            # combined label under a column headed Normal is a silent lie.
+            cell = f"{tot}" if lab == "Normal" else f"{tot} <sub>({lab})</sub>"
+        else:
+            cell = "—"
         anchor = re.sub(r"[^a-z0-9 -]", "", label.lower()).replace(" ", "-")
-        L.append(f"| [{label}](#{anchor}) | {d['objective'] or '—'} | {tot or '—'} "
+        L.append(f"| [{label}](#{anchor}) | {d['objective'] or '—'} | {cell} "
                  f"| {g.get('shape','—')} | {g.get('pressure','—')} |")
     L.append("\n---\n")
 
@@ -256,21 +301,20 @@ def render(records, glosses):
                  + (f"  ·  **Lose**: {d['lose']}" if d.get("lose") else ""))
         if d.get("deploy"):
             L.append(f"- **Deploy**: {d['deploy']}")
-        for tier in ("Easy", "Normal", "Difficult"):
-            rows = d["tiers"].get(tier)
-            if not rows:
-                continue
+        for tier, rows in playable_tiers(d["tiers"]):
             tot, avg, by = summarize(rows)
             mix = ", ".join(f"{v}× {k}" for k, v in by.most_common(6))
             L.append(f"- **{tier}**: {tot} enemies · avg L{avg:.1f} — {mix}")
-        n = d["tiers"].get("Normal")
-        h = d["tiers"].get("Difficult")
-        if n and h:
-            a = summarize(n)[2]
-            b = summarize(h)[2]
-            delta = {k: b[k] - a.get(k, 0) for k in b if b[k] != a.get(k, 0)}
+        nl, n = tier_like(d["tiers"], "Normal")
+        hl, h = tier_like(d["tiers"], "Difficult")
+        if n and h and nl != hl:
+            a, b = summarize(n)[2], summarize(h)[2]
+            # union of BOTH key sets: a class REMOVED on Difficult is a delta too,
+            # and iterating only the Difficult counter would never show it.
+            delta = {k: b.get(k, 0) - a.get(k, 0) for k in set(a) | set(b)
+                     if b.get(k, 0) != a.get(k, 0)}
             if delta:
-                L.append(f"- **Hard-mode delta**: {delta} — a UNIT change, not just a level shift")
+                L.append(f"- **Delta {nl} → {hl}**: {delta} — a UNIT change, not a level shift")
         for key, name in (("shape", "Shape"), ("pressure", "Pressure"), ("teaches", "Teaches")):
             if g.get(key):
                 L.append(f"- **{name}**: {g[key]}")
@@ -287,6 +331,8 @@ def main():
     ap.add_argument("--render", action="store_true")
     ap.add_argument("--strategy", metavar="SLUG")
     ap.add_argument("--delay", type=float, default=4.0)
+    ap.add_argument("--render-anyway", action="store_true",
+                    help="render even if the fetch had failures (writes a partial digest)")
     ap.add_argument("--cache", default=CACHE)
     a = ap.parse_args()
     globals()["CACHE"] = a.cache
@@ -300,8 +346,13 @@ def main():
 
     if not (a.fetch or a.render):
         a.fetch = a.render = True
+    failures = 0
     if a.fetch:
-        fetch_all(a.delay)
+        failures = fetch_all(a.delay)
+    if a.render and failures and not a.render_anyway:
+        sys.exit(f"ERROR: {failures} page(s) failed to fetch — refusing to overwrite the "
+                 f"committed digest from a partial cache. Re-run --fetch (it resumes), "
+                 f"or pass --render-anyway if a partial digest is what you want.")
     if a.render:
         records, missing = [], []
         for slug, title, label in CHAPTERS:

--- a/tools/fe8_guide_mine.py
+++ b/tools/fe8_guide_mine.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Mine fireemblemwiki.org into a generated FE8 parity + playstyle reference.
+
+WHY THIS EXISTS. `fireemblem8u/` answers "what does vanilla CONTAIN" -- rosters,
+flags, drops. It cannot answer "how is the chapter meant to be WON", and that is
+what a `parity_reference:` is really reaching for. When a session of the D&D
+campaign has to become a chapter, the question is "which vanilla chapter is this
+SHAPED like", and only a walkthrough answers it.
+
+NOT a source of truth for OUR chapters -- that is
+`campaigns/<id>/chapters/*.yaml`. This records VANILLA only.
+
+WHY THIS SOURCE. fireemblemwod.com was the first attempt and is a dead end: its
+`ENG_` pages 403 permanently, and a burst of requests earns a sustained IP block
+that survived two hours of silence and was immune to cookies. fireemblemwiki.org
+serves cleanly AND is richer -- structured Chapter/Enemy/Boss/Item data plus a
+Strategy section, where the walkthrough had prose only. Fandom is not an option
+(403s a non-browser client).
+
+Two things that cost real time, recorded so nobody repeats them:
+  * The wiki's difficulty tabs are `<div class="tab&#95;content">` -- the class
+    attribute is HTML-ESCAPED in the source, so every `class="tab_content"`
+    regex silently matches nothing. Byte-offset heuristics over `<table>` are
+    NOT a substitute; match the divs with a depth counter.
+  * Retrying FAST is what keeps a rate-block alive. One request, no retry, a
+    real gap between them, and resume from cache.
+
+USAGE
+    python3 tools/fe8_guide_mine.py --fetch      # populate the cache (slow, resumable)
+    python3 tools/fe8_guide_mine.py --render     # cache -> docs/fe8-guide.md
+    python3 tools/fe8_guide_mine.py --strategy ch6
+
+The HTML cache lives outside the repo in the gitignored `.fe8-guide-cache/`;
+only the derived, attributed digest is committed.
+"""
+
+import argparse
+import collections
+import html
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE = "https://fireemblemwiki.org/wiki/"
+CACHE = os.path.join(REPO, ".fe8-guide-cache", "wiki")
+OUT = os.path.join(REPO, "docs", "fe8-guide.md")
+GLOSSES = os.path.join(REPO, "docs", "fe8-guide-glosses.json")
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/120.0 Safari/537.36")
+
+# (slug, wiki page title, display label). Neither the titles nor the NUMBERS are
+# guesses. Titles are the chapter-title strings the decomp ships (MSG_0160..MSG_017B
+# in fireemblem8u/tools/textencode/msg_list.txt). The numbers come from
+# include/constants/chapters.h, which is the only thing that settles them: the
+# message-list ORDER does not match the chapter numbering, and reading numbers off
+# it puts Landing at Taizel at Ch11 (it is Ch12) and drops Creeping Darkness and
+# Phantom Ship, the two Ch11s, entirely.
+CHAPTERS = [
+    ("prologue", "The Fall of Renais",   "Prologue"),
+    ("ch1",      "Escape!",              "Chapter 1"),
+    ("ch2",      "The Protected",        "Chapter 2"),
+    ("ch3",      "The Bandits of Borgo", "Chapter 3"),
+    ("ch4",      "Ancient Horrors",      "Chapter 4"),
+    ("ch5",      "The Empire's Reach",   "Chapter 5"),
+    ("ch5x",     "Unbroken Heart",       "Chapter 5x"),
+    ("ch6",      "Victims of War",       "Chapter 6"),
+    ("ch7",      "Waterside Renvall",    "Chapter 7"),
+    ("ch8",      "It's a Trap!",         "Chapter 8"),
+    ("eirika9",  "Distant Blade",        "Chapter 9 (Eirika)"),
+    ("eirika10", "Revolt at Carcino",    "Chapter 10 (Eirika)"),
+    ("eirika11", "Creeping Darkness",    "Chapter 11 (Eirika)"),
+    ("eirika12", "Village of Silence",   "Chapter 12 (Eirika)"),
+    ("eirika13", "Hamill Canyon",        "Chapter 13 (Eirika)"),
+    ("eirika14", "Queen of White Dunes", "Chapter 14 (Eirika)"),
+    ("ephraim9",  "Fort Rigwald",        "Chapter 9 (Ephraim)"),
+    ("ephraim10", "Turning Traitor",     "Chapter 10 (Ephraim)"),
+    ("ephraim11", "Phantom Ship",        "Chapter 11 (Ephraim)"),
+    ("ephraim12", "Landing at Taizel",   "Chapter 12 (Ephraim)"),
+    ("ephraim13", "Fluorspar's Oath",    "Chapter 13 (Ephraim)"),
+    ("ephraim14", "Father and Son",      "Chapter 14 (Ephraim)"),
+    ("ch15", "Scorched Sand",     "Chapter 15"),
+    ("ch16", "Ruled by Madness",  "Chapter 16"),
+    ("ch17", "River of Regrets",  "Chapter 17"),
+    ("ch18", "Two Faces of Evil", "Chapter 18"),
+    ("ch19", "Last Hope",         "Chapter 19"),
+    ("ch20", "Darkling Woods",    "Chapter 20"),
+]
+
+STAT_COLS = ["HP", "S/M", "Mag", "Skill", "Spd", "Lck", "Prf", "Wlv", "Def"]
+
+
+# ---------------------------------------------------------------- fetching ---
+
+def fetch(slug, title, delay=4.0):
+    """One page, resuming from cache. This host is well behaved; the delay is
+    courtesy, not evasion."""
+    dest = os.path.join(CACHE, slug + ".html")
+    if os.path.exists(dest) and os.path.getsize(dest) > 20000:
+        return "cached"
+    url = BASE + title.replace(" ", "_").replace("'", "%27")
+    p = subprocess.run(["curl", "-sS", "--compressed", "-A", UA,
+                        "-w", "%{http_code}", "-o", dest, url],
+                       capture_output=True, text=True, timeout=60)
+    code = (p.stdout or "").strip()[-3:]
+    size = os.path.getsize(dest) if os.path.exists(dest) else 0
+    ok = code == "200" and size > 20000
+    if not ok and os.path.exists(dest):
+        os.remove(dest)
+    time.sleep(delay)
+    return "%d bytes" % size if ok else "HTTP %s" % code
+
+
+def fetch_all(delay=4.0):
+    os.makedirs(CACHE, exist_ok=True)
+    bad = 0
+    for slug, title, _ in CHAPTERS:
+        r = fetch(slug, title, delay)
+        failed = r.startswith("HTTP")
+        bad += failed
+        print(f"  {'FAIL' if failed else 'ok  '} {slug:12s} {title:24s} {r}", flush=True)
+    print(f"\n{len(CHAPTERS)-bad} cached, {bad} failed. Re-run to retry only the failures.")
+    return bad
+
+
+# ----------------------------------------------------------------- parsing ---
+
+def _text(fragment):
+    t = html.unescape(re.sub(r"<[^>]+>", " ", fragment))
+    return re.sub(r"\s+", " ", t).strip()
+
+
+def _section(page, sect, nxt):
+    i = page.find(f'id="{sect}"')
+    j = page.find(f'id="{nxt}"')
+    return page[i:j if j > i else len(page)] if i >= 0 else ""
+
+
+def _tab_panes(chunk):
+    """Pair the tab LABELS with their content divs.
+
+    The class attribute is escaped as `tab&#95;content` in the served HTML, and
+    the panes nest further divs, so this walks depth rather than regexing a
+    closing tag.
+    """
+    m = re.search(r'<div class="tab&#95;main"', chunk)
+    if not m:
+        return []
+    g = m.start()
+    labels = [_text(l) for l in re.findall(
+        r'<span class="tab&#95;tab[^"]*">(.*?)</span>', chunk[g:g + 1500], re.S)]
+    panes = []
+    for pm in re.finditer(r'<div class="tab&#95;content"', chunk[g:]):
+        p = g + pm.start()
+        depth, k = 0, p
+        while True:
+            nxt = re.search(r"<div\b|</div>", chunk[k:])
+            if not nxt:
+                break
+            k += nxt.end()
+            depth += 1 if nxt.group(0).startswith("<div") else -1
+            if depth == 0:
+                panes.append(chunk[p:k])
+                break
+    return list(zip(labels, panes))
+
+
+def _rows(pane):
+    out = []
+    for tr in re.findall(r"<tr[^>]*>(.*?)</tr>", pane, re.S):
+        cells = [_text(c) for c in re.findall(r"<t[dh][^>]*>(.*?)</t[dh]>", tr, re.S)]
+        if len(cells) >= 6 and re.fullmatch(r"\d{1,2}", cells[3]) and \
+           re.fullmatch(r"\d{1,2}", cells[4]):
+            out.append({"name": cells[1], "klass": cells[2],
+                        "level": int(cells[3]), "count": int(cells[4])})
+    return out
+
+
+def parse(path):
+    page = open(path, encoding="utf-8", errors="replace").read()
+    page = re.sub(r"<(script|style)[^>]*>.*?</\1>", "", page, flags=re.S | re.I)
+    d = {}
+
+    cd = _text(_section(page, "Chapter_data", "Character_data"))
+    m = re.search(r"Victory:\s*(.+?)\s+(?:Player|Defeat:)", cd)
+    d["objective"] = m.group(1).strip() if m else ""
+    m = re.search(r"Defeat:\s*(.+?)\s+\d", cd)
+    d["lose"] = m.group(1).strip() if m else ""
+    m = re.search(r"(\d+)[–-](\d+)(\+\d+)?", cd)
+    d["deploy"] = (m.group(0) if m else "")
+
+    d["tiers"] = {}
+    for label, pane in _tab_panes(_section(page, "Enemy_data", "Boss_data")):
+        rows = _rows(pane)
+        if rows:
+            d["tiers"][label] = rows
+
+    boss = _text(_section(page, "Boss_data", "Strategy"))
+    d["boss"] = boss[:400]
+
+    strat = _section(page, "Strategy", "Trivia") or _section(page, "Strategy", "Etymology")
+    d["strategy"] = _text(strat).replace("Strategy ", "", 1)
+
+    items = _text(_section(page, "Item_data", "Enemy_data"))
+    d["items"] = items[:400]
+    return d
+
+
+def summarize(tier_rows):
+    total = sum(r["count"] for r in tier_rows)
+    avg = sum(r["level"] * r["count"] for r in tier_rows) / total if total else 0
+    by = collections.Counter()
+    for r in tier_rows:
+        by[r["klass"]] += r["count"]
+    return total, avg, by
+
+
+# --------------------------------------------------------------- rendering ---
+
+def render(records, glosses):
+    L = ["# FE8 chapter guide — parity and playstyle reference\n",
+         "**Generated** by `tools/fe8_guide_mine.py`. Do not hand-edit; re-run the tool.\n",
+         "Source: **Fire Emblem Wiki** (<https://fireemblemwiki.org>), the independent wiki. "
+         "Credited in `CREDITS.md`.\n",
+         "**Vanilla FE8 only.** This is the *how is it played* half of parity — the decomp already "
+         "answers *what it contains*. Facts about OUR chapters live in "
+         "`campaigns/<id>/chapters/*.yaml`; never source a claim about our design from here.\n",
+         "Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level shift* "
+         "(`chapter_settings`: easyMalus/normalMalus/difficultBonus), not a different force — so a "
+         "tier that adds or removes UNITS is a real design signal and is called out.\n",
+         "**Shape / Pressure / Teaches** digest each chapter's Strategy section into design "
+         "vocabulary, from `docs/fe8-guide-glosses.json`. The index below is the donor-selection "
+         "view.\n", "---\n", "## Donor-selection index\n",
+         "| Chapter | Objective | Enemies (N) | Shape | Pressure comes from |", "|---|---|---|---|---|"]
+
+    for slug, label, d in records:
+        g = glosses.get(slug) or {}
+        if isinstance(g, str):
+            g = {"playstyle": g}
+        normal = d["tiers"].get("Normal") or next(iter(d["tiers"].values()), [])
+        tot, avg, _ = summarize(normal) if normal else (0, 0, {})
+        anchor = re.sub(r"[^a-z0-9 -]", "", label.lower()).replace(" ", "-")
+        L.append(f"| [{label}](#{anchor}) | {d['objective'] or '—'} | {tot or '—'} "
+                 f"| {g.get('shape','—')} | {g.get('pressure','—')} |")
+    L.append("\n---\n")
+
+    for slug, label, d in records:
+        g = glosses.get(slug) or {}
+        if isinstance(g, str):
+            g = {"playstyle": g}
+        L.append(f"## {label}\n")
+        L.append(f"- **Objective**: {d['objective'] or '—'}"
+                 + (f"  ·  **Lose**: {d['lose']}" if d.get("lose") else ""))
+        if d.get("deploy"):
+            L.append(f"- **Deploy**: {d['deploy']}")
+        for tier in ("Easy", "Normal", "Difficult"):
+            rows = d["tiers"].get(tier)
+            if not rows:
+                continue
+            tot, avg, by = summarize(rows)
+            mix = ", ".join(f"{v}× {k}" for k, v in by.most_common(6))
+            L.append(f"- **{tier}**: {tot} enemies · avg L{avg:.1f} — {mix}")
+        n = d["tiers"].get("Normal")
+        h = d["tiers"].get("Difficult")
+        if n and h:
+            a = summarize(n)[2]
+            b = summarize(h)[2]
+            delta = {k: b[k] - a.get(k, 0) for k in b if b[k] != a.get(k, 0)}
+            if delta:
+                L.append(f"- **Hard-mode delta**: {delta} — a UNIT change, not just a level shift")
+        for key, name in (("shape", "Shape"), ("pressure", "Pressure"), ("teaches", "Teaches")):
+            if g.get(key):
+                L.append(f"- **{name}**: {g[key]}")
+        L.append(f"- **Playstyle**: {g['playstyle']}" if g.get("playstyle") else
+                 f"- **Playstyle**: *not yet digested — "
+                 f"`tools/fe8_guide_mine.py --strategy {slug}`*")
+        L.append("")
+    return "\n".join(L) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--fetch", action="store_true")
+    ap.add_argument("--render", action="store_true")
+    ap.add_argument("--strategy", metavar="SLUG")
+    ap.add_argument("--delay", type=float, default=4.0)
+    ap.add_argument("--cache", default=CACHE)
+    a = ap.parse_args()
+    globals()["CACHE"] = a.cache
+
+    if a.strategy:
+        p = os.path.join(a.cache, a.strategy + ".html")
+        if not os.path.exists(p):
+            sys.exit(f"not cached: {a.strategy} (run --fetch)")
+        print(parse(p)["strategy"] or "(no Strategy section)")
+        return
+
+    if not (a.fetch or a.render):
+        a.fetch = a.render = True
+    if a.fetch:
+        fetch_all(a.delay)
+    if a.render:
+        records, missing = [], []
+        for slug, title, label in CHAPTERS:
+            p = os.path.join(a.cache, slug + ".html")
+            if os.path.exists(p) and os.path.getsize(p) > 20000:
+                records.append((slug, label, parse(p)))
+            else:
+                missing.append(slug)
+        if not records:
+            sys.exit("ERROR: cache empty — run with --fetch first (%s)" % a.cache)
+        glosses = json.load(open(GLOSSES, encoding="utf-8")) if os.path.exists(GLOSSES) else {}
+        os.makedirs(os.path.dirname(OUT), exist_ok=True)
+        open(OUT, "w", encoding="utf-8").write(render(records, glosses))
+        print(f"wrote {OUT} — {len(records)}/{len(CHAPTERS)} chapters")
+        if missing:
+            print("  MISSING (re-run --fetch): " + ", ".join(missing))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `docs/fe8-guide.md` — all 28 vanilla chapters with objective, deploy cap, per-difficulty enemy tables, and a **donor-selection index** (objective / enemy count / shape / pressure). This is the half of parity the decomp cannot answer: *how is this chapter meant to be won.*

Used immediately by #26 — it is what settled the ch06 donor.

**Why this source.** Started on fireemblemwod; its `ENG_` pages 403 permanently and a request burst earns a sustained IP block. fireemblemwiki.org serves cleanly and is richer (structured per-difficulty enemy tables vs prose). Fandom 403s a non-browser client.

**Gotchas recorded in the docstring** so nobody repeats them:
- the wiki difficulty tabs are `<div class="tab&#95;content">` — HTML-escaped, so `class="tab_content"` regexes match nothing
- retrying fast is what keeps a rate-block alive
- chapter NUMBERS come from `chapters.h`, never the message-list order (which puts Landing at Taizel at Ch11 and drops both Ch11s)

**Only facts are committed.** The wiki Strategy prose is not reproduced; `Shape`/`Pressure`/`Teaches`/`Playstyle` in `docs/fe8-guide-glosses.json` are ours, written from it. Three chapters digested so far (1, 6, 7); the rest carry a pointer to `--strategy <slug>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)