### PR TITLE
ch01: drop grunt_class, a helper #347 hollowed out

### DIFF
--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -7953,21 +7953,16 @@ def inject_ch01(campaign, verbose=True):
     spear, axe = by_eid['goblin-spear'], by_eid['goblin-axe']
     chief, reinf = by_eid['goblin-chief'], by_eid['goblin-reinforcements']
 
-    # A reskin's identity is its SLOT, and CH01_CLASS_IDS names it directly -- see #347 for
-    # why deriving it from the base class here could not work.
-    def grunt_class(cls_label):
-        return CH01_CLASS_IDS[cls_label]
-
     enemies = []
     for index, (x, y) in enumerate(spear['positions']):
         enemies.append(_enemy_unit_entry(
-            '0x80', grunt_class(spear['class']), spear['level'], True, x, y,
+            '0x80', CH01_CLASS_IDS[spear['class']], spear['level'], True, x, y,
             CH01_ITEM_IDS[spear['inventory'][0]['id']],
             enemy_ai_initialiser(chap, spear, index),
             ' /* goblin spear -- camp approach */'))
     for index, (x, y) in enumerate(axe['positions']):
         enemies.append(_enemy_unit_entry(
-            '0x80', grunt_class(axe['class']), axe['level'], True, x, y,
+            '0x80', CH01_CLASS_IDS[axe['class']], axe['level'], True, x, y,
             CH01_ITEM_IDS[axe['inventory'][0]['id']],
             enemy_ai_initialiser(chap, axe, index),
             ' /* goblin raider -- mid-trail pursuer */'))
@@ -7983,7 +7978,7 @@ def inject_ch01(campaign, verbose=True):
     reinforce = []
     for index, (cls, (x, y)) in enumerate(zip(reinf['composition'], reinf['positions'])):
         reinforce.append(_enemy_unit_entry(
-            '0x80', grunt_class(cls), reinf['level'], True, x, y,
+            '0x80', CH01_CLASS_IDS[cls], reinf['level'], True, x, y,
             CH01_ITEM_IDS[reinf['inventory_by_class'][cls][0]],
             enemy_ai_initialiser(chap, reinf, index), ' /* west reinforcement, turn %d */'
             % reinf['spawn_turn']))


### PR DESCRIPTION
Follow-up cleanup from #348.

`grunt_class` existed to remap a vanilla base class to its reskin slot. #347 deleted that
remap, which left:

```python
def grunt_class(cls_label):
    return CH01_CLASS_IDS[cls_label]
```

A dict lookup wearing a name. I hollowed it out and left the shell standing rather than
finishing the cleanup — and then defended it as "documenting intent" when #348's reviewer
flagged it. Nicolas independently asked what the term meant and why it was in the code.
Two readers finding the same thing odd is the tell that it documents nothing.

The four call sites now read `CH01_CLASS_IDS[...]` uniformly, so the grunts and the chief
look the same at the point of use — which is honest, because they resolve the same way.

**"grunt" itself stays** — it is campaign vocabulary, not an invention of the code:
`campaign.yaml`'s *"Ch1 grunts (the Foaming Mugs goblins)"*, the `kobold-grunt` reskin, and
ch03's roster all use it for rank-and-file-versus-boss. It belongs in the data, not in a
function that no longer does anything.

## Verification

**Pure refactor**: the emitted `events_udefs.c` is byte-identical before and after
(re-ran the injection and diffed — empty). 607 tests green, drift clean.
