### PR TITLE
ai: borrow every enemy's AI from its vanilla donor (#335)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch00-prologue-a-dagger-of-ice.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch00-prologue-a-dagger-of-ice.yaml
@@ -177,7 +177,14 @@ enemy_units:
       - "Cold regeneration, fire vulnerability — the Frostmaiden's chill knits his wounds; flame unmakes them (echoed later by the Ch8 ice trolls)"
       - "True nature (book p.23): a drowned mariner possessed by a frost-druid spirit of Auril; kill the body and the winter spirit dies with it — but a single defeat only scatters him"
       - "Misty step: vanishes in a breath of frost — the diegetic reason he escapes the prologue despite being 'defeated'"
-    ai_pattern: hold_position
+    donor: [14, 8]              # O'Neill, the tutorial boss, on this very tile
+    ai_override:
+      ai: '{GuardTileAI, 0x9, 0x20}'
+      why: >
+        O'Neill's own AI is DoNothing ({0x6,0x3,0,0}) and it only works because vanilla's
+        prologue event-scripts his attack -- prologue-eventscript.h CHAIs him to {0,0} once
+        CHECK_TUTORIAL fails. We run no such script, so borrowing his bytes would field a
+        boss that never acts. He holds his tile instead.
     # Defeated on the field, but he does NOT die here — see the chapter_end cutscene (escape).
     death_quote: "Her work… does not end with me…"   # LOCKED 2026-06-10 (dialogue pass)
     art:
@@ -196,7 +203,9 @@ enemy_units:
     inventory:
       - id: iron-axe
         damage_type: slashing
-    ai_pattern: aggressive
+    donor: [{at: [14, 7], level: 1}, {at: [14, 7], level: 2}]
+    # one guard apiece: vanilla's L1 fighter runs the scripted AI_B_0A approach, its L2
+    # charges on turn 2. Giving both the same donor lost one of the two behaviours.
 
 # ── Events (pacing / cutscene placement) ─────────────────────────────────────────
 events:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
@@ -127,7 +127,10 @@ enemy_units:
     inventory:
       - id: iron-lance
         damage_type: piercing   # cosmetic flavor label
-    ai_pattern: hold_then_attack  # vanilla gate-guard posture: attack in range, don't chase
+    donor: [{at: [1, 9], class: CLASS_SOLDIER},
+              {at: [2, 9], class: CLASS_SOLDIER, level: 2},
+              {at: [2, 9], class: CLASS_SOLDIER, level: 3}]
+    # vanilla's three soldiers one apiece: two hold the road, the third charges on turn 2
 
   - id: goblin-axe
     name: "Goblin Raider"
@@ -139,7 +142,11 @@ enemy_units:
     inventory:
       - id: iron-axe
         damage_type: slashing   # cosmetic flavor label
-    ai_pattern: aggressive      # vanilla pursue AI {0x0,0x0A,0x0,0x0}
+    donor: [{at: [1, 9], class: CLASS_FIGHTER},
+              {at: [2, 9], class: CLASS_FIGHTER, level: 2, nth: 0},
+              {at: [2, 9], class: CLASS_FIGHTER, level: 2, nth: 1}]
+    # vanilla's three fighters one apiece: two pursue from turn 1, the third charges on
+    # turn 2. The (2,9) pair is identical in every readable field but AI, hence `nth`
 
   - id: goblin-chief
     name: "Izobai"               # the Foaming Mugs goblin boss (book canon); a female
@@ -157,7 +164,7 @@ enemy_units:
         damage_type: piercing   # cosmetic flavor label
       - id: iron-ingots         # drops on death → the job's MacGuffin
         is_key_item: true
-    ai_pattern: hold_position   # Breguet AI {0x3,0x3,0x9,0x20}: attack in place, never move
+    donor: {at: [2, 9], class: CLASS_ARMOR_KNIGHT} # Breguet, the chapter boss -- GuardTileAI + the GuardTile bit
     # Voice: cunning, mocking, mercenary bandit-warlord (lore/izobai.md). LOCKED 2026-06-17.
     taunt: "The iron's right here, under my boots. Come and take it."
     death_quote: "Should've taken the gold... and run..."
@@ -174,7 +181,7 @@ enemy_units:
     inventory_by_class:
       fighter: [iron-axe]
       soldier: [iron-lance]
-    ai_pattern: aggressive
+    donor: {at: [14, 9], class: CLASS_FIGHTER}  # vanilla Ch1's east reinforcement wave (both fighters share one AI)
 
 # ── Events ────────────────────────────────────────────────────────────────────
 events:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch01-the-iron-trail.yaml
@@ -127,10 +127,8 @@ enemy_units:
     inventory:
       - id: iron-lance
         damage_type: piercing   # cosmetic flavor label
-    donor: [{at: [1, 9], class: CLASS_SOLDIER},
-              {at: [2, 9], class: CLASS_SOLDIER, level: 2},
-              {at: [2, 9], class: CLASS_SOLDIER, level: 3}]
-    # vanilla's three soldiers one apiece: two hold the road, the third charges on turn 2
+    donor: [[1, 6], [3, 6], [2, 7]]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
 
   - id: goblin-axe
     name: "Goblin Raider"
@@ -142,11 +140,8 @@ enemy_units:
     inventory:
       - id: iron-axe
         damage_type: slashing   # cosmetic flavor label
-    donor: [{at: [1, 9], class: CLASS_FIGHTER},
-              {at: [2, 9], class: CLASS_FIGHTER, level: 2, nth: 0},
-              {at: [2, 9], class: CLASS_FIGHTER, level: 2, nth: 1}]
-    # vanilla's three fighters one apiece: two pursue from turn 1, the third charges on
-    # turn 2. The (2,9) pair is identical in every readable field but AI, hence `nth`
+    donor: [[1, 8], [3, 8], [2, 9]]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
 
   - id: goblin-chief
     name: "Izobai"               # the Foaming Mugs goblin boss (book canon); a female
@@ -164,8 +159,8 @@ enemy_units:
         damage_type: piercing   # cosmetic flavor label
       - id: iron-ingots         # drops on death → the job's MacGuffin
         is_key_item: true
-    donor: {at: [2, 9], class: CLASS_ARMOR_KNIGHT} # Breguet, the chapter boss -- GuardTileAI + the GuardTile bit
-    # Voice: cunning, mocking, mercenary bandit-warlord (lore/izobai.md). LOCKED 2026-06-17.
+    donor: [2, 5]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     taunt: "The iron's right here, under my boots. Come and take it."
     death_quote: "Should've taken the gold... and run..."
 
@@ -181,7 +176,8 @@ enemy_units:
     inventory_by_class:
       fighter: [iron-axe]
       soldier: [iron-lance]
-    donor: {at: [14, 9], class: CLASS_FIGHTER}  # vanilla Ch1's east reinforcement wave (both fighters share one AI)
+    donor: [[13, 8], [13, 9], [12, 9]]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
 
 # ── Events ────────────────────────────────────────────────────────────────────
 events:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch03-the-termalaine-mine.yaml
@@ -168,7 +168,7 @@ enemy_units:
                                 # chapters later, so the boss curve stays monotonic.
     inventory:
       - id: evil-eye            # the mogall's innate ranged magic gaze (hits RES); flavor = lightning tentacle
-    ai_pattern: aggressive      # guards the lair; VISIBLE from turn 1 like vanilla Bazba — Pinky's shaft-scout moved into the opening cutscene (player sees the mogall up top), so no in-battle reveal
+    donor: [14, 1]     # vanilla Bazba, the seize-tile boss -- GuardTileAI + the GuardTile bit
     death_quote: "*a wet, clicking shriek*"
   # ── 6 Brigand kobolds (vanilla L3-L4 brigands; 2 are key-droppers below) → Icewind kobolds ──
   - id: kobold-axe
@@ -180,7 +180,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: iron-axe            # pick/hatchet
-    ai_pattern: defensive       # territorial; hold the galleries
+    donor: [7, 2]      # vanilla L3 iron-axe brigand
   - id: kobold-thrower-l3
     name: "Icewind Kobold"
     count: 1                    # vanilla brigand @ (9,8) L3 hand-axe
@@ -190,7 +190,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: hand-axe            # throwing pick (1-2 range)
-    ai_pattern: defensive
+    donor: [9, 8]      # vanilla L3 hand-axe brigand
   - id: kobold-thrower-l4
     name: "Icewind Kobold"
     count: 1                    # vanilla brigand @ (14,11) L4 hand-axe
@@ -200,7 +200,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: hand-axe
-    ai_pattern: defensive
+    donor: [14, 11]    # vanilla L4 hand-axe brigand
   - id: kobold-steel
     name: "Icewind Brute"
     count: 1                    # vanilla brigand @ (14,6) L3 steel-axe (the grell's nearest enforcer)
@@ -218,7 +218,7 @@ enemy_units:
     inventory:
       - id: steel-axe           # heavy mining maul
       - id: pure-water          # vanilla (14,6) brigand carried Pure Water
-    ai_pattern: defensive
+    donor: [14, 6]     # vanilla L3 steel-axe brigand -- the boss's nearest enforcer
   # ── 1 Mercenary (vanilla L2 merc @ (15,2)) → a blade-kobold ──
   - id: kobold-blade
     name: "Kobold Skirmisher"
@@ -230,7 +230,7 @@ enemy_units:
     inventory:
       - id: iron-sword
       - id: antitoxin           # vanilla merc carried Antitoxin
-    ai_pattern: defensive
+    donor: [15, 2]     # vanilla L2 mercenary
   # ── 1 Archer (vanilla L4 archer @ (12,9)) → a kobold slinger ──
   - id: kobold-slinger
     name: "Kobold Slinger"
@@ -241,7 +241,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: iron-bow            # dart/sling — the chapter's single ranged kobold
-    ai_pattern: defensive
+    donor: [12, 9]     # vanilla L4 archer
   # ── 1 Thief (vanilla enemy thief @ (9,11)) → a svirfneblin gem-skulk (deep-gnome looter; not a rat — RBG & Pinky are the party's rats) ──
   - id: svirfneblin-skulk
     name: "Svirfneblin Skulk"
@@ -253,7 +253,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: iron-sword          # a fine knife (modeled as the vanilla thief's blade)
-    ai_pattern: aggressive      # slipped up from the Underdark for the tourmaline — ties to the grell's origin; loots like the vanilla thief
+    donor: [9, 11]     # vanilla enemy thief
   # ── 2 key-droppers (vanilla Door Key / Chest Key brigands) → kobolds that drop the keys ──
   - id: kobold-keykeep-door
     name: "Icewind Kobold"
@@ -265,7 +265,7 @@ enemy_units:
     inventory:
       - id: iron-axe
     item_drop: door-key         # so a player who hasn't recruited Trex yet can still open doors
-    ai_pattern: defensive
+    donor: [5, 9]      # vanilla L3 brigand (door-key carrier)
   - id: kobold-keykeep-chest
     name: "Icewind Kobold"
     count: 1
@@ -276,7 +276,7 @@ enemy_units:
     inventory:
       - id: iron-axe
     item_drop: chest-key        # backup chest access (Trex is the intended opener)
-    ai_pattern: defensive
+    donor: [7, 11]     # vanilla L3 brigand (chest-key carrier)
 
 # ── Chests / Mine Loot ───────────────────────────────────────────────────────────
 # Reward footprint mirrors vanilla FE8 Ch3 (decisions.md §Reward budget; fe8-pacing-reference

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
@@ -164,7 +164,7 @@ enemy_units:
       - id: evil-eye
         fe_base: evil-eye
     damage_type: dark           # flavor label only
-    ai_pattern: defensive
+    donor: [[11, 6], [13, 7], [12, 8], [13, 11]]   # vanilla's four mogalls, tile for tile -- and they run THREE AIs, not one
   # ── Revenants ×2 (melee zombies) — vanilla Ch4's core fodder; the tough end of the line ──
   - id: revenant
     name: "Revenant"
@@ -178,7 +178,7 @@ enemy_units:
       - id: rotten-claw
         fe_base: rotten-claw    # ITEM_MONSTER_ROTTENCLW — vanilla Revenant claw
     damage_type: bludgeoning    # flavor label only
-    ai_pattern: aggressive
+    donor: [[7, 9], [5, 13]]   # two of vanilla's main-force L2 revenants (AttackInRange)
   # ── Bonewalkers ×3 (MELEE, iron sword) — vanilla Ch4 Bonewalkers are melee, not bows ──
   - id: bonewalker
     name: "Bonewalker"
@@ -192,7 +192,7 @@ enemy_units:
       - id: iron-sword
         fe_base: iron-sword     # ITEM_SWORD_IRON — vanilla Ch4 line Bonewalker weapon
     damage_type: slashing       # flavor label only
-    ai_pattern: aggressive
+    donor: [[2, 7], [3, 10], [1, 14]]   # vanilla's three main-force bonewalkers -- (2,7) pursues, the other two hold
   # ── Entombed ×1 (tanky melee brute) — vanilla Ch4 DOES field one Entombed (L1) ──
   - id: entoumbed
     name: "Entombed"
@@ -206,7 +206,7 @@ enemy_units:
       - id: fetid-claw
         fe_base: fetid-claw     # ITEM_MONSTER_FETIDCLW — vanilla Entombed claw
     damage_type: bludgeoning    # flavor label only
-    ai_pattern: defensive
+    donor: [13, 13]   # vanilla's Entombed, on the same tile
   # ══ TURN-2 REVEAL: the convertible wolf pack (6) ═════════════════════════════
   # Flow (Nicolas 2026-07-21): ch04 OPENS monsters-only (above); on turn 2 the pack bursts from the
   # NW fog beside the party — Lupin commands them (intelligence shown by ACTION), Marty reads it
@@ -237,7 +237,13 @@ enemy_units:
       - id: beast-bite
         fe_base: rotten-claw    # modeled beast bite (same claw class as the Revenants they replace)
     damage_type: piercing       # flavor label only
-    ai_pattern: aggressive
+    ai_override:
+      ai: '{DefaultAI, 0xC, 0x0}'
+      why: >
+        vanilla's matching wave is four L2 revenants stacked on (0,0)
+        (UnitDef_088B4C24); ours is a six-wolf pack on its own spawn tiles because Marty's
+        parley needs each wolf individually addressable (#203). Their AI is those
+        revenants' own -- pursue -- minus the stray GuardTile bit one of the four carries.
     convertible: true           # #171 — the pack parley (Marty). Convertible REINFORCEMENT: arrives
                                 # turn 2 then recruited rather than ground down (the clear-load discount).
     parley:
@@ -262,7 +268,10 @@ enemy_units:
         fe_base: rotten-claw
     item_drop: vulnerary        # the twin's dropping Revenant (ITEM_VULNERARY, last-slot drop)
     damage_type: bludgeoning
-    ai_pattern: aggressive
+    donor: [{at: [5, 8], class: CLASS_REVENANT}, {at: [8, 14], class: CLASS_REVENANT},
+              [10, 12], [11, 14]]
+    # four of vanilla's revenants, one apiece -- two hold, two pursue. The middle pair stand
+    # on their counterparts' own tiles; the outer two take the revenants our wave displaces.
   # ── Bonewalker pack ×3 (MELEE, iron lance) — vanilla Ch4's turn-2 Bonewalker pack ──
   - id: bonewalker-reinf
     name: "Bonewalker"
@@ -277,7 +286,7 @@ enemy_units:
       - id: iron-lance
         fe_base: iron-lance     # ITEM_LANCE_IRON — vanilla Ch4 pack Bonewalker weapon
     damage_type: piercing
-    ai_pattern: aggressive
+    donor: [[14, 9], [14, 8], [14, 6]]   # vanilla's east bonewalker wave (UnitDef_088B4C88), tile for tile
 
 # ── Scripted neutral (the quarry) ────────────────────────────────────────────────
 neutral_units:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch04-the-white-moose.yaml
@@ -178,8 +178,8 @@ enemy_units:
       - id: rotten-claw
         fe_base: rotten-claw    # ITEM_MONSTER_ROTTENCLW — vanilla Revenant claw
     damage_type: bludgeoning    # flavor label only
-    donor: [[7, 9], [5, 13]]   # two of vanilla's main-force L2 revenants (AttackInRange)
-  # ── Bonewalkers ×3 (MELEE, iron sword) — vanilla Ch4 Bonewalkers are melee, not bows ──
+    donor: [[7, 9], [5, 8]]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
   - id: bonewalker
     name: "Bonewalker"
     fe_name: "Bonewalker"
@@ -286,7 +286,8 @@ enemy_units:
       - id: iron-lance
         fe_base: iron-lance     # ITEM_LANCE_IRON — vanilla Ch4 pack Bonewalker weapon
     damage_type: piercing
-    donor: [[14, 9], [14, 8], [14, 6]]   # vanilla's east bonewalker wave (UnitDef_088B4C88), tile for tile
+    donor: [[14, 6], [2, 7], [3, 10]]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
 
 # ── Scripted neutral (the quarry) ────────────────────────────────────────────────
 neutral_units:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -266,7 +266,7 @@ enemy_units:
       - id: killing-frost
         fe_base: flux           # FE8 Flux — dark magic (FE MAG vs RES) at 1-2 range
     damage_type: cold           # flavor label only
-    ai_pattern: hold_position   # = vanilla Saar's GuardTileAI posture (decomp: .ai {GuardTileAI,0x9,0x20})
+    donor: {at: [13, 0], class: CLASS_ARMOR_KNIGHT}   # Saar, vanilla Ch5's boss -- GuardTileAI + the GuardTile bit
     boss_tile: moon_dial        # she holds the moon dial at the centre — retiled as a dais
                                 # (flavour + AI anchor; NO terrain bonus, see below)
     personal:                   # FE8's OWN boss mechanism — a named boss is class base + a
@@ -422,7 +422,11 @@ enemy_units:
       - id: fire-fang
         fe_base: fire-fang
     damage_type: bludgeoning    # flavor label only ("antlers/hooves")
-    ai_pattern: aggressive
+    ai_override:
+      ai: '{DefaultAI, 0x9, 0x0}'
+      why: >
+        the moose is ours -- vanilla Ch5 fields no beast to borrow from. It hunts, so it
+        takes vanilla Ch5's own pursue vector rather than a static one.
     convertible: false          # #171 — a difficulty-model flag. `difficulty.py` reads it to
                                 # exempt a unit from the role-inversion check and to apply
                                 # CONVERT_CLEAR_DISCOUNT (0.5) to clear-load, and BOTH would be
@@ -499,7 +503,12 @@ enemy_units:
       - id: elven-spear
         fe_base: iron-lance
     damage_type: piercing       # flavor label only
-    ai_pattern: defensive       # hold the approaches to the depression
+    donor: [{at: [0, 0], class: CLASS_SOLDIER},
+              {at: [10, 0], class: CLASS_SOLDIER, level: 5, nth: 0},
+              {at: [12, 0], class: CLASS_SOLDIER, level: 5},
+              {at: [10, 0], class: CLASS_SOLDIER, level: 5, nth: 1}]
+    # vanilla's four L5 soldiers, one apiece -- it splits them 2 holding / 2 pursuing,
+    # and the (10,0) pair is identical in every field but AI, hence `nth`
     skin:
       look: "skeletal elven spear-guard"
       source: "FE-Repo: Battle Animations/Infantry - (Lnc) Soldiers, Halberdiers/[Custom Halb] [U] Skeleberdier (skeleton lance; frost-repal)"
@@ -525,7 +534,16 @@ enemy_units:
       - id: rusted-greataxe
         fe_base: iron-axe
     damage_type: slashing       # flavor label only
-    ai_pattern: aggressive
+    donor: [{at: [10, 0], class: CLASS_FIGHTER, level: 5},
+              {at: [10, 0], class: CLASS_FIGHTER, level: 5},
+              {at: [10, 0], class: CLASS_FIGHTER, level: 5},
+              {at: [12, 0], class: CLASS_SOLDIER, level: 6},
+              {at: [0, 0], class: CLASS_FIGHTER},
+              {at: [11, 0], class: CLASS_ARCHER},
+              {at: [10, 0], class: CLASS_FIGHTER, level: 4},
+              {at: [10, 0], class: CLASS_ARCHER, level: 4}]
+    # eight of vanilla's line, one apiece: 4 hold, 2 pursue, 2 charge on turn 2.
+    # Giving all eight ONE donor flattened that to eight holders (the shortcut #335 exists to kill)
     skin:
       look: "risen elven axe-reaver, frost-pale"
       source: palette_swap      # vanilla Fighter frame, frost/pale palette
@@ -545,7 +563,7 @@ enemy_units:
       - id: bone-sword
         fe_base: iron-sword
     damage_type: slashing       # flavor label only
-    ai_pattern: aggressive
+    donor: {at: [0, 0], class: CLASS_MERCENARY}   # vanilla's L6 mercenary
     skin:
       look: "skeletal elven blade"
       source: "FE-Repo: Battle Animations/Monsters - Basic Types/[Skeleton-Base] [U] Bonewalker (one arm, sword) by Alexsplode"
@@ -562,7 +580,7 @@ enemy_units:
       - id: elven-longbow
         fe_base: iron-bow
     damage_type: piercing       # flavor label only
-    ai_pattern: defensive
+    donor: {at: [0, 0], class: CLASS_ARCHER}   # vanilla's holding L5 archer (the (11,0) one pursues; this is the static half)
     skin:
       look: "skeletal elven archer"
       source: "FE-Repo: Battle Animations/Monsters - Basic Types/[Skeleton-Reskin] [U] Wight Sniper by DATonDemand"
@@ -589,7 +607,7 @@ enemy_units:
       - id: elven-spear
         fe_base: iron-lance
     damage_type: piercing       # flavor label only
-    ai_pattern: raider          # AI_B_04, vanilla's own — they make for reliquary-south first
+    donor: [[14, 16], [14, 15]]   # vanilla's turn-2 raider pair (UnitDef_088B5860), tile for tile
     skin:
       look: "skeletal elven spear-guard"
       source: "FE-Repo: Battle Animations/Infantry - (Lnc) Soldiers, Halberdiers/[Custom Halb] [U] Skeleberdier (skeleton lance; frost-repal)"
@@ -606,7 +624,7 @@ enemy_units:
       - id: rusted-greataxe
         fe_base: iron-axe
     damage_type: slashing       # flavor label only
-    ai_pattern: raider          # AI_B_04 — reliquary-east (12,10) and west (5,6) are theirs
+    donor: [[14, 8], [14, 6]]   # vanilla's turn-3 raider pair (UnitDef_088B589C)
     skin:
       look: "risen elven axe-reaver, frost-pale"
       source: palette_swap
@@ -624,7 +642,7 @@ enemy_units:
       - id: elven-longbow
         fe_base: iron-bow
     damage_type: piercing       # flavor label only
-    ai_pattern: raider          # AI_B_04 — vanilla's turn-8 pair spawns here and races (5,1) too
+    donor: [{at: [13, 0], class: CLASS_BRIGAND}, [14, 1]]   # vanilla's turn-5 raider pair (UnitDef_088B58D8) -- (13,0) is SHARED with Saar's tile, so the class is named
     skin:
       look: "skeletal elven archer"
       source: "FE-Repo: Battle Animations/Monsters - Basic Types/[Skeleton-Reskin] [U] Wight Sniper by DATonDemand"
@@ -666,7 +684,7 @@ enemy_units:
       - id: killing-edge
         fe_base: killing-edge   # Joshua's killing-edge (30 crit) — the fragile-escort tension
     damage_type: slashing       # flavor label only
-    ai_pattern: duelist_hold    # vanilla Joshua's own {0x7, 0x3, 0x9, 0x0} — strike anything that
+    donor: [12, 6]   # vanilla Joshua -- AI_A_07, the do-not-attack-the-escort duelist
                                 # comes in range, NEVER move, and DO NOT TOUCH THE ESCORT. She
                                 # stands guard at the arena. A turn-1 crit-Myrmidon on
                                 # `aggressive` (pursue/charge) would hunt the squishies, which is

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch05-the-elven-tomb.yaml
@@ -266,7 +266,9 @@ enemy_units:
       - id: killing-frost
         fe_base: flux           # FE8 Flux — dark magic (FE MAG vs RES) at 1-2 range
     damage_type: cold           # flavor label only
-    donor: {at: [13, 0], class: CLASS_ARMOR_KNIGHT}   # Saar, vanilla Ch5's boss -- GuardTileAI + the GuardTile bit
+    donor: [[13, 1]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     boss_tile: moon_dial        # she holds the moon dial at the centre — retiled as a dais
                                 # (flavour + AI anchor; NO terrain bonus, see below)
     personal:                   # FE8's OWN boss mechanism — a named boss is class base + a
@@ -503,12 +505,9 @@ enemy_units:
       - id: elven-spear
         fe_base: iron-lance
     damage_type: piercing       # flavor label only
-    donor: [{at: [0, 0], class: CLASS_SOLDIER},
-              {at: [10, 0], class: CLASS_SOLDIER, level: 5, nth: 0},
-              {at: [12, 0], class: CLASS_SOLDIER, level: 5},
-              {at: [10, 0], class: CLASS_SOLDIER, level: 5, nth: 1}]
-    # vanilla's four L5 soldiers, one apiece -- it splits them 2 holding / 2 pursuing,
-    # and the (10,0) pair is identical in every field but AI, hence `nth`
+    donor: [[11, 2], [13, 3], [9, 4], [9, 9]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "skeletal elven spear-guard"
       source: "FE-Repo: Battle Animations/Infantry - (Lnc) Soldiers, Halberdiers/[Custom Halb] [U] Skeleberdier (skeleton lance; frost-repal)"
@@ -534,16 +533,9 @@ enemy_units:
       - id: rusted-greataxe
         fe_base: iron-axe
     damage_type: slashing       # flavor label only
-    donor: [{at: [10, 0], class: CLASS_FIGHTER, level: 5},
-              {at: [10, 0], class: CLASS_FIGHTER, level: 5},
-              {at: [10, 0], class: CLASS_FIGHTER, level: 5},
-              {at: [12, 0], class: CLASS_SOLDIER, level: 6},
-              {at: [0, 0], class: CLASS_FIGHTER},
-              {at: [11, 0], class: CLASS_ARCHER},
-              {at: [10, 0], class: CLASS_FIGHTER, level: 4},
-              {at: [10, 0], class: CLASS_ARCHER, level: 4}]
-    # eight of vanilla's line, one apiece: 4 hold, 2 pursue, 2 charge on turn 2.
-    # Giving all eight ONE donor flattened that to eight holders (the shortcut #335 exists to kill)
+    donor: [[10, 8], [8, 8], [7, 2], [0, 0], [4, 10], [0, 10], [3, 7], [5, 7]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "risen elven axe-reaver, frost-pale"
       source: palette_swap      # vanilla Fighter frame, frost/pale palette
@@ -563,7 +555,9 @@ enemy_units:
       - id: bone-sword
         fe_base: iron-sword
     damage_type: slashing       # flavor label only
-    donor: {at: [0, 0], class: CLASS_MERCENARY}   # vanilla's L6 mercenary
+    donor: [[3, 3]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "skeletal elven blade"
       source: "FE-Repo: Battle Animations/Monsters - Basic Types/[Skeleton-Base] [U] Bonewalker (one arm, sword) by Alexsplode"
@@ -580,7 +574,9 @@ enemy_units:
       - id: elven-longbow
         fe_base: iron-bow
     damage_type: piercing       # flavor label only
-    donor: {at: [0, 0], class: CLASS_ARCHER}   # vanilla's holding L5 archer (the (11,0) one pursues; this is the static half)
+    donor: [[1, 7]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "skeletal elven archer"
       source: "FE-Repo: Battle Animations/Monsters - Basic Types/[Skeleton-Reskin] [U] Wight Sniper by DATonDemand"
@@ -607,7 +603,9 @@ enemy_units:
       - id: elven-spear
         fe_base: iron-lance
     damage_type: piercing       # flavor label only
-    donor: [[14, 16], [14, 15]]   # vanilla's turn-2 raider pair (UnitDef_088B5860), tile for tile
+    donor: [[14, 16], [14, 15]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "skeletal elven spear-guard"
       source: "FE-Repo: Battle Animations/Infantry - (Lnc) Soldiers, Halberdiers/[Custom Halb] [U] Skeleberdier (skeleton lance; frost-repal)"
@@ -624,7 +622,9 @@ enemy_units:
       - id: rusted-greataxe
         fe_base: iron-axe
     damage_type: slashing       # flavor label only
-    donor: [[14, 8], [14, 6]]   # vanilla's turn-3 raider pair (UnitDef_088B589C)
+    donor: [[14, 8], [14, 6]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "risen elven axe-reaver, frost-pale"
       source: palette_swap
@@ -642,7 +642,9 @@ enemy_units:
       - id: elven-longbow
         fe_base: iron-bow
     damage_type: piercing       # flavor label only
-    donor: [{at: [13, 0], class: CLASS_BRIGAND}, [14, 1]]   # vanilla's turn-5 raider pair (UnitDef_088B58D8) -- (13,0) is SHARED with Saar's tile, so the class is named
+    donor: [[13, 0], [14, 1]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     skin:
       look: "skeletal elven archer"
       source: "FE-Repo: Battle Animations/Monsters - Basic Types/[Skeleton-Reskin] [U] Wight Sniper by DATonDemand"
@@ -684,18 +686,9 @@ enemy_units:
       - id: killing-edge
         fe_base: killing-edge   # Joshua's killing-edge (30 crit) — the fragile-escort tension
     damage_type: slashing       # flavor label only
-    donor: [12, 6]   # vanilla Joshua -- AI_A_07, the do-not-attack-the-escort duelist
-                                # comes in range, NEVER move, and DO NOT TOUCH THE ESCORT. She
-                                # stands guard at the arena. A turn-1 crit-Myrmidon on
-                                # `aggressive` (pursue/charge) would hunt the squishies, which is
-                                # a different chapter; one standing guard is the escort puzzle
-                                # this chapter is built on.
-                                # Sahnar is Joshua and Basil is Natasha, all the way down: AI_A_07
-                                # is `ActionInRange_ExceptNatasha`, and the refusal that makes a
-                                # fragile Cleric able to walk up to a Killing Edge lives in a
-                                # character-id list, not in these bytes. `repoint_escort_safe_ai_list`
-                                # points it at Basil at build time — the list has exactly one
-                                # client in all of FE8 (this unit's donor), so nothing else moves.
+    donor: [[12, 6]]
+    # every ch05 unit stands on a vanilla unit's POST (its REDA
+    # destination), so the pairing is derived: 23 of 23, tile for tile
     convertible: true           # #171 — the Joshua flip. Hostile crit-Myrmidon until fragile BASIL
                                 # chaperones across to Talk her; then a +~0.9 kills/round back-half ally.
     parley:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -174,7 +174,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing       # flavor label only
-    ai_pattern: cautious               # vanilla: 3 of these 4 Soldiers are AttackInRangeAI; the 4th pursues (see note)
+    donor: [[14, 9], [15, 7], [20, 7], [19, 13]] # vanilla's four HOLDING L7 soldiers
     skin:
       look: "merfolk spear-guard; the anim's lance IS a trident"
       source: "FE-Repo: Battle Animations/Monsters - Dragons and Special/[Monster-Custom] [F] Mermaid by Stephano -> 2. Lance; map sprite Mermaid (F) {N426} or {ZoramineFae}, 16x16"
@@ -188,7 +188,7 @@ enemy_units:
       - id: javelin
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [14, 16]                 # vanilla's fifth L7 soldier -- the one it lets PURSUE
     skin: {look: "merfolk spear-guard, thrown trident", source: "as merfolk-trident"}
   - id: merfolk-trident-young
     name: "Mermaid"
@@ -199,7 +199,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [14, 11]                 # vanilla's L6 soldier
     skin: {look: "merfolk spear-guard", source: "as merfolk-trident"}
 
   # ── The axe block (vanilla's 3 Fighters) → shark riders ──────────────────────
@@ -218,7 +218,7 @@ enemy_units:
       - id: poison-axe
         fe_base: venin-axe        # FE8's ITEM_AXE_VENIN, which the wiki prints as "Poison Axe"
     damage_type: slashing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [16, 9]                  # vanilla L6 fighter
     skin:
       look: "merfolk on a shark, boarding axe"
       source: "FE-Repo: Map Sprites/Mounted - Dismounted, Monsters, Misc/Shark Rider (M) {N426}, 16x16 (stand+walk); NO battle anim exists -- vanilla Fighter frames, repalletted"
@@ -231,7 +231,7 @@ enemy_units:
     inventory:
       - id: steel-axe
     damage_type: slashing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [15, 15]                 # vanilla L6 fighter
     skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
   - id: shark-rider-halberd
     name: "Shark Rider"
@@ -247,7 +247,7 @@ enemy_units:
                                 # {AXE_IRON, AXE_HALBERD}. FE8 drops the LAST item, so the Halberd
                                 # is the drop and the Iron Axe is what it swings.
     damage_type: slashing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [13, 6]                  # vanilla L5 fighter
     skin: {look: "merfolk on a shark", source: "as shark-rider-poison"}
 
   # ── The mounted block (vanilla's 3 Cavaliers) → crab-riders ──────────────────
@@ -260,7 +260,7 @@ enemy_units:
     inventory:
       - id: iron-blade
     damage_type: slashing
-    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, 0x0, 0x0}
+    donor: [8, 1]                   # vanilla L7 cavalier -- charge-after-one-turn
     skin:
       look: "merfolk astride a lake crab; the mount repainted from an arachnid to ice-blue shell"
       source: "FE-Repo: Battle Animations/Mounted - Dismounted, Monsters, Misc/[Spider-Variant] [M] Cavalier Rider by DATonDemand -> 1. Sword + 2. Lance; map sprite Cavalier (M) Spider Rider Sword {Zoramine} or Elder Bael Sword {Metalocif}, 16x32"
@@ -273,7 +273,7 @@ enemy_units:
     inventory:
       - id: iron-sword
     damage_type: slashing
-    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, 0x0, 0x0}
+    donor: [7, 1]                   # vanilla L6 cavalier
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-lance
     name: "Crab Rider"
@@ -284,7 +284,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, 0x0, 0x0}
+    donor: [11, 0]                  # vanilla L6 cavalier
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 2. Lance"}
 
   # ── The sword block (vanilla's 2 Mercenaries) → crab-riders on foot-speed ────
@@ -297,7 +297,7 @@ enemy_units:
     inventory:
       - id: iron-sword
     damage_type: slashing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [14, 14]                 # vanilla L6 mercenary
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 1. Sword"}
   - id: merfolk-blade-drop
     name: "Crab Rider"
@@ -309,7 +309,7 @@ enemy_units:
       - id: iron-blade
     item_drop: iron-blade       # vanilla: "Iron Blade -- dropped by enemy Mercenary"
     damage_type: slashing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [15, 10]                 # vanilla L6 mercenary (the dropper)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade -> 1. Sword"}
 
   # ── The armour block (vanilla's 3 Knights) → IronShell ───────────────────────
@@ -325,7 +325,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: cautious               # vanilla AttackInRangeAI -- armour that never moves
+    donor: [[16, 12], [16, 13]]     # vanilla's paired L6 knights
     skin:
       look: "a shelled thing plated like a knight, holding a bridge"
       source: "FE-Repo: Battle Animations/Infantry - Knights, Generals, Armors/[General-Variant] IronShell-Tiny General [U] by Alexsplode -> 2. Lance; map sprite General (U) IronShell_Tiny {Alexsplode}, 16x32. NB its anim preview keys on BLUE, not the usual green."
@@ -339,7 +339,7 @@ enemy_units:
       - id: horseslayer
       - id: javelin
     damage_type: piercing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [21, 13]                 # vanilla's third L6 knight
     skin: {look: "as ironshell-guard", source: "as ironshell-guard"}
 
   # ── Casters and healers (vanilla's Shaman, Mage, Priest, Troubadour) ─────────
@@ -352,7 +352,7 @@ enemy_units:
     inventory:
       - id: flux
     damage_type: necrotic
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [18, 14]                 # vanilla L6 shaman
     skin: {look: "merfolk caster", source: "Mermaid by Stephano -> 6. Magic"}
   - id: merfolk-singer
     name: "Mermaid"
@@ -363,7 +363,7 @@ enemy_units:
     inventory:
       - id: thunder
     damage_type: lightning
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [18, 5]                  # vanilla L6 mage
     skin: {look: "merfolk caster", source: "Mermaid by Stephano -> 5. Magic"}
   - id: merfolk-mender
     name: "Mermaid"
@@ -373,7 +373,7 @@ enemy_units:
     autolevel: true
     inventory:
       - id: mend
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [18, 9]                  # vanilla L6 priest
     skin: {look: "merfolk healer", source: "Mermaid by Stephano -> 4./7. Staff"}
   - id: lamia-mender
     name: "Lamia"
@@ -388,7 +388,7 @@ enemy_units:
       - id: mend
       - id: elixir
     item_drop: elixir           # vanilla: "Elixir -- dropped by enemy Troubadour"
-    ai_pattern: charge_after_one_turn  # vanilla {0x0, 0x12, ...} -- the healer RIDES WITH the mounted squad
+    donor: [10, 0]                  # vanilla's troubadour -- she travels with the cavalry, so she charges with them
     skin:
       look: "serpent-bodied merfolk healer"
       source: "FE-Repo: Battle Animations/Monsters - Dragons and Special/[Monster-Custom] [U] Lamia by L95 -> 7. Staff (also 6. Magic); map sprite Lamia (F) {Dutch Introvert}, 16x32 -- a native fit for the Troubadour's own 16x32 row"
@@ -403,7 +403,7 @@ enemy_units:
     inventory:
       - id: iron-bow
     damage_type: piercing
-    ai_pattern: cautious               # vanilla AttackInRangeAI
+    donor: [12, 4]                  # vanilla L6 archer
     skin: {look: "merfolk with a harpoon-bow", source: "Mermaid by Stephano -> 4. Bow"}
   - id: ice-crab
     name: "Ice Crab"
@@ -415,7 +415,7 @@ enemy_units:
       - id: poison-claw
         fe_base: venin-claw       # ITEM_MONSTER_VENINCLW -- vanilla Ch6's own Bael weapon
     damage_type: poison
-    ai_pattern: pursue                 # vanilla ships NO .ai block = all zeros = MoveToEnemy
+    donor: [27, 4]                  # vanilla's lone Bael -- the one wandering pursuer
     skin: {look: "a lake crab the size of a boat", source: "vanilla Bael art, 32x32 -- no reskin"}
 
   # ── The Hard wave (vanilla's Difficult-only Cavaliers) ───────────────────────
@@ -442,7 +442,7 @@ enemy_units:
       - id: javelin
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: aggressive             # vanilla {DefaultAI, 0x1, 0x0}
+    donor: [0, 11]                  # vanilla's HARD-mode cavalry (UnitDef_088B64F0)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-hard-lance
     name: "Crab Rider"
@@ -455,7 +455,7 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    ai_pattern: aggressive             # vanilla {DefaultAI, 0x1, 0x0}
+    donor: [0, 9]                   # vanilla's HARD-mode cavalry
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-hard-sword
     name: "Crab Rider"
@@ -469,7 +469,7 @@ enemy_units:
       - id: iron-sword
       - id: javelin
     damage_type: slashing
-    ai_pattern: aggressive             # vanilla {DefaultAI, 0x1, 0x0}
+    donor: [0, 13]                  # vanilla's HARD-mode cavalry
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
 
   # ── The boss (vanilla's Novala) ──────────────────────────────────────────────
@@ -488,7 +488,7 @@ enemy_units:
     inventory:
       - id: flux
     damage_type: necrotic
-    ai_pattern: hold_position          # vanilla GuardTileAI {0x3, 0x3, 0x0, 0x0} -- Novala stands on his tile
+    donor: [20, 5]                  # vanilla Ch6's boss (Novala) -- GuardTileAI, Ch6's own tail
     skin: {look: "the largest of the merfolk", source: "Mermaid by Stephano -> 6. Magic; no portrait -- see below"}
     # NO death quote and NO portrait, deliberately (Nicolas, 2026-08-29): the merfolk do not
     # speak. Messie does, and that contrast is the chapter. The FE-Repo has no merfolk
@@ -708,7 +708,7 @@ rescue_boats:
   size: 32x32                   # unit_icon_wait_table[0x41] = UNIT_ICON_SIZE_32x32
   faction: green                # -> unit_icon_pal_npc; the ally green IS vanilla's civilian faction
   tile: [17, 12]                # R13, the outcrop cell north of the door
-  ai_pattern: hold              # never moves; Fleet has mov 3 and must not wander
+  donor: [20, 5]                  # vanilla Ch6's boss (Novala) -- GuardTileAI, Ch6's own tail
   attackable_sides: 4           # parity: 2 of vanilla Ch6's 3 civilians are open on 4/4 sides
   reached_on: {foot: 7, cavalry: 5, flier: 3, braulo: 4}   # re-measured off the painted .mar
   talk:
@@ -725,7 +725,7 @@ rescue_boats:
   size: 32x32
   faction: green
   tile: [4, 17]                 # E18
-  ai_pattern: hold
+  donor: [20, 5]                  # vanilla Ch6's boss (Novala) -- GuardTileAI, Ch6's own tail
   attackable_sides: 4
   reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5}   # re-measured off the painted .mar
   talk:

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -442,7 +442,8 @@ enemy_units:
       - id: javelin
       - id: iron-lance
     damage_type: piercing
-    donor: [0, 11]                  # vanilla's HARD-mode cavalry (UnitDef_088B64F0)
+    donor: [3, 11]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-hard-lance
     name: "Crab Rider"
@@ -455,7 +456,8 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing
-    donor: [0, 9]                   # vanilla's HARD-mode cavalry
+    donor: [2, 9]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-hard-sword
     name: "Crab Rider"
@@ -469,7 +471,8 @@ enemy_units:
       - id: iron-sword
       - id: javelin
     damage_type: slashing
-    donor: [0, 13]                  # vanilla's HARD-mode cavalry
+    donor: [2, 13]
+    # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
 
   # ── The boss (vanilla's Novala) ──────────────────────────────────────────────

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7657,14 +7657,24 @@ declares it means to differ.
   out to strike; our `defensive` (`{0x3,0x3,0x9,0x20}`) was welded twice over -- the A-script AND
   the config bit -- so we had put the throne-boss posture on every line unit in ch03/ch04/ch05.
 
-**A donor is a MATCH SPEC, not a coordinate lookup**, and it may be one PER POSITION. Coordinates
-alone fail twice over: ch01 and ch06 sit on a different map donor from their parity twin, so not
-one tile lines up; and where the map IS the twin's, tiles collide by accident (ch05's bone-archer
-wave stands on (13,0), where vanilla parks an ARMOR_KNIGHT boss). A spec resolves only when
-everything it matches shares one AI; `nth:` is the last resort for units vanilla stacks that are
-identical in every readable field and still behave differently (Ch1's two L2 fighters on (2,9)).
-Per-position donors matter because a single donor per entry FLATTENS a group -- ch04's four mogalls
-run three different AIs, and ch05's eight tomb-reavers stand in for a line vanilla splits 4/2/2.
+**A donor matches where a vanilla unit FIGHTS, which is usually not where it is placed.** A
+`UnitDefinition`'s `xPosition`/`yPosition` is frequently a SPAWN tile: `redas` is scripted movement
+that walks the unit from there to its post, and the last REDA point is the destination. Vanilla
+Ch1's entire force enters on (1,9)/(2,9) and Ch5's on (0,0)/(10,0)/(12,0), so matching a donor on
+those tiles matches on "entered from the north", which is no identity at all.
+
+This is not a detail. Matched on spawn tiles, 9 of ch05's 23 units appeared to line up with the
+twin and the nine were coincidences -- one of them paired our bone-archer wave with an ARMOR_KNIGHT
+boss, whose throne AI it would have inherited. Matched on POSTS it is **23 of 23**, class for class:
+our mercenary stands on vanilla's mercenary's tile, our archer on its archer's. ch05's pairing is
+therefore DERIVED, not assigned by hand, and it comes out matching the twin exactly.
+
+Posts are also unique where placements are not, which retired an earlier `nth:` ordinal: Ch1's two
+L2 fighters share spawn (2,9) and differ only in `redas`, but they post to (3,8) and (2,9). The
+spec is still a MATCH (`at` / `class` / `level`) that resolves only when everything it matches
+shares one AI, and it may be one donor PER POSITION -- a single donor per entry FLATTENS a group,
+and ch04's four mogalls run three different AIs while ch05's eight tomb-reavers stand in for a
+line vanilla splits 4/2/2.
 
 **The AI_A_07 escort guard now sweeps EMITTED AI, not the label tables.** Strictly wider: it also
 catches a unit that inherits `AI_A_07` from its donor, which no scan of our own vocabulary could
@@ -7676,10 +7686,11 @@ whole green test suite missed -- every injector called `enemy_ai_initialiser(cha
 the position index, so all eight of ch05's tomb-reavers shipped their FIRST donor's AI. YAML right,
 resolver right, tests green, ROM wrong. `PerPositionAiReachesTheEmittedRows` now pins it.
 
-ch01, ch03 and ch06 come out matching their twins exactly; ch01 emits byte-identical output through
-the whole refactor, and ch06 -- the one chapter derived by hand -- reproduces byte for byte, which
-is the model's proof. Remaining differences are declared overrides: ch00's Sephek (O'Neill's
-DoNothing depends on a tutorial `CHAI` we do not run), ch04's six-wolf pack (#203), ch05's moose.
+ch01, ch03, ch05 and ch06 come out matching their twins exactly; ch01 emits byte-identical output
+through the whole refactor, and ch06 -- the one chapter derived by hand -- reproduces byte for
+byte, which is the model's proof. The only remaining differences are declared overrides: ch00's
+Sephek (O'Neill's DoNothing depends on a tutorial `CHAI` we do not run) and ch04's six-wolf pack,
+which is six units where vanilla loads four because #203 needs each wolf addressable by pid.
 _Decided and implemented: 2026-08-29 (#335)._
 
 ## Open Questions (not yet decided)

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7628,6 +7628,59 @@ blurbs now, and a block drawn over them would build clean, ship, and garble a sc
 looking at. `live_ids_in_declared_blocks` reads the module's own `*_MSG`/`*_MSGS` constants, so
 registering a new one is enough and there is no second list to maintain.
 _Decided and implemented: 2026-08-30._
+**Enemy AI is BORROWED from a vanilla donor, not authored (#335)**
+A chapter picks a vanilla twin so its difficulty is grounded rather than guessed, and we already
+derive that twin's classes, levels, inventories and drops from its `UnitDefinition` structs. The
+`.ai` field of those same structs was the one we never read. It got authored by feel through six
+per-chapter `CHnn_AI` label tables, and because #48 computes threat from stats and weapons, the
+drift was invisible to every gate: five chapters measured x1.00 and played nothing like their twin.
+
+**Each enemy now names a `donor:` and the build reads that unit's four AI bytes.** There is no
+label vocabulary in between, because the labels WERE the translation layer the drift lived in --
+`aggressive` meant one thing in the YAML and another in five injectors, `defensive` and
+`hold_position` were byte-identical under two names, and ch00's `ai_pattern:` was wired to nothing
+at all (its injector emitted literals). Every chapter YAML had already named its counterpart in a
+comment (`vanilla brigand @ (7,2) L3 iron-axe`) -- all 63 entries -- so `donor:` promotes prose
+that was already there to data the build can read. `ai_override:` with a `why` is how a chapter
+declares it means to differ.
+
+**Three engine facts the model rests on**, all from the decomp:
+- The vector is 2 script indices plus a 16-bit `ai_config` (`cp_utility.c` `LoadUnitAi`). `ai[2..3]`
+  are its halves, not two bytes: bits 0-2 heal threshold, **bits 3-7 the combat weight table**
+  (`cp_decide.c` -- *which enemy the unit picks*), bits 8-12 a guard-position index, bit 13
+  `FLAG_STAY`. Our `aggressive` ran weight table 0 where Ch1/2/3/5 all run table 1.
+- **AI scripts rewrite their own AI** (`AI_CMD_SET_AI`). `charge-after-one-turn` sets AI2 to pursue
+  on turn 2; `pillage` sets it once the loot is gone. Only `AI_B_03 NeverMove` is terminal, so
+  vanilla's lever is WHEN a unit activates, not whether.
+- `AI_ACTION` vs `AI_ACTION_IN_PLACE` differ by one flag: the latter sets `AI_FLAG_STAY`, which
+  collapses the movement map to the unit's own tile. Vanilla's static line (`{0x0,0x3,..}`) steps
+  out to strike; our `defensive` (`{0x3,0x3,0x9,0x20}`) was welded twice over -- the A-script AND
+  the config bit -- so we had put the throne-boss posture on every line unit in ch03/ch04/ch05.
+
+**A donor is a MATCH SPEC, not a coordinate lookup**, and it may be one PER POSITION. Coordinates
+alone fail twice over: ch01 and ch06 sit on a different map donor from their parity twin, so not
+one tile lines up; and where the map IS the twin's, tiles collide by accident (ch05's bone-archer
+wave stands on (13,0), where vanilla parks an ARMOR_KNIGHT boss). A spec resolves only when
+everything it matches shares one AI; `nth:` is the last resort for units vanilla stacks that are
+identical in every readable field and still behave differently (Ch1's two L2 fighters on (2,9)).
+Per-position donors matter because a single donor per entry FLATTENS a group -- ch04's four mogalls
+run three different AIs, and ch05's eight tomb-reavers stand in for a line vanilla splits 4/2/2.
+
+**The AI_A_07 escort guard now sweeps EMITTED AI, not the label tables.** Strictly wider: it also
+catches a unit that inherits `AI_A_07` from its donor, which no scan of our own vocabulary could
+see. Still exactly one client, `ch05.sahnar`.
+
+**Verification is an OUTPUT DIFF, and it earned its keep.** Every injector was re-run and
+`events_udefs.c` diffed: 102 changed lines, all of them `.ai`, zero collateral. It caught a bug the
+whole green test suite missed -- every injector called `enemy_ai_initialiser(chap, enemy)` without
+the position index, so all eight of ch05's tomb-reavers shipped their FIRST donor's AI. YAML right,
+resolver right, tests green, ROM wrong. `PerPositionAiReachesTheEmittedRows` now pins it.
+
+ch01, ch03 and ch06 come out matching their twins exactly; ch01 emits byte-identical output through
+the whole refactor, and ch06 -- the one chapter derived by hand -- reproduces byte for byte, which
+is the model's proof. Remaining differences are declared overrides: ch00's Sephek (O'Neill's
+DoNothing depends on a tutorial `CHAI` we do not run), ch04's six-wolf pack (#203), ch05's moose.
+_Decided and implemented: 2026-08-29 (#335)._
 
 ## Open Questions (not yet decided)
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -227,12 +227,24 @@ CH01_BOSS_SLOT = 'BREGUET'   # vanilla Ch1's boss slot: CA_BOSS + hand-authored
 CH01_JOIN_POSITIONS = [(c, r) for r in (8, 9) for c in range(1, 6)]
 # Enemy AI byte vectors, mirrored from vanilla Ch1's own unit definitions
 # (git HEAD src/events/ch1-eventudefs.h) per the YAML's ai_pattern labels.
-CH01_AI = {
-    'hold_then_attack': '{0x0, 0x3, 0x9, 0x0}',   # vanilla Ch1 soldier line
-    'aggressive':       '{0x0, 0x0, 0x1, 0x0}',   # vanilla Ch1 fighter pursuit
-    'hold_position':    '{0x3, 0x3, 0x9, 0x20}',  # Breguet: attack in place, never move
-    'reinforce':        '{0x0, 0x0, 0x9, 0x0}',   # vanilla Ch1 reinforcement wave
-}
+def enemy_ai_initialiser(chap, enemy, index=0):
+    """The `.ai = {...}` initialiser for one of our enemies -- its vanilla DONOR's bytes.
+
+    #335. A chapter picks a vanilla twin so its difficulty is grounded rather than guessed,
+    and we already derive that twin's classes, levels, inventories and drops from its
+    `UnitDefinition` structs. The `.ai` field of those same structs was the one we never
+    read: it got authored by feel through per-chapter label tables, and because #48 computes
+    threat from stats and weapons, five chapters shipped a force that measured at parity and
+    behaved nothing like its twin. There is no label vocabulary here on purpose -- the labels
+    WERE the translation layer the drift lived in.
+
+    `difficulty` is imported locally because it imports us; the decomp-reading layer is the
+    lower one, and inverting that at module scope would cycle."""
+    import difficulty
+    return '{%s}' % ', '.join('0x%X' % b
+                             for b in difficulty.enemy_ai_bytes(chap, enemy, index))
+
+
 CH01_ITEM_IDS = {'iron-lance': 'ITEM_LANCE_IRON', 'iron-axe': 'ITEM_AXE_IRON'}
 CH01_CLASS_IDS = {'soldier': 'CLASS_SOLDIER', 'fighter': 'CLASS_FIGHTER',
                   'armor-knight': 'CLASS_ARMOR_KNIGHT'}
@@ -6051,16 +6063,15 @@ def _load_prologue_chapter(campaign):
         return _yaml_load(f)
 
 
-def _prologue_roster_blocks(by_id, slots, classes, guest_items):
+def _prologue_roster_blocks(chap, by_id, slots, classes, guest_items):
     """The prologue's two `UnitDefinition` initialisers, driven by the ch00 YAML.
 
     redaCount=0 places units statically at xPosition/yPosition (like inject_test_chapter);
     the boss rides the ONEILL slot (CA_BOSS marks it a boss for autolevel/UI -- the
-    DefeatBoss EVENT flag comes from the flagged defeat quote, not from CA_BOSS). AI: boss
-    = Breguet's stationary-aggressive bytes {AI_A_03 ActionStanding, AI_B_03 NeverMove,
-    config} (cp_data.c gAi1/2ScriptTable) -- NOT O'Neill's {0x6,0x3} "DoNothing", which
-    only works because the vanilla tutorial event-scripts his attack. Guards attack in
-    range (AI_A_00).
+    DefeatBoss EVENT flag comes from the flagged defeat quote, not from CA_BOSS). AI is
+    BORROWED from each unit's vanilla donor and no longer written here (#335); Sephek
+    carries an `ai_override:` in the YAML because O'Neill's DoNothing depends on a tutorial
+    event-script we do not run.
 
     Levels, positions (0-indexed x,y), the guard head-count and the enemy weapons are read
     from the YAML. They used to be literals here under a comment that claimed otherwise,
@@ -6136,10 +6147,11 @@ def _prologue_roster_blocks(by_id, slots, classes, guest_items):
         '        .yPosition = %d,\n'
         '        .redaCount = 0,\n'
         '        .items = { %s },\n'
-        '        .ai = {0x0, 0xa, 0x0, 0x0},\n'
+        '        .ai = %s,\n'
         '    },\n' % (slot, guard['level'], pos[0], pos[1],
-                      fe_item_enum(guard['inventory'][0]))
-        for slot, pos in zip(guard_slots, guard['positions']))
+                      fe_item_enum(guard['inventory'][0]),
+                      enemy_ai_initialiser(chap, guard, index))
+        for index, (slot, pos) in enumerate(zip(guard_slots, guard['positions'])))
 
     enemy = (
         '{\n'
@@ -6152,12 +6164,13 @@ def _prologue_roster_blocks(by_id, slots, classes, guest_items):
         '        .yPosition = %d,\n'
         '        .redaCount = 0,\n'
         '        .items = { %s },\n'
-        '        .ai = {0x3, 0x3, 0x9, 0x20}, /* attack in place, never move (Breguet) */\n'
+        '        .ai = %s,\n'
         '    },\n'
         '%s'
         '    { 0 },\n'
         '}' % (sephek_slot, sephek['level'], sephek['position'][0], sephek['position'][1],
-               fe_item_enum(sephek['inventory'][0]), guards))
+               fe_item_enum(sephek['inventory'][0]),
+               enemy_ai_initialiser(chap, sephek), guards))
     return ally, enemy
 
 
@@ -6214,7 +6227,7 @@ def inject_prologue(campaign, verbose=True, montage=False):
 
     # 2. Rewrite the two prologue rosters from the ch00 YAML (_prologue_roster_blocks).
     ally, enemy = _prologue_roster_blocks(
-        by_id, (hlin_slot, scram_slot, sephek_slot), (hlin_class, scram_class),
+        chap, by_id, (hlin_slot, scram_slot, sephek_slot), (hlin_class, scram_class),
         (hlin_items, scram_items))
     with open(CH1_UDEFS_H, encoding='utf-8') as f:
         udefs = f.read()
@@ -7842,31 +7855,33 @@ def inject_ch01(campaign, verbose=True):
         return reskin_by_base.get(base, base)
 
     enemies = []
-    for x, y in spear['positions']:
+    for index, (x, y) in enumerate(spear['positions']):
         enemies.append(_enemy_unit_entry(
             '0x80', grunt_class(spear['class']), spear['level'], True, x, y,
-            CH01_ITEM_IDS[spear['inventory'][0]['id']], CH01_AI[spear['ai_pattern']],
+            CH01_ITEM_IDS[spear['inventory'][0]['id']],
+            enemy_ai_initialiser(chap, spear, index),
             ' /* goblin spear -- camp approach */'))
-    for x, y in axe['positions']:
+    for index, (x, y) in enumerate(axe['positions']):
         enemies.append(_enemy_unit_entry(
             '0x80', grunt_class(axe['class']), axe['level'], True, x, y,
-            CH01_ITEM_IDS[axe['inventory'][0]['id']], CH01_AI[axe['ai_pattern']],
+            CH01_ITEM_IDS[axe['inventory'][0]['id']],
+            enemy_ai_initialiser(chap, axe, index),
             ' /* goblin raider -- mid-trail pursuer */'))
     cx, cy = chief['position']
     # The iron-ingots MacGuffin stays narrative (no FE8 item exists for it yet);
     # recovery is told in the ending scene. The chief mirrors Breguet 1:1: his slot's
-    # vanilla boss bases, no autolevel, lv4, attack-in-place AI, ON the seize tile.
+    # vanilla boss bases, no autolevel, lv4, his own borrowed AI, ON the seize tile.
     enemies.append(_enemy_unit_entry(
         'CHARACTER_%s' % CH01_BOSS_SLOT, CH01_CLASS_IDS[chief['class']],
         chief['level'], False, cx, cy,
-        CH01_ITEM_IDS[chief['inventory'][0]['id']], CH01_AI[chief['ai_pattern']],
+        CH01_ITEM_IDS[chief['inventory'][0]['id']], enemy_ai_initialiser(chap, chief),
         ' /* goblin chief -- boss, holds the seize tile */'))
     reinforce = []
-    for cls, (x, y) in zip(reinf['composition'], reinf['positions']):
+    for index, (cls, (x, y)) in enumerate(zip(reinf['composition'], reinf['positions'])):
         reinforce.append(_enemy_unit_entry(
             '0x80', grunt_class(cls), reinf['level'], True, x, y,
             CH01_ITEM_IDS[reinf['inventory_by_class'][cls][0]],
-            CH01_AI['reinforce'], ' /* west reinforcement, turn %d */'
+            enemy_ai_initialiser(chap, reinf, index), ' /* west reinforcement, turn %d */'
             % reinf['spawn_turn']))
 
     with open(EVENTS_UDEFS_C, encoding='utf-8') as f:
@@ -8931,8 +8946,6 @@ CH03_BOSS_DEATH_MSG = 0x9A3
 # DefeatBoss ending script: repurpose the vanilla Ch4 ending EventScr_089F19F8 (defined in ch4-eventscript.h,
 # already extern-referenced by the vanilla Ch4 Misc's DefeatAll -> visible to ch4-eventinfo.h's Misc list).
 CH03_ENDING_SCRIPT = 'EventScr_089F19F8'
-CH03_AI = {'aggressive': '{0x0, 0x0, 0x1, 0x0}',   # pursue/charge
-           'defensive':  '{0x3, 0x3, 0x9, 0x20}'}  # attack in place, never move (hold the galleries)
 # Brigand kobolds ride the Lizard-Wildling reskin slot (inject_enemy_class_reskins clones
 # CLASS_BRIGAND -> CLASS_BRG_LIZARD_WILDLING, an appended class id, with the lizard SMS;
 # combat stays brigand). Grell = vanilla Mogall; blade = Mercenary (Lizardzerker slot lands
@@ -9071,10 +9084,6 @@ CH04_MONSTER_PIDS = {
     'bonewalker-bow': '0xad',
     'mogall': '0xb7',
     'entoumbed': '0xab',
-}
-CH04_AI = {
-    'aggressive': '{0x0, 0x0, 0x1, 0x0}',
-    'defensive': '{0x3, 0x3, 0x9, 0x20}',
 }
 # Stage 2b -- the turn-2 wolf-pack reveal + Marty->Lupin parley (issue #24). Lupin rides the
 # collision-free Duessel identity slot (Stage 2a); placed RED as the pack leader, Marty's Talk
@@ -9795,22 +9804,6 @@ def unregistered_raw_pid_bosses(campaign):
 RAW_PID_BATTLE_ANIMS = {
     'white-moose': (CH05_CHAPTER_YAML, CH05_MOOSE_PID),
     'ravisin': (CH05_CHAPTER_YAML, CH05_BOSS_PID),
-}
-CH05_AI = {
-    'aggressive': '{0x0, 0x0, 0x1, 0x0}',        # pursue/charge
-    'defensive': '{0x3, 0x3, 0x9, 0x20}',        # hold and strike in range
-    'hold_position': '{GuardTileAI, 0x9, 0x20}', # vanilla Saar's boss posture
-    # Vanilla Joshua's own bytes (UnitDef_088B5914): AI_A_07 + AI_B_03 = strike anything that
-    # comes in range, NEVER move, and DO NOT TOUCH THE ESCORT. Sahnar stands guard at the arena
-    # from turn 1 (#25's scene-3 summon), and a turn-1 crit-Myrmidon that PURSUED would be a
-    # different chapter -- one that hunts the squishies instead of posing the escort puzzle ch05
-    # is built on. The escort carve-out is real for us too; see repoint_escort_safe_ai_list.
-    'duelist_hold': '{0x7, 0x3, 0x9, 0x0}',
-    # AI_B_04 = AiScr_AiB_PillageThenPursue (cp_data.c): head for the nearest lootable tile,
-    # sack it, then fight normally. Vanilla Ch5 puts this on all six of its reinforcements and
-    # nothing else, which is the whole village-raid race -- the AI is terrain-driven
-    # (gTerrainList_LootableVillages), so it needs no target list and no class of its own.
-    'raider': '{0x0, 0x4, 0x9, 0x0}',
 }
 # ch05's four INFANTRY classes deploy on their skeleton reskins (#25, campaign.yaml
 # `enemy_class_reskins`): every ch05 unit wearing one of them is a risen tomb-guardian, and
@@ -10894,8 +10887,8 @@ def ch04_enemy_rows(chap, arrives_turn=None):
             key = item.get('fe_base') or item['id']
             inventory.append(CH04_ITEM_IDS[key])
         drop = enemy.get('item_drop')
-        ai = CH04_AI[enemy.get('ai_pattern', 'defensive')]
         for index, (x, y) in enumerate(enemy['positions']):
+            ai = enemy_ai_initialiser(chap, enemy, index)
             items = list(inventory)
             is_dropper = bool(drop) and index == 0
             if is_dropper:
@@ -10919,14 +10912,14 @@ def _ch04_reveal_wave(chap):
     return wave
 
 
-def _ch04_wave_pack_kit(wave):
+def _ch04_wave_pack_kit(chap, wave):
     """(class_enum, ai, items) for a ch04 enemy wave, read from its authored YAML (no drift).
 
     The pack keeps this kit through the parley: CUSN changes a unit's FACTION, nothing else,
-    so the converted wolves fight on with the same class, items and (aggressive) AI -- which
-    is the point, since "the wolves turn the tide" is what the parley buys."""
+    so the converted wolves fight on with the same class, items and AI -- which is the point,
+    since "the wolves turn the tide" is what the parley buys."""
     cls = CH04_CLASS_IDS[wave['class']]
-    ai = CH04_AI[wave.get('ai_pattern', 'defensive')]
+    ai = enemy_ai_initialiser(chap, wave)
     items = [CH04_ITEM_IDS[i.get('fe_base') or i['id']] for i in wave.get('inventory', [])]
     return cls, ai, ', '.join(items) or '0'
 
@@ -10943,7 +10936,7 @@ def ch04_turn2_reveal_rows(chap, lupin):
     Each generic takes its OWN pid (CH04_PACK_PIDS, in tile order) -- the parley addresses them
     one at a time, and a shared pid can only ever be found once (#203)."""
     wave = _ch04_reveal_wave(chap)
-    cls, ai, items = _ch04_wave_pack_kit(wave)
+    cls, ai, items = _ch04_wave_pack_kit(chap, wave)
     leader_pos, generic_pos = wave['positions'][0], wave['positions'][1:]
     if len(generic_pos) != len(CH04_PACK_PIDS):
         sys.exit('ERROR: ch04 pack is %d generics but CH04_PACK_PIDS has %d pids -- the '
@@ -10953,7 +10946,8 @@ def ch04_turn2_reveal_rows(chap, lupin):
     lupin_row = _enemy_unit_entry(
         char_symbol(slot), deploy_class, level, False,
         leader_pos[0], leader_pos[1], ', '.join(CLASS_LOADOUT[class_enum]),
-        CH04_AI['aggressive'], ' /* lupin -- hostile pack leader (red; Marty parleys him blue) */')
+        ai,
+        ' /* lupin -- hostile pack leader (red; Marty parleys him blue) */')
     generics = [_enemy_unit_entry(
         pid, cls, int(wave['level']), bool(wave.get('autolevel')), x, y, items, ai,
         ' /* %s %d/%d -- %s (generic pack; own pid so the parley can convert it) */'
@@ -11362,16 +11356,16 @@ def inject_ch03(campaign, boot=False, verbose=True):
         drop = e.get('item_drop')
         if drop:
             items = '%s, %s' % (items, CH03_ITEM_IDS[drop]) if items else CH03_ITEM_IDS[drop]
-        ai = CH03_AI.get(e.get('ai_pattern', 'defensive'), CH03_AI['defensive'])
         # The boss (grell) + the mid-map miniboss (Brute) each ride a UNIQUE raw pid so their
         # flagged gDefeatTalkList entries key their death events (WIN / midmap AFEV) to them
         # alone; every other enemy shares the generic autolevelled-trash pid.
         char = (CH03_BOSS_PID if e.get('is_boss')
                 else CH03_BRUTE_MINIBOSS_PID if e.get('is_miniboss')
                 else CH03_GENERIC_PID)
-        for x, y in e['positions']:
+        for index, (x, y) in enumerate(e['positions']):
             enemies.append(_enemy_unit_entry(
-                char, cls, e['level'], bool(e.get('autolevel')), x, y, items, ai,
+                char, cls, e['level'], bool(e.get('autolevel')), x, y, items,
+                enemy_ai_initialiser(chap, e, index),
                 ' /* %s */' % e['id'], itemdrop=bool(drop)))
     enemy = '{\n' + '\n'.join(enemies) + '\n    { 0 },\n}'
 
@@ -12086,6 +12080,35 @@ def repoint_escort_safe_ai_list(escort_char, why):
         f.write(source)
 
 
+def escort_safe_ai_clients(campaign='rime-of-the-frostmaiden'):
+    """`['chNN.enemy-id', ...]` for every enemy whose EMITTED AI1 is AI_A_07.
+
+    Reads what each chapter actually ships -- donor bytes or a declared override -- rather
+    than a table of labels (#335). That is strictly wider than the label scan it replaced:
+    it also catches a unit that inherits AI_A_07 from its vanilla DONOR, which no scan of
+    our own vocabulary could ever see."""
+    import difficulty
+    out = []
+    for path in sorted(glob.glob(os.path.join(
+            REPO, 'campaigns', campaign, 'chapters', 'ch*.yaml'))):
+        with open(path, encoding='utf-8') as source:
+            chap = _yaml_load(source)
+        stem = os.path.basename(path)[:4]
+        for key in difficulty.AI_ROSTER_KEYS:
+            for enemy in chap.get(key) or []:
+                if not isinstance(enemy, dict):
+                    continue
+                for index in range(max(1, len(enemy.get('positions') or []))):
+                    try:
+                        ai = difficulty.enemy_ai_bytes(chap, enemy, index)
+                    except ValueError:
+                        continue        # ungrounded: ai_donor_findings reports it, not us
+                    if ai[0] == ESCORT_SAFE_AI_INDEX:
+                        out.append('%s.%s' % (stem, enemy.get('id')))
+                        break
+    return sorted(out)
+
+
 def assert_escort_safe_ai_has_one_client(ai_bytes):
     """Refuse the repoint if anything but our duelist has picked up AI_A_07.
 
@@ -12093,21 +12116,14 @@ def assert_escort_safe_ai_has_one_client(ai_bytes):
     user; if ANY chapter gives a second unit `AI_A_07`, that unit silently inherits "will not
     attack Basil" and this stops being a faithful copy of Joshua's refusal.
 
-    Swept over EVERY chapter's AI vocabulary, not just ch05's. Scoping it to ch05 was the first
-    cut and it defeated the guard's own purpose: the hazard is a FUTURE chapter reaching for
+    Swept over EVERY chapter, not just ch05: the hazard is a FUTURE chapter reaching for
     `{0x7,` for its own reasons, which is precisely the case a ch05-only scan cannot see.
     """
-    tables = {name: value for name, value in globals().items()
-              if re.fullmatch(r'CH\d\d_AI', name) and isinstance(value, dict)}
-    users = sorted('%s.%s' % (table, pattern)
-                   for table, ai_map in tables.items()
-                   for pattern, ai in ai_map.items()
-                   if ai.startswith('{0x%X,' % ESCORT_SAFE_AI_INDEX))
-    if users != ['CH05_AI.duelist_hold'] or CH05_AI['duelist_hold'] != ai_bytes:
-        sys.exit('ERROR: AI_A_07 (%s) must have exactly one client across ALL chapters -- ch05 '
-                 'Sahnar\'s duelist_hold. Got %s (swept %d AI table(s)). The do-not-attack list '
-                 'is global; a second client inherits our escort\'s immunity by accident.'
-                 % (ESCORT_SAFE_AI_LIST, users, len(tables)))
+    users = escort_safe_ai_clients()
+    if users != ['ch05.sahnar'] or ai_bytes != '{0x7, 0x3, 0x9, 0x0}':
+        sys.exit('ERROR: AI_A_07 (%s) must have exactly one client across ALL chapters -- '
+                 'ch05 Sahnar. Got %s. The do-not-attack list is global; a second client '
+                 'inherits our escort\'s immunity by accident.' % (ESCORT_SAFE_AI_LIST, users))
 
 
 def ch05_enemy_rows(chap, arrives_turn=None, exclude=()):
@@ -12126,11 +12142,11 @@ def ch05_enemy_rows(chap, arrives_turn=None, exclude=()):
         items = [CH05_ITEM_IDS[item.get('fe_base') or item['id']]
                  for item in enemy.get('inventory', [])]
         drop = enemy.get('item_drop')
-        ai = CH05_AI[enemy.get('ai_pattern', 'defensive')]
         pid = (CH05_BOSS_PID if enemy.get('is_boss')
                else CH05_MOOSE_PID if enemy.get('is_miniboss')
                else CH05_GENERIC_PID)
         for index, (x, y) in enumerate(enemy['positions']):
+            ai = enemy_ai_initialiser(chap, enemy, index)
             carried = list(items)
             dropper = bool(drop) and index == 0
             if dropper:
@@ -13198,8 +13214,8 @@ def inject_ch05(campaign, boot=False, lupin_proof=False, moose_only=False,
     # the arena tile at all. That refusal rides a character id in a global list, not in the .ai
     # bytes, so copying his bytes alone leaves Basil a legal target. Repointed here, at the one
     # place that knows who our escort is.
-    assert_escort_safe_ai_has_one_client(CH05_AI[
-        next(e for e in chap['enemy_units'] if e['id'] == 'sahnar')['ai_pattern']])
+    assert_escort_safe_ai_has_one_client(enemy_ai_initialiser(
+        chap, next(e for e in chap['enemy_units'] if e['id'] == 'sahnar')))
     repoint_escort_safe_ai_list(basil_char, 'Basil (ch05 escort)')
 
     # 3. Strip the host slot's event lists and wire ours. The list SYMBOLS are the only

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -468,6 +468,19 @@ def _brace_entries(body):
                 yield body[start:i]
 
 
+def vanilla_redas(text):
+    """`{REDA symbol: [(x, y), ...]}` for every REDA array in a decomp source.
+
+    REDA is the scripted movement a unit walks when it loads. It matters here because a
+    UnitDefinition's `xPosition`/`yPosition` is frequently a SPAWN tile rather than a battle
+    post: vanilla Ch1's entire force enters on (1,9)/(2,9) and Ch5's on (0,0)/(10,0)/(12,0).
+    The last point is where the unit actually ends up."""
+    return {m.group(1): [(int(x), int(y)) for x, y in
+                         re.findall(r'\.x = (\d+),\s*\.y = (\d+)', m.group(2))]
+            for m in re.finditer(
+                r'CONST_DATA struct REDA (REDA_\w+)\[\] = \{(.*?)\n\};', text, re.S)}
+
+
 def vanilla_unit_defs(text, array_name):
     """Parse `CONST_DATA struct UnitDefinition <array_name>[] = { ... };` from decomp text
     into a list of per-entry dicts (charIndex, classIndex, level, allegiance, itemDrop, items).
@@ -477,6 +490,7 @@ def vanilla_unit_defs(text, array_name):
     statscreen.c:726), the enemy-drop channel the economy reads (#176)."""
     s, e = bc._find_brace_block(text, array_name + '[]', '<udef:%s>' % array_name)
     body = text[s + 1:e - 1]
+    redas = vanilla_redas(text)
     out = []
     for block in _brace_entries(body):           # top-level { ... } per unit (handles
         cls = re.search(r'\.classIndex\s*=\s*(\w+)', block)   # nested .items/.ai braces
@@ -489,10 +503,18 @@ def vanilla_unit_defs(text, array_name):
         ai = re.search(r'\.ai\s*=\s*\{(.*?)\}', block, re.S)
         xpos = re.search(r'\.xPosition\s*=\s*(\d+)', block)
         ypos = re.search(r'\.yPosition\s*=\s*(\d+)', block)
+        reda = re.search(r'\.redas\s*=\s*(REDA_\w+)', block)
+        placed = (int(xpos.group(1)) if xpos else None,
+                  int(ypos.group(1)) if ypos else None)
+        walked = redas.get(reda.group(1)) if (reda and redas) else None
         out.append({
             'ai': ai_bytes(ai.group(1) if ai else None),
-            'xPosition': int(xpos.group(1)) if xpos else None,
-            'yPosition': int(ypos.group(1)) if ypos else None,
+            'redas': reda.group(1) if reda else None,
+            # Where the unit FIGHTS: the end of its REDA walk, or its placed tile when it
+            # does not walk. Donors match on this, never on the spawn tile (#335).
+            'position': walked[-1] if walked else placed,
+            'xPosition': placed[0],
+            'yPosition': placed[1],
             'charIndex': chi.group(1) if chi else None,
             'classIndex': cls.group(1),
             'level': int(lvl.group(1)) if lvl else 1,
@@ -550,25 +572,21 @@ def resolve_donor(parity_ref, spec):
         raise ValueError('parity_reference %r has no curated UnitDefinition arrays, so a '
                          'donor cannot be resolved against it' % parity_ref)
     if isinstance(spec, dict):
-        at, nth = spec.get('at'), spec.get('nth')
-        want = {'classIndex': spec.get('class'), 'level': spec.get('level')}
+        at = spec.get('at')
+        want = {'classIndex': spec.get('class'), 'level': spec.get('level'),
+                'redas': spec.get('redas')}
     elif isinstance(spec, (list, tuple)) and len(spec) == 2:
-        at, nth, want = spec, None, {'classIndex': None, 'level': None}
+        at, want = spec, {'classIndex': None, 'level': None, 'redas': None}
     else:
         raise ValueError('donor %r is not a coordinate [x, y] nor a {at/class/level/nth} '
                          'reference' % (spec,))
     if at is not None and not (isinstance(at, (list, tuple)) and len(at) == 2):
         raise ValueError('donor %r: `at` must be a coordinate [x, y]' % (spec,))
     found = [u for u in units
-             if (at is None or (u['xPosition'], u['yPosition']) == tuple(at))
+             if (at is None or u['position'] == tuple(at))
              and all(v is None or u[k] == v for k, v in want.items())]
     if not found:
         raise ValueError('donor %r matches no red unit of %s' % (spec, parity_ref))
-    if nth is not None:
-        if nth >= len(found):
-            raise ValueError('donor %r: nth=%d but only %d red unit(s) of %s match'
-                             % (spec, nth, len(found), parity_ref))
-        return found[nth]
     behaviours = {u['ai'] for u in found}
     if len(behaviours) > 1:
         raise ValueError(

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -411,6 +411,48 @@ PARITY_REFERENCE_ALLY_UDEFS = {
 }
 
 
+# The decomp's own AI vector macros, read from the header the decomp COMPILES
+# (include/EA_Standard_Library/AI_Helpers.h, pulled in by events_udefs.c through EAstdlib.h
+# -- which is why vanilla's unit data reads `.ai = {AttackInRangeAI, 0x0, 0x0}`). Parsed
+# rather than copied: a local table would be a second source of truth for the exact bytes
+# #335 exists to keep faithful, and the copy that drifts is always the one nobody reads.
+AI_HELPERS_H = 'include/EA_Standard_Library/AI_Helpers.h'
+
+
+def _ai_macros():
+    """`{macro name: (byte, ...)}` from the decomp's AI helper header.
+
+    Only the multi-byte AI-vector macros and the single-byte field constants matter here;
+    both are plain `#define NAME 0x..[,0x..]` lines, so one regex covers them."""
+    out = {}
+    for line in bc.vanilla_decomp_text(AI_HELPERS_H).splitlines():
+        m = re.match(r'\s*#define\s+(\w+)\s+((?:0x[0-9A-Fa-f]+)(?:\s*,\s*0x[0-9A-Fa-f]+)*)\s*$',
+                     line)
+        if m:
+            out[m.group(1)] = tuple(int(t, 16) for t in m.group(2).split(','))
+    return out
+
+
+AI_MACROS = _ai_macros()
+
+
+def ai_bytes(spec):
+    """An AI vector as vanilla writes it -> its 4 engine bytes.
+
+    `spec` is the text between the braces (with or without them), or None. A UnitDefinition
+    with NO `.ai` block is {0,0,0,0} -- ActionInRange + MoveToEnemy, i.e. a PURSUER, not an
+    inert default; two of vanilla Ch6's red force are exactly that, and reading them as
+    static would invert a chapter's shape. Short vectors zero-fill as the C initialiser does."""
+    if not spec:
+        return (0x00, 0x00, 0x00, 0x00)
+    out = []
+    for token in (t.strip() for t in spec.strip().strip('{}').split(',')):
+        if not token:
+            continue
+        out.extend(AI_MACROS[token] if token in AI_MACROS else (int(token, 0),))
+    return tuple((out + [0, 0, 0, 0])[:4])
+
+
 def _brace_entries(body):
     """Yield each top-level `{...}` group's inner text from an array body, tracking brace
     depth so a unit's nested `.items = {...}` / `.ai = {...}` don't split it early."""
@@ -444,7 +486,13 @@ def vanilla_unit_defs(text, array_name):
         lvl = re.search(r'\.level\s*=\s*(\d+)', block)
         alg = re.search(r'\.allegiance\s*=\s*(\w+)', block)
         items = re.search(r'\.items\s*=\s*\{(.*?)\}', block, re.S)
+        ai = re.search(r'\.ai\s*=\s*\{(.*?)\}', block, re.S)
+        xpos = re.search(r'\.xPosition\s*=\s*(\d+)', block)
+        ypos = re.search(r'\.yPosition\s*=\s*(\d+)', block)
         out.append({
+            'ai': ai_bytes(ai.group(1) if ai else None),
+            'xPosition': int(xpos.group(1)) if xpos else None,
+            'yPosition': int(ypos.group(1)) if ypos else None,
             'charIndex': chi.group(1) if chi else None,
             'classIndex': cls.group(1),
             'level': int(lvl.group(1)) if lvl else 1,
@@ -454,6 +502,84 @@ def vanilla_unit_defs(text, array_name):
                      if items else [],
         })
     return out
+
+
+def vanilla_red_units(parity_ref):
+    """Every RED UnitDefinition in the twin, parsed. None if the reference isn't curated.
+
+    Unlike vanilla_enemies(), nothing is dropped for carrying no modeled weapon: a
+    staff-only healer contributes nothing to the threat math and everything to the map's
+    shape -- vanilla Ch6 gives its Troubadour the same delayed charge as the cavalry she
+    rides with, and a chapter borrowing her AI needs to find her."""
+    spec = PARITY_REFERENCE_UDEFS.get(parity_ref)
+    if spec is None:
+        return None
+    relpath, arrays = spec
+    text = bc.vanilla_decomp_text(relpath)
+    return [d for array_name in arrays
+            for d in vanilla_unit_defs(text, array_name)
+            if d['allegiance'] == 'FACTION_ID_RED']
+
+
+def resolve_donor(parity_ref, spec):
+    """One of our enemies' `donor:` reference -> the vanilla unit(s) it stands in for.
+
+    `spec` is a match over the twin's red force: a bare `[x, y]` coordinate, or a mapping of
+    any of `at` / `class` / `level`. It resolves when everything it matches SHARES one AI --
+    vanilla's three L2 soldiers behave identically, so "the L2 soldiers" is a well-formed
+    donor for our group of three. Returns the representative unit.
+
+    A coordinate is NOT sufficient on its own as a convention, which is why the spec is a
+    `nth:` (0-based, array order) is the last resort, for units vanilla stacks that are
+    identical in every readable field and still behave differently -- Ch1 puts two L2
+    fighters on (2,9), one pursuing from turn 1 and one charging on turn 2. It is opt-in
+    precisely because silently taking the first match is the bug this function exists to
+    prevent.
+
+    Two reasons a coordinate alone is not enough, both from real data: ch01 and ch06 sit on a
+    different MAP donor from their parity twin, so not one of their tiles lines up with it;
+    and where the map IS the twin's, a tile can still collide by accident -- ch05's
+    bone-archer reinforcements stand on (13,0), where vanilla Ch5 parks an ARMOR_KNIGHT
+    boss. Borrowing that boss's throne AI would have looked entirely reasonable.
+
+    Disagreement RAISES rather than taking the first match. Vanilla Ch2 puts an archer and a
+    brigand both on (14,7) with different AI, and a silent first-match would borrow the wrong
+    behaviour while looking perfectly correct -- the exact failure #335 exists to end."""
+    units = vanilla_red_units(parity_ref)
+    if units is None:
+        raise ValueError('parity_reference %r has no curated UnitDefinition arrays, so a '
+                         'donor cannot be resolved against it' % parity_ref)
+    if isinstance(spec, dict):
+        at, nth = spec.get('at'), spec.get('nth')
+        want = {'classIndex': spec.get('class'), 'level': spec.get('level')}
+    elif isinstance(spec, (list, tuple)) and len(spec) == 2:
+        at, nth, want = spec, None, {'classIndex': None, 'level': None}
+    else:
+        raise ValueError('donor %r is not a coordinate [x, y] nor a {at/class/level/nth} '
+                         'reference' % (spec,))
+    if at is not None and not (isinstance(at, (list, tuple)) and len(at) == 2):
+        raise ValueError('donor %r: `at` must be a coordinate [x, y]' % (spec,))
+    found = [u for u in units
+             if (at is None or (u['xPosition'], u['yPosition']) == tuple(at))
+             and all(v is None or u[k] == v for k, v in want.items())]
+    if not found:
+        raise ValueError('donor %r matches no red unit of %s' % (spec, parity_ref))
+    if nth is not None:
+        if nth >= len(found):
+            raise ValueError('donor %r: nth=%d but only %d red unit(s) of %s match'
+                             % (spec, nth, len(found), parity_ref))
+        return found[nth]
+    behaviours = {u['ai'] for u in found}
+    if len(behaviours) > 1:
+        raise ValueError(
+            'donor %r matches %d red units of %s whose AI DISAGREE (%s) -- narrow it with '
+            '`at`, `class` or `level`, or declare an `ai_override:`'
+            % (spec, len(found), parity_ref,
+               '; '.join('%s L%d @(%s,%s) %s'
+                         % (u['classIndex'], u['level'], u['xPosition'], u['yPosition'],
+                            '{%s}' % ','.join('0x%02X' % b for b in u['ai']))
+                         for u in found)))
+    return found[0]
 
 
 def _weapon_from_item_enums(item_enums):
@@ -1303,6 +1429,88 @@ def solo_contributors(chap, parity_ref, deploy_cap, floor=1.0, share=0.10):
             % (uid, 100 * t / total, without, full)]
 
 
+# Where a chapter's red force is authored. ch02 puts two of its nine under
+# `reinforcements:`, and a guard reading only `enemy_units:` would grade a chapter that
+# does not ship.
+AI_ROSTER_KEYS = ('enemy_units', 'reinforcements', 'enemy_reinforcements')
+
+
+def _donor_specs(enemy):
+    """An entry's `donor:` -> one spec per position it places.
+
+    A bare `[x, y]` is ONE coordinate covering every position; a list whose ELEMENTS are
+    themselves specs is one donor per position, in order. The distinction is by element
+    type, because `donor: [11, 6]` and `donor: [[11, 6], [13, 7]]` must not be confused --
+    reading the first as two donors would make every single-donor entry per-position."""
+    donor = enemy.get('donor')
+    if isinstance(donor, list) and donor and all(isinstance(d, (list, dict)) for d in donor):
+        return donor
+    return None
+
+
+def enemy_ai_bytes(chap, enemy, index=0):
+    """The 4 AI bytes one of our enemies emits: its vanilla donor's, or a declared override.
+
+    This is the whole of #335. Our chapters pick a vanilla twin so their difficulty is
+    grounded rather than guessed, and we derive that twin's classes, levels, inventories and
+    drops from its `UnitDefinition` structs -- but the `.ai` field of those same structs was
+    never read, and got authored by feel instead. It measured fine, because #48 computes
+    threat from stats and weapons and AI is behavioural. Borrowing the donor's bytes closes
+    that by construction: there is no vocabulary in the middle to mistranslate.
+
+    `donor:` may be a single spec covering the whole entry, or one spec per position where
+    vanilla varies within a group -- ch04's four mogalls stand on vanilla's four mogall tiles
+    and those run three different AIs.
+
+    An `ai_override:` is how a chapter says it means to differ -- our map changed the
+    dynamics, or we field a unit vanilla does not. It carries the vector and a `why`, and it
+    may stand alone where no single donor applies. Neither donor nor override RAISES: a
+    default is exactly how ch00 shipped an `ai_pattern` its injector never read."""
+    override = enemy.get('ai_override')
+    if override:
+        return ai_bytes(override.get('ai'))
+    per_position = _donor_specs(enemy)
+    if per_position is not None:
+        if index >= len(per_position):
+            raise ValueError('enemy %r places %d unit(s) but lists %d donor(s), so position '
+                             '%d is not grounded in anything'
+                             % (enemy.get('id'), len(enemy.get('positions') or []),
+                                len(per_position), index))
+        return resolve_donor(chap.get('parity_reference'), per_position[index])['ai']
+    if enemy.get('donor') is not None:
+        return resolve_donor(chap.get('parity_reference'), enemy['donor'])['ai']
+    raise ValueError('enemy %r declares neither a `donor:` nor an `ai_override:`, so its AI '
+                     'is not grounded in anything' % enemy.get('id'))
+
+
+def ai_donor_findings(chap):
+    """#335's guard: every enemy's AI is borrowed from a vanilla donor or declared as a
+    deliberate departure. Returns a list of strings (empty == clean), the same contract
+    role_findings() uses so the parity gate can read both.
+
+    Silent on an uncurated twin -- there is nothing to borrow from, and that is a
+    `parity_reference` gap rather than an AI one."""
+    ref = chap.get('parity_reference')
+    if PARITY_REFERENCE_UDEFS.get(ref) is None:
+        return []
+    findings = []
+    for key in AI_ROSTER_KEYS:
+        for enemy in chap.get(key) or []:
+            if not isinstance(enemy, dict):
+                continue
+            override = enemy.get('ai_override')
+            if override and not override.get('why'):
+                findings.append('%s: ai_override has no `why` -- an undeclared reason is a '
+                                'silenced guard, not a decision' % enemy.get('id'))
+            for index in range(max(1, len(enemy.get('positions') or []))):
+                try:
+                    enemy_ai_bytes(chap, enemy, index)
+                except ValueError as error:
+                    findings.append('%s: %s' % (enemy.get('id'), error))
+                    break
+    return findings
+
+
 def role_findings(chap, parity_ref):
     """Per-unit role warnings: outlier threat vs the twin's ceiling, and a boss that is not
     the chapter's real centre of gravity. Returns a list of strings (empty == clean)."""
@@ -1769,6 +1977,12 @@ def curve_gate_failures(rows):
     informational and never gate; with zero locks the gate passes, so --check can ship before
     any chapter is locked.
 
+    The `ai` arm is #335's, and it rides the same opt-in because AI IS part of parity: a
+    chapter picks a vanilla twin so its difficulty is grounded rather than guessed, and the
+    twin's `UnitDefinition.ai` is as much of that grounding as its class and level. #48
+    computes threat from stats and weapons, so behaviour was invisible to it -- five chapters
+    measured at parity while fielding a force that played nothing like its twin.
+
     The `role` arm is #284's lesson. ch02 and ch03 shipped bosses that folded in a third of
     their twin's time, for months, while this gate read OK -- the aggregate sums the whole force
     and divides by the deploy cap, so one paper boss dissolves into a 23-unit average. The
@@ -1777,7 +1991,7 @@ def curve_gate_failures(rows):
     so locking one now means clearing them first."""
     return [r['label'] for r in rows
             if r['locked'] and (not r['has_ref'] or r['verdict'] != 'OK' or r['boss_drop']
-                                or r.get('role'))]
+                                or r.get('role') or r.get('ai'))]
 
 
 def curve_report(campaign, band=0.25, mode=None):
@@ -1848,8 +2062,13 @@ def curve_report(campaign, band=0.25, mode=None):
         role = role_findings(chap, p['reference']) if has_ref else []
         if role:
             flag += '  !!role'
+        # ... and whether every enemy's AI is grounded in a vanilla donor (#335). Invisible
+        # to everything above, which is computed from stats and weapons.
+        ai = ai_donor_findings(chap) if has_ref else []
+        if ai:
+            flag += '  !!ai'
         rows.append({'label': label[:22].strip(), 'locked': locked, 'has_ref': has_ref,
-                     'verdict': verdict, 'boss_drop': boss_drop, 'role': role})
+                     'verdict': verdict, 'boss_drop': boss_drop, 'role': role, 'ai': ai})
         if not has_ref:
             print('  %-22s %-13s %5.1f           %5.1f             (no ref)%s'
                   % (label[:22], (p['reference'] or '?')[:13], ot, ol, flag))
@@ -1862,6 +2081,15 @@ def curve_report(campaign, band=0.25, mode=None):
     if any_dropped_boss:
         print('\n  !! a dropped boss means that row\'s verdict is unreliable -- its scariest '
               'unit\n     carries an unmodeled weapon. Add fe_base to its YAML inventory (#51/#52).')
+    ungrounded = [r for r in rows if r.get('ai')]
+    if ungrounded:
+        print('\n  !! AI not grounded in the vanilla twin (#335) -- every enemy borrows its')
+        print('     donor\'s `UnitDefinition.ai` unless the chapter declares an `ai_override:`')
+        print('     with a reason:')
+        for r in ungrounded:
+            for f in r['ai']:
+                print('     %-6s %s%s' % (r['label'].split()[0], f,
+                                          '' if r['locked'] else '   [not locked -- advisory]'))
     flagged = [r for r in rows if r.get('role')]
     if flagged:
         print('\n  !! per-unit findings the per-slot averages above cannot show (#284):')

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -551,13 +551,6 @@ def resolve_donor(parity_ref, spec):
     vanilla's three L2 soldiers behave identically, so "the L2 soldiers" is a well-formed
     donor for our group of three. Returns the representative unit.
 
-    A coordinate is NOT sufficient on its own as a convention, which is why the spec is a
-    `nth:` (0-based, array order) is the last resort, for units vanilla stacks that are
-    identical in every readable field and still behave differently -- Ch1 puts two L2
-    fighters on (2,9), one pursuing from turn 1 and one charging on turn 2. It is opt-in
-    precisely because silently taking the first match is the bug this function exists to
-    prevent.
-
     Two reasons a coordinate alone is not enough, both from real data: ch01 and ch06 sit on a
     different MAP donor from their parity twin, so not one of their tiles lines up with it;
     and where the map IS the twin's, a tile can still collide by accident -- ch05's
@@ -578,7 +571,7 @@ def resolve_donor(parity_ref, spec):
     elif isinstance(spec, (list, tuple)) and len(spec) == 2:
         at, want = spec, {'classIndex': None, 'level': None, 'redas': None}
     else:
-        raise ValueError('donor %r is not a coordinate [x, y] nor a {at/class/level/nth} '
+        raise ValueError('donor %r is not a coordinate [x, y] nor a {at/class/level} '
                          'reference' % (spec,))
     if at is not None and not (isinstance(at, (list, tuple)) and len(at) == 2):
         raise ValueError('donor %r: `at` must be a coordinate [x, y]' % (spec,))
@@ -1482,10 +1475,16 @@ def enemy_ai_bytes(chap, enemy, index=0):
 
     An `ai_override:` is how a chapter says it means to differ -- our map changed the
     dynamics, or we field a unit vanilla does not. It carries the vector and a `why`, and it
-    may stand alone where no single donor applies. Neither donor nor override RAISES: a
+    may stand alone where no single donor applies. The `why` is REQUIRED here, not merely
+    reported by the curve gate: that gate only reaches balance_locked chapters, so an
+    override authored in a chapter still being written could skip its reason entirely. Neither donor nor override RAISES: a
     default is exactly how ch00 shipped an `ai_pattern` its injector never read."""
     override = enemy.get('ai_override')
     if override:
+        if not str(override.get('why') or '').strip():
+            raise ValueError('enemy %r declares an `ai_override:` with no `why` -- an '
+                             'undeclared reason is a silenced guard, not a decision'
+                             % enemy.get('id'))
         return ai_bytes(override.get('ai'))
     per_position = _donor_specs(enemy)
     if per_position is not None:

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -117,9 +117,15 @@ class PrologueRosterFromYaml(unittest.TestCase):
             'hlin-trollbane': {'level': 3, 'position': [8, 5]},
             'scramsax': {'level': 1, 'position': [13, 9]},
             'sephek-kaltro': {'level': 5, 'position': [14, 8],
+                              # #335: the boss holds his tile by declared override, because
+                              # O'Neill's own DoNothing depends on a tutorial event-script
+                              # we do not run.
+                              'ai_override': {'ai': '{GuardTileAI, 0x9, 0x20}',
+                                              'why': 'see the ch00 YAML'},
                               'inventory': [{'id': 'ice-longsword',
                                              'fe_base': 'steel-sword'}]},
             'caravan-guard': {'level': 2, 'count': 2, 'positions': [[14, 7], [13, 7]],
+                              'donor': {'at': [14, 7], 'level': 2},
                               'inventory': [{'id': 'iron-axe'}]},
         }
         for uid, fields in over.items():                 # kwarg ids use _ for -
@@ -127,7 +133,10 @@ class PrologueRosterFromYaml(unittest.TestCase):
         return units
 
     def blocks(self, **over):
-        return bc._prologue_roster_blocks(self.by_id(**over), self.SLOTS, self.CLASSES,
+        units = self.by_id(**over)
+        chap = {'parity_reference': 'FE8 Prologue',
+                'enemy_units': [units['sephek-kaltro'], units['caravan-guard']]}
+        return bc._prologue_roster_blocks(chap, units, self.SLOTS, self.CLASSES,
                                           self.GUEST_ITEMS)
 
     def test_boss_level_tracks_the_yaml(self):
@@ -3814,9 +3823,15 @@ class Ch05SahnarIsJoshuaAndBasilIsNatasha(unittest.TestCase):
         chap = bc._load_chapter_yaml(self.CAMPAIGN, bc.CH05_CHAPTER_YAML)
         return next(e for e in chap['enemy_units'] if e['id'] == 'sahnar')
 
+    def _chap(self):
+        return bc._yaml_load(open(os.path.join(
+            bc.REPO, 'campaigns/rime-of-the-frostmaiden/chapters',
+            bc.CH05_CHAPTER_YAML), encoding='utf-8'))
+
     def test_she_carries_joshuas_exact_ai_bytes(self):
-        self.assertEqual('duelist_hold', self._sahnar()['ai_pattern'])
-        self.assertEqual('{0x7, 0x3, 0x9, 0x0}', bc.CH05_AI['duelist_hold'])
+        # #335: borrowed from vanilla Joshua's own UnitDefinition, not authored.
+        self.assertEqual('{0x7, 0x3, 0x9, 0x0}',
+                         bc.enemy_ai_initialiser(self._chap(), self._sahnar()))
 
     def test_the_list_has_exactly_one_client_which_is_what_makes_it_safe(self):
         """`.ai = {0x7,` appears ONCE in all of FE8 -- `UnitDef_088B5914`, vanilla Ch5's
@@ -3825,20 +3840,22 @@ class Ch05SahnarIsJoshuaAndBasilIsNatasha(unittest.TestCase):
         self.assertEqual(1, udefs.count('.ai = {0x7,'))
         bc.assert_escort_safe_ai_has_one_client('{0x7, 0x3, 0x9, 0x0}')
 
-    def test_a_second_client_is_refused(self):
-        with mock.patch.dict(bc.CH05_AI, {'someone_else': '{0x7, 0x0, 0x0, 0x0}'}):
+    def test_a_second_client_in_ANY_chapter_is_refused(self):
+        """The list is global, so the hazard is another chapter's unit reaching for `{0x7,`
+        on its own account. Since #335 the sweep reads the AI every enemy actually EMITS
+        rather than a table of labels -- which also catches a unit that inherits AI_A_07
+        from its vanilla DONOR, a case the old table scan could not see at all."""
+        planted = {'id': 'interloper', 'ai_override': {'ai': '{0x7, 0x3, 0x9, 0x0}',
+                                                       'why': 'test'}}
+        real = bc.escort_safe_ai_clients
+        with mock.patch.object(bc, 'escort_safe_ai_clients',
+                               lambda: real() + ['ch04.interloper']):
             with self.assertRaises(SystemExit):
                 bc.assert_escort_safe_ai_has_one_client('{0x7, 0x3, 0x9, 0x0}')
+        self.assertIsNotNone(planted)
 
-    def test_the_sweep_covers_EVERY_chapter_not_just_ch05(self):
-        """The list is global, so the hazard is a FUTURE chapter reaching for `{0x7,` on its
-        own account -- exactly the case a ch05-only scan cannot see. Scoping it to CH05_AI was
-        the first cut and it defeated the guard's own purpose."""
-        with mock.patch.dict(bc.CH04_AI, {'borrowed': '{0x7, 0x3, 0x9, 0x0}'}):
-            with self.assertRaises(SystemExit):
-                bc.assert_escort_safe_ai_has_one_client('{0x7, 0x3, 0x9, 0x0}')
-        # and the sweep really is finding more than one table
-        self.assertGreater(len([n for n in dir(bc) if re.fullmatch(r'CH\d\d_AI', n)]), 1)
+    def test_the_sweep_reads_every_chapter_and_finds_exactly_our_duelist(self):
+        self.assertEqual(bc.escort_safe_ai_clients(), ['ch05.sahnar'])
 
     def test_the_repoint_swaps_natasha_for_our_escort_and_keeps_the_shape(self):
         """`AiIsInShortList` takes `const u16*` and stops on a zero entry, so the u8 array
@@ -4945,6 +4962,40 @@ class MessageBlockPool(unittest.TestCase):
         self.assertEqual([], bc.live_ids_in_declared_blocks(
             {'bogus': ((0x969, 0x96C),)},
             claims={'bogus': (0x969, 0x96A, 0x96B, 0x96C)}))
+class PerPositionAiReachesTheEmittedRows(unittest.TestCase):
+    """#335: an entry with one donor PER POSITION must emit those distinct AIs.
+
+    This is a regression test for a real bug, caught by the output diff and not by any unit
+    test: every injector called `enemy_ai_initialiser(chap, enemy)` without the position
+    index, so all eight of ch05's tomb-reavers shipped their FIRST donor's AI. The YAML was
+    right, the resolver was right, the tests were green, and the ROM got eight identical
+    holders -- exactly the flattening the per-position donors exist to prevent."""
+
+    def _chap(self, stem):
+        import glob
+        path = glob.glob(os.path.join(
+            bc.REPO, 'campaigns/rime-of-the-frostmaiden/chapters', stem + '*.yaml'))[0]
+        with open(path, encoding='utf-8') as source:
+            return bc._yaml_load(source)
+
+    def test_ch05_tomb_reavers_emit_three_distinct_behaviours(self):
+        chap = self._chap('ch05')
+        rows = '\n'.join(bc.ch05_enemy_rows(chap, exclude=('sahnar',)))
+        reaver_ais = re.findall(r'tomb-reaver -- .*?\n(?:.*?\n)*?\s*\.ai = (\{[^}]*\})',
+                                rows)
+        self.assertEqual(8, len(reaver_ais), 'expected eight tomb-reavers')
+        self.assertEqual({'{0x0, 0x3, 0x9, 0x0}', '{0x0, 0x0, 0x9, 0x0}',
+                          '{0x0, 0x12, 0x9, 0x0}'}, set(reaver_ais))
+
+    def test_ch01_spears_and_axes_each_ship_one_delayed_charger(self):
+        chap = self._chap('ch01')
+        spear = next(e for e in chap['enemy_units'] if e['id'] == 'goblin-spear')
+        axe = next(e for e in chap['enemy_units'] if e['id'] == 'goblin-axe')
+        import difficulty
+        self.assertEqual(1, sum(1 for i in range(3)
+                                if difficulty.enemy_ai_bytes(chap, spear, i)[1] == 0x12))
+        self.assertEqual(1, sum(1 for i in range(3)
+                                if difficulty.enemy_ai_bytes(chap, axe, i)[1] == 0x12))
 
 
 class Ch05VillageRaidRace(unittest.TestCase):
@@ -5043,12 +5094,13 @@ class Ch05VillageRaidRace(unittest.TestCase):
         waves = [e for e in self._chap()['enemy_units'] if e.get('arrives_turn')
                  and e['id'] != 'sahnar']
         self.assertEqual(3, len(waves), 'ch05 has three eruption waves')
+        chap = self._chap()
         for wave in waves:
-            self.assertEqual('raider', wave.get('ai_pattern'),
-                             '%s does not race the reliquaries' % wave['id'])
-        self.assertEqual('{0x0, 0x4, 0x9, 0x0}', bc.CH05_AI['raider'],
-                         "vanilla Ch5's own raider AI, byte for byte (AI_B_04 = "
-                         'AiScr_AiB_PillageThenPursue)')
+            self.assertEqual('{0x0, 0x4, 0x9, 0x0}',
+                             bc.enemy_ai_initialiser(chap, wave),
+                             "%s does not race the reliquaries -- vanilla Ch5's own raider "
+                             'AI, byte for byte (AI_B_04 = AiScr_AiB_PillageThenPursue), is '
+                             'what its donor carries' % wave['id'])
 
     def test_a_raider_row_carries_the_pillage_ai_into_the_table(self):
         rows = '\n'.join(bc.ch05_enemy_rows(self._chap(), arrives_turn=2, exclude=('sahnar',)))

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -297,6 +297,22 @@ class EnemyAiBytes(unittest.TestCase):
         with self.assertRaises(ValueError):
             df.enemy_ai_bytes(chap, self._enemy())
 
+    def test_an_override_without_a_why_is_refused_at_build_time(self):
+        # The `why` is the whole difference between a declared divergence and a silenced
+        # guard. Reporting it only in the curve gate left it optional for every chapter
+        # that is not balance_locked -- which is where new AI actually gets authored.
+        chap = {'parity_reference': 'FE8 Ch3'}
+        enemy = self._enemy(donor=[7, 2], ai_override={'ai': '{DefaultAI, 0x9, 0x0}'})
+        with self.assertRaises(ValueError):
+            df.enemy_ai_bytes(chap, enemy)
+
+    def test_an_override_with_a_blank_why_is_refused_too(self):
+        chap = {'parity_reference': 'FE8 Ch3'}
+        enemy = self._enemy(donor=[7, 2],
+                            ai_override={'ai': '{DefaultAI, 0x9, 0x0}', 'why': '   '})
+        with self.assertRaises(ValueError):
+            df.enemy_ai_bytes(chap, enemy)
+
 
 class AiDonorFindings(unittest.TestCase):
     """The guard. Same contract as role_findings(): a list of strings, empty == clean."""

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -183,6 +183,301 @@ class CurveGate(unittest.TestCase):
         self.assertEqual(df.curve_gate_failures(rows), [])
 
 
+class VanillaAiBytes(unittest.TestCase):
+    """#335: an AI vector as vanilla writes it -> the 4 bytes the engine loads.
+
+    Vanilla writes its own UnitDefinition AI in the decomp's compiled EA macros
+    (include/EA_Standard_Library/AI_Helpers.h, reached from events_udefs.c via EAstdlib.h),
+    falling back to raw literals for the combinations that have no macro. We read BOTH,
+    from the header itself -- a hand-copied macro table here would be a second source of
+    truth for the exact bytes this whole feature exists to keep faithful."""
+
+    def test_literal_bytes_pass_through(self):
+        self.assertEqual(df.ai_bytes('{0x0, 0x3, 0x9, 0x0}'), (0x00, 0x03, 0x09, 0x00))
+
+    def test_a_two_byte_macro_expands_in_place(self):
+        # AI_Helpers.h: #define GuardTileAI 0x03,0x03
+        self.assertEqual(df.ai_bytes('{GuardTileAI, 0x9, 0x20}'), (0x03, 0x03, 0x09, 0x20))
+
+    def test_a_four_byte_macro_fills_the_whole_vector(self):
+        # #define NeverMoveAI 0x03,0x03,0x04,0x20
+        self.assertEqual(df.ai_bytes('{NeverMoveAI}'), (0x03, 0x03, 0x04, 0x20))
+
+    def test_a_missing_ai_block_is_all_zeros(self):
+        # No .ai in a UnitDefinition means {0,0,0,0} = ActionInRange + MoveToEnemy, which is
+        # a PURSUER. Two of vanilla Ch6's red units are exactly that.
+        self.assertEqual(df.ai_bytes(None), (0x00, 0x00, 0x00, 0x00))
+
+    def test_macros_are_read_from_the_decomp_header_not_a_local_copy(self):
+        # The guard against the mistake this feature is fixing one level up: every macro the
+        # header defines must resolve, so adding one there needs no edit here.
+        self.assertIn('AttackInRangeAI', df.AI_MACROS)
+        self.assertEqual(df.AI_MACROS['AttackInRangeAI'], (0x00, 0x03))
+        self.assertEqual(df.AI_MACROS['DoNothing'], (0x06, 0x03))
+
+
+class DonorResolution(unittest.TestCase):
+    """#335: each of our enemies stands in for a unit in its chapter's vanilla twin, and the
+    twin's UnitDefinition already carries that unit's AI. The chapter YAMLs have named their
+    counterpart in a comment since they were written ("vanilla brigand @ (7,2) L3 iron-axe");
+    `donor:` promotes that prose to a field so the build can read it.
+
+    Keyed on the twin's map COORDINATE, the way the comments already write it. Vanilla stacks
+    several units on one tile in places, so the reference may add `class`/`level` to pick one
+    -- and an ambiguous reference is an ERROR, never a silent first-match."""
+
+    def test_a_coordinate_resolves_to_that_units_ai(self):
+        # vanilla Ch3's brigand at (7,2): AttackInRangeAI, the static line.
+        self.assertEqual(df.resolve_donor('FE8 Ch3', [7, 2])['ai'], (0x00, 0x03, 0x09, 0x00))
+
+    def test_the_boss_tile_resolves_to_the_boss(self):
+        # Bazba at (14,1) -- GuardTileAI + the GuardTile config bit.
+        donor = df.resolve_donor('FE8 Ch3', [14, 1])
+        self.assertEqual(donor['ai'], (0x03, 0x03, 0x09, 0x20))
+        self.assertEqual(donor['classIndex'], 'CLASS_BRIGAND')
+
+    def test_a_tile_vanilla_stacks_is_ambiguous_and_raises(self):
+        # vanilla Ch2 puts an ARCHER and a BRIGAND both on (14,7), and they do NOT share an
+        # AI ({0,0x12,..} vs {0,0x11,..}). First-match would silently pick one.
+        with self.assertRaises(ValueError) as caught:
+            df.resolve_donor('FE8 Ch2', [14, 7])
+        self.assertIn('disagree', str(caught.exception).lower())
+
+    def test_class_disambiguates_a_stacked_tile(self):
+        self.assertEqual(
+            df.resolve_donor('FE8 Ch2', {'at': [14, 7], 'class': 'CLASS_ARCHER'})['ai'],
+            (0x00, 0x12, 0x09, 0x00))
+
+    def test_level_disambiguates_a_stacked_tile(self):
+        # (14,8) carries a L4 and a L6 brigand.
+        self.assertEqual(
+            df.resolve_donor('FE8 Ch2', {'at': [14, 8], 'level': 6})['level'], 6)
+
+    def test_a_coordinate_no_red_unit_occupies_raises(self):
+        with self.assertRaises(ValueError) as caught:
+            df.resolve_donor('FE8 Ch3', [0, 0])
+        self.assertIn('matches no red unit', str(caught.exception).lower())
+
+    def test_an_uncurated_twin_raises_rather_than_returning_nothing(self):
+        with self.assertRaises(ValueError):
+            df.resolve_donor('FE8 Ch99', [1, 1])
+
+
+class EnemyAiBytes(unittest.TestCase):
+    """#335: an enemy's AI is BORROWED from its vanilla donor unless the chapter says
+    otherwise in writing. No label vocabulary in between -- the labels were the translation
+    layer every one of these bugs lived in (`aggressive` meaning one thing in the YAML and
+    another in five injectors; `defensive` and `hold_position` being the same bytes under
+    two names; ch00's label wired to nothing at all)."""
+
+    def _enemy(self, **kw):
+        return dict({'id': 'e', 'class': 'brigand', 'level': 3}, **kw)
+
+    def test_an_enemy_borrows_its_donors_ai(self):
+        chap = {'parity_reference': 'FE8 Ch3'}
+        self.assertEqual(df.enemy_ai_bytes(chap, self._enemy(donor=[7, 2])),
+                         (0x00, 0x03, 0x09, 0x00))
+
+    def test_an_override_replaces_the_donors_ai(self):
+        chap = {'parity_reference': 'FE8 Ch3'}
+        enemy = self._enemy(donor=[7, 2], ai_override={
+            'ai': '{DefaultAI, 0x9, 0x0}', 'why': 'our map moves the fight to the entrance'})
+        self.assertEqual(df.enemy_ai_bytes(chap, enemy), (0x00, 0x00, 0x09, 0x00))
+
+    def test_an_override_may_stand_alone_where_we_field_a_unit_vanilla_does_not(self):
+        # ch04's wolf pack is six units where vanilla loads four revenants on one corner
+        # tile; there is no single donor to point at, so the override IS the declaration.
+        chap = {'parity_reference': 'FE8 Ch4'}
+        enemy = self._enemy(ai_override={'ai': '{AttackInRangeAI, 0xC, 0x0}',
+                                         'why': 'the pack is ours, not a vanilla unit'})
+        self.assertEqual(df.enemy_ai_bytes(chap, enemy), (0x00, 0x03, 0x0C, 0x00))
+
+    def test_an_enemy_with_neither_is_an_error_not_a_default(self):
+        # A default here is how ch00 shipped an ai_pattern nobody read. Refuse instead.
+        chap = {'parity_reference': 'FE8 Ch3'}
+        with self.assertRaises(ValueError):
+            df.enemy_ai_bytes(chap, self._enemy())
+
+
+class AiDonorFindings(unittest.TestCase):
+    """The guard. Same contract as role_findings(): a list of strings, empty == clean."""
+
+    def _chap(self, enemies, ref='FE8 Ch3'):
+        return {'parity_reference': ref, 'enemy_units': enemies}
+
+    def test_a_fully_donored_chapter_is_clean(self):
+        self.assertEqual(df.ai_donor_findings(
+            self._chap([{'id': 'a', 'donor': [7, 2]}, {'id': 'b', 'donor': [14, 1]}])), [])
+
+    def test_an_enemy_with_no_donor_is_reported(self):
+        findings = df.ai_donor_findings(self._chap([{'id': 'stray'}]))
+        self.assertTrue(any('stray' in f for f in findings), findings)
+
+    def test_an_override_without_a_reason_is_reported(self):
+        findings = df.ai_donor_findings(self._chap(
+            [{'id': 'a', 'donor': [7, 2], 'ai_override': {'ai': '{DefaultAI, 0x9, 0x0}'}}]))
+        self.assertTrue(any('why' in f for f in findings), findings)
+
+    def test_an_unresolvable_donor_is_reported_with_the_reason_it_failed(self):
+        findings = df.ai_donor_findings(self._chap([{'id': 'a', 'donor': [14, 7]}],
+                                                   ref='FE8 Ch2'))
+        self.assertTrue(any('disagree' in f.lower() for f in findings), findings)
+
+    def test_reinforcement_waves_are_checked_too(self):
+        # ch02 declares two of its nine reds under `reinforcements:`.
+        chap = self._chap([{'id': 'a', 'donor': [7, 2]}])
+        chap['reinforcements'] = [{'id': 'late'}]
+        findings = df.ai_donor_findings(chap)
+        self.assertTrue(any('late' in f for f in findings), findings)
+
+    def test_an_uncurated_twin_yields_no_findings(self):
+        self.assertEqual(
+            df.ai_donor_findings(self._chap([{'id': 'a'}], ref='FE8 Ch99')), [])
+
+
+class DonorGroupResolution(unittest.TestCase):
+    """A donor reference need not be a coordinate. ch01 and ch06 sit on a DIFFERENT map
+    donor from their parity twin (Ch13Eirika and Ch13Ephraim), so no tile of theirs lines up
+    with the twin at all -- but their forces pair by role, 1:1. And coordinates are actively
+    treacherous as a lone key: ch05's bone-archer reinforcement wave sits on (13,0), where
+    vanilla Ch5 happens to park an ARMOR_KNIGHT boss.
+
+    So the reference is a MATCH SPEC over the twin's red force -- coordinate, class, level,
+    any combination -- and it resolves when every unit it matches SHARES an AI. Vanilla's
+    three L2 soldiers behave identically, so 'the L2 soldiers' is a well-formed donor for our
+    group of three; where the matches disagree, it raises and asks for a narrower spec."""
+
+    def test_a_class_spec_resolves_a_whole_group_that_shares_one_ai(self):
+        # vanilla Ch3's five L3 brigands are all AttackInRangeAI -- one behaviour, so "the
+        # L3 brigands" is a well-formed donor for a group of ours.
+        self.assertEqual(
+            df.resolve_donor('FE8 Ch3', {'class': 'CLASS_BRIGAND', 'level': 3})['ai'],
+            (0x00, 0x03, 0x09, 0x00))
+
+    def test_a_class_spec_spanning_line_and_reinforcements_raises(self):
+        # Ch1's three L2 SOLDIERs look interchangeable and are not: the two on the line are
+        # AttackInRange, the one in the reinforcement wave PURSUES. Same class, same level,
+        # different chapter role -- exactly the collapse that authoring by feel produces.
+        with self.assertRaises(ValueError) as caught:
+            df.resolve_donor('FE8 Ch1', {'class': 'CLASS_SOLDIER', 'level': 2})
+        self.assertIn('disagree', str(caught.exception).lower())
+
+    def test_a_coordinate_still_works_where_the_map_is_the_twins(self):
+        self.assertEqual(df.resolve_donor('FE8 Ch3', [7, 2])['ai'], (0x00, 0x03, 0x09, 0x00))
+
+    def test_coordinate_and_class_combine(self):
+        self.assertEqual(
+            df.resolve_donor('FE8 Ch2', {'at': [14, 7], 'class': 'CLASS_ARCHER'})['ai'],
+            (0x00, 0x12, 0x09, 0x00))
+
+    def test_a_spec_matching_nothing_raises(self):
+        with self.assertRaises(ValueError) as caught:
+            df.resolve_donor('FE8 Ch3', {'class': 'CLASS_PEGASUS_KNIGHT'})
+        self.assertIn('matches no red unit', str(caught.exception).lower())
+
+
+class PerPositionDonors(unittest.TestCase):
+    """An entry may carry ONE donor per position. ch04's `mogall` entry places four units on
+    vanilla Ch4's four mogall tiles, and those four vanilla mogalls run THREE different AIs
+    (AttackInRange x2, pursue, charge-after-one-turn). A single donor per entry would flatten
+    that into one behaviour and quietly lose the map's texture -- the same collapse that
+    authoring by label produced in the first place."""
+
+    CHAP = {'parity_reference': 'FE8 Ch4'}
+
+    def test_a_list_of_donors_gives_each_position_its_own_ai(self):
+        enemy = {'id': 'mogall', 'count': 4,
+                 'positions': [[11, 6], [13, 7], [12, 8], [13, 11]],
+                 'donor': [[11, 6], [13, 7], [12, 8], [13, 11]]}
+        self.assertEqual([df.enemy_ai_bytes(self.CHAP, enemy, i) for i in range(4)],
+                         [(0x00, 0x03, 0x0C, 0x00), (0x00, 0x00, 0x0C, 0x00),
+                          (0x00, 0x12, 0x0C, 0x00), (0x00, 0x03, 0x0C, 0x00)])
+
+    def test_a_single_donor_still_covers_every_position(self):
+        enemy = {'id': 'pack', 'count': 3, 'positions': [[1, 1], [2, 2], [3, 3]],
+                 'donor': [11, 6]}
+        self.assertEqual([df.enemy_ai_bytes(self.CHAP, enemy, i) for i in range(3)],
+                         [(0x00, 0x03, 0x0C, 0x00)] * 3)
+
+    def test_a_donor_list_that_does_not_cover_every_position_raises(self):
+        # Silently reusing the last donor would ship a unit nobody grounded.
+        enemy = {'id': 'short', 'count': 3, 'positions': [[1, 1], [2, 2], [3, 3]],
+                 'donor': [[11, 6], [13, 7]]}
+        with self.assertRaises(ValueError) as caught:
+            df.enemy_ai_bytes(self.CHAP, enemy, 2)
+        self.assertIn('2 donor', str(caught.exception))
+
+    def test_a_bare_coordinate_is_not_read_as_a_list_of_two_donors(self):
+        # `donor: [11, 6]` is ONE coordinate, not two donors. Getting this backwards would
+        # make every single-donor entry silently per-position.
+        enemy = {'id': 'one', 'positions': [[1, 1]], 'donor': [11, 6]}
+        self.assertEqual(df.enemy_ai_bytes(self.CHAP, enemy, 0), (0x00, 0x03, 0x0C, 0x00))
+
+
+class AiGateArm(unittest.TestCase):
+    """#335 joins #284's `role` arm on the SAME opt-in. AI is part of parity -- a chapter
+    marked balance-final whose force is not grounded in its twin is the same contradiction as
+    one carrying an open per-unit finding."""
+
+    def _row(self, label, locked=False, ai=()):
+        return {'label': label, 'locked': locked, 'has_ref': True, 'verdict': 'OK',
+                'boss_drop': False, 'role': [], 'ai': list(ai)}
+
+    def test_a_locked_chapter_with_an_ungrounded_enemy_fails(self):
+        rows = [self._row('CH2', locked=True, ai=['raider-captain: no donor'])]
+        self.assertEqual(df.curve_gate_failures(rows), ['CH2'])
+
+    def test_an_unlocked_chapter_stays_advisory(self):
+        rows = [self._row('CH6', locked=False, ai=['nerra: no donor'])]
+        self.assertEqual(df.curve_gate_failures(rows), [])
+
+    def test_a_locked_chapter_with_every_enemy_grounded_passes(self):
+        self.assertEqual(df.curve_gate_failures([self._row('CH3', locked=True)]), [])
+
+
+class AiFindingsInTheCurveReport(unittest.TestCase):
+    """The report must read EACH chapter's own donors. Runs against the real campaign data:
+    the wiring is the thing under test, and a report that silently graded the wrong chapter
+    would look exactly like a clean one."""
+
+    def _rows(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            return {r['label'].split()[0]: r
+                    for r in df.curve_report('rime-of-the-frostmaiden')}
+
+    def test_a_fully_donored_chapter_reports_clean(self):
+        self.assertEqual(self._rows()['CH3']['ai'], [])
+
+    def test_every_row_carries_the_ai_key_so_the_gate_can_read_it(self):
+        self.assertTrue(all('ai' in r for r in self._rows().values()))
+
+
+class DonorNthDiscriminator(unittest.TestCase):
+    """Vanilla sometimes stacks units that are identical in every readable field and still
+    behave differently: Ch1 puts TWO L2 fighters on (2,9), one pursuing from turn 1 and one
+    charging on turn 2. Coordinate, class and level cannot separate them, so the spec takes
+    an `nth:` -- 0-based, in array order. It is the last resort, not the first: everything
+    else names a property, and `nth` names a slot."""
+
+    def test_nth_picks_between_units_identical_in_every_other_field(self):
+        base = {'at': [2, 9], 'class': 'CLASS_FIGHTER', 'level': 2}
+        self.assertEqual(df.resolve_donor('FE8 Ch1', dict(base, nth=0))['ai'],
+                         (0x00, 0x00, 0x01, 0x00))
+        self.assertEqual(df.resolve_donor('FE8 Ch1', dict(base, nth=1))['ai'],
+                         (0x00, 0x12, 0x01, 0x00))
+
+    def test_nth_past_the_end_raises(self):
+        with self.assertRaises(ValueError) as caught:
+            df.resolve_donor('FE8 Ch1', {'at': [2, 9], 'class': 'CLASS_FIGHTER',
+                                         'level': 2, 'nth': 5})
+        self.assertIn('nth', str(caught.exception).lower())
+
+    def test_without_nth_that_pair_still_raises(self):
+        # nth must be opt-in: silently taking the first match is the bug it exists to avoid.
+        with self.assertRaises(ValueError):
+            df.resolve_donor('FE8 Ch1', {'at': [2, 9], 'class': 'CLASS_FIGHTER', 'level': 2})
+
+
 class ChapterEnemyForce(unittest.TestCase):
     def test_expands_count_and_composition_into_per_unit_force(self):
         chap = {'enemy_units': [
@@ -260,6 +555,9 @@ CONST_DATA struct UnitDefinition UnitDef_Test[] = {
         .charIndex = CHARACTER_BREGUET,
         .classIndex = CLASS_ARMOR_KNIGHT,
         .allegiance = FACTION_ID_RED,
+        .ai = {GuardTileAI, 0x9, 0x20},
+        .xPosition = 11,
+        .yPosition = 3,
         .level = 4,
         .items = {
             ITEM_LANCE_IRON,
@@ -322,6 +620,8 @@ class VanillaUnitDefParser(unittest.TestCase):
         defs = df.vanilla_unit_defs(_UDEF_SNIPPET, 'UnitDef_Test')
         self.assertEqual(len(defs), 3)           # the { 0 } terminator is skipped
         self.assertEqual(defs[0], {'charIndex': 'CHARACTER_BREGUET',
+                                   'ai': (0x03, 0x03, 0x09, 0x20),
+                                   'xPosition': 11, 'yPosition': 3,
                                    'classIndex': 'CLASS_ARMOR_KNIGHT', 'level': 4,
                                    'allegiance': 'FACTION_ID_RED', 'itemDrop': False,
                                    'items': ['ITEM_LANCE_IRON']})
@@ -334,6 +634,13 @@ class VanillaUnitDefParser(unittest.TestCase):
         defs = df.vanilla_unit_defs(_UDEF_SNIPPET, 'UnitDef_Test')
         self.assertEqual(defs[0]['charIndex'], 'CHARACTER_BREGUET')
         self.assertEqual(defs[2]['charIndex'], 'CHARACTER_EIRIKA')
+
+    def test_captures_the_ai_vector_and_defaults_it_to_all_zeros(self):
+        # #335. A nested .ai must not split the entry (that is what _brace_entries guards),
+        # and an entry WITHOUT one is {0,0,0,0} -- a pursuer, not an inert default.
+        defs = df.vanilla_unit_defs(_UDEF_SNIPPET, 'UnitDef_Test')
+        self.assertEqual(defs[0]['ai'], (0x03, 0x03, 0x09, 0x20))
+        self.assertEqual(defs[1]['ai'], (0x00, 0x00, 0x00, 0x00))
 
     def test_captures_item_drop_bit(self):
         # #176: a unit flagged .itemDrop = 1 drops its LAST item (US_DROP_ITEM, the final

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -236,22 +236,21 @@ class DonorResolution(unittest.TestCase):
         self.assertEqual(donor['ai'], (0x03, 0x03, 0x09, 0x20))
         self.assertEqual(donor['classIndex'], 'CLASS_BRIGAND')
 
-    def test_a_tile_vanilla_stacks_is_ambiguous_and_raises(self):
-        # vanilla Ch2 puts an ARCHER and a BRIGAND both on (14,7), and they do NOT share an
-        # AI ({0,0x12,..} vs {0,0x11,..}). First-match would silently pick one.
+    def test_a_post_two_units_share_is_ambiguous_and_raises(self):
+        # The prologue stands its two caravan guards on (14,7) with different AI
+        # ({0,0xA,..} scripted approach vs {0,0x12,..} charge-on-turn-2). First-match would
+        # silently pick one. Posts are otherwise unique in every twin we use.
         with self.assertRaises(ValueError) as caught:
-            df.resolve_donor('FE8 Ch2', [14, 7])
+            df.resolve_donor('FE8 Prologue', [14, 7])
         self.assertIn('disagree', str(caught.exception).lower())
 
-    def test_class_disambiguates_a_stacked_tile(self):
+    def test_level_disambiguates_a_shared_post(self):
         self.assertEqual(
-            df.resolve_donor('FE8 Ch2', {'at': [14, 7], 'class': 'CLASS_ARCHER'})['ai'],
-            (0x00, 0x12, 0x09, 0x00))
-
-    def test_level_disambiguates_a_stacked_tile(self):
-        # (14,8) carries a L4 and a L6 brigand.
+            df.resolve_donor('FE8 Prologue', {'at': [14, 7], 'level': 1})['ai'],
+            (0x00, 0x0A, 0x00, 0x00))
         self.assertEqual(
-            df.resolve_donor('FE8 Ch2', {'at': [14, 8], 'level': 6})['level'], 6)
+            df.resolve_donor('FE8 Prologue', {'at': [14, 7], 'level': 2})['ai'],
+            (0x00, 0x12, 0x02, 0x00))
 
     def test_a_coordinate_no_red_unit_occupies_raises(self):
         with self.assertRaises(ValueError) as caught:
@@ -320,7 +319,7 @@ class AiDonorFindings(unittest.TestCase):
 
     def test_an_unresolvable_donor_is_reported_with_the_reason_it_failed(self):
         findings = df.ai_donor_findings(self._chap([{'id': 'a', 'donor': [14, 7]}],
-                                                   ref='FE8 Ch2'))
+                                                   ref='FE8 Prologue'))
         self.assertTrue(any('disagree' in f.lower() for f in findings), findings)
 
     def test_reinforcement_waves_are_checked_too(self):
@@ -367,7 +366,7 @@ class DonorGroupResolution(unittest.TestCase):
 
     def test_coordinate_and_class_combine(self):
         self.assertEqual(
-            df.resolve_donor('FE8 Ch2', {'at': [14, 7], 'class': 'CLASS_ARCHER'})['ai'],
+            df.resolve_donor('FE8 Ch2', {'at': [14, 9], 'class': 'CLASS_ARCHER'})['ai'],
             (0x00, 0x12, 0x09, 0x00))
 
     def test_a_spec_matching_nothing_raises(self):
@@ -452,30 +451,53 @@ class AiFindingsInTheCurveReport(unittest.TestCase):
         self.assertTrue(all('ai' in r for r in self._rows().values()))
 
 
-class DonorNthDiscriminator(unittest.TestCase):
-    """Vanilla sometimes stacks units that are identical in every readable field and still
-    behave differently: Ch1 puts TWO L2 fighters on (2,9), one pursuing from turn 1 and one
-    charging on turn 2. Coordinate, class and level cannot separate them, so the spec takes
-    an `nth:` -- 0-based, in array order. It is the last resort, not the first: everything
-    else names a property, and `nth` names a slot."""
+class VanillaUnitDestinations(unittest.TestCase):
+    """#335: a vanilla unit's `xPosition`/`yPosition` is often a SPAWN tile, not where it
+    fights. `redas` is scripted movement data that walks it from there to its post, and the
+    last REDA point is the destination.
 
-    def test_nth_picks_between_units_identical_in_every_other_field(self):
-        base = {'at': [2, 9], 'class': 'CLASS_FIGHTER', 'level': 2}
-        self.assertEqual(df.resolve_donor('FE8 Ch1', dict(base, nth=0))['ai'],
-                         (0x00, 0x00, 0x01, 0x00))
-        self.assertEqual(df.resolve_donor('FE8 Ch1', dict(base, nth=1))['ai'],
-                         (0x00, 0x12, 0x01, 0x00))
+    This is load-bearing for donors. Vanilla Ch1's whole force enters on (1,9)/(2,9) and
+    Ch5's on (0,0)/(10,0)/(12,0) -- matching a donor on those tiles is matching on "entered
+    from the north", which is no identity at all. Matched on DESTINATION, every one of our
+    23 ch05 units lands exactly on a vanilla unit's post, and Ch1's two seemingly identical
+    L2 fighters separate cleanly (they walk to (3,8) and (2,9))."""
 
-    def test_nth_past_the_end_raises(self):
-        with self.assertRaises(ValueError) as caught:
-            df.resolve_donor('FE8 Ch1', {'at': [2, 9], 'class': 'CLASS_FIGHTER',
-                                         'level': 2, 'nth': 5})
-        self.assertIn('nth', str(caught.exception).lower())
+    def test_a_unit_with_redas_reports_its_destination_not_its_spawn(self):
+        units = df.vanilla_red_units('FE8 Ch1')
+        knight = next(u for u in units if u['classIndex'] == 'CLASS_ARMOR_KNIGHT')
+        self.assertEqual((2, 9), (knight['xPosition'], knight['yPosition']))
+        self.assertEqual((2, 5), knight['position'])
 
-    def test_without_nth_that_pair_still_raises(self):
-        # nth must be opt-in: silently taking the first match is the bug it exists to avoid.
-        with self.assertRaises(ValueError):
-            df.resolve_donor('FE8 Ch1', {'at': [2, 9], 'class': 'CLASS_FIGHTER', 'level': 2})
+    def test_a_unit_with_no_redas_falls_back_to_its_placed_tile(self):
+        # ch03's force is placed statically -- no REDA, so position IS xPosition/yPosition.
+        for unit in df.vanilla_red_units('FE8 Ch3'):
+            self.assertEqual((unit['xPosition'], unit['yPosition']), unit['position'])
+
+    def test_destinations_separate_units_identical_in_every_other_field(self):
+        # The pair that made me reach for `nth`: same class, level and spawn tile, different
+        # AI. Their destinations differ, so no ordinal is needed.
+        pair = [u for u in df.vanilla_red_units('FE8 Ch1')
+                if u['classIndex'] == 'CLASS_FIGHTER' and u['level'] == 2
+                and (u['xPosition'], u['yPosition']) == (2, 9)]
+        self.assertEqual(2, len(pair))
+        self.assertEqual({(3, 8), (2, 9)}, {u['position'] for u in pair})
+        self.assertNotEqual(pair[0]['ai'], pair[1]['ai'])
+
+    def test_a_donor_at_matches_the_destination(self):
+        self.assertEqual(df.resolve_donor('FE8 Ch1', [3, 8])['ai'], (0x00, 0x00, 0x01, 0x00))
+        self.assertEqual(df.resolve_donor('FE8 Ch1', [2, 9])['ai'], (0x00, 0x12, 0x01, 0x00))
+
+    def test_every_ch05_unit_of_ours_stands_on_a_vanilla_destination(self):
+        # 23/23 -- the ch05 pairing is DERIVED, not assigned by hand. Matched on spawn tiles
+        # it was 9/23, and the nine were coincidences.
+        posts = {u['position'] for u in df.vanilla_red_units('FE8 Ch5')}
+        with open(df.chapter_path('rime-of-the-frostmaiden', 'ch05'),
+                  encoding='utf-8') as source:
+            chap = bc.yaml.safe_load(source)
+        ours = [tuple(p) for key in df.AI_ROSTER_KEYS
+                for e in (chap.get(key) or []) if isinstance(e, dict)
+                for p in (e.get('positions') or [])]
+        self.assertEqual([], [p for p in ours if p not in posts])
 
 
 class ChapterEnemyForce(unittest.TestCase):
@@ -621,6 +643,7 @@ class VanillaUnitDefParser(unittest.TestCase):
         self.assertEqual(len(defs), 3)           # the { 0 } terminator is skipped
         self.assertEqual(defs[0], {'charIndex': 'CHARACTER_BREGUET',
                                    'ai': (0x03, 0x03, 0x09, 0x20),
+                                   'redas': None, 'position': (11, 3),
                                    'xPosition': 11, 'yPosition': 3,
                                    'classIndex': 'CLASS_ARMOR_KNIGHT', 'level': 4,
                                    'allegiance': 'FACTION_ID_RED', 'itemDrop': False,


### PR DESCRIPTION
**Stack 1 of 5.** Merge in order; each PR is based on the one before it.

## What

A chapter picks a vanilla twin so its difficulty is grounded rather than guessed, and we already derive that twin's classes, levels, inventories and drops from its `UnitDefinition` structs. The `.ai` field of those same structs was the one we never read — it was authored by feel through six per-chapter `CHnn_AI` label tables.

Because #48 computes threat from stats and weapons, the drift was invisible to every gate: five chapters measured x1.00 and played nothing like their twin.

**Each enemy now names a `donor:` and the build reads that unit's four AI bytes.** No label vocabulary in between — the labels *were* the translation layer the drift lived in (`aggressive` meant one thing in the YAML and another in five injectors; `defensive` and `hold_position` were byte-identical under two names; ch00's `ai_pattern:` was wired to nothing at all). All 63 entries already named their counterpart in a comment, so `donor:` promotes prose that was already there to data the build reads. `ai_override:` with a mandatory `why` is how a chapter declares it means to differ.

## The part worth reviewing closely

**A donor matches where a vanilla unit FIGHTS, not where it is placed.** `xPosition`/`yPosition` is frequently a SPAWN tile; `redas` walks the unit to its post, and the last REDA point is the destination. Matched on spawn tiles, 9 of ch05's 23 units appeared to line up and the nine were coincidences — one paired our bone-archer wave with an ARMOR_KNIGHT boss whose throne AI it would have inherited. Matched on posts it is **23 of 23**, class for class.

## Verification

An **output diff**, not just the tests: every injector re-run and `events_udefs.c` diffed — 102 changed lines, all `.ai`, zero collateral. It caught a bug the whole green suite missed: every injector called `enemy_ai_initialiser(chap, enemy)` without the position index, so all eight of ch05's tomb-reavers shipped their *first* donor's AI. YAML right, resolver right, tests green, ROM wrong. `PerPositionAiReachesTheEmittedRows` pins it.

`make check` green.

Refs #335
