### PR TITLE
docs: /code-review is the review step, and the author never reviews their own PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ Rationale + long form: `docs/decisions.md` → Coordination model. The operating
 - A task = a GitHub issue → short-lived `feat/<n>-slug` branch off `main` → PR → CI + `/code-review`
   → squash-merge → delete the branch. A feature may span engine + content — ownership lives on the
   PR + issue, not a file glob.
+- **Review is `/code-review`, and the author is never the reviewer.** It is the default on every
+  PR, not an optional extra, and a hand-rolled reviewer prompt is not a substitute — a skill
+  reconstructed from memory runs last month's process. Use
+  `superpowers:requesting-code-review` instead only for a STACK or where the PR needs context
+  the diff cannot carry: one fresh reviewer per PR, reviewed DOWN the stack, since a fix to an
+  earlier PR rebases every PR above it.
 - **A stack of PRs lands with `--merge`, not `--squash`, and every child is retargeted to `main`
   (`gh pr edit <child> --base main`) BEFORE the parent's branch is deleted** — deleting a base branch
   closes the PRs on it, and a closed PR can't be retargeted (`decisions.md` → stacked PRs).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -376,6 +376,17 @@ and got welded onto the same `inst/<track>` worktree, forcing work to partition 
 - **Feature-flow.** A task = issue → short-lived `feat/<n>-slug` branch off `main` → an **ephemeral**
   worktree (isolation only) → a **PR** → CI + `/code-review` → squash-merge → drop the branch + worktree.
   Concurrency = N feature worktrees, not two fixed slots. A PR may span the old seam; that is the point.
+**`/code-review` is the review step, and the author never reviews their own PR (2026-09-02)**
+The flow above names `/code-review`, and it is mandatory rather than a suggestion. Two things
+kept going wrong. An author re-reading their own diff finds nothing: #338 shipped unreviewed
+and a fresh reviewer then found two real defects the author had read past twice, and the #335
+stack repeated it at scale — four of five PRs needed fixes and two were Critical, including a
+guard that was defined, unit-tested, and never registered in the gate it was written for. And
+a reviewer prompt improvised in the moment is not the skill: skills change, so reconstructing
+one from memory quietly runs an older process. `superpowers:requesting-code-review` is the
+variant for a STACK, or where a PR needs context the diff cannot carry — one fresh reviewer
+per PR, working DOWN the stack, because a fix to an earlier PR rebases every PR above it.
+
 - **The "not my job" propagation test runs at PR review** — push the change through the desks and watch
   the reactions (my job / I can help / no impact / no need to know). Review is where ownership is decided,
   replacing the pre-commit glob block.


### PR DESCRIPTION
Writes down the review convention Nicolas asked to make explicit.

The flow already named `/code-review`. It did not say the step was **mandatory**, and it did
not say **who may run it**. Both gaps were live this session.

## Why

**An author re-reading their own diff finds nothing.** #338 shipped unreviewed and a fresh
reviewer then found two real defects the author had read past twice. The #335 stack repeated
it at scale: four of five PRs needed fixes, two Critical — including a guard that was
defined, unit-tested, and never registered in the gate it was written for, and an s8 change
that silently made 23 off-map guards vacuous. A green suite passed straight through both.

**A reviewer prompt improvised in the moment is not the skill.** Skills change, so
reconstructing one from memory quietly runs an older process. That happened here: hand-rolled
review prompts stood in for `/code-review` on #348, a normal single-feature PR.

## What changes

- `AGENTS.md` feature-flow gains one rule: review is `/code-review`, the author is never the
  reviewer, and `superpowers:requesting-code-review` is the variant for a STACK or where a PR
  needs context the diff cannot carry.
- `docs/decisions.md` Coordination model gains the dated ADR with the evidence above.

Docs only — no code, no behaviour change. Drift lint clean.

**Not sending this one to a reviewer**: it is a two-file documentation change whose entire
content is the rule itself, and the diff carries no logic to get wrong. Flagging that
explicitly rather than quietly skipping, since the rule being added is precisely "don't
quietly skip review."
