### PR TITLE
tooling: chapters may hold several message-id ranges, and deadness is checked

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7603,6 +7603,32 @@ underwater", and only a human reading the category can answer it.
 Cost is a few API calls and one pass of reading. The alternative cost ch06 an afternoon of
 believing the axe block had to be redesigned around an asset gap that did not exist.
 
+**Message ids were rationed by a placeholder rule, and the pool is 528**
+Every hosted chapter took "the dead block of the vanilla slot it displaces" -- ch03 got Ch4's
+23 ids, ch04 got Ch5's 19, ch05 got Ch6's 18. That rule is safe with no analysis at all, since
+blanking slot N's event lists kills slot N's text references, and it was the right first move.
+It also caps a chapter at whatever one vanilla chapter happened to spend: **ch05 reached 0 free
+and its next scene "cost a redesign, not an id"** while the id space sat 85% unspoken-for.
+
+Measured: the table is **3404 ids**; 752 are referenced by any event script; 224 belong to the
+seven slots we host in; **528 belong exclusively to chapters we never ship** -- Ch7-Ch21, the
+route splits, the tower, the ruins -- in **14 contiguous runs of 16+, the largest 48 wide**, and
+*none* of them referenced anywhere outside `src/events/`.
+
+So a chapter now declares a TUPLE OF RANGES. ch02 takes `0xAC0-0xAEF` (it had no block at all,
+which is why `make chapter` could not report its headroom); ch05 keeps `0x9E4-0x9F5` and gains
+`0xBC5-0xBF2`. **Existing ranges are never renumbered** -- moving a shipped message id is a text
+regression that surfaces only when the ROM runs.
+
+**The guard is about OUR ids, not vanilla's.** The first version of it checked whether a range
+was referenced by a chapter we host, and it flagged all three existing blocks -- correctly, and
+uselessly, because those references die when we blank the slot. The real hazard is an id we have
+**repurposed**: vanilla Ch2's three village texts (`0x969-0x96C`) are ch01's lord-select candidate
+blurbs now, and a block drawn over them would build clean, ship, and garble a scene nobody was
+looking at. `live_ids_in_declared_blocks` reads the module's own `*_MSG`/`*_MSGS` constants, so
+registering a new one is enough and there is no second list to maintain.
+_Decided and implemented: 2026-08-30._
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/fe8-guide.md
+++ b/docs/fe8-guide.md
@@ -147,7 +147,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 38 enemies · avg L8.1 — 10× Mercenary, 8× Soldier, 5× Archer, 4× Fighter, 3× Pirate, 3× Mage
 - **Normal**: 38 enemies · avg L8.1 — 10× Mercenary, 8× Soldier, 5× Archer, 4× Fighter, 3× Pirate, 3× Mage
 - **Difficult**: 46 enemies · avg L8.3 — 10× Mercenary, 8× Soldier, 7× Archer, 7× Pirate, 6× Fighter, 3× Mage
-- **Delta Normal → Difficult**: {'Fighter': 2, 'Pirate': 4, 'Archer': 2} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Archer': 2, 'Fighter': 2, 'Pirate': 4} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika9`*
 
 ## Chapter 10 (Eirika)
@@ -157,7 +157,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 51 enemies · avg L9.5 — 11× Brigand, 8× Myrmidon, 7× Soldier, 5× Mercenary, 4× Archer, 4× Pegasus Knight
 - **Normal**: 51 enemies · avg L9.5 — 11× Brigand, 8× Myrmidon, 7× Soldier, 5× Mercenary, 4× Archer, 4× Pegasus Knight
 - **Difficult**: 60 enemies · avg L9.6 — 11× Brigand, 8× Soldier, 8× Myrmidon, 7× Mercenary, 7× Pegasus Knight, 6× Archer
-- **Delta Normal → Difficult**: {'Fighter': 1, 'Pegasus Knight': 3, 'Mercenary': 2, 'Archer': 2, 'Soldier': 1} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Archer': 2, 'Fighter': 1, 'Mercenary': 2, 'Pegasus Knight': 3, 'Soldier': 1} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika10`*
 
 ## Chapter 11 (Eirika)
@@ -166,7 +166,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 42 enemies · avg L8.6 — 24× Bonewalker, 4× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
 - **Normal**: 42 enemies · avg L8.6 — 24× Bonewalker, 4× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
 - **Difficult**: 54 enemies · avg L8.9 — 30× Bonewalker, 10× Revenant, 4× Mogall, 4× Gargoyle, 3× Mauthe Doog, 1× Entombed
-- **Delta Normal → Difficult**: {'Revenant': 6, 'Bonewalker': 6} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Bonewalker': 6, 'Revenant': 6} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika11`*
 
 ## Chapter 12 (Eirika)
@@ -175,7 +175,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 44 enemies · avg L9.1 — 15× Gargoyle, 8× Bael, 8× Mauthe Doog, 4× Mogall, 3× Revenant, 2× Bonewalker
 - **Normal**: 44 enemies · avg L9.1 — 15× Gargoyle, 8× Bael, 8× Mauthe Doog, 4× Mogall, 3× Revenant, 2× Bonewalker
 - **Difficult**: 53 enemies · avg L9.1 — 19× Gargoyle, 9× Mauthe Doog, 8× Bael, 5× Mogall, 5× Revenant, 3× Bonewalker
-- **Delta Normal → Difficult**: {'Gargoyle': 4, 'Revenant': 2, 'Mogall': 1, 'Bonewalker': 1, 'Mauthe Doog': 1} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Bonewalker': 1, 'Gargoyle': 4, 'Mauthe Doog': 1, 'Mogall': 1, 'Revenant': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika12`*
 
 ## Chapter 13 (Eirika)
@@ -185,7 +185,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 58 enemies · avg L10.8 — 19× Cavalier, 6× Mercenary, 4× Archer, 4× Knight, 4× Fighter, 4× Brigand
 - **Normal**: 58 enemies · avg L10.8 — 19× Cavalier, 6× Mercenary, 4× Archer, 4× Knight, 4× Fighter, 4× Brigand
 - **Difficult**: 66 enemies · avg L10.9 — 21× Cavalier, 7× Mercenary, 6× Archer, 6× Soldier, 4× Knight, 4× Fighter
-- **Delta Normal → Difficult**: {'Mercenary': 1, 'Archer': 2, 'Cavalier': 2, 'Soldier': 3} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Archer': 2, 'Cavalier': 2, 'Mercenary': 1, 'Soldier': 3} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy eirika13`*
 
 ## Chapter 14 (Eirika)
@@ -213,7 +213,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 43 enemies · avg L9.6 — 16× Mercenary, 7× Cavalier, 3× Pirate, 3× Fighter, 3× Wyvern Rider, 2× Soldier
 - **Normal**: 43 enemies · avg L9.6 — 16× Mercenary, 7× Cavalier, 3× Pirate, 3× Fighter, 3× Wyvern Rider, 2× Soldier
 - **Difficult**: 49 enemies · avg L9.6 — 16× Mercenary, 9× Cavalier, 6× Pirate, 4× Fighter, 3× Wyvern Rider, 2× Soldier
-- **Delta Normal → Difficult**: {'Fighter': 1, 'Pirate': 3, 'Cavalier': 2} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Cavalier': 2, 'Fighter': 1, 'Pirate': 3} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim10`*
 
 ## Chapter 11 (Ephraim)
@@ -233,7 +233,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 51 enemies · avg L10.4 — 10× Shaman, 7× Cavalier, 5× Mage, 5× Bonewalker, 4× Fighter, 4× Archer
 - **Normal**: 51 enemies · avg L10.4 — 10× Shaman, 7× Cavalier, 5× Mage, 5× Bonewalker, 4× Fighter, 4× Archer
 - **Difficult**: 67 enemies · avg L10.3 — 11× Bonewalker, 10× Shaman, 8× Bael, 7× Cavalier, 6× Archer, 5× Mage
-- **Delta Normal → Difficult**: {'Bael': 6, 'Bonewalker': 6, 'Mercenary': 2, 'Archer': 2} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Archer': 2, 'Bael': 6, 'Bonewalker': 6, 'Mercenary': 2} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim12`*
 
 ## Chapter 13 (Ephraim)
@@ -251,7 +251,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 71 enemies · avg L12.2 — 15× Knight, 14× Shaman, 8× Fighter, 7× Mage, 6× Myrmidon, 6× Soldier
 - **Normal**: 71 enemies · avg L12.2 — 15× Knight, 14× Shaman, 8× Fighter, 7× Mage, 6× Myrmidon, 6× Soldier
 - **Difficult**: 81 enemies · avg L12.3 — 20× Shaman, 15× Knight, 9× Mage, 8× Fighter, 6× Myrmidon, 6× Soldier
-- **Delta Normal → Difficult**: {'Mage': 2, 'Shaman': 6, 'Priest': 2} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Mage': 2, 'Priest': 2, 'Shaman': 6} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ephraim14`*
 
 ## Chapter 15
@@ -274,7 +274,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Ephraim Easy**: 52 enemies · avg L11.7 — 6× Druid, 6× Cavalier, 5× Knight, 4× Mercenary, 4× Monk, 4× Fighter
 - **Ephraim Normal**: 52 enemies · avg L11.7 — 6× Druid, 6× Cavalier, 5× Knight, 4× Mercenary, 4× Monk, 4× Fighter
 - **Ephraim Difficult**: 57 enemies · avg L11.4 — 7× Knight, 6× Druid, 6× Cavalier, 4× Mercenary, 4× Shaman, 4× Monk
-- **Delta Eirika Normal → Eirika Difficult**: {'Swordmaster': 1, 'Druid': 3, 'Knight': 5} — a UNIT change, not a level shift
+- **Delta Eirika Normal → Eirika Difficult**: {'Druid': 3, 'Knight': 5, 'Swordmaster': 1} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch16`*
 
 ## Chapter 17
@@ -292,7 +292,7 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 46 enemies · avg L6.1 — 21× Gorgon, 18× Gorgon Egg, 4× Mogall, 3× Gargoyle
 - **Normal**: 46 enemies · avg L6.1 — 21× Gorgon, 18× Gorgon Egg, 4× Mogall, 3× Gargoyle
 - **Difficult**: 69 enemies · avg L7.4 — 27× Gorgon, 24× Gorgon Egg, 9× Bael, 5× Gargoyle, 4× Mogall
-- **Delta Normal → Difficult**: {'Gargoyle': 2, 'Bael': 9, 'Gorgon': 6, 'Gorgon Egg': 6} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Bael': 9, 'Gargoyle': 2, 'Gorgon': 6, 'Gorgon Egg': 6} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch18`*
 
 ## Chapter 19
@@ -311,6 +311,6 @@ Enemy counts are **Normal** unless noted. In FE8 the difficulty dial is a *level
 - **Easy**: 122 enemies · avg L6.3 — 30× Deathgoyle, 22× Wight, 20× Mogall, 16× Maelduin, 15× Elder Bael, 9× Cyclops
 - **Normal**: 122 enemies · avg L6.3 — 30× Deathgoyle, 22× Wight, 20× Mogall, 16× Maelduin, 15× Elder Bael, 9× Cyclops
 - **Difficult**: 157 enemies · avg L6.3 — 33× Deathgoyle, 22× Wight, 20× Mogall, 20× Elder Bael, 19× Maelduin, 15× Gwyllgi
-- **Delta Normal → Difficult**: {'Deathgoyle': 3, 'Gwyllgi': 15, 'Arch Mogall': 3, 'Gargoyle': 6, 'Elder Bael': 5, 'Maelduin': 3} — a UNIT change, not a level shift
+- **Delta Normal → Difficult**: {'Arch Mogall': 3, 'Deathgoyle': 3, 'Elder Bael': 5, 'Gargoyle': 6, 'Gwyllgi': 15, 'Maelduin': 3} — a UNIT change, not a level shift
 - **Playstyle**: *not yet digested — `tools/fe8_guide_mine.py --strategy ch20`*
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -9916,11 +9916,81 @@ HOSTED_CHAPTER_MESSAGE_IDS = {
 #
 # A block's free ids are the ones NOBODY claims, not the ones its owner has not taken: ch05's
 # ending borrowed 0x9C9/0x9CA out of ch04's block, with the reason recorded at CH05_ENDING_MSGS.
+# Message id ranges a hosted chapter may spend, as a TUPLE OF RANGES per chapter.
+#
+# The first rule was "take the dead block of the slot you displace" -- safe with no analysis,
+# since blanking slot N's events kills slot N's text references. It also caps a chapter at
+# whatever that one vanilla chapter happened to spend, and ch05 hit 0 free at 18 ids while
+# 528 ids belonging to chapters we never ship sat unclaimed in contiguous runs up to 48 wide.
+# Extra ranges come from that pool; `live_ids_in_declared_blocks` is what makes taking them
+# safe, by CHECKING deadness rather than assuming it. Existing ranges are never renumbered --
+# a shipped message id moving is a text regression nobody would see until the ROM ran.
 HOSTED_CHAPTER_MESSAGE_BLOCKS = {
-    'ch03': (0x9A3, 0x9B9),   # the dead vanilla Ch4 block (slot 4)
-    'ch04': (0x9BA, 0x9CC),   # the dead vanilla Ch5 block (slot 5)
-    'ch05': (0x9E4, 0x9F5),   # the dead vanilla Ch6 block (slot 6)
+    'ch02': ((0xAC0, 0xAEF),),                    # from the never-shipped pool (48 ids)
+    'ch03': ((0x9A3, 0x9B9),),                    # the dead vanilla Ch4 block (slot 4)
+    'ch04': ((0x9BA, 0x9CC),),                    # the dead vanilla Ch5 block (slot 5)
+    'ch05': ((0x9E4, 0x9F5), (0xBC5, 0xBF2)),     # its slot-6 block, plus 46 from the pool
 }
+
+# The size of vanilla's message table (gMsgTable). Ids at or above this are not messages.
+VANILLA_MESSAGE_COUNT = 0xD4C
+
+# Vanilla chapter slots we HOST in. A message id referenced only by the event scripts of
+# chapters outside this set is unreachable in our ROM, which is what makes it claimable.
+HOSTED_VANILLA_SLOTS = ('prologue', 'ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6')
+
+
+def message_block_ranges(chapter, blocks=None):
+    """The (lo, hi) ranges a hosted chapter may spend. Empty when it declares none."""
+    return tuple((blocks if blocks is not None
+                  else HOSTED_CHAPTER_MESSAGE_BLOCKS).get(chapter, ()))
+
+
+def message_block_capacity(chapter, blocks=None):
+    """How many ids a chapter's declared ranges hold in total."""
+    return sum(hi - lo + 1 for lo, hi in message_block_ranges(chapter, blocks))
+
+
+def injector_message_ids():
+    """{message id: constant name} for every id THIS module hardcodes.
+
+    The hazard a widened block actually faces. Vanilla's own references to a slot we host
+    die when our injector blanks that slot's event lists -- but ids we have REPURPOSED are
+    very much alive, and they no longer look like what they were. Vanilla Ch2's three
+    village texts (0x969-0x96C) are ch01's lord-select candidate blurbs now; a block drawn
+    over them would compile, ship, and garble a scene nobody was looking at.
+
+    Read off the module's own `*_MSG` / `*_MSGS` constants, so registering a new one is
+    enough -- there is no second list to remember.
+    """
+    out = {}
+    for name, value in sorted(globals().items()):
+        if not re.search(r'_MSGS?$', name):
+            continue
+        values = value if isinstance(value, (tuple, list, set)) else (value,)
+        for mid in values:
+            if isinstance(mid, int) and 0x300 <= mid < VANILLA_MESSAGE_COUNT:
+                out.setdefault(mid, name)
+    return out
+
+
+def live_ids_in_declared_blocks(blocks=None, claims=None):
+    """Ids inside a declared block that something else already spends. Empty == safe.
+
+    A chapter's own claims are fine -- that is what a block is FOR. What is refused is a
+    range drawn over an id another part of the build hardcodes, because nothing downstream
+    would notice: the build succeeds, the ROM ships, and one scene reads another's text.
+    """
+    spent = injector_message_ids()
+    owned = (claims if claims is not None else HOSTED_CHAPTER_MESSAGE_IDS)
+    bad = []
+    for chapter, ranges in sorted((blocks if blocks is not None
+                                   else HOSTED_CHAPTER_MESSAGE_BLOCKS).items()):
+        mine = set(owned.get(chapter, ()))
+        for lo, hi in ranges:
+            bad += ['%s 0x%X (%s)' % (chapter, m, spent[m])
+                    for m in range(lo, hi + 1) if m in spent and m not in mine]
+    return bad
 
 
 def assert_message_blocks_disjoint(blocks=None):
@@ -9930,13 +10000,18 @@ def assert_message_blocks_disjoint(blocks=None):
     setup that makes that inevitable -- two chapters told to help themselves to the same
     range -- before either has spent it.
     """
-    ordered = sorted((blocks if blocks is not None
-                      else HOSTED_CHAPTER_MESSAGE_BLOCKS).items(), key=lambda kv: kv[1])
+    flat = sorted(((lo, hi), name)
+                  for name, ranges in (blocks if blocks is not None
+                                       else HOSTED_CHAPTER_MESSAGE_BLOCKS).items()
+                  for lo, hi in ranges)
+    ordered = [(name, span) for span, name in flat]
     for (a, (a_lo, a_hi)), (b, (b_lo, b_hi)) in zip(ordered, ordered[1:]):
         if b_lo <= a_hi:
             sys.exit('ERROR: %s (0x%X-0x%X) and %s (0x%X-0x%X) declare OVERLAPPING message '
-                     'blocks -- two chapters cannot both be free to spend the same ids'
-                     % (a, a_lo, a_hi, b, b_lo, b_hi))
+                     'ranges -- two ranges cannot both be free to spend the same ids%s'
+                     % (a, a_lo, a_hi, b, b_lo, b_hi,
+                        ' (and they are the SAME chapter, which would double-count its own '
+                        'headroom)' if a == b else ''))
     return True
 
 

--- a/tools/chapter_status.py
+++ b/tools/chapter_status.py
@@ -136,17 +136,21 @@ def message_ids(name, campaign=campaign_chapters.CAMPAIGN):
     if bc is None:
         return Room(None, UNKNOWN, (), (), None)
     claimed = tuple(sorted(set(bc.HOSTED_CHAPTER_MESSAGE_IDS.get(chapter, ()))))
-    block = bc.HOSTED_CHAPTER_MESSAGE_BLOCKS.get(chapter)
-    if block is None:
+    ranges = bc.message_block_ranges(chapter)
+    if not ranges:
         return Room(claimed, None, (), (), None)
-    lo, hi = block
     owner = {}
     for other, ids in bc.HOSTED_CHAPTER_MESSAGE_IDS.items():
         for mid in ids:
             owner[mid] = other
-    used = tuple(sorted(m for m in owner if lo <= m <= hi))
+    # A chapter may hold SEVERAL ranges (#335 follow-up): ch05 spent its slot-6 block to
+    # zero and draws the rest from the never-shipped pool, so headroom sums across all of
+    # them -- reading only the first would still report it FULL.
+    inside = lambda m: any(lo <= m <= hi for lo, hi in ranges)
+    used = tuple(sorted(m for m in owner if inside(m)))
     borrowed = tuple(sorted(m for m in used if owner[m] != chapter))
-    return Room(claimed, (lo, hi), used, borrowed, (hi - lo + 1) - len(used))
+    capacity = bc.message_block_capacity(chapter)
+    return Room(claimed, ranges, used, borrowed, capacity - len(used))
 
 
 ArtRow = collections.namedtuple('ArtRow', 'unit role portrait map_sprite battle_anim missing')
@@ -394,9 +398,11 @@ def loose_ends(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
         out.append('claims %d message id(s) but declares no host block, so headroom is '
                    'unknown (see HOSTED_CHAPTER_MESSAGE_BLOCKS)' % len(room.claimed))
     elif room.block is not None and room.free == 0:
-        out.append('the host block is full: 0x%03X-0x%03X, all %d spent -- the next scene '
-                   'costs a redesign, not an id' % (room.block[0], room.block[1],
-                                                    len(room.used_in_block)))
+        out.append('the host block is full: %s, all %d spent -- the next scene costs a '
+                   'redesign, not an id (extend it from the never-shipped pool; see '
+                   'HOSTED_CHAPTER_MESSAGE_BLOCKS)'
+                   % (' + '.join('0x%03X-0x%03X' % r for r in room.block),
+                      len(room.used_in_block)))
     if room.borrowed:
         out.append('%d id(s) inside this block are held by another chapter: %s'
                    % (len(room.borrowed), ', '.join('0x%03X' % m for m in room.borrowed)))
@@ -480,8 +486,9 @@ def report(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
         out.append('  message ids  %d claimed; no host block declared, headroom unknown'
                    % len(room.claimed))
     else:
-        out.append('  message ids  %d claimed; block 0x%03X-0x%03X, %d spent, %s FREE'
-                   % (len(room.claimed), room.block[0], room.block[1],
+        out.append('  message ids  %d claimed; block %s, %d spent, %s FREE'
+                   % (len(room.claimed),
+                      ' + '.join('0x%03X-0x%03X' % r for r in room.block),
                       len(room.used_in_block), room.free))
         if room.borrowed:
             out.append('               held by another chapter: %s'

--- a/tools/fe8_guide_mine.py
+++ b/tools/fe8_guide_mine.py
@@ -311,7 +311,9 @@ def render(records, glosses):
             a, b = summarize(n)[2], summarize(h)[2]
             # union of BOTH key sets: a class REMOVED on Difficult is a delta too,
             # and iterating only the Difficult counter would never show it.
-            delta = {k: b.get(k, 0) - a.get(k, 0) for k in set(a) | set(b)
+            # sorted(): a set union iterates in hash order, so an unsorted dict here
+            # renders differently run to run and every --render produced a spurious diff.
+            delta = {k: b.get(k, 0) - a.get(k, 0) for k in sorted(set(a) | set(b))
                      if b.get(k, 0) != a.get(k, 0)}
             if delta:
                 L.append(f"- **Delta {nl} → {hl}**: {delta} — a UNIT change, not a level shift")

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -4893,6 +4893,60 @@ def _ch05_ending(chap):
     return bc.ch05_ending_script(chap, 'CHARACTER_ARTUR', 'CHARACTER_MARISA')
 
 
+class MessageBlockPool(unittest.TestCase):
+    """A hosted chapter may declare MORE THAN ONE id range, and every range it declares must
+    be genuinely dead.
+
+    The original rule -- "take the dead block of the slot you displace" -- was safe without
+    analysis, because blanking slot N's events kills slot N's text references. It also caps
+    every chapter at whatever that one vanilla chapter happened to spend: ch05 hit 0 free at
+    18 ids while 528 ids belonging to chapters we never ship sat unclaimed in runs up to 48.
+    Widening is only safe if "this range is dead" is CHECKED, which is what these do.
+    """
+
+    def test_a_chapter_may_declare_several_ranges(self):
+        ranges = bc.message_block_ranges('ch05')
+        self.assertGreater(len(ranges), 1)
+        self.assertIn((0x9E4, 0x9F5), ranges)      # its original block, ids unmoved
+
+    def test_capacity_sums_every_range(self):
+        self.assertEqual(sum(hi - lo + 1 for lo, hi in bc.message_block_ranges('ch05')),
+                         bc.message_block_capacity('ch05'))
+
+    def test_overlap_is_refused_across_ranges_not_just_blocks(self):
+        with self.assertRaises(SystemExit):
+            bc.assert_message_blocks_disjoint(
+                {'a': ((0x100, 0x110), (0x300, 0x310)),
+                 'b': ((0x200, 0x210), (0x305, 0x320))})
+
+    def test_a_chapter_overlapping_ITSELF_is_refused(self):
+        # Two ranges on one chapter double-count its own headroom, which reads as free space
+        # that is not there.
+        with self.assertRaises(SystemExit):
+            bc.assert_message_blocks_disjoint({'a': ((0x100, 0x110), (0x108, 0x120))})
+
+    def test_no_declared_block_is_drawn_over_an_id_the_build_already_spends(self):
+        """The guard that makes widening safe. Vanilla's references to a slot we host die
+        when we blank that slot's events -- but ids we REPURPOSED are alive and no longer
+        look like what they were."""
+        self.assertEqual([], bc.live_ids_in_declared_blocks())
+
+    def test_the_guard_catches_a_range_drawn_over_a_repurposed_id(self):
+        """0x969 was vanilla Ch2's first village text and is now a lord-select blurb. A
+        block over it would build clean and garble a scene in play."""
+        self.assertIn(0x969, bc.injector_message_ids())
+        offenders = bc.live_ids_in_declared_blocks({'bogus': ((0x969, 0x96C),)})
+        self.assertTrue(any('0x969' in o for o in offenders), offenders)
+
+    def test_a_chapter_s_OWN_claims_inside_its_block_are_not_offenders(self):
+        """Same range as the test above -- the only difference is that the chapter claims
+        those ids, which is what a block is FOR. Without this carve-out every chapter would
+        report its own scenes as collisions."""
+        self.assertEqual([], bc.live_ids_in_declared_blocks(
+            {'bogus': ((0x969, 0x96C),)},
+            claims={'bogus': (0x969, 0x96A, 0x96B, 0x96C)}))
+
+
 class Ch05VillageRaidRace(unittest.TestCase):
     """ch05's declared structure: the eruption's dead race the party for the four reliquaries,
     and saving all four pays out (#25). Vanilla Ch5 is the reference for both halves -- it wires

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -67,10 +67,18 @@ class MessageIds(unittest.TestCase):
         reliquary lines, the moose's appended name), and those are claims but not headroom:
         counting them as block usage would report the block as overfull."""
         room = cs.message_ids('ch05')
-        lo, hi = room.block
-        self.assertTrue(all(lo <= m <= hi for m in room.used_in_block))
-        self.assertTrue(any(m < lo or m > hi for m in room.claimed))
-        self.assertEqual(hi - lo + 1 - len(room.used_in_block), room.free)
+        inside = lambda m: any(lo <= m <= hi for lo, hi in room.block)
+        self.assertTrue(all(inside(m) for m in room.used_in_block))
+        self.assertTrue(any(not inside(m) for m in room.claimed))
+        capacity = sum(hi - lo + 1 for lo, hi in room.block)
+        self.assertEqual(capacity - len(room.used_in_block), room.free)
+
+    def test_headroom_sums_across_every_declared_range(self):
+        """ch05 spends its slot-6 block down to zero and draws the rest from the pool, so a
+        reader that looked at only the first range would still call it FULL."""
+        room = cs.message_ids('ch05')
+        self.assertGreater(len(room.block), 1)
+        self.assertGreater(room.free, 0)
 
     def test_two_chapters_may_not_declare_overlapping_blocks(self):
         """`assert_message_ids_unique` catches two chapters writing the same id. This catches
@@ -78,10 +86,11 @@ class MessageIds(unittest.TestCase):
         import build_campaign as bc
         self.assertTrue(bc.assert_message_blocks_disjoint())
         with self.assertRaises(SystemExit):
-            bc.assert_message_blocks_disjoint({'a': (0x100, 0x110), 'b': (0x105, 0x120)})
+            bc.assert_message_blocks_disjoint({'a': ((0x100, 0x110),),
+                                               'b': ((0x105, 0x120),)})
 
     def test_a_chapter_with_no_declared_block_says_so_rather_than_guessing(self):
-        """ch01/ch02 predate the per-chapter block registry. Reporting 0 free would read as
+        """ch01 predates the per-chapter block registry. Reporting 0 free would read as
         'full' when the truth is 'nobody wrote it down'."""
         self.assertIsNone(cs.message_ids('ch01').block)
 
@@ -124,11 +133,12 @@ class Scenarios(unittest.TestCase):
 
 
 class LooseEnds(unittest.TestCase):
-    def test_ch05_s_message_block_is_reported_as_full(self):
-        """It is: 0x9E4-0x9F5, all eighteen spent. That is the number that decides whether
-        ch05's next scene costs an id or a redesign, and nothing computed it before."""
-        self.assertEqual(0, cs.message_ids('ch05').free)
-        self.assertTrue(any('block is full' in e for e in cs.loose_ends('ch05')))
+    def test_ch05_is_no_longer_out_of_message_ids(self):
+        """It WAS full -- 0x9E4-0x9F5, all eighteen spent -- because the first allocation
+        rule capped every chapter at whatever its host slot happened to spend. A second
+        range from the never-shipped pool is what unblocks its next scene."""
+        self.assertGreater(cs.message_ids('ch05').free, 0)
+        self.assertFalse(any('block is full' in e for e in cs.loose_ends('ch05')))
 
     def test_a_planned_chapter_reports_its_unwritten_scenes_and_missing_art(self):
         ends = cs.loose_ends('ch06')


### PR DESCRIPTION
Every hosted chapter took *"the dead block of the vanilla slot it displaces"* — ch03 got Ch4's 23 ids, ch04 got Ch5's 19, ch05 got Ch6's 18. That rule is safe with no analysis (blanking slot N's events kills slot N's text references) and was the right first move. It also caps a chapter at whatever one vanilla chapter happened to spend: **ch05 hit 0 free**, and `make chapter` reported its next scene "costs a redesign, not an id" — while the id space sat 85% unspoken-for.

## Measured

| | |
|---|---|
| message ids in the table | **3404** |
| referenced by any event script | 752 |
| used by the seven slots we host in | 224 |
| **used only by chapters we never ship** | **528** |

Those 528 sit in **14 contiguous runs of 16+**, largest **48**, and none is referenced anywhere outside `src/events/`.

## Change

`HOSTED_CHAPTER_MESSAGE_BLOCKS` values become a **tuple of ranges**.

- **ch02** to `0xAC0-0xAEF` (it had no block at all, which is why its headroom was unreportable) — **48 free**
- **ch05** keeps `0x9E4-0x9F5`, gains `0xBC5-0xBF2` — **46 free**, was 0
- ch03/ch04 unchanged; they extend the same way when they need it
- **No existing id is renumbered** — moving a shipped message id is a text regression that surfaces only when the ROM runs

## The guard is about OUR ids, not vanilla's

The first version checked whether a range was referenced by a slot we host. It flagged all three existing blocks — correctly, and uselessly, because those references die when the slot is blanked.

The real hazard is a **repurposed** id. `0x969`-`0x96C` were vanilla Ch2's three village texts and are ch01's lord-select candidate blurbs now; a block drawn over them builds clean, ships, and garbles a scene nobody is watching. `live_ids_in_declared_blocks` reads the module's own `*_MSG`/`*_MSGS` constants, so registering a new one is enough — there is no second list to maintain.

Also included: `fe8_guide_mine --render` emitted a dict built over a set union, so it iterated in hash order and every regeneration produced a spurious 11-line diff. Sorted.

`make check` green · 586 + 29 tests · ADR in `docs/decisions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
