### PR TITLE
playtest: recordenemy names its foes from the table, not from memory

### DIFF
--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -4809,8 +4809,14 @@ scenarios.recordenemy = function()
                     [sel]
     local want = (not wantPid) and (RESKIN_ENEMY_CLASS[sel] or tonumber(sel)) or nil
     if not want and not wantPid then
+        local names = {}
+        for k in pairs(RESKIN_ENEMY_CLASS) do names[#names + 1] = k end
+        table.sort(names)
+        -- Derived, not retyped: the hand-written list had gone stale and omitted the two
+        -- goblin classes, which sent a reader looking for a raw class id for a foe the
+        -- table already names (#347's confirmation run).
         return result("FAIL", "unknown enemy '" .. sel .. "' -- one of: "
-            .. "kobold-grunt kobold-blade kobold-brute white-moose ravisin, or a raw class id "
+            .. table.concat(names, " ") .. " white-moose ravisin, or a raw class id "
             .. "(e.g. 0x82)") end
     local function classOf(u) return ru8(ru32(u.addr + 0x04) + 0x04) end
     -- the chosen foe: by CHARACTER for a raw-pid creature, by CLASS for a class-level reskin


### PR DESCRIPTION
The `unknown enemy` message listed five names while `RESKIN_ENEMY_CLASS` holds nine — it omitted `goblin-soldier` and `goblin-fighter`, the two classes #347 was about.

Confirming that fix, I read the message, concluded the goblins weren't named, and went looking for a raw class id for a foe the table already names. Small, but it sends the next reader the long way round.

The list is now derived from the table so it cannot drift again. `white-moose`/`ravisin` stay appended — they're raw-pid creatures on the separate `wantPid` branch, not `RESKIN_ENEMY_CLASS` entries.

Lua chunks load, local headroom unmoved at 2, harness tests green.