### PR TITLE
ch06: the roster is the merfolk, and Messie stops being a fight (#26)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -136,6 +136,32 @@ deployment:
 # below are INTENT; the wiring lands in campaign.yaml when the slice is built.
 #
 # MESSIE IS NOT HERE. He is not an encounter -- he arrives in the boss-death cutscene.
+# ── AI, derived from vanilla's own UnitDefinitions ───────────────────────────────
+# CORRECTED 2026-08-29: an earlier draft AUTHORED these labels and got the chapter's shape
+# backwards (13 pursuing units). Vanilla Ch6 is a STATIC map, and its `src/events_udefs.c`
+# arrays say so unit by unit:
+#
+#   17 of 24   AttackInRangeAI  = {AI_A_00 ActionInRange, AI_B_03 NeverMove}  -> `cautious`
+#    4         {0x0, 0x12, 0, 0} = AI_B_12 MoveToEnemyAfterOneTurn            -> `charge_after_one_turn`
+#              (the 3 Cavaliers AND the Troubadour -- vanilla's healer travels with its cavalry)
+#    2         no .ai block at all = {0,0,0,0} = ActionInRange + MoveToEnemy  -> `pursue`
+#    1 boss    GuardTileAI = {AI_A_03 ActionStanding, AI_B_03 NeverMove}      -> `hold_position`
+#    3 Hard    {DefaultAI, 0x1, 0x0}                                          -> `aggressive`
+#
+# So nothing charges the player on turn 1 except two units and a Bael: the map holds still and
+# the player advances into fixed threat ranges. That is WHY Ch6's difficulty was the hostage
+# clock and the fog rather than an enemy tide -- and it is the shape our marooned boats inherit.
+#
+# EXACT BYTES for `CH06_AI` when the injector lands (two labels our other chapters lack):
+#   cautious              {0x0, 0x3, 0x0, 0x0}    -- already ch01's spelling of AttackInRangeAI
+#   charge_after_one_turn {0x0, 0x12, 0x0, 0x0}   -- NEW
+#   pursue                {0x0, 0x0, 0x0, 0x0}    -- NEW
+#   hold_position         {0x3, 0x3, 0x0, 0x0}    -- Ch6's own tail, NOT ch05's {..., 0x9, 0x20}
+#   aggressive            {0x0, 0x0, 0x1, 0x0}    -- already ch03/ch04/ch05's spelling
+#
+# One divergence, declared: vanilla gives ONE of its four L7 Iron-Lance Soldiers the pursuing
+# all-zero AI and the other three AttackInRange. Ours are a single `count: 4` entry and take
+# the majority behaviour; splitting one out is a placement-time decision, not a roster one.
 enemy_units:
   # ── The trident line (vanilla's 6 Soldiers) → merfolk, Mermaid `2. Lance` ─────
   - id: merfolk-trident
@@ -147,7 +173,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing       # flavor label only
-    ai_pattern: aggressive      # the boat squads -- see `roster_roles` below
+    ai_pattern: cautious               # vanilla: 3 of these 4 Soldiers are AttackInRangeAI; the 4th pursues (see note)
     skin:
       look: "merfolk spear-guard; the anim's lance IS a trident"
       source: "FE-Repo: Battle Animations/Monsters - Dragons and Special/[Monster-Custom] [F] Mermaid by Stephano -> 2. Lance; map sprite Mermaid (F) {N426} or {ZoramineFae}, 16x16"
@@ -161,7 +187,7 @@ enemy_units:
       - id: javelin
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: aggressive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk spear-guard, thrown trident", source: "as merfolk-trident"}
   - id: merfolk-trident-young
     name: "Mermaid"
@@ -172,7 +198,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: defensive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk spear-guard", source: "as merfolk-trident"}
 
   # ── The axe block (vanilla's 3 Fighters) → shark riders ──────────────────────
@@ -191,7 +217,7 @@ enemy_units:
       - id: poison-axe
         fe_base: venin-axe        # FE8's ITEM_AXE_VENIN, which the wiki prints as "Poison Axe"
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin:
       look: "merfolk on a shark, boarding axe"
       source: "FE-Repo: Map Sprites/Mounted - Dismounted, Monsters, Misc/Shark Rider (M) {N426}, 16x16 (stand+walk); NO battle anim exists -- vanilla Fighter frames, repalletted"
@@ -204,7 +230,7 @@ enemy_units:
     inventory:
       - id: steel-axe
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
   - id: shark-rider-halberd
     name: "Shark Rider"
@@ -220,7 +246,7 @@ enemy_units:
                                 # this row carries two items, so the second drop is unresolved
                                 # from the wiki alone -- confirm against the ROM when ch06 is hosted.
     damage_type: slashing
-    ai_pattern: defensive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
 
   # ── The mounted block (vanilla's 3 Cavaliers) → crab-riders ──────────────────
@@ -233,7 +259,7 @@ enemy_units:
     inventory:
       - id: iron-blade
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, 0x0, 0x0}
     skin:
       look: "merfolk astride a lake crab; the mount repainted from an arachnid to ice-blue shell"
       source: "FE-Repo: Battle Animations/Mounted - Dismounted, Monsters, Misc/[Spider-Variant] [M] Cavalier Rider by DATonDemand -> 1. Sword + 2. Lance; map sprite Cavalier (M) Spider Rider Sword {Zoramine} or Elder Bael Sword {Metalocif}, 16x32"
@@ -246,7 +272,7 @@ enemy_units:
     inventory:
       - id: iron-sword
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, 0x0, 0x0}
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-lance
     name: "Crab Rider"
@@ -257,7 +283,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: aggressive
+    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, 0x0, 0x0}
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 2. Lance"}
 
   # ── The sword block (vanilla's 2 Mercenaries) → crab-riders on foot-speed ────
@@ -270,7 +296,7 @@ enemy_units:
     inventory:
       - id: iron-sword
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 1. Sword"}
   - id: merfolk-blade-drop
     name: "Crab Rider"
@@ -282,7 +308,7 @@ enemy_units:
       - id: iron-blade
     item_drop: iron-blade       # vanilla: "Iron Blade -- dropped by enemy Mercenary"
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 1. Sword"}
 
   # ── The armour block (vanilla's 3 Knights) → IronShell ───────────────────────
@@ -298,7 +324,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: hold_position   # the crossings -- a 1-tile bridge is what armour is for
+    ai_pattern: cautious               # vanilla AttackInRangeAI -- armour that never moves
     skin:
       look: "a shelled thing plated like a knight, holding a bridge"
       source: "FE-Repo: Battle Animations/Infantry - Knights, Generals, Armors/[General-Variant] IronShell-Tiny General [U] by Alexsplode -> 2. Lance; map sprite General (U) IronShell_Tiny {Alexsplode}, 16x32. NB its anim preview keys on BLUE, not the usual green."
@@ -312,7 +338,7 @@ enemy_units:
       - id: horseslayer
       - id: javelin
     damage_type: piercing
-    ai_pattern: hold_position
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "as ironshell-guard", source: "as ironshell-guard"}
 
   # ── Casters and healers (vanilla's Shaman, Mage, Priest, Troubadour) ─────────
@@ -325,7 +351,7 @@ enemy_units:
     inventory:
       - id: flux
     damage_type: necrotic
-    ai_pattern: cautious
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk caster", source: "Mermaid by Stephano -> 6. Magic"}
   - id: merfolk-singer
     name: "Mermaid"
@@ -336,7 +362,7 @@ enemy_units:
     inventory:
       - id: thunder
     damage_type: lightning
-    ai_pattern: cautious
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk caster", source: "Mermaid by Stephano -> 5. Magic"}
   - id: merfolk-mender
     name: "Mermaid"
@@ -346,7 +372,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: mend
-    ai_pattern: defensive       # vanilla Ch6 TEACHES enemies that heal; both healers stay
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk healer", source: "Mermaid by Stephano -> 4./7. Staff"}
   - id: lamia-mender
     name: "Lamia"
@@ -361,7 +387,7 @@ enemy_units:
       - id: mend
       - id: elixir
     item_drop: elixir           # vanilla: "Elixir -- dropped by enemy Troubadour"
-    ai_pattern: defensive
+    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, ...} -- the healer RIDES WITH the mounted squad
     skin:
       look: "serpent-bodied merfolk healer"
       source: "FE-Repo: Battle Animations/Monsters - Dragons and Special/[Monster-Custom] [U] Lamia by L95 -> 7. Staff (also 6. Magic); map sprite Lamia (F) {Dutch Introvert}, 16x32 -- a native fit for the Troubadour's own 16x32 row"
@@ -376,7 +402,7 @@ enemy_units:
     inventory:
       - id: iron-bow
     damage_type: piercing
-    ai_pattern: defensive       # punishes the crossings from across a channel
+    ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk with a harpoon-bow", source: "Mermaid by Stephano -> 4. Bow"}
   - id: ice-crab
     name: "Ice Crab"
@@ -388,7 +414,7 @@ enemy_units:
       - id: poison-claw
         fe_base: venin-claw       # ITEM_MONSTER_VENINCLW -- vanilla Ch6's own Bael weapon
     damage_type: poison
-    ai_pattern: aggressive
+    ai_pattern: pursue                 # vanilla ships NO .ai block = all zeros = MoveToEnemy
     skin: {look: "a lake crab the size of a boat", source: "vanilla Bael art, 32x32 -- no reskin"}
 
   # ── The Hard wave (vanilla's Difficult-only Cavaliers) ───────────────────────
@@ -410,7 +436,7 @@ enemy_units:
       - id: javelin
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: aggressive
+    ai_pattern: aggressive             # vanilla {DefaultAI, 0x1, 0x0}
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-hard-lance
     name: "Crab Rider"
@@ -422,7 +448,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: aggressive
+    ai_pattern: aggressive             # vanilla {DefaultAI, 0x1, 0x0}
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-hard-sword
     name: "Crab Rider"
@@ -435,7 +461,7 @@ enemy_units:
       - id: iron-sword
       - id: javelin
     damage_type: slashing
-    ai_pattern: aggressive
+    ai_pattern: aggressive             # vanilla {DefaultAI, 0x1, 0x0}
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
 
   # ── The boss (vanilla's Novala) ──────────────────────────────────────────────
@@ -454,7 +480,7 @@ enemy_units:
     inventory:
       - id: flux
     damage_type: necrotic
-    ai_pattern: hold_position   # as Novala, who teleports to his corner and waits
+    ai_pattern: hold_position          # vanilla GuardTileAI {0x3, 0x3, 0x0, 0x0} -- Novala stands on his tile
     skin: {look: "the largest of the merfolk", source: "Mermaid by Stephano -> 6. Magic; no portrait -- see below"}
     # NO death quote and NO portrait, deliberately (Nicolas, 2026-08-29): the merfolk do not
     # speak. Messie does, and that contrast is the chapter. The FE-Repo has no merfolk

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -19,18 +19,24 @@ parity_reference: "FE8 Ch6"   # #48 enemy-pressure parity bar — Victims of War
                               # because this is >= FE8 Ch5 (decisions.md, reward ladder).
 
 # ── Narrative ──────────────────────────────────────────────────────────────────
+# REFRAMED 2026-08-29 (Nicolas). Messie is NOT the antagonist and is NOT a fight: the
+# merfolk are. He sank Bremen's boats to keep their crews off water the merfolk control --
+# clumsy protection, which the town read as a monster. Canon supports this rather than
+# bending it (Rime pp. 28-31): the plesiosaurus "recognizes boats from Bremen but does not
+# attack indiscriminately", "prefers to dine on fish, not people", was told by Ravisin only
+# to SPREAD FEAR among the fishers, and its whole behaviour table is boat damage. Tali's own
+# deduction is that ONLY Bremen boats were attacked. The Pronged Goat "was found by fishers
+# the next day, drifting crewless" -- a marooned Bremen boat is the book's own image.
 narrative: >
-  In Bremen, on the frozen west bank of Maer Dualdon, a rude shield-dwarf named
-  Grynsk Berylbore drafts the party onto his two fishing boats — the Burly Ram
-  and the Pronged Goat (the latter still bearing a huge bite-mark). They meet
-  Tali, a half-elf wildlife researcher (they/them) who warns that something has
-  been sinking the boats and hands the party a notebook, asking them to record
-  whatever they find. They haul in knucklehead trout for stingy pay, then see a
-  vast shadow beneath the ice: Messie, an awakened plesiosaur, capsizing boats.
-  Messie separates the party's two boats and attacks. Marty's Talk with Animals
-  reveals she was "awakened" by a frost druid, fears losing her new intelligence,
-  and was ordered to terrorize the town. The party can fight her down — or talk
-  her down.
+  Bremen sends the party onto the frozen mouth of Maer Dualdon to bring back two boats
+  that went out and never came home. The lake around the docks is frozen solid -- the
+  fishers pull their rowboats up onto the ice -- so the party walks out across it, into
+  water the merfolk consider theirs. The merfolk are what has been sinking Bremen's
+  crews. Messie, the awakened plesiosaur the town blames for it, has been ramming those
+  same boats to turn them back before they reached deep water. When the merfolk are
+  broken, he hauls himself up onto the ice, and Marty and Braulo find out what he is:
+  a creature Ravisin woke, ordered to frighten the fishers, and who has been quietly
+  disobeying her by protecting them instead.
 
 # ── Map ────────────────────────────────────────────────────────────────────────
 map:
@@ -42,39 +48,43 @@ map:
                                 # once snowy-bern won the look (decisions.md, the ice ADR).
   size: "22×22"                 # Ch13EphraimMap; 137 TERRAIN_RIVER in concentric channels
   description: >
-    Tight water map over the frozen mouth of Maer Dualdon. Two boat-deck platforms —
-    the Burly Ram (small creatures) and the Pronged Goat (Braulo/Wolfram) — drift
-    apart across open water; Messie roams the deeps; the knucklehead swarm flanks the
-    boats. Drifting ice floes choke the lanes between the two decks.
-  # FE-native terrain mapping of the book's ice-floe hazard (grounded in
-  # fireemblem8u/include/constants/terrains.h — vanilla, no engine work):
+    The frozen mouth of Maer Dualdon, 22x22. Concentric channels of cracked-open water ring
+    the map, crossed at eight points; everything else is walkable lake ice. Two marooned
+    fishing boats sit in ice outcrops at opposite corners -- the Burly Ram east (17,12),
+    the Pronged Goat west (4,17) -- and a six-cell ice shelf holds the map's centre,
+    reachable on foot only over the bridges at (8,11) and (10,14).
+  # FE-native terrain, grounded in fireemblem8u/include/constants/terrains.h. The lake is
+  # FROZEN: every combatant walks. Only the ring channels are open water.
   terrain_mechanic:
-    open_water: TERRAIN_SEA       # 0x15 — impassable to foot/mounted units; this is WHY the
-                                  #        knucklehead swarm is a flier class (gargoyle) and the
-                                  #        PCs are confined to the two boat decks.
-    boat_decks: TERRAIN_SHIP_FLAT # 0x2A — the walkable Burly Ram / Pronged Goat platforms.
-    ice_floes: TERRAIN_SNAG       # 0x33 — DESTRUCTIBLE drifting floes blocking the lanes between
-                                  #        the decks. Attack to break one open (vanilla snag rule),
-                                  #        creating stepping-stones to cross boats or reach Messie.
-    ice_walls: TERRAIN_PEAK       # 0x12 — permanent ridges. NOT glacier: TERRAIN_GLACIER costs 1 for
-                              #        EVERY class (incl. armour), so it shapes nothing at all.
+    lake_ice: TERRAIN_PLAINS      # 0x01 -- 255 cells; the frozen surface everyone fights on
+    channels: TERRAIN_RIVER       # 0x10 -- 136 cells; impassable to our foot/armour/horse
+                                  #         classes, cost 2 to Braulo (Pirate) and 5 to Trex
+                                  #         (Thief), 1 to Pinky. The party's three answers.
+    crossings: TERRAIN_BRIDGE_REGULAR  # 0x13 -- 7 bridges + one BRIDGE_SNAG = 8 crossings
+    snow_drifts: TERRAIN_FOREST   # 0x0C -- 41 cells, +20 avoid / +1 Def, cost 2. Nine ring
+                                  #         each boat (the repainted village footprints);
+                                  #         (7,11) covers the west door onto the centre shelf.
+    ice_walls: TERRAIN_PEAK       # 0x12 -- permanent ridges. NOT glacier: TERRAIN_GLACIER
+                                  #         costs 1 for EVERY class, so it shapes nothing.
   terrain_note: >
-    The two boats start separated by an impassable channel webbed with snag-floes.
-    Clearing floes (or waiting for Messie to smash them) is how foot units bridge the
-    gap — turning the book's "steer around the ice floes" into a vanilla movement puzzle.
+    Measured off the painted .mar: foot reaches 306 of 484 cells and they form ONE connected
+    component -- the eight crossings wire the whole lake together, so the channels shape the
+    route without ever stranding anyone. Foot reaches the west boat turn 6 and the east turn 7;
+    Braulo swims to them turn 5 and 4; Pinky flies to both turn 3. That is vanilla Ch6's own
+    math, where the guide tells you to send a flier at the hostages.
 
 # ── Objective ──────────────────────────────────────────────────────────────────
+# PLAIN DefeatBoss, as vanilla Ch6 (2026-08-29). The old `defeat_boss_or_talk` + hidden
+# Talk resolution is GONE: Messie is not an enemy unit, so there is nothing to talk down
+# mid-battle. He arrives in the boss-death cutscene instead, which means every player sees
+# the chapter's signature beat instead of the few who would have tried Talk on a boss.
+# This also puts ch06 on the wiring ch03 and ch05 already ship (a borrowed vanilla
+# defeat_boss goal template) rather than an invented dual win condition.
 objective:
-  type: defeat_boss_or_talk              # mirrors FE8 Ch5 = DefeatBoss; Talk is our hidden alt-resolution
-  description: "Defeat Messie OR have Marty Talk to her while adjacent"
-  hidden_resolution:
-    unit: marty
-    target: messie
-    condition: adjacent
-    command: talk
-    result: peaceful_resolution
+  type: defeat_boss
+  description: "Defeat Nerra, the merfolk elder"
 
-win_condition: messie_defeated_OR_messie_talked
+win_condition: nerra_defeated
 lose_condition: all_player_units_defeated
 
 # ── Difficulty (D3) ─────────────────────────────────────────────────────────────
@@ -95,96 +105,439 @@ difficulty:
 fog: none
 
 difficulty_note: >
-  A REAL boss fight (≈FE8 Ch5 difficulty) — Messie is tough but beatable in 8–12
-  turns through combat. The Talk option is discoverable, never forced: pre-chapter
-  dialogue hints Marty can speak with beasts; the Talk command appears only when
-  Marty is adjacent. The long combat window gives players time to notice Talk
-  organically. Two outcomes (see events).
+  The difficulty is the merfolk and the two marooned boats, never the boss -- which is
+  vanilla Ch6's own shape, where Novala is a Def 5 shaman the guide says to throw physical
+  units at and the real pressure is a hostage clock under fog. We drop the fog (the route
+  is legible and the channels do that work) and keep the clock: merfolk stand in reach of
+  both boats from turn 1, and the boats can die. Nerra inherits Novala's softness on
+  purpose. Messie is a cutscene, not an encounter, so no route skips XP.
 
 # ── Deployment ──────────────────────────────────────────────────────────────────
 deployment:
   deploy_limit: 10              # D4 -- FE8 Ch6 parity (deploy 1-10); the donor map ships 11 slots
   start_area: "x4-10, y0-2 (the donor's own deploy block, top-centre) -- forces the spiral"
-  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit (TBD), split across the two boats — small units (Basil/Trex/Sahnar/casters) on the Burly Ram, Braulo/Wolfram on the Pronged Goat. Marty MUST be deployable (his Talk is the hidden resolution). The beast-cavalry (Baxby/Lupin) may bench on the boat map by terrain — authoring call. Only the pack direwolves stay non-combat dressing. Positions set in Tiled."
-
+  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit. NOTHING is forced: Messie's scene is a cutscene, so Marty and Braulo are loaded as scene actors whether or not they were deployed (vanilla stages cutscene characters exactly this way -- ch04's moose sighting is ours). Braulo is a Pirate and the only PC who can cross the channels on foot; Pinky is the only flier. Positions set in Tiled."
 # ── Enemy Units (vanilla FE) ─────────────────────────────────────────────────────
+# DERIVED, not invented: every row below is one of vanilla Ch6's own 24 units -- same class,
+# same level, same inventory -- re-dressed as merfolk. Source is the Fire Emblem Wiki enemy
+# table for Victims of War (Normal), the same page `tools/fe8_guide_mine.py` mines; the
+# guide's digest prints only the top six classes, so the per-unit levels here come from the
+# cached page directly. Totals check: 24 units, levels summing to 148, average 6.17 --
+# vanilla's own 6.17 to the decimal.
+#
+# ART (decided 2026-08-29, Nicolas): the merfolk carry lance/bow/staff/magic on Stephano's
+# Mermaid anim, which ships no sword and no axe -- so the axe block rides the Shark Rider
+# map sprite with a regular axe anim, the mounted and sword blocks ride a spider-rider
+# repainted as a crab, the Knights are the IronShell General (the one armour anim that
+# carries a LANCE), and vanilla's Troubadour stays a Troubadour on the Lamia, whose serpent
+# body IS the mount. Sprite size is a declared field, not a constraint -- `frame:` in
+# `campaign.yaml` -> `enemy_class_reskins` sets the wait-row size flag, as ch01's 16x32 Fire
+# Imp on a Soldier and ch03's Lizard Wildling on a Brigand already do. The `skin:` notes
+# below are INTENT; the wiring lands in campaign.yaml when the slice is built.
+#
+# MESSIE IS NOT HERE. He is not an encounter -- he arrives in the boss-death cutscene.
 enemy_units:
-  - id: messie
-    name: "Messie"
+  # ── The trident line (vanilla's 6 Soldiers) → merfolk, Mermaid `2. Lance` ─────
+  - id: merfolk-trident
+    name: "Mermaid"
+    count: 4
+    class: soldier              # vanilla: 4x Lv7 Soldier, Iron Lance
+    level: 7
+    autolevel: true
+    inventory:
+      - id: iron-lance
+    damage_type: piercing       # flavor label only
+    ai_pattern: aggressive      # the boat squads -- see `roster_roles` below
+    skin:
+      look: "merfolk spear-guard; the anim's lance IS a trident"
+      source: "FE-Repo: Battle Animations/Monsters - Dragons and Special/[Monster-Custom] [F] Mermaid by Stephano -> 2. Lance; map sprite Mermaid (F) {N426} or {ZoramineFae}, 16x16"
+  - id: merfolk-thrower
+    name: "Mermaid"
+    count: 1
+    class: soldier              # vanilla: 1x Lv7 Soldier, Javelin + Iron Lance
+    level: 7
+    autolevel: true
+    inventory:
+      - id: javelin
+      - id: iron-lance
+    damage_type: piercing
+    ai_pattern: aggressive
+    skin: {look: "merfolk spear-guard, thrown trident", source: "as merfolk-trident"}
+  - id: merfolk-trident-young
+    name: "Mermaid"
+    count: 1
+    class: soldier              # vanilla: 1x Lv6 Soldier, Iron Lance
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-lance
+    damage_type: piercing
+    ai_pattern: defensive
+    skin: {look: "merfolk spear-guard", source: "as merfolk-trident"}
+
+  # ── The axe block (vanilla's 3 Fighters) → shark riders ──────────────────────
+  # No aquatic AXE anim exists that reads as one of these people (the FE-Repo's only
+  # candidate, Stephano's Squidsmith, is a Shantae-styled figure swinging a squid), so
+  # these ride the SHARK RIDER map sprite over a regular axe animation -- Nicolas's call,
+  # and the same trade ch03 makes where the archer and thief stay vanilla so the player
+  # can still read the class.
+  - id: shark-rider-poison
+    name: "Shark Rider"
+    count: 1
+    class: fighter              # vanilla: 1x Lv6 Fighter, Poison Axe
+    level: 6
+    autolevel: true
+    inventory:
+      - id: poison-axe
+        fe_base: venin-axe        # FE8's ITEM_AXE_VENIN, which the wiki prints as "Poison Axe"
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin:
+      look: "merfolk on a shark, boarding axe"
+      source: "FE-Repo: Map Sprites/Mounted - Dismounted, Monsters, Misc/Shark Rider (M) {N426}, 16x16 (stand+walk); NO battle anim exists -- vanilla Fighter frames, repalletted"
+  - id: shark-rider-steel
+    name: "Shark Rider"
+    count: 1
+    class: fighter              # vanilla: 1x Lv6 Fighter, Steel Axe
+    level: 6
+    autolevel: true
+    inventory:
+      - id: steel-axe
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
+  - id: shark-rider-halberd
+    name: "Shark Rider"
+    count: 1
+    class: fighter              # vanilla: 1x Lv5 Fighter, Iron Axe + Halberd
+    level: 5
+    autolevel: true
+    inventory:
+      - id: iron-axe
+      - id: halberd
+    item_drop: halberd          # vanilla drops the UNEQUIPPED item off a Fighter (item table).
+                                # The same table also lists an Iron Axe as a Fighter drop; only
+                                # this row carries two items, so the second drop is unresolved
+                                # from the wiki alone -- confirm against the ROM when ch06 is hosted.
+    damage_type: slashing
+    ai_pattern: defensive
+    skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
+
+  # ── The mounted block (vanilla's 3 Cavaliers) → crab-riders ──────────────────
+  - id: crab-rider-blade
+    name: "Crab Rider"
+    count: 1
+    class: cavalier             # vanilla: 1x Lv7 Cavalier, Iron Blade
+    level: 7
+    autolevel: true
+    inventory:
+      - id: iron-blade
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin:
+      look: "merfolk astride a lake crab; the mount repainted from an arachnid to ice-blue shell"
+      source: "FE-Repo: Battle Animations/Mounted - Dismounted, Monsters, Misc/[Spider-Variant] [M] Cavalier Rider by DATonDemand -> 1. Sword + 2. Lance; map sprite Cavalier (M) Spider Rider Sword {Zoramine} or Elder Bael Sword {Metalocif}, 16x32"
+  - id: crab-rider-sword
+    name: "Crab Rider"
+    count: 1
+    class: cavalier             # vanilla: 1x Lv6 Cavalier, Iron Sword
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-sword
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
+  - id: crab-rider-lance
+    name: "Crab Rider"
+    count: 1
+    class: cavalier             # vanilla: 1x Lv6 Cavalier, Iron Lance
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-lance
+    damage_type: piercing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 2. Lance"}
+
+  # ── The sword block (vanilla's 2 Mercenaries) → crab-riders on foot-speed ────
+  - id: merfolk-blade
+    name: "Crab Rider"
+    count: 1
+    class: mercenary            # vanilla: 1x Lv6 Mercenary, Iron Sword
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-sword
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 1. Sword"}
+  - id: merfolk-blade-drop
+    name: "Crab Rider"
+    count: 1
+    class: mercenary            # vanilla: 1x Lv6 Mercenary, Iron Blade
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-blade
+    item_drop: iron-blade       # vanilla: "Iron Blade -- dropped by enemy Mercenary"
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 1. Sword"}
+
+  # ── The armour block (vanilla's 3 Knights) → IronShell ───────────────────────
+  # The Bael is NOT reused here: it is already the one Bael vanilla fields, and it is
+  # already the crab-riders' mount. IronShell is the only armour anim in the repo that
+  # carries a LANCE, so the Knights keep vanilla's weapon as well as its class.
+  - id: ironshell-guard
+    name: "Ironshell"
+    count: 2
+    class: armor-knight         # vanilla: 2x Lv6 Knight, Iron Lance (FE8 CLASS_ARMOR_KNIGHT)
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-lance
+    damage_type: piercing
+    ai_pattern: hold_position   # the crossings -- a 1-tile bridge is what armour is for
+    skin:
+      look: "a shelled thing plated like a knight, holding a bridge"
+      source: "FE-Repo: Battle Animations/Infantry - Knights, Generals, Armors/[General-Variant] IronShell-Tiny General [U] by Alexsplode -> 2. Lance; map sprite General (U) IronShell_Tiny {Alexsplode}, 16x32. NB its anim preview keys on BLUE, not the usual green."
+  - id: ironshell-horseslayer
+    name: "Ironshell"
+    count: 1
+    class: armor-knight         # vanilla: 1x Lv6 Knight, Horseslayer + Javelin
+    level: 6
+    autolevel: true
+    inventory:
+      - id: horseslayer
+      - id: javelin
+    damage_type: piercing
+    ai_pattern: hold_position
+    skin: {look: "as ironshell-guard", source: "as ironshell-guard"}
+
+  # ── Casters and healers (vanilla's Shaman, Mage, Priest, Troubadour) ─────────
+  - id: merfolk-tidecaller
+    name: "Mermaid"
+    count: 1
+    class: shaman               # vanilla: 1x Lv6 Shaman, Flux
+    level: 6
+    autolevel: true
+    inventory:
+      - id: flux
+    damage_type: necrotic
+    ai_pattern: cautious
+    skin: {look: "merfolk caster", source: "Mermaid by Stephano -> 6. Magic"}
+  - id: merfolk-singer
+    name: "Mermaid"
+    count: 1
+    class: mage                 # vanilla: 1x Lv6 Mage, Thunder
+    level: 6
+    autolevel: true
+    inventory:
+      - id: thunder
+    damage_type: lightning
+    ai_pattern: cautious
+    skin: {look: "merfolk caster", source: "Mermaid by Stephano -> 5. Magic"}
+  - id: merfolk-mender
+    name: "Mermaid"
+    count: 1
+    class: priest               # vanilla: 1x Lv6 Priest, Mend
+    level: 6
+    autolevel: true
+    inventory:
+      - id: mend
+    ai_pattern: defensive       # vanilla Ch6 TEACHES enemies that heal; both healers stay
+    skin: {look: "merfolk healer", source: "Mermaid by Stephano -> 4./7. Staff"}
+  - id: lamia-mender
+    name: "Lamia"
+    count: 1
+    class: troubadour           # vanilla: 1x Lv6 Troubadour, Mend + Elixir. KEPT MOUNTED --
+                                # a lamia's serpent body is the mount, so vanilla's mounted
+                                # healer stays a Troubadour (mov 6) instead of dismounting
+                                # to a Cleric. Nicolas, 2026-08-29.
+    level: 6
+    autolevel: true
+    inventory:
+      - id: mend
+      - id: elixir
+    item_drop: elixir           # vanilla: "Elixir -- dropped by enemy Troubadour"
+    ai_pattern: defensive
+    skin:
+      look: "serpent-bodied merfolk healer"
+      source: "FE-Repo: Battle Animations/Monsters - Dragons and Special/[Monster-Custom] [U] Lamia by L95 -> 7. Staff (also 6. Magic); map sprite Lamia (F) {Dutch Introvert}, 16x32 -- a native fit for the Troubadour's own 16x32 row"
+
+  # ── Bow and beast (vanilla's Archer and its one Bael) ────────────────────────
+  - id: merfolk-bow
+    name: "Mermaid"
+    count: 1
+    class: archer               # vanilla: 1x Lv6 Archer, Iron Bow
+    level: 6
+    autolevel: true
+    inventory:
+      - id: iron-bow
+    damage_type: piercing
+    ai_pattern: defensive       # punishes the crossings from across a channel
+    skin: {look: "merfolk with a harpoon-bow", source: "Mermaid by Stephano -> 4. Bow"}
+  - id: ice-crab
+    name: "Ice Crab"
+    count: 1
+    class: bael                 # vanilla: 1x Lv1 Bael, Poison Claw -- kept as itself
+    level: 1
+    autolevel: true
+    inventory:
+      - id: poison-claw
+        fe_base: venin-claw       # ITEM_MONSTER_VENINCLW -- vanilla Ch6's own Bael weapon
+    damage_type: poison
+    ai_pattern: aggressive
+    skin: {look: "a lake crab the size of a boat", source: "vanilla Bael art, 32x32 -- no reskin"}
+
+  # ── The Hard wave (vanilla's Difficult-only Cavaliers) ───────────────────────
+  # Vanilla Ch6 keeps three extra Cavaliers in a SEPARATE UnitDefinition array, loaded by a
+  # turn-4 player-phase event and present only on Difficult -- the guide's "Hard-mode cavalry
+  # spawning behind you", and the whole of its Normal->Difficult delta (24 -> 27; the wiki
+  # calls it "a UNIT change, not a level shift"). We field the same three, as crab-riders,
+  # with vanilla's own levels and inventories. #48's static bar folds that array in on the
+  # vanilla side unconditionally, so declaring ours is what makes the two sides count the
+  # same force: with them, the comparison reads x1.00 on both metrics instead of x0.88/x0.82.
+  - id: crab-rider-hard-javelin
+    name: "Crab Rider"
+    count: 1
+    class: cavalier             # vanilla (Difficult array): 1x Lv6 Cavalier, Javelin + Iron Lance
+    level: 6
+    autolevel: true
+    arrives_turn: 4             # vanilla's own turn-4 player-phase load
+    inventory:
+      - id: javelin
+      - id: iron-lance
+    damage_type: piercing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
+  - id: crab-rider-hard-lance
+    name: "Crab Rider"
+    count: 1
+    class: cavalier             # vanilla (Difficult array): 1x Lv7 Cavalier, Iron Lance
+    level: 7
+    autolevel: true
+    arrives_turn: 4
+    inventory:
+      - id: iron-lance
+    damage_type: piercing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
+  - id: crab-rider-hard-sword
+    name: "Crab Rider"
+    count: 1
+    class: cavalier             # vanilla (Difficult array): 1x Lv6 Cavalier, Iron Sword + Javelin
+    level: 6
+    autolevel: true
+    arrives_turn: 4
+    inventory:
+      - id: iron-sword
+      - id: javelin
+    damage_type: slashing
+    ai_pattern: aggressive
+    skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
+
+  # ── The boss (vanilla's Novala) ──────────────────────────────────────────────
+  # Novala's own line, from the wiki's boss table: Shaman Lv10, HP 28, Mag 10, Skl 8,
+  # Spd 6, Lck 7, DEF 5, Res 9, Con 7, Mov 5, carrying Flux, dropping nothing. Def 5 is
+  # why the guide says to throw physical units at him, and that softness is the point:
+  # vanilla Ch6 puts its difficulty in the hostage clock, not the boss. No personal: block
+  # -- ch06 has no injector yet, and #284 requires every declared line to have a route.
+  - id: nerra
+    name: "Nerra"
+    fe_name: "Nerra"
     is_boss: true
     count: 1
-    class: draco-zombie         # FE8 monster boss class (dragon-tier); reskinned as Messie the plesiosaur
-    level: 9
-    damage_type: bludgeoning    # flavor label only
-    ai_pattern: boss_roam
-    recruitable_via_talk: marty  # not a playable recruit — becomes a Bremen NPC
-    death_quote: "*a mournful, fading cry beneath the ice*"
-    pronouns: he/him            # SETTLED 2026-08-26 (Nicolas). The DM notes and the book
-                                # both say "it"; an earlier draft of this file said "she".
-                                # He/him holds through ch07's Speaker installation.
-    art_note: >
-      32x32 is the ENGINE CEILING for a map sprite -- UNIT_ICON_SIZE_* has exactly three
-      values (16x16, 16x32, 32x32) and bmudisp.c switches on them in five places, so
-      anything larger is an engine change plus SMS VRAM we do not have spare. Braulo,
-      Meesmickle, Wolfram, the moose, Manakete 2 and the Demon King already sit in that
-      top tier: there is no rung above them, and size therefore has to come from FILLING
-      the cell corner to corner (what the Demon King does and Baxby does not).
-      He never moves and never joins, so he needs NO 32x480 walk sheet -- only the
-      3-frame idle. Design intent (2026-08-26): give the unit a breaching head-and-neck
-      and paint the REST of him into the tilemap, which has no size limit and costs no
-      engine work. "A large mass glides through the dark water below you" is the book's
-      own line (p.30).
-  - id: harrier-fish
-    name: "Knucklehead Swarm"
-    count: 8                     # boss-chapter pacing bump (6 -> 9 enemies; decisions 2026-06-06)
-    class: gargoyle             # FE8 monster class (agile flier); reskinned as a leaping fish swarm
-    level: 5
-    damage_type: piercing
-    ai_pattern: harass          # flank the boats, split player attention
+    class: shaman
+    level: 10
+    inventory:
+      - id: flux
+    damage_type: necrotic
+    ai_pattern: hold_position   # as Novala, who teleports to his corner and waits
+    skin: {look: "the largest of the merfolk", source: "Mermaid by Stephano -> 6. Magic; no portrait -- see below"}
+    # NO death quote and NO portrait, deliberately (Nicolas, 2026-08-29): the merfolk do not
+    # speak. Messie does, and that contrast is the chapter. The FE-Repo has no merfolk
+    # portrait at all -- 17,341 files searched; the nearest is a HUMAN knight in a fin-crested
+    # helm ("Shark Knight" {Sphealnuke}) -- so a speaking boss would have cost authored art
+    # for nothing. The name is arbitrary and touches one string.
 
 # ── Events (pacing / cutscene placement) ─────────────────────────────────────────
+# THREE scenes, down from four (2026-08-29). The `unit_adjacent` Talk unlock is gone with
+# the boss fight: Messie is not on the field, so there is nothing to walk up to. The two
+# ending arms collapse to one, because "kill the creature that was protecting the town" is
+# not a choice this version offers.
 events:
   - trigger: chapter_start
     type: cutscene
     ea_file: events/ch06-opening.ea
     description: >
-      Bremen docks; Grynsk Berylbore drafts the crew onto the Burly Ram and Pronged
-      Goat; Tali (half-elf researcher, they/them) warns of the boat-sinkings and hands
-      over a notebook; Marty's pre-chapter beast-speech hint ('I can talk to animals,
-      remember?'). Boats set out.
-  - trigger: unit_adjacent
-    unit: marty
-    target: messie
-    type: command_unlock
-    ea_file: events/ch06-messie-talk.ea
+      Bremen docks. Two boats went out and neither came back, and the town wants them
+      brought in before the ice closes. Grynsk Berylbore -- who sent those crews -- and
+      Tali, the half-elf researcher (they/them), are both out there. The party walks onto
+      the frozen lake. NOTE: the merfolk are not introduced here; the player meets them by
+      being attacked, and learns what they are from the two rescued crews.
+  - trigger: boss_defeated
+    unit: nerra
+    type: cutscene
+    ea_file: events/ch06-messie.ea
     description: >
-      The Talk command appears. If used: marty_messie_talk — Messie's story, his
-      fear, the peaceful resolution (the campaign-defining beat). Suggest he run
-      for Speaker of Bremen. The ARGUMENT is the ch05 payoff: the book names Ravisin
-      (p.31) as the druid who awakened him, and he keeps attacking only because he
-      fears she will take the gift back. She is already dead -- the party killed her
-      at the tomb -- and an awaken spell is permanent.
-  - trigger: chapter_end_talk
+      THE CHAPTER. With the merfolk broken, the ice cracks and Messie hauls himself up onto
+      it -- the mass the whole town has been calling a monster, lying on the ice in front of
+      the people who came to kill it. Marty speaks to him (his beast-speech), and the answer
+      comes back in Common, because Ravisin's awaken spell gave him language along with a
+      mind (book p.28: Intelligence 10 and speech in Common; his own line on p.31 is
+      "I'm listening"). Braulo is the second voice -- lake fauna talking to lake fauna.
+      What comes out: Ravisin woke him and told him to spread fear among Bremen's fishers;
+      he has been ramming their boats instead, to turn them back before they reached
+      merfolk water. He fears losing the mind he was given. She is already dead -- the party
+      killed her at the tomb -- and an awaken spell is permanent. He is free and does not
+      know it yet.
+  - trigger: chapter_end
     type: cutscene
-    ea_file: events/ch06-ending-peace.ea
-    description: "Peaceful payoff: Messie spared, joins Bremen, set up to become Speaker (pays off in ch07)."
-  - trigger: chapter_end_kill
-    type: cutscene
-    ea_file: events/ch06-ending-kill.ea
-    description: "Brute-force ending: Messie slain; a sadder, quieter scene. Bremen Speaker plot in ch07 differs."
+    ea_file: events/ch06-ending.ea
+    description: >
+      Back at Bremen with the rescued crews. Messie is not a monster and the town has to
+      swallow it; the Speaker seed for ch07 is planted here. If both boats survived, the
+      Orion's Bolt is handed over in this scene, exactly as vanilla Ch6 pays its own
+      save-them-all reward (CHECK_ALIVE on both).
+
+# ── Messie (cutscene actor, NOT an enemy unit) ───────────────────────────────────
+# He has no class, no level and no AI: he is loaded by `events/ch06-messie.ea`, speaks, and
+# leaves. That deletes the campaign's single hardest art dependency -- `docs/fe-repo-scouting.md`
+# records that NO plesiosaur/sea-monster battle animation exists anywhere in the FE-Repo, and a
+# unit that never fights needs none. What he still needs is a map sprite, which is NICOLAS'S
+# (taken back 2026-08-26); do not re-open it.
+messie:
+  name: "Messie"
+  pronouns: he/him              # SETTLED 2026-08-26 (Nicolas). The DM notes and the book both
+                                # say "it"; an earlier draft of this file said "she" throughout.
+  role: cutscene_actor
+  appears_in: events/ch06-messie.ea
+  art_note: >
+    32x32 is the ENGINE CEILING for a map sprite -- UNIT_ICON_SIZE_* has exactly three values
+    and bmudisp.c switches on them in five places -- so size has to come from FILLING the cell
+    corner to corner. He never moves and never fights, so he needs no walk sheet and NO battle
+    animation: a 3-frame idle is the whole ask. Design intent (2026-08-26): a breaching
+    head-and-neck as the sprite, with the REST of him painted into the tilemap, which has no
+    size limit and costs no engine work. "A large mass glides through the dark water below
+    you" is the book's own line (p.30).
 
 # ── Post-Chapter ─────────────────────────────────────────────────────────────────
 post_chapter:
   gold_reward: 400
   available_shops: [bremen]
   units_available_to_recruit: []   # Messie is an NPC, not a playable unit
-  branch_flag: messie_spared       # consumed by ch07 dialogue
   unlocks_chapter: ch07-blood-in-bremen
+  # NO branch_flag. There is one outcome now (2026-08-29): the fight is against the merfolk,
+  # and Messie's scene plays for every player. ch07 is unwritten, so nothing was orphaned.
 
 # ── Signature Moment anchored here ───────────────────────────────────────────────
 signature_moments:
   - pc: marty
-    trigger: marty_messie_talk     # PRIMARY — see pcs/marty.yaml
+    trigger: ch06_messie_scene     # PRIMARY — see pcs/marty.yaml. Now a guaranteed
+                                   # cutscene rather than a hidden Talk: every player
+                                   # sees it, nobody has to guess the command exists.
 
 # ── Forest composition (declared departure from #193) ───────────────────────────
 # A frozen lake has no trees, so ch06 replaces the concept: all 23 of the donor's FOREST

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -1,5 +1,6 @@
 # chapters/ch06-the-maer-monster.yaml
-# Chapter index: docs/CHAPTERS.md (generated from this file). Rationale: docs/decisions.md (esp. the Ch6 Talk-resolution beat).
+# Chapter index: docs/CHAPTERS.md (generated from this file).
+# Rationale: docs/decisions.md -> "Messie is a cutscene, not a boss" (2026-08-29).
 # Combat is vanilla FE (see docs/decisions.md §Combat). damage_type labels are cosmetic.
 
 id: ch06-the-maer-monster
@@ -116,7 +117,7 @@ difficulty_note: >
 deployment:
   deploy_limit: 10              # D4 -- FE8 Ch6 parity (deploy 1-10); the donor map ships 11 slots
   start_area: "x4-10, y0-2 (the donor's own deploy block, top-centre) -- forces the spiral"
-  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit. NOTHING is forced: Messie's scene is a cutscene, so Marty and Braulo are loaded as scene actors whether or not they were deployed (vanilla stages cutscene characters exactly this way -- ch04's moose sighting is ours). Braulo is a Pirate and the only PC who can cross the channels on foot; Pinky is the only flier. Positions set in Tiled."
+  note: "Deployable pool: 7 PCs + Pinky + Baxby (Cav) + Trex (Thief) + Lupin (beast-Cav) + Sahnar (Myr) + Basil (Cleric), capped by deploy_limit. NOTHING is forced: Messie's scene is a cutscene, so Marty and Braulo are loaded as scene actors whether or not they were deployed (vanilla stages cutscene characters exactly this way -- ch04's moose sighting is ours). Braulo (Pirate, river cost 2) and Trex (Thief, cost 5 -- one channel cell per turn at mov 6) are the only PCs who cross the channels on foot; Pinky is the only flier. Positions set in Tiled."
 # ── Enemy Units (vanilla FE) ─────────────────────────────────────────────────────
 # DERIVED, not invented: every row below is one of vanilla Ch6's own 24 units -- same class,
 # same level, same inventory -- re-dressed as merfolk. Source is the Fire Emblem Wiki enemy
@@ -241,10 +242,10 @@ enemy_units:
     inventory:
       - id: iron-axe
       - id: halberd
-    item_drop: halberd          # vanilla drops the UNEQUIPPED item off a Fighter (item table).
-                                # The same table also lists an Iron Axe as a Fighter drop; only
-                                # this row carries two items, so the second drop is unresolved
-                                # from the wiki alone -- confirm against the ROM when ch06 is hosted.
+    item_drop: halberd          # SETTLED from events_udefs.c, not the wiki: this L5 Fighter is the
+                                # only Ch6 unit with `.itemDrop = 1` on an axe, carrying
+                                # {AXE_IRON, AXE_HALBERD}. FE8 drops the LAST item, so the Halberd
+                                # is the drop and the Iron Axe is what it swings.
     damage_type: slashing
     ai_pattern: cautious               # vanilla AttackInRangeAI
     skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
@@ -432,6 +433,11 @@ enemy_units:
     level: 6
     autolevel: true
     arrives_turn: 4             # vanilla's own turn-4 player-phase load
+    hard_mode_only: true        # vanilla loads this array with CALL(EventScr_LoadReinforceHardMode)
+                                # (ch6-eventscript.h, EventScr_089F2B74) -- DIFFICULT ONLY. Without
+                                # this flag Normal would field 27 where vanilla fields 24, and the
+                                # static bar cannot see it: #48 folds vanilla's Hard array into the
+                                # comparison on BOTH sides, so the x1.00 stays x1.00 either way.
     inventory:
       - id: javelin
       - id: iron-lance
@@ -445,6 +451,7 @@ enemy_units:
     level: 7
     autolevel: true
     arrives_turn: 4
+    hard_mode_only: true        # as above -- EventScr_LoadReinforceHardMode
     inventory:
       - id: iron-lance
     damage_type: piercing
@@ -457,6 +464,7 @@ enemy_units:
     level: 6
     autolevel: true
     arrives_turn: 4
+    hard_mode_only: true        # as above -- EventScr_LoadReinforceHardMode
     inventory:
       - id: iron-sword
       - id: javelin
@@ -702,7 +710,7 @@ rescue_boats:
   tile: [17, 12]                # R13, the outcrop cell north of the door
   ai_pattern: hold              # never moves; Fleet has mov 3 and must not wander
   attackable_sides: 4           # parity: 2 of vanilla Ch6's 3 civilians are open on 4/4 sides
-  reached_on: {foot: 6, cavalry: 5, flier: 3}
+  reached_on: {foot: 7, cavalry: 5, flier: 3, braulo: 4}   # re-measured off the painted .mar
   talk:
     background: bg_Boat         # vendored from FE-Repo; the boarding CG
     ea_file: events/ch06-boat-east.ea
@@ -719,7 +727,7 @@ rescue_boats:
   tile: [4, 17]                 # E18
   ai_pattern: hold
   attackable_sides: 4
-  reached_on: {foot: 6, cavalry: 5, flier: 3}
+  reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5}   # re-measured off the painted .mar
   talk:
     background: bg_Boat
     ea_file: events/ch06-boat-west.ea
@@ -742,6 +750,23 @@ economy:
 # on purpose rather than placeholder prose.
 
 design_notes: >
-  The emotional centerpiece of the MVP and Marty's primary signature beat. Keep
-  the fight genuinely hard so the Talk feels earned, not handed out. Track the
-  messie_spared flag — ch07's Speaker-installation scene branches on it.
+  The emotional centerpiece of the MVP and Marty's primary signature beat -- and as of
+  2026-08-29 it is a CUTSCENE, not a hidden Talk. The fight is the merfolk; Messie hauls
+  himself onto the ice once Nerra falls. There is no messie_spared flag and no second
+  ending: every player sees the beat, and nobody has to guess a command exists on a boss.
+  Keep the merfolk honest (they are vanilla Ch6's own 24) and keep the two marooned boats
+  killable -- that clock, not the boss, is where this chapter's difficulty lives.
+
+# ── Cutscene actor availability (classic permadeath) ─────────────────────────────
+# `permadeath.default_mode: classic` means Marty or Braulo can be DEAD when the boss falls.
+# The retired Talk design degraded on its own (no Marty, no Talk, fight it out); a cutscene
+# does not. events/ch06-messie.ea must therefore branch on CHECK_ALIVE for both speakers:
+# Marty is the one who can talk to animals and Braulo is lake fauna himself, so each can
+# carry the scene alone, and if BOTH are dead the scene plays with Messie unanswered --
+# he surfaces, waits, and submerges. Vanilla precedent for loading a scene actor regardless
+# of deployment is ch04's moose sighting; vanilla precedent for gating on the living is
+# Ch6's own Orion's Bolt (CHECK_ALIVE on its civilians).
+cutscene_actors:
+  required: []                  # nothing is force-deployed; the scene adapts instead
+  speakers: [marty, braulo]     # each sufficient alone
+  if_all_dead: "Messie surfaces, is not answered, and submerges -- the chapter still ends"

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch07-blood-in-bremen.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch07-blood-in-bremen.yaml
@@ -105,7 +105,9 @@ events:
     description: >
       Dorbulgruf refuses payment — paranoid, half-remembering, accusing the party of
       swindling him. Tensions rise. Braulo swings first (braulo_first_swing) — combat
-      begins. Branches on the ch06 messie_spared flag.
+      begins. SINGLE outcome as of 2026-08-29: ch06 no longer branches (Messie is a
+      cutscene, not a boss), so there is no messie_spared flag to read -- he is always alive
+      and always the Speaker candidate.
   - trigger: unit_engages_boss
     unit: wolfram
     target: dorbulgruf
@@ -119,7 +121,8 @@ events:
     type: cutscene
     ea_file: events/ch07-ending.ea
     description: >
-      If messie_spared: Messie installed as Speaker; uneasy but hopeful town.
+      Messie installed as Speaker; uneasy but hopeful town. (No longer conditional --
+      ch06 has one ending.)
       If Messie was slain in ch06: a colder installation scene / different
       Speaker outcome. Either way the party leaves in a trail of blood, mixed
       reception. Foreshadow: a town crier mentions Easthaven heard of Bremen.
@@ -141,5 +144,5 @@ design_notes: >
   genuinely greedy old miser AND a sick old man whose dementia has sharpened the
   bitterness — the party isn't wrong that he's stiffing them, but they still cut down
   a confused, dying elder. Don't resolve which he is. Civilian no-kill constraint is
-  the design hook. Ending branches on messie_spared. The town crier's Easthaven line
+  the design hook. ONE ending (ch06 no longer branches). The town crier's Easthaven line
   seeds the ch08 ambush (word of Bremen traveled).

--- a/campaigns/rime-of-the-frostmaiden/pcs/marty.yaml
+++ b/campaigns/rime-of-the-frostmaiden/pcs/marty.yaml
@@ -138,12 +138,18 @@ battle_anim:
 
 signature_moment:
   chapter: ch06-the-maer-monster
+  trigger: ch06_messie_scene    # matches the chapter YAML; was `marty_messie_talk`
   description: >
-    The Messie Talk. Marty uses Talk with Animals on the plesiosaur Messie mid-fight,
-    learns she was "awakened" by the frost druids and fears losing her intelligence,
-    and resolves the boss peacefully — the moment that "changed everything" in the
-    real campaign (Ch 6 — see docs/CHAPTERS.md). Mechanically the chapter's hidden Talk
-    resolution: get Marty adjacent to Messie and the Talk command appears.
+    Marty speaks with Messie. REFRAMED 2026-08-29: Messie is not a boss and this is not a
+    hidden Talk — the fight on Maer Dualdon is against the merfolk, and when their elder
+    falls Messie hauls himself onto the ice. Marty speaks to him with beast-speech and the
+    answer comes back in Common, because Ravisin's awaken spell gave him language along
+    with a mind. He was told to spread fear among Bremen's fishers and has been ramming
+    their boats instead, to turn the crews back before they reached merfolk water; he fears
+    losing the mind he was given, and does not yet know Ravisin is dead. Braulo is the
+    second voice. The moment that "changed everything" in the real campaign (Ch 6 — see
+    docs/CHAPTERS.md), and now every player sees it rather than the few who would have
+    tried Talk on a boss.
   dialogue_trigger: marty_messie_talk
   # Sourced from the DM notes. (His earlier Lonelywood direwolf-taming,
   # Ch 4 area, is a secondary beat — see ch04 YAML.)

--- a/docs/CHAPTERS.md
+++ b/docs/CHAPTERS.md
@@ -20,6 +20,6 @@ rules) lives in `docs/decisions.md` and `docs/fe8-pacing-reference.md`.
 | 3 | The Termalaine Mine | 🟥 big battle (seize) | DefeatBoss — Fight down through the kobold-held rooms to the deep workings — the grell's lair at the bottom of the central shaft (14,1) — and kill the grell. DEVIATION from vanilla Ch3 (which is Seize the boss tile): our win is Defeat Boss (slay the aberration), which reads truer for a monster kill than capturing a throne (Nicolas, 2026-07-06; decisions.md). The grell is visible from turn 1. | — | Ch 4 |
 | 4 | The White Moose | 🟨 monster debut (fog) | DefeatAll — Rout the forest's hostile beasts and spirits | lupin +npc: lupin-pack | Ch 5 |
 | 5 | The Elven Tomb | 🟥 first boss | DefeatBoss — Defeat Ravisin, the frost druid (her guardians and the moose needn't all fall) | sahnar, basil | Ch 6 |
-| 6 | The Maer Monster | 🎬 marquee set-piece | DefeatBoss / Talk — Defeat Messie OR have Marty Talk to her while adjacent | — | Ch 7 |
+| 6 | The Maer Monster | 🎬 marquee set-piece | DefeatBoss — Defeat Nerra, the merfolk elder | — | Ch 7 |
 | 7 | Blood in Bremen | 🟥 big battle (gray) | DefeatBoss — Defeat Dorbulgruf (his guards needn't all fall) | — | Ch 8 |
 | 8 | The Eastway Ambush | 🎬 scripted defeat | Survive — Survive 8–10 turns — the outcome is scripted (unwinnable by design) | — | Ch 9 (post-MVP) |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -66,7 +66,7 @@ Nicolas ran a multi-year D&D 5e campaign (*Rime of the Frostmaiden*) with 6 frie
 - **Recruit NPC allies** (Trex, Basil, the Mummy, …) as the story progresses so the roster grows like a real FE game.
 - **Casual or Classic mode** (FE8's toggle) so permadeath is my choice.
 - **Campaign-specific dialogue and story beats** (the kobold execution, Messie becoming Speaker, Braulo smashing shackles) so it feels like *our* campaign.
-- **Discover Marty can Talk to Messie in Ch 6** — rewarded for paying attention to the story, not a tutorial prompt.
+- **Watch Marty talk the Maer monster down in Ch 6** — the fight is the merfolk; Messie climbs onto the ice afterwards and answers him in Common.
 - **Ch 8 ends in a scripted defeat** so the Revel's End cliffhanger lands hard.
 
 ---
@@ -177,7 +177,7 @@ The MVP is **done** when:
 5. Combat plays as vanilla FE, reskinned with D&D-flavored names/art + a cosmetic d20 crit flourish (no damage-type mechanic).
 6. Vanilla FE weapon effectiveness works for iconic matchups (armorslayer vs knights, monster-effective vs skeletons/ice trolls).
 7. Spell-tome charges deplete and restock correctly.
-8. Ch 6 (Messie) is resolvable via Talk.
+8. Ch 6 ends on the Messie cutscene: the merfolk elder falls, Messie surfaces, Marty and Braulo speak with him.
 9. Ch 8 ends in a scripted defeat with the Revel's End cliffhanger text.
 10. Casual/Classic toggle works.
 11. Playtested end-to-end at least twice (bugs, then balance).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7472,6 +7472,63 @@ ch06 paints **Ch13EphraimMap** and measures against **FE8 Ch6**. Approved by Nic
 
 _Board: `https://claude.ai/code/artifact/6952f53d-0fde-4a0f-b07c-b8fc846d6f10`. Checklist: issue #26._
 
+### Messie is a cutscene, not a boss (2026-08-29)
+
+ch06 shipped as `defeat_boss_or_talk`: Messie was the boss, and a hidden Talk from Marty was the
+alternative resolution. Every problem that design produced traced back to one premise -- that the
+creature the town calls a monster is the party's enemy.
+
+**It is not, and the source book says so.** The plesiosaur "recognizes boats from Bremen but does
+not attack indiscriminately"; it "prefers to dine on fish, not people"; Ravisin told it only to
+**spread fear** among the fishers; its entire behaviour table is boat damage; and Tali's own
+deduction is that *only Bremen boats* were attacked. The *Pronged Goat* "was found by fishers the
+next day, drifting crewless" (Rime pp. 28-31). So: Messie has been ramming Bremen's boats to turn
+their crews back before they reached water the MERFOLK hold. The merfolk are the violence. The
+town blames the monster it can see.
+
+**What the reframe buys.**
+- **No route asymmetry.** The old Talk arm skipped the boss's XP and paid only in story, because
+  Messie is not a recruitable unit -- it punished the player who found the intended beat. One
+  roster, one XP total, no clock to balance.
+- **The objective is plain `defeat_boss`**, the wiring ch03 and ch05 already ship (a borrowed
+  vanilla goal template). The Talk-command unlock, the dual win condition, `branch_flag:
+  messie_spared` and one of the two ending arms all disappear rather than needing to be built.
+- **The campaign's hardest art dependency retires.** `docs/fe-repo-scouting.md` records that NO
+  plesiosaur or sea-monster battle animation exists in the FE-Repo -- it was a commission or a
+  custom build. A unit that never fights needs none: Messie keeps a map sprite and a 3-frame idle.
+- **The signature beat becomes guaranteed.** Every player sees it, instead of the few who would
+  have thought to try Talk on a boss.
+
+**The cost, taken deliberately:** the kill/spare branch is gone, and with it ch07's
+`messie_spared` conditional (rewritten to a single outcome in the same commit). "Kill the creature
+that was protecting the town" is not a choice this version offers.
+
+**The boss slot goes to the merfolk elder**, who rides `CHARACTER_NOVALA` via `ENEMY_BASE_SLOT` --
+ch06's `parity_reference` IS FE8 Ch6, so the boss we measure against and the slot we deploy on are
+the same character, and she inherits his real line (HP 28 / Mag 10 / Def 5) instead of an invented
+`personal:` block with no route into the ROM (#284). She has no portrait, no death quote and no
+dialogue, and that is the point: the merfolk do not speak. Messie does.
+
+### The AI is in the UnitDefs, so it is DERIVED (2026-08-29)
+
+ch06's first roster authored its `ai_pattern` labels by feel and got the chapter backwards -- 13
+pursuing units where vanilla Ch6 fields two. `src/events_udefs.c` answers it unit by unit:
+17 `AttackInRangeAI` (ActionInRange + NeverMove), 4 on `AI_B_12 MoveToEnemyAfterOneTurn` (the three
+Cavaliers **and** the Troubadour -- vanilla's healer rides with its cavalry), 2 with no `.ai` block
+at all (= pursue), the boss on `GuardTileAI`, and 3 Hard-only Cavaliers on `{DefaultAI, 0x1, 0x0}`
+loaded by `CALL(EventScr_LoadReinforceHardMode)`.
+
+**Vanilla Ch6 is a static map.** Nothing charges on turn 1 but two units and a Bael; the player
+advances into fixed threat ranges. That is *why* its difficulty was the hostage clock and the fog
+rather than an enemy tide -- and it is the shape our two marooned boats inherit.
+
+The general lesson, and why this is an ADR rather than a chapter note: **#48's threat and
+clear-load are computed from stats and weapons, so a chapter can measure x1.00 and still play like
+a different map.** No gate catches behavioural drift. An audit of ch00-ch05 against their twins
+found the same gap almost everywhere, biased toward aggression (ch04 fields 78% pursuers against a
+half-static twin); ch05's `raider` and `duelist_hold` are the exceptions, derived exactly. Tracked
+with a guard proposal in issue #335.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -806,6 +806,12 @@ ENEMY_BASE_SLOT = {
     'goblin-chief':  'CHARACTER_%s' % CH01_BOSS_SLOT,
     'raider-captain': 'CHARACTER_%s' % CH02_BOSS_SLOT,
     'raider-bruiser': 'CHARACTER_%s' % CH02_MINIBOSS_SLOT,
+    # ch06's merfolk elder RIDES NOVALA (2026-08-29). Her chapter's parity_reference IS
+    # FE8 Ch6, so the boss the bar measures against and the slot she deploys on are the
+    # same character -- she inherits his real line (HP 28 / Mag 10 / Def 5) instead of
+    # needing an invented `personal:` block and a RAW_PID_PERSONAL_SOURCES route. Both
+    # sides of the comparison then read the same article.
+    'nerra': 'CHARACTER_NOVALA',
 }
 
 


### PR DESCRIPTION
D5 — the ch06 enemy roster.

## Parity

Vanilla Ch6's 24 units, class for class and level for level, re-dressed as merfolk — plus its three Difficult-only Cavaliers, which vanilla keeps in a separate turn-4 array and #48's static bar folds in unconditionally.

```
ENEMY-PRESSURE PARITY (vs FE8 Ch6)
  vanilla (25): threat/slot 14.9 · clear-load/slot 7.5
  ours    (25): threat/slot 14.9 (x1.00 OK) · clear-load/slot 7.5 (x1.00 OK)
  verdict: PARITY (within band)
  per-unit role check: clean -- no threat outliers, boss is the chapter's hardest hitter

BATTLEFIELD DYNAMICS (#171)
  vanilla  line 22 · reinf 3 · convertible 0 -> threat 12.2 (turn-1) · clear-load 7.1
  ours     line 22 · reinf 3 · convertible 0 -> threat 12.2 (turn-1) · clear-load 7.1
```

Levels sum to 148 over 24 at Normal — vanilla's 6.17 average to the decimal. Drops mirror vanilla exactly: halberd, iron-blade, elixir.

## Messie is not an enemy

He sank Bremen's boats to keep their crews off water the merfolk control — clumsy protection the town read as a monster — so he arrives in the boss-death cutscene rather than fighting. Canon supports this rather than bending it (Rime pp. 28–31): he "recognizes boats from Bremen but does not attack indiscriminately", "prefers to dine on fish, not people", and Ravisin told him only to *spread fear*.

Consequences: `defeat_boss_or_talk` collapses to plain `defeat_boss` (the wiring ch03 and ch05 already ship), and the Talk unlock, the branch flag and one ending arm all go. It also retires the campaign's hardest art dependency — no plesiosaur battle animation exists anywhere in the FE-Repo, and a unit that never fights needs none.

## The boss rides Novala

`ENEMY_BASE_SLOT: nerra -> CHARACTER_NOVALA`, so she inherits his real line (HP 28 / Mag 10 / Def 5) instead of an invented `personal:` block with no route into the ROM (#284). The chapter's `parity_reference` *is* FE8 Ch6, so the boss we measure against and the slot we deploy on are the same character. Her level (10) equals the donor slot's baseLevel, so she doesn't cross `bosses_over_their_donor_base_level`.

## Art

Scouted from the FE-Repo git trees — Map Sprites complete (3,074 files), battle-anim folders for all 23 categories, Portrait Repository (17,341 files). Board: https://claude.ai/code/artifact/d783c124-429c-4955-a575-0ae93b3cacd3

| block | dressed as |
|---|---|
| Soldier x6, Shaman, Mage, Priest, Archer | Mermaid — lance (a trident), magic, staff, bow |
| Fighter x3 | Shark Rider sprite over a regular axe anim |
| Cavalier x3, Mercenary x2 | spider-rider repainted as a crab (ships sword *and* lance) |
| Knight x3 | IronShell General — the one armour anim carrying a **lance** |
| Troubadour | **Lamia** — kept mounted, because the serpent body *is* the mount |
| Bael | vanilla, as itself |

No merfolk portrait exists in the repo, so the boss has no portrait, no death quote and no dialogue: the merfolk don't speak, Messie does.

## AI is derived, not authored

Corrected in the second commit. `src/events_udefs.c` carries vanilla Ch6's AI unit by unit, so this was never a judgment call:

```
17 of 24  AttackInRangeAI  {AI_A_00 ActionInRange, AI_B_03 NeverMove}
 4        {0x0, 0x12, 0, 0} AI_B_12 MoveToEnemyAfterOneTurn
 2        no .ai block = {0,0,0,0} = ActionInRange + MoveToEnemy
 1 boss   GuardTileAI {AI_A_03 ActionStanding, AI_B_03 NeverMove}
 3 Hard   {DefaultAI, 0x1, 0x0}
```

Vanilla Ch6 is a **static map** — nothing charges on turn 1 but two units and a Bael, and the player advances into fixed threat ranges. That is why its difficulty was the hostage clock and the fog rather than an enemy tide, and it is the shape our marooned boats inherit. The first draft had 13 pursuers, which would have played as a different chapter at the same measured pressure. Vanilla's healer travels *with* its cavalry (`AI_B_12`), so the lamia does too.

Two new labels carry their exact bytes for `CH06_AI` at injection: `charge_after_one_turn` `{0x0,0x12,0,0}` and `pursue` `{0,0,0,0}`. `hold_position` here is Ch6's own `{0x3,0x3,0x0,0x0}`, not ch05's `{0x3,0x3,0x9,0x20}`.

This same check across ch00–ch05 found the rest of the campaign has the same gap, tracked in #335.

## Owed, deliberately not here

**Enemy positions.** Not derivable: ch05 lifted its coordinates from its vanilla twin because its map *is* that twin's retile, but ch06 splits donor from bar (layout Ch13Ephraim, pressure Ch6), so neither source transfers. Placement is authored against this map's own geometry — the two 3x3 drift pockets at the boats, the eight crossings, the six-cell centre shelf with its two one-tile doors — and wants a render to drive it.

## Verification

- `make difficulty CH=ch06` — PARITY, x1.00 / x1.00, role check clean
- `tools/check.py` — green, drift check clean
- `tools/test_check_chapter_schema.py` (26 tests), `tools/test_chapter_status.py` (28 tests) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
