### PR TITLE
ch01: the goblins are goblins again — a reskin is its SLOT, not its base class (#347)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3694,6 +3694,36 @@ _Decided: 2026-07-17_
 
 ## Class Mapping & Promotions
 
+**A reskin is resolved by its SLOT, never by the class it clones (2026-09-02, #347)**
+A reskin clones a vanilla class into its own otherwise-unused class slot, and BOTH the map
+sprite (`SMSId`) and the battle animation (`pBattleAnimDef`) are fields of that slot's class
+entry. So the slot IS the creature's identity, and the base class is only the chassis it was
+copied from — **many creatures legitimately clone one chassis.** Four bases are claimed twice
+today: goblin-soldier and ch05's risen-spear both clone `CLASS_SOLDIER`; goblin-fighter and
+tomb-reaver both clone `CLASS_FIGHTER`; kobold-grunt/kobold-brute share `CLASS_BRIGAND`;
+kobold-blade/crypt-blade share `CLASS_MERCENARY`.
+
+`inject_ch01` used to look a skin up from the base class through a `{base: slot}` dict. Being
+a dict, it kept the LAST claim — so ch05's undead quietly took ch01's Fire Imps, and the
+goblins shipped with the skeleton map sprite *and* the skeleton battle anim, because both ride
+the class. It went twelve days unnoticed: `#48` measures stats, the playtest scenarios assert
+memory state, and nothing anywhere reads which sprite a unit wears.
+
+Every chapter therefore **names the slot** in its `CHnn_CLASS_IDS` (ch05: `'soldier' ->
+CLASS_SOL_SKELEBERDIER`; ch01: `'soldier' -> CLASS_BLST_REGULAR_EMPTY`). ch03/ch04/ch05 always
+did; ch01 was the sole exception and is now fixed. Naming a *vanilla* class stays correct where
+the chapter genuinely wants vanilla — ch02's raiders are human `CLASS_BRIGAND` even though two
+kobolds clone that chassis.
+
+The guarded invariant is **slot uniqueness**, not base uniqueness: two creatures in one slot
+lose art, whereas two creatures on one base is the normal case. `reskin_by_base` is registered
+in `DEAD_CONCEPTS` so the pattern cannot return by name.
+
+**This is a precondition for ch06.** Its roster reskins `soldier` (mermaids), `fighter` (shark
+riders), `mercenary` (crab-blades) and `archer` (merfolk-bow) — four already-contested bases.
+Wired under the old resolution it would have taken `CLASS_SOLDIER` from ch05 exactly as ch05
+took it from ch01.
+
 All 8 PCs (and recruits) are **stock vanilla FE8 classes** — class bases, caps, MOV, and CON come
 from the class (`fireemblem8u/src/data_classes.c`). **No custom classes, no per-character
 abilities.** Individuality comes from flavor text, sprite/portrait art, and palette.

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -246,7 +246,13 @@ def enemy_ai_initialiser(chap, enemy, index=0):
 
 
 CH01_ITEM_IDS = {'iron-lance': 'ITEM_LANCE_IRON', 'iron-axe': 'ITEM_AXE_IRON'}
-CH01_CLASS_IDS = {'soldier': 'CLASS_SOLDIER', 'fighter': 'CLASS_FIGHTER',
+# ch01's grunts are goblins: they ride the CLONED goblin classes, whose own class entries
+# carry the Fire Imp map sprite (SMSId) and the goblin AnimConf. Name the SLOT here, the way
+# every other chapter does (ch05: 'soldier' -> CLASS_SOL_SKELEBERDIER) -- resolving a skin
+# from the vanilla base at build time is what shipped ch01 as ch05's skeletons (#347).
+# armor-knight is reskinned by nobody, so the chief stays a vanilla Knight.
+CH01_CLASS_IDS = {'soldier': 'CLASS_BLST_REGULAR_EMPTY',
+                  'fighter': 'CLASS_BLST_LONG_EMPTY',
                   'armor-knight': 'CLASS_ARMOR_KNIGHT'}
 
 # Lord select (#42): in ch01's beginning scene (after the Northlook muster, before
@@ -7947,15 +7953,10 @@ def inject_ch01(campaign, verbose=True):
     spear, axe = by_eid['goblin-spear'], by_eid['goblin-axe']
     chief, reinf = by_eid['goblin-chief'], by_eid['goblin-reinforcements']
 
-    # Ch1's grunts are goblins on the map: swap their vanilla class for the cloned goblin
-    # class (same stats/anim, goblin map sprite -- inject_enemy_class_reskins). Keyed by
-    # the base class enum so only declared reskins apply; the chief (armor-knight) has no
-    # reskin and stays the vanilla Knight sprite.
-    reskin_by_base = {rk['base']: rk['slot'] for rk in enemy_class_reskins(campaign)}
-
+    # A reskin's identity is its SLOT, and CH01_CLASS_IDS names it directly -- see #347 for
+    # why deriving it from the base class here could not work.
     def grunt_class(cls_label):
-        base = CH01_CLASS_IDS[cls_label]
-        return reskin_by_base.get(base, base)
+        return CH01_CLASS_IDS[cls_label]
 
     enemies = []
     for index, (x, y) in enumerate(spear['positions']):

--- a/tools/check.py
+++ b/tools/check.py
@@ -64,6 +64,10 @@ DEAD_CONCEPTS = [
     # postscript, and HANDOFF's #298 entry, which survived the correction because nothing
     # scanned for it. Registering it is what the ADR log calls registry discipline.
     r'presses? ==\s*authored boxes', r'wrapper never invents a page break',
+    # retired by #347: a reskin CLONES a vanilla class into its own slot, so `base` is
+    # many-to-one -- four bases are claimed twice, and a base-keyed dict silently handed
+    # ch01's Fire Imps to ch05's skeletons for twelve days. A skin is resolved by its SLOT.
+    r'reskin_by_base',
     r'tileset_stem\s*=',               # _register_chapter_map reads the layout's stamp
     r'BATTLE_FOLLOWUP_THRESHOLD',      # misnomer; real: BATTLE_FOLLOWUP_SPEED_THRESHOLD
     # Marty's "spore covenant" (2026-07-29): a ch05 villain-foil thread we drifted away

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -4947,6 +4947,57 @@ class PerPositionAiReachesTheEmittedRows(unittest.TestCase):
                                 if difficulty.enemy_ai_bytes(chap, spear, i)[1] == 0x12))
         self.assertEqual(1, sum(1 for i in range(3)
                                 if difficulty.enemy_ai_bytes(chap, axe, i)[1] == 0x12))
+class AReskinIsResolvedByItsOwnSlot(unittest.TestCase):
+    """A reskin CLONES a vanilla class into its OWN class slot, so `base` is many-to-one.
+
+    ch01 resolved its goblins through a dict keyed on the base class
+    (`{rk['base']: rk['slot'] ...}`), and four bases are claimed twice -- goblin-soldier and
+    ch05's risen-spear both clone CLASS_SOLDIER, goblin-fighter and tomb-reaver both clone
+    CLASS_FIGHTER. Last-wins, so ch01's Fire Imps shipped as ch05's skeletons for twelve
+    days (#347). Nothing failed: #48 measures stats, the playtest scenarios assert memory
+    state, and neither reads which sprite a unit wears.
+
+    Every other chapter names its slot outright (ch05: 'soldier' -> CLASS_SOL_SKELEBERDIER),
+    which is correct by construction. ch01 now does the same.
+    """
+
+    CAMPAIGN = 'rime-of-the-frostmaiden'
+
+    def _slot_of(self, reskin_id):
+        rk = next(r for r in bc.enemy_class_reskins(self.CAMPAIGN)
+                  if r['id'] == reskin_id)
+        return rk['slot']
+
+    def test_ch01_names_the_goblin_slots_not_the_vanilla_chassis(self):
+        # Read the slot from campaign.yaml rather than repeating it here: the bug was the
+        # code and the data disagreeing, so a test that hardcodes both cannot see it.
+        self.assertEqual(self._slot_of('goblin-soldier'), bc.CH01_CLASS_IDS['soldier'])
+        self.assertEqual(self._slot_of('goblin-fighter'), bc.CH01_CLASS_IDS['fighter'])
+
+    def test_the_chief_has_no_reskin_and_stays_a_vanilla_knight(self):
+        # armor-knight is claimed by no reskin, so naming the vanilla class is right here.
+        self.assertEqual('CLASS_ARMOR_KNIGHT', bc.CH01_CLASS_IDS['armor-knight'])
+        bases = {r['base'] for r in bc.enemy_class_reskins(self.CAMPAIGN)}
+        self.assertNotIn('CLASS_ARMOR_KNIGHT', bases)
+
+    def test_no_two_reskins_claim_the_same_slot(self):
+        # THIS is the invariant, not "no two share a base" -- sharing a base is legitimate
+        # and four pairs do it. A slot is the identity; two creatures in one slot is the
+        # collision that would actually lose art.
+        slots = [r['slot'] for r in bc.enemy_class_reskins(self.CAMPAIGN)]
+        self.assertEqual(len(slots), len(set(slots)),
+                         'a reskin slot is claimed twice: %s' % sorted(
+                             s for s in slots if slots.count(s) > 1))
+
+    def test_a_contested_base_is_still_allowed(self):
+        # Guard the guard: several creatures rightly clone one chassis, and a check that
+        # rejected duplicate bases would forbid ch05's skeletons and ch06's merfolk.
+        bases = [r['base'] for r in bc.enemy_class_reskins(self.CAMPAIGN)]
+        self.assertGreater(len(bases), len(set(bases)),
+                           'bases are expected to be reused; if this ever stops being true '
+                           'the many-to-one hazard is gone and this suite can relax')
+
+
 class SetMessageBodyReplacesTheWholeBody(unittest.TestCase):
     """A message body runs to the NEXT header, not to the first blank line.
 


### PR DESCRIPTION
Closes #347. ch01's goblins were shipping as ch05's skeletons. Nicolas found it by playing.

## What was wrong

`inject_ch01` resolved a skin from the vanilla **base** class through a `{base: slot}` dict.

A reskin CLONES a vanilla class into its own slot, so **base is many-to-one by design** —
four bases are claimed twice today (goblin-soldier/risen-spear on `CLASS_SOLDIER`,
goblin-fighter/tomb-reaver on `CLASS_FIGHTER`, plus the two kobold pairs). Being a dict it
kept the LAST claim, so ch05's undead took ch01's Fire Imps the day they landed — `e7d1887`,
2026-08-21.

## It cost the battle anims too, not just the map sprite

Nicolas asked about this specifically, and he was right. `SMSId` and `pBattleAnimDef` are
fields of the **same class entry**, so the goblins had the skeleton walk cycle *and* the
skeleton battle animation — only the map sprite is visible before a fight starts.

| slot | battle anim | SMSId |
|---|---|---|
| `CLASS_BLST_REGULAR_EMPTY` (goblin) | `AnimConf_goblin_soldier` | `0x6f` |
| `CLASS_SOL_SKELEBERDIER` (ch05) | `AnimConf_risen_spear` | `0x73` |

Naming the right class fixes both at once — which is exactly why the slot is the identity.
Verified in the built `data_classes.c`, not inferred.

## Why nothing caught it

Twelve days invisible, because **nothing reads a unit's LOOK**. `#48` measures stats; the
playtest scenarios assert memory state. Same blind spot as #335, one layer over — and no
matrix run could have found it.

## The fix

ch01 names its slots, the way ch03/ch04/ch05 always have (ch05:
`'soldier' -> CLASS_SOL_SKELEBERDIER`). ch01 was the sole chapter deriving a skin at build
time, and that indirection is deleted. Naming a *vanilla* class stays correct where a chapter
genuinely wants vanilla — ch02's raiders are human `CLASS_BRIGAND` though two kobolds clone
that chassis.

The guarded invariant is **slot uniqueness, not base uniqueness**. A test asserts bases are
still reused, because a check rejecting duplicate bases would forbid ch05's skeletons and
ch06's merfolk. `reskin_by_base` is registered in `DEAD_CONCEPTS` so the pattern cannot
return by name.

## Verification

**Output diff at a like-for-like config** (the first comparison was confounded by the tree
being built `CH05LUPIN=1`, so I re-ran both sides at the same flags): **exactly 18 lines,
9 units** — 6 field grunts + 3 reinforcements — every one a `classIndex`, **zero collateral**.
The chief keeps `CLASS_ARMOR_KNIGHT`; no reskin claims it.

837 tests green; drift clean.

## Why this had to land before ch06

ch06's roster reskins `soldier` (mermaids), `fighter` (shark riders), `mercenary`
(crab-blades) and `archer` (merfolk-bow) — four already-contested bases. Wired under the old
resolution it would have taken `CLASS_SOLDIER` from ch05 exactly as ch05 took it from ch01,
compounding the bug a third time.

ADR: `docs/decisions.md` → *"A reskin is resolved by its SLOT, never by the class it clones"*.
