### PR TITLE
decisions: permadeath is a combat rule; and the FE-Repo is READ, not grepped

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -757,16 +757,11 @@ design_notes: >
   Keep the merfolk honest (they are vanilla Ch6's own 24) and keep the two marooned boats
   killable -- that clock, not the boss, is where this chapter's difficulty lives.
 
-# ── Cutscene actor availability (classic permadeath) ─────────────────────────────
-# `permadeath.default_mode: classic` means Marty or Braulo can be DEAD when the boss falls.
-# The retired Talk design degraded on its own (no Marty, no Talk, fight it out); a cutscene
-# does not. events/ch06-messie.ea must therefore branch on CHECK_ALIVE for both speakers:
-# Marty is the one who can talk to animals and Braulo is lake fauna himself, so each can
-# carry the scene alone, and if BOTH are dead the scene plays with Messie unanswered --
-# he surfaces, waits, and submerges. Vanilla precedent for loading a scene actor regardless
-# of deployment is ch04's moose sighting; vanilla precedent for gating on the living is
-# Ch6's own Orion's Bolt (CHECK_ALIVE on its civilians).
-cutscene_actors:
-  required: []                  # nothing is force-deployed; the scene adapts instead
-  speakers: [marty, braulo]     # each sufficient alone
-  if_all_dead: "Messie surfaces, is not answered, and submerges -- the chapter still ends"
+# ── Cutscene actors ──────────────────────────────────────────────────────────────
+# The eight PCs appear in cutscenes whether or not they are alive -- permadeath is a COMBAT
+# rule here, not a narrative one (decisions.md, "Permadeath is a combat rule"). So this scene
+# does NOT gate on Marty or Braulo: they speak, always. The invariant that makes that safe is
+# that events/ch06-messie.ea must LOAD its actors rather than assume they are standing on the
+# map (`LoadUnit` has no death check; `GetUnitFromCharId` returns NULL for an absent unit, and
+# a CUMO/MOVE on NULL is the never-returns soft-lock assert_scripted_move_reachable exists for).
+cutscene_actors: [marty, braulo]

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7561,6 +7561,48 @@ standing on the map is the never-returns soft-lock `assert_scripted_move_reachab
 for. Vanilla's own scenes `LOAD1`/`LOAD2` their actors before staging them; ch04's moose does the
 same. Every scene of ours must.
 
+### The FE-Repo is READ, not grepped (2026-08-29)
+
+Scouting the FE-Repo by keyword misses the assets that matter. ch06's search found nothing useful
+until the method changed; then it found five, and every one of them **contains no word describing
+what it is**:
+
+| the asset | what it actually is | the word that would have found it |
+|---|---|---|
+| `[Berserker-Hawkeye] Squidsmith` | the only aquatic AXE anim | none |
+| `[General-Variant] IronShell-Tiny General` | the only armour anim carrying a LANCE | none |
+| `[Spider-Variant] Cavalier Rider` | mounted **sword + lance**, one palette from a crab | none |
+| `[Monster-Custom] Lamia` | a mounted-footprint staff healer | none |
+| `Shark Rider (M/F)` | mounted merfolk, map sprite only | "shark", by luck |
+
+A broad aquatic keyword sweep over the same tree returned **2,966 name hits**, almost all noise --
+it matches artist handles (`SeaLion`, `WAve`, `Squidaccus`, `Shark3134`) and words like "sea" and
+"ice" inside unrelated filenames -- and still surfaced none of the five. Keyword search answers
+"who is named like a fish", which is not the question. The question is "what can wield an axe
+underwater", and only a human reading the category can answer it.
+
+**The method that works:**
+
+1. **Pull the git trees, per top-level directory.** The root `git/trees/HEAD?recursive=1` call
+   TRUNCATES (40,326 entries, `truncated: true`) and silently drops whole categories -- its
+   top-level listing stops at "Battle Animations", so `Map Sprites` never appears. Fetch the root
+   tree non-recursively for the directory SHAs, then recurse each one:
+   `Map Sprites` returns complete at 3,074 files, `Portrait Repository` at 17,341; `Battle
+   Animations` truncates at 44,200, so fetch its 23 category subtrees individually.
+2. **Read the category listing by eye.** The monster and mounted categories are short enough
+   (~100-210 names each) to scan, and scanning is what surfaced every asset above.
+3. **Open the mode folders before believing anything about weapons.** `docs/fe-repo-scouting.md`
+   already warns that its table says where an anim LIVES, not what it does. Do not `head` the
+   listing either: the Mermaid's modes were first reported off a truncated list, and the full one
+   (`2. Lance`, `4. Bow`, `4. Staff`, `5/6. Magic`, `7. Staff`, `8. Refresh/Unarmed`, and NO sword
+   or axe) is what actually decided the roster.
+4. **Check the map-sprite half separately.** An anim without a map sprite is half an asset, and the
+   reverse (Kraken, Shark, Shark Rider) is common -- they look right walking and produce a vanilla
+   monster's animation the moment combat starts.
+
+Cost is a few API calls and one pass of reading. The alternative cost ch06 an afternoon of
+believing the axe block had to be redesigned around an asset gap that did not exist.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7529,6 +7529,38 @@ found the same gap almost everywhere, biased toward aggression (ch04 fields 78% 
 half-static twin); ch05's `raider` and `duelist_hold` are the exceptions, derived exactly. Tracked
 with a guard proposal in issue #335.
 
+### Permadeath is a combat rule, not a narrative one (2026-08-29)
+
+**The eight PCs appear in every cutscene whether or not they are alive.** No `CHECK_ALIVE`, no
+alternate lines, no fallback speaker. Recruits and NPCs -- Basil, Sahnar, Lupin, the boat crews --
+keep vanilla's treatment and branch normally.
+
+**Why we diverge from vanilla here, deliberately.** Vanilla gates dialogue on aliveness 121 times,
+110 of them on 33 *named playable* characters, and its idiom is cheap: `CHECK_ALIVE` picks a
+message id rather than forking the scene (`SVAL(EVT_SLOT_2, <id>)` then one `TEXTSHOW`), and where
+several characters matter the checks collapse to one shared label -- two characters give two
+outcomes, not four. The FALLBACK is what we cannot copy: vanilla hands the dead character's lines
+to someone who *cannot* die. FE8 Ch4's recruit scene is the model -- Artur recruits Lute
+(`MSG_9AD`), and if Artur is dead **Eirika** speaks the identical beat and Lute answers "Yes? Who
+are you?" instead of greeting a friend (`MSG_9AE`); `MSG_9AF`'s four-hander becomes the same
+conversation between Eirika and Seth alone (`MSG_9B0`).
+
+That strategy rests on a character who is structurally always present. **We have none:** the
+player picks their lord at the start, and `difficulty.py`'s lord sweep tests every PC as the
+must-survive unit. There is no Eirika to hand the line to.
+
+And the deeper reason: these scenes are a record of a D&D campaign that actually happened. Writing
+a PC out of one because a player lost them on a map would rewrite what the table did -- the hack
+would stop resembling the campaign it exists to preserve. Combat is FE; the story is theirs.
+
+**The invariant that makes it safe: a cutscene LOADs its actors, never assumes them.** `LoadUnit`
+performs no death check (`bmunit.c`), so loading a dead character works and always has -- vanilla's
+gating is an authorial choice, not an engine limit. But `GetUnitFromCharId` returns NULL for an
+absent unit, and `CUMO_CHAR`/`MOVE` resolve through it, so a staged beat that assumes a unit is
+standing on the map is the never-returns soft-lock `assert_scripted_move_reachable` was written
+for. Vanilla's own scenes `LOAD1`/`LOAD2` their actors before staging them; ch04's moose does the
+same. Every scene of ours must.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/fe-repo-scouting.md
+++ b/docs/fe-repo-scouting.md
@@ -9,6 +9,12 @@ Rationale for the whole approach — **"divorce skin from class"**: `docs/decisi
 skin-divorce refinement (put our skins on the vanilla FE8 twin's classes → parity by construction;
 the ch01 goblin-skinned Soldiers/Fighters are the precedent).
 
+⚠️ **HOW to search this repo is a decided thing:** `docs/decisions.md` -> *"The FE-Repo is READ,
+not grepped"*. Pull the git trees per top-level directory (the root recursive call truncates and
+silently drops categories) and READ the category listings -- the assets that matter are named
+`Squidsmith`, `IronShell-Tiny General` and `[Spider-Variant] Cavalier Rider`, and no keyword
+sweep will ever find them.
+
 Source: **[Klokinator/FE-Repo](https://github.com/Klokinator/FE-Repo)** (the public GBAFE graphics
 repo; FEUniverse mirror). Scanned 2026-07-23.
 


### PR DESCRIPTION
Settles the question ch06's cutscene raised: if Marty and Braulo are both dead, who speaks?

**Answer: they do.** The eight PCs appear in every cutscene regardless of death. Recruits and NPCs (Basil, Sahnar, Lupin, the boat crews) keep vanilla's treatment and branch normally.

## Why we diverge from vanilla deliberately

Vanilla gates dialogue on aliveness **121 times, 110 of them on 33 named playable characters**. The mechanism is cheap — `CHECK_ALIVE` picks a message id rather than forking the scene, and several characters collapse to one shared label (two characters, two outcomes, not four).

What we can't copy is the **fallback**. Vanilla hands a dead character's lines to someone who *cannot* die. FE8 Ch4: Artur recruits Lute (`MSG_9AD`); with Artur dead, **Eirika** speaks the identical beat and Lute answers "Yes? Who are you?" instead of greeting a friend (`MSG_9AE`). That rests on a structurally-always-present character. We have none — the player picks their lord at campaign start.

And these scenes record a D&D campaign that actually happened. Writing a PC out of one because a player lost them on a map would rewrite what the table did.

## The invariant

**A cutscene LOADs its actors, never assumes them.** `LoadUnit` performs no death check (`bmunit.c`), so loading a dead character works and always has — vanilla's gating is authorial, not an engine limit. But `GetUnitFromCharId` returns NULL for an absent unit and `CUMO_CHAR`/`MOVE` resolve through it, which is the never-returns soft-lock `assert_scripted_move_reachable` was written for.

ch06 drops the invented three-arm fallback for a plain `cutscene_actors: [marty, braulo]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)