### PR TITLE
tooling: a bare-literal message id registers itself (#346)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4237,15 +4237,26 @@ BINDINGS, not text, because `msg_id` is positional at all 71 call sites and `gre
 none of them -- and attributes each to the injector that writes it. `injector_message_ids` folds
 them in, so deadness is checked with no human step.
 
-**Discovery cannot invent an OWNER, so the registry stays, and it stays a gate.**
-`HOSTED_CHAPTER_MESSAGE_IDS` is what `assert_message_ids_unique` collides on and what
-`make chapter` reads for headroom; an id spent but unclaimed reads as free room already spent.
-`check_message_literals_are_registered` requires the claim and names the tuple to add it to. The
-two halves split cleanly: **discovery makes the id safe, registration makes it accountable.**
+**Discovery cannot invent an OWNER, so the registry stays -- but the ownership check belongs
+where the registry is REAL.** `HOSTED_CHAPTER_MESSAGE_IDS` is what `assert_message_ids_unique`
+collides on and what `make chapter` reads for headroom; an id spent but unclaimed reads as free
+room already spent. The first cut asserted that in `check.py` by reading the registry with an AST
+evaluator, and #356's review killed it: the registry is written as generators, subscripts and
+tuple-unpacked constants (`*(msg for (_slot, msg, _boxes, _what) in CH05_OPENING_SLOTS)`,
+`CH05_ARRIVAL_SLOT[1]`, `CH04_VILLAGE_MSG`), so the static read was wrong in **both** directions
+-- it missed ch04's `0x9C3`/`0x9C6` and would have demanded a registration that makes
+`assert_message_ids_unique` exit, and it swept up ch05's box counts so an unclaimed `0x13` passed.
+**A hand-rolled evaluator of a data structure is a second, worse implementation of it.** Ownership
+now lives in `build_campaign.assert_literals_are_claimed`, called from `main()` beside
+`assert_message_ids_unique`, where the dict is a real Python object and the answer is exact.
 
-The guard is registered in `check.py`'s `main()` tuple and pinned by a test that reads that
-function's source, and it fails when the live scan finds zero literals -- both because of the
-lesson directly above.
+The split that survives: **`check.py` owns DISCOVERY** -- stdlib-only, so the lean CI `checks` job
+runs it for real -- and **the BUILD owns OWNERSHIP.** Discovery makes the id safe (it folds into
+`injector_message_ids`, so deadness is checked with no human step); ownership makes it accountable.
+
+The discovery guard is registered in `check.py`'s `main()` tuple and pinned by a test that reads
+that function's source, and it fails when the live scan finds zero literals -- both because of the
+lesson directly above. The build-time half is pinned the same way, by a test reading `main`.
 
 - **Dressing a portrait slot and NORMALIZING its mouth/eye window are two steps, and missing the
   second is silent** (2026-08-09, #25). `patch_portrait_geometry` only knew about `PORTRAIT_MAP`

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4221,6 +4221,32 @@ The unifying test: after any change to a check, an encoding, or a sentinel, ask 
 now be different if this were broken?* If the answer is "nothing observable", that is the
 bug, not the reassurance.
 
+**A message id written as a bare literal now registers itself (2026-09-02, #346)**
+`injector_message_ids` finds an id by the NAME of the constant holding it, and promised that
+"registering a new one is enough -- there is no second list to remember". That was false for an id
+passed as hex at the `set_message_body` call site: the prologue and ch01 write twelve, and they
+reached the deadness guard only because someone grepped for them once and hand-transcribed them
+into `PROLOGUE_LITERAL_MSGS` / `CH01_LITERAL_MSGS`. The next one was invisible until a human
+noticed it. `0xC25` is the sharp case -- it sits `0x33` above ch05's `0xBC5-0xBF2` pool, so
+extending that range upward, the obvious next move, would have been accepted by every guard and
+would have overwritten Scramsax's defeat quote.
+
+**The mechanism, not the discipline, was missing.** `inject.hosts.literal_message_ids` reads the
+literals out of `build_campaign.py`'s own source through `tools/callsites.py` -- argument
+BINDINGS, not text, because `msg_id` is positional at all 71 call sites and `grep msg_id=` finds
+none of them -- and attributes each to the injector that writes it. `injector_message_ids` folds
+them in, so deadness is checked with no human step.
+
+**Discovery cannot invent an OWNER, so the registry stays, and it stays a gate.**
+`HOSTED_CHAPTER_MESSAGE_IDS` is what `assert_message_ids_unique` collides on and what
+`make chapter` reads for headroom; an id spent but unclaimed reads as free room already spent.
+`check_message_literals_are_registered` requires the claim and names the tuple to add it to. The
+two halves split cleanly: **discovery makes the id safe, registration makes it accountable.**
+
+The guard is registered in `check.py`'s `main()` tuple and pinned by a test that reads that
+function's source, and it fails when the live scan finds zero literals -- both because of the
+lesson directly above.
+
 - **Dressing a portrait slot and NORMALIZING its mouth/eye window are two steps, and missing the
   second is silent** (2026-08-09, #25). `patch_portrait_geometry` only knew about `PORTRAIT_MAP`
   and the guests, so any other dressed slot kept the VANILLA character's mouth coordinates and the

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -10256,6 +10256,43 @@ def assert_message_ids_unique(claims=None):
     return owner
 
 
+def assert_literals_are_claimed(literals=None, claims=None):
+    """Guard: a message id written as a BARE LITERAL must still be CLAIMED by its chapter.
+
+    Discovery (`inject.hosts.literal_message_ids`) makes a bare literal SAFE -- it folds into
+    `injector_message_ids`, so the deadness check sees it whether or not anyone wrote it down.
+    What discovery cannot do is give the id an OWNER. `HOSTED_CHAPTER_MESSAGE_IDS` is what
+    `assert_message_ids_unique` collides on and what `make chapter CH=chNN` reads for headroom,
+    and a chapter that spends an id it does not claim reads as having room it has already
+    spent. 0xC25 is the case that pays for this: it sits 0x33 above ch05's pool, so extending
+    that range upward would have silently overwritten Scramsax's defeat quote.
+
+    This lives HERE, at build time, and not in `check.py`, because here the registry is a real
+    dict. #356's review killed the static version: the registry is written as generators,
+    subscripts and splats, so reading it with an AST evaluator was wrong in both directions --
+    it missed ch04's 0x9C3/0x9C6 (tuple-unpacked constants) and demanded a registration that
+    makes `assert_message_ids_unique` exit, and it over-collected ch05's box counts and let an
+    unclaimed 0x13 through. Import the registry where it is real; never re-derive it.
+    """
+    from inject import hosts
+    literals = hosts.literal_message_ids() if literals is None else literals
+    claims = HOSTED_CHAPTER_MESSAGE_IDS if claims is None else claims
+    for lit in literals:
+        if lit.chapter is None:
+            continue                              # check.py's discovery guard owns this shape
+        if lit.msg_id not in set(claims.get(lit.chapter, ())):
+            holder = ('PROLOGUE_LITERAL_MSGS' if lit.chapter == 'ch00'
+                      else '%s_LITERAL_MSGS' % lit.chapter.upper())
+            sys.exit(
+                'ERROR: build_campaign.py:%d writes message 0x%X as a BARE LITERAL in %s, but '
+                '%s does not claim it in HOSTED_CHAPTER_MESSAGE_IDS -- so the id has no owner, '
+                'assert_message_ids_unique cannot collide on it, and `make chapter CH=%s` '
+                'counts it as free headroom it has already spent. Add 0x%X to %s.'
+                % (lit.lineno, lit.msg_id, lit.chapter, lit.chapter, lit.chapter,
+                   lit.msg_id, holder))
+    return literals
+
+
 def assert_message_id_unclaimed(msg_id, chapter, what):
     """A chapter may DISPLAY a vanilla message id it does not own -- that is the placeholder
     pattern (decisions.md "Vanilla prose is a legitimate PLACEHOLDER"), and ch05's reliquary
@@ -14219,6 +14256,7 @@ def main():
         # hosted chapters claim one message id -- a double-claim is otherwise silent, since
         # verify_text checks runaway text, not who owns a slot.
         assert_message_ids_unique()
+        assert_literals_are_claimed()
         assert_message_blocks_disjoint()   # the setup that would make a collision inevitable
         # And the third of the same family. It ran only from the tests, so `make check` caught
         # it but a plain `make` with an edited block table still produced a ROM -- and the whole

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -77,7 +77,8 @@ from inject.hosts import (  # noqa: E402,F401
     CH01_HOST_INDEX, CH01_EVENT_GROUP, CH02_HOST_INDEX, CH02_EVENT_GROUP,
     CH03_HOST_INDEX, CH03_EVENT_GROUP, CH04_HOST_INDEX, CH04_EVENT_GROUP,
     CH05_HOST_INDEX, CH05_EVENT_GROUP,
-    HostedChapter, hosted_chapters, injector_chapters, undeclared_injectors)
+    HostedChapter, hosted_chapters, injector_chapters, undeclared_injectors,
+    MessageLiteral, literal_message_ids)
 
 PORTRAIT_DIR = os.path.join(DECOMP, 'graphics', 'portrait')
 # Palette index 0 of an FE8 bust is the transparent key, and our authored busts all carry
@@ -10143,6 +10144,12 @@ def injector_message_ids():
     `live_ids_in_declared_blocks` folds `HOSTED_CHAPTER_MESSAGE_IDS` on top for that reason --
     naming this limit is what keeps the guard from resting on a convention nothing enforces.
 
+    A BARE LITERAL at the call site has no constant either, and that hole is now closed from
+    the other side: `literal_message_ids` (inject/hosts.py) reads them out of this module's
+    SOURCE and they are folded in below, so a literal no longer waits on a human to notice it
+    (#346). `check_message_literals_are_registered` is the half that still asks for a NAME --
+    only a named id lands in HOSTED_CHAPTER_MESSAGE_IDS, and only that gives it an owner.
+
     A constant may hold its ids in a dict as readily as a tuple -- `PC_DEATH_QUOTE_MSGS` maps
     unit -> id -- and reading only the tuple shape hid all 13 of its death quotes while its
     NAME followed the convention perfectly.
@@ -10162,6 +10169,18 @@ def injector_message_ids():
         for mid in values:
             if isinstance(mid, int) and 0 < mid < VANILLA_MESSAGE_COUNT:
                 out.setdefault(mid, name)
+    # And the ids with no constant to be found by: a BARE LITERAL at the `set_message_body`
+    # call site (#346). The prologue and ch01 write twelve, and they were visible here only
+    # because someone grepped for them and hand-transcribed them into PROLOGUE_LITERAL_MSGS /
+    # CH01_LITERAL_MSGS -- so for that class the promise above ("registering a new one is
+    # enough") held only for whoever remembered to do the transcribing. `literal_message_ids`
+    # reads them out of this module's own SOURCE, so the next one registers itself the moment
+    # it is written. 0xC25 is why it matters: it sits 0x33 above ch05's pool, and extending
+    # that range upward -- the obvious next move -- would have overwritten a defeat quote.
+    for lit in literal_message_ids():
+        if 0 < lit.msg_id < VANILLA_MESSAGE_COUNT:
+            out.setdefault(lit.msg_id, 'literal in %s (build_campaign.py:%d)'
+                           % (lit.chapter or 'a module-level helper', lit.lineno))
     return out
 
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -1868,6 +1868,163 @@ def check_vanilla_reads_come_from_head(fail, sources=None):
     return fail
 
 
+# The registry a bare literal has to reach to be OWNED. Read out of build_campaign.py's
+# SOURCE rather than imported, for the reason check_vanilla_reads_come_from_head states: the
+# module pulls in portrait_tool -> PIL, the lean `checks` CI job installs neither, and a guard
+# that skips in CI is half a guard.
+MESSAGE_CLAIMS_REGISTRY = 'HOSTED_CHAPTER_MESSAGE_IDS'
+
+
+def _module_int_table(tree):
+    """{name: {int, ...}} for every module-level assignment, as much as a static read can say.
+
+    Ints are collected from the whole value subtree, so a tuple, a nested tuple and a dict all
+    work -- a dict contributes its VALUES only, because `PC_DEATH_QUOTE_MSGS` is keyed by unit
+    id and those are not message ids. Two shapes are deliberately out of reach and both only
+    ever make this set SMALLER: a tuple-unpacking target (`A, B = SLOTS['x'][:2]`, which is how
+    CH04_VILLAGE_MSG is written) and a value built by a call. A missing name can only ever ask
+    for a literal to be registered that already is, which is harmless advice; it can never let
+    an unregistered one through.
+    """
+    table = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if not names:
+            continue
+        subtrees = node.value.values if isinstance(node.value, ast.Dict) else [node.value]
+        ints = {n.value for sub in subtrees for n in ast.walk(sub)
+                if isinstance(n, ast.Constant) and isinstance(n.value, int)
+                and not isinstance(n.value, bool)}
+        for name in names:
+            table.setdefault(name, set()).update(ints)
+    return table
+
+
+def _chapter_message_claims(tree, table):
+    """{chapter: {message id, ...}} as HOSTED_CHAPTER_MESSAGE_IDS declares it, read statically.
+
+    The dict is written as names and splats (`*CH03_OPENING_MSGS`, `*CH05_ENDING_MSGS.values()`),
+    so it is not a literal and `literal_eval` refuses it outright -- the same shape
+    check_vanilla_reads_come_from_head meets in PATCHED_DECOMP_FILES. Every Name in a chapter's
+    subtree is resolved through `table` and every inline int is taken as itself.
+    """
+    claims = {}
+    for node in tree.body:
+        if not (isinstance(node, ast.Assign)
+                and any(getattr(t, 'id', None) == MESSAGE_CLAIMS_REGISTRY
+                        for t in node.targets)):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            continue
+        for key, value in zip(node.value.keys, node.value.values):
+            if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
+                continue
+            ids = set()
+            for sub in ast.walk(value):
+                if isinstance(sub, ast.Name):
+                    ids |= table.get(sub.id, set())
+                elif (isinstance(sub, ast.Constant) and isinstance(sub.value, int)
+                      and not isinstance(sub.value, bool)):
+                    ids.add(sub.value)
+            claims[key.value] = ids
+    return claims
+
+
+def _literal_msgs_tuple(chapter):
+    """The constant a chapter registers its bare literals in. The prologue's is not CH00_."""
+    return ('PROLOGUE_LITERAL_MSGS' if chapter == 'ch00'
+            else '%s_LITERAL_MSGS' % chapter.upper())
+
+
+def check_message_literals_are_registered(fail, source=None):
+    """Guard: a message id written as a BARE LITERAL must still be CLAIMED by its chapter.
+
+    `injector_message_ids` finds ids by the NAME of the constant holding them, and #346's
+    complaint is that a hex id at the `set_message_body` call site has no name to be found by.
+    Twelve exist -- the prologue's eight and ch01's four -- and they reached the guards only
+    because someone grepped for them once and hand-transcribed them into `PROLOGUE_LITERAL_MSGS`
+    / `CH01_LITERAL_MSGS`. `literal_message_ids` now discovers them from source, which closes
+    the DEADNESS half automatically: a block drawn over a bare literal is refused whether or not
+    anyone wrote the id down.
+
+    What discovery cannot do is give the id an OWNER. `HOSTED_CHAPTER_MESSAGE_IDS` is what
+    `assert_message_ids_unique` collides on and what `make chapter CH=chNN` reads for headroom,
+    and a chapter that spends an id it does not claim reads as having room it has already
+    spent. So the transcription still has to happen -- it just stops being something a human
+    has to notice. 0xC25 is the case that pays for this: it sits 0x33 above ch05's pool, so
+    extending that range upward would have silently overwritten Scramsax's defeat quote.
+
+    Reads build_campaign.py's SOURCE and never imports it (no Pillow in the lean `checks`
+    job), through the stdlib-only `inject.hosts` -- the same route check_hosted_chapters_declared
+    takes for the host-slot registry.
+    """
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    try:
+        from inject import hosts
+    except Exception as exc:                      # pragma: no cover - import guard
+        fail.append('check_message_literals_are_registered: inject.hosts does not import: %s'
+                    % exc)
+        return fail
+    finally:
+        sys.path.remove(os.path.join(REPO, 'tools'))
+
+    live = source is None
+    if live:
+        with open(os.path.join(REPO, 'tools', 'build_campaign.py'), encoding='utf-8') as fh:
+            source = fh.read()
+    try:
+        literals = hosts.literal_message_ids(source=source)
+        tree = ast.parse(source, 'build_campaign.py')
+    except (ValueError, SyntaxError) as exc:
+        fail.append('check_message_literals_are_registered: cannot scan build_campaign.py: %s'
+                    % exc)
+        return fail
+
+    # A scan that finds nothing and a tree with nothing to find look identical from outside --
+    # the shape decisions.md 2026-09-02 names. There are twelve on main; zero means the scan
+    # broke, not that the campaign stopped writing literals.
+    if live and not literals:
+        fail.append('check_message_literals_are_registered: found NO bare message-id literal '
+                    'in build_campaign.py. There are twelve, so the scan is broken and the '
+                    'guard would pass vacuously.')
+        return fail
+
+    table = _module_int_table(tree)
+    claims = _chapter_message_claims(tree, table)
+    if live and not claims:
+        fail.append('check_message_literals_are_registered: could not read %s out of '
+                    'build_campaign.py -- the guard has nothing to check against.'
+                    % MESSAGE_CLAIMS_REGISTRY)
+        return fail
+    named = set()
+    for name, ids in table.items():
+        if re.search(r'_MSGS?$', name):
+            named |= ids
+
+    for lit in literals:
+        if lit.chapter is None:
+            # No injector encloses it, so nothing can say whose id it is. A name is then the
+            # only handle it has.
+            if lit.msg_id not in named:
+                fail.append(
+                    'build_campaign.py:%d writes message 0x%X as a BARE LITERAL outside every '
+                    'injector, and no `*_MSG`/`*_MSGS` constant holds it -- so no guard, no '
+                    'deadness check and no headroom read can see it. Hold the id in a named '
+                    'constant.' % (lit.lineno, lit.msg_id))
+            continue
+        if lit.msg_id not in claims.get(lit.chapter, set()):
+            fail.append(
+                'build_campaign.py:%d writes message 0x%X as a BARE LITERAL in %s, but %s does '
+                'not claim it in %s -- so the id has no owner, `assert_message_ids_unique` '
+                'cannot collide on it and `make chapter CH=%s` counts it as free headroom it '
+                'has already spent. Add 0x%X to %s.'
+                % (lit.lineno, lit.msg_id, lit.chapter, lit.chapter, MESSAGE_CLAIMS_REGISTRY,
+                   lit.chapter, lit.msg_id, _literal_msgs_tuple(lit.chapter)))
+    return fail
+
+
 def check_handoff_only_on_main(fail):
     """HANDOFF.md is live state and live state is global -- author it on main, never on a
     feature branch. See the block comment above for the incident this encodes."""
@@ -1968,6 +2125,7 @@ def main():
                   check_recordenemy_knows_every_raw_pid,
                   check_wrap_widths_are_pixels,
                   check_vanilla_reads_come_from_head,
+                  check_message_literals_are_registered,
                   check_handoff_only_on_main,
                   check_lane_ownership):
         check(fail)

--- a/tools/check.py
+++ b/tools/check.py
@@ -1868,101 +1868,37 @@ def check_vanilla_reads_come_from_head(fail, sources=None):
     return fail
 
 
-# The registry a bare literal has to reach to be OWNED. Read out of build_campaign.py's
-# SOURCE rather than imported, for the reason check_vanilla_reads_come_from_head states: the
-# module pulls in portrait_tool -> PIL, the lean `checks` CI job installs neither, and a guard
-# that skips in CI is half a guard.
-MESSAGE_CLAIMS_REGISTRY = 'HOSTED_CHAPTER_MESSAGE_IDS'
-
-
-def _module_int_table(tree):
-    """{name: {int, ...}} for every module-level assignment, as much as a static read can say.
-
-    Ints are collected from the whole value subtree, so a tuple, a nested tuple and a dict all
-    work -- a dict contributes its VALUES only, because `PC_DEATH_QUOTE_MSGS` is keyed by unit
-    id and those are not message ids. Two shapes are deliberately out of reach and both only
-    ever make this set SMALLER: a tuple-unpacking target (`A, B = SLOTS['x'][:2]`, which is how
-    CH04_VILLAGE_MSG is written) and a value built by a call. A missing name can only ever ask
-    for a literal to be registered that already is, which is harmless advice; it can never let
-    an unregistered one through.
-    """
-    table = {}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign):
-            continue
-        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
-        if not names:
-            continue
-        subtrees = node.value.values if isinstance(node.value, ast.Dict) else [node.value]
-        ints = {n.value for sub in subtrees for n in ast.walk(sub)
-                if isinstance(n, ast.Constant) and isinstance(n.value, int)
-                and not isinstance(n.value, bool)}
-        for name in names:
-            table.setdefault(name, set()).update(ints)
-    return table
-
-
-def _chapter_message_claims(tree, table):
-    """{chapter: {message id, ...}} as HOSTED_CHAPTER_MESSAGE_IDS declares it, read statically.
-
-    The dict is written as names and splats (`*CH03_OPENING_MSGS`, `*CH05_ENDING_MSGS.values()`),
-    so it is not a literal and `literal_eval` refuses it outright -- the same shape
-    check_vanilla_reads_come_from_head meets in PATCHED_DECOMP_FILES. Every Name in a chapter's
-    subtree is resolved through `table` and every inline int is taken as itself.
-    """
-    claims = {}
-    for node in tree.body:
-        if not (isinstance(node, ast.Assign)
-                and any(getattr(t, 'id', None) == MESSAGE_CLAIMS_REGISTRY
-                        for t in node.targets)):
-            continue
-        if not isinstance(node.value, ast.Dict):
-            continue
-        for key, value in zip(node.value.keys, node.value.values):
-            if not (isinstance(key, ast.Constant) and isinstance(key.value, str)):
-                continue
-            ids = set()
-            for sub in ast.walk(value):
-                if isinstance(sub, ast.Name):
-                    ids |= table.get(sub.id, set())
-                elif (isinstance(sub, ast.Constant) and isinstance(sub.value, int)
-                      and not isinstance(sub.value, bool)):
-                    ids.add(sub.value)
-            claims[key.value] = ids
-    return claims
-
-
-def _literal_msgs_tuple(chapter):
-    """The constant a chapter registers its bare literals in. The prologue's is not CH00_."""
-    return ('PROLOGUE_LITERAL_MSGS' if chapter == 'ch00'
-            else '%s_LITERAL_MSGS' % chapter.upper())
-
-
 def check_message_literals_are_registered(fail, source=None):
-    """Guard: a message id written as a BARE LITERAL must still be CLAIMED by its chapter.
+    """Guard: every bare-literal message id must be DISCOVERABLE and ATTRIBUTABLE.
 
-    `injector_message_ids` finds ids by the NAME of the constant holding them, and #346's
+    `injector_message_ids` finds an id by the NAME of the constant holding it, and #346's
     complaint is that a hex id at the `set_message_body` call site has no name to be found by.
     Twelve exist -- the prologue's eight and ch01's four -- and they reached the guards only
     because someone grepped for them once and hand-transcribed them into `PROLOGUE_LITERAL_MSGS`
-    / `CH01_LITERAL_MSGS`. `literal_message_ids` now discovers them from source, which closes
-    the DEADNESS half automatically: a block drawn over a bare literal is refused whether or not
-    anyone wrote the id down.
+    / `CH01_LITERAL_MSGS`. `hosts.literal_message_ids` now discovers them from source, which
+    closes the DEADNESS half automatically: a block drawn over a bare literal is refused whether
+    or not anyone wrote the id down.
 
-    What discovery cannot do is give the id an OWNER. `HOSTED_CHAPTER_MESSAGE_IDS` is what
-    `assert_message_ids_unique` collides on and what `make chapter CH=chNN` reads for headroom,
-    and a chapter that spends an id it does not claim reads as having room it has already
-    spent. So the transcription still has to happen -- it just stops being something a human
-    has to notice. 0xC25 is the case that pays for this: it sits 0x33 above ch05's pool, so
-    extending that range upward would have silently overwritten Scramsax's defeat quote.
+    This check owns the DISCOVERY half only -- that the scan runs, finds what is there, and can
+    name an owner for each hit. **OWNERSHIP is asserted at BUILD time**, by
+    `build_campaign.assert_literals_are_claimed`, and deliberately not here. It was tried here
+    first and the review of #356 killed it: `HOSTED_CHAPTER_MESSAGE_IDS` is written as
+    generators, subscripts and splats (`*(msg for (_slot, msg, _boxes, _what) in
+    CH05_OPENING_SLOTS)`, `CH05_ARRIVAL_SLOT[1]`, `CH04_VILLAGE_MSG` from a tuple-unpacked
+    assignment), so a hand-rolled static evaluator of it was wrong in BOTH directions --
+    it missed ch04's 0x9C3/0x9C6 and so would have demanded a registration that makes
+    `assert_message_ids_unique` exit, and it over-collected ch05's box counts and so passed a
+    literal 0x13 that nothing claimed. At build time the dict is a real Python object and the
+    answer is exact. **Do not re-implement the registry statically; import it where it is real.**
 
-    Reads build_campaign.py's SOURCE and never imports it (no Pillow in the lean `checks`
-    job), through the stdlib-only `inject.hosts` -- the same route check_hosted_chapters_declared
+    Reads build_campaign.py's SOURCE and never imports it (no Pillow in the lean `checks` job),
+    through the stdlib-only `inject.hosts` -- the same route check_hosted_chapters_declared
     takes for the host-slot registry.
     """
     sys.path.insert(0, os.path.join(REPO, 'tools'))
     try:
         from inject import hosts
+        import callsites
     except Exception as exc:                      # pragma: no cover - import guard
         fail.append('check_message_literals_are_registered: inject.hosts does not import: %s'
                     % exc)
@@ -1976,52 +1912,29 @@ def check_message_literals_are_registered(fail, source=None):
             source = fh.read()
     try:
         literals = hosts.literal_message_ids(source=source)
-        tree = ast.parse(source, 'build_campaign.py')
-    except (ValueError, SyntaxError) as exc:
+    except (ValueError, SyntaxError, callsites.ParseError) as exc:
         fail.append('check_message_literals_are_registered: cannot scan build_campaign.py: %s'
                     % exc)
         return fail
 
     # A scan that finds nothing and a tree with nothing to find look identical from outside --
-    # the shape decisions.md 2026-09-02 names. There are twelve on main; zero means the scan
-    # broke, not that the campaign stopped writing literals.
+    # the shape decisions.md 2026-09-02 names. There are bare literals on main today; zero means
+    # the scan broke, not that the campaign stopped writing them.
     if live and not literals:
         fail.append('check_message_literals_are_registered: found NO bare message-id literal '
-                    'in build_campaign.py. There are twelve, so the scan is broken and the '
+                    'in build_campaign.py. There are some, so the scan is broken and the '
                     'guard would pass vacuously.')
         return fail
 
-    table = _module_int_table(tree)
-    claims = _chapter_message_claims(tree, table)
-    if live and not claims:
-        fail.append('check_message_literals_are_registered: could not read %s out of '
-                    'build_campaign.py -- the guard has nothing to check against.'
-                    % MESSAGE_CLAIMS_REGISTRY)
-        return fail
-    named = set()
-    for name, ids in table.items():
-        if re.search(r'_MSGS?$', name):
-            named |= ids
-
     for lit in literals:
         if lit.chapter is None:
-            # No injector encloses it, so nothing can say whose id it is. A name is then the
-            # only handle it has.
-            if lit.msg_id not in named:
-                fail.append(
-                    'build_campaign.py:%d writes message 0x%X as a BARE LITERAL outside every '
-                    'injector, and no `*_MSG`/`*_MSGS` constant holds it -- so no guard, no '
-                    'deadness check and no headroom read can see it. Hold the id in a named '
-                    'constant.' % (lit.lineno, lit.msg_id))
-            continue
-        if lit.msg_id not in claims.get(lit.chapter, set()):
+            # No injector encloses it, so nothing can say whose id it is -- and the build-time
+            # ownership assertion has no chapter to check it against either.
             fail.append(
-                'build_campaign.py:%d writes message 0x%X as a BARE LITERAL in %s, but %s does '
-                'not claim it in %s -- so the id has no owner, `assert_message_ids_unique` '
-                'cannot collide on it and `make chapter CH=%s` counts it as free headroom it '
-                'has already spent. Add 0x%X to %s.'
-                % (lit.lineno, lit.msg_id, lit.chapter, lit.chapter, MESSAGE_CLAIMS_REGISTRY,
-                   lit.chapter, lit.msg_id, _literal_msgs_tuple(lit.chapter)))
+                'build_campaign.py:%d writes message 0x%X as a BARE LITERAL outside every '
+                'injector, so no chapter can claim it and `assert_literals_are_claimed` cannot '
+                'see it. Move it inside its injector, or hold the id in a named constant.'
+                % (lit.lineno, lit.msg_id))
     return fail
 
 

--- a/tools/inject/hosts.py
+++ b/tools/inject/hosts.py
@@ -16,6 +16,7 @@ import ast
 import collections
 import os
 import re
+import sys
 
 _TOOLS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BUILD_CAMPAIGN_PY = os.path.join(_TOOLS, 'build_campaign.py')
@@ -142,3 +143,99 @@ def undeclared_injectors(path=BUILD_CAMPAIGN_PY, source=None, scope=None):
     """
     enrolled = {c.name for c in hosted_chapters(scope)}
     return [name for name in injector_chapters(path, source) if name not in enrolled]
+
+
+# --- bare-literal message ids (#346) ----------------------------------------------------
+
+MessageLiteral = collections.namedtuple('MessageLiteral', 'msg_id chapter lineno')
+
+# The one function that WRITES a message body. Every id the build spends passes through it.
+MESSAGE_WRITER = 'set_message_body'
+
+_literal_cache = {}
+
+
+def _callsites():
+    """`tools/callsites.py`, imported off _TOOLS rather than off whoever set sys.path.
+
+    Stdlib-only, like everything else here -- it imports ast and dataclasses and nothing
+    else -- so this keeps the promise the module docstring makes: the lean `checks` CI job
+    can read this file without Pillow.
+    """
+    if _TOOLS not in sys.path:
+        sys.path.insert(0, _TOOLS)
+    import callsites
+    return callsites
+
+
+def literal_message_ids(path=BUILD_CAMPAIGN_PY, source=None):
+    """Message ids written as a BARE LITERAL at a `set_message_body` call site, from SOURCE.
+
+    `build_campaign.injector_message_ids` finds an id by the NAME of the constant holding
+    it, so an id passed as hex AT the call site has no name to be found by. The prologue and
+    ch01 write twelve of them, and they are visible to the guards today only because someone
+    grepped for them once and hand-transcribed them into `PROLOGUE_LITERAL_MSGS` /
+    `CH01_LITERAL_MSGS`. That makes the promise in that docstring -- "registering a new one
+    is enough, there is no second list to remember" -- false for exactly this class: the next
+    bare literal is invisible until a human notices it (#346). This is the mechanism.
+
+    Read through `callsites`, not a regex: `msg_id` is passed POSITIONALLY at all 71 call
+    sites, so `grep msg_id=` finds none of them, and binding "the second argument" by hand is
+    the assumption `callsites` exists to remove. Same reason `check_wrap_widths_are_pixels`
+    reads bindings rather than text.
+
+    Each literal is attributed to the injector that WRITES it -- `inject_prologue` is ch00,
+    `inject_chNN` is chNN, which are HOSTED_CHAPTER_MESSAGE_IDS' own keys -- so a literal
+    carries an OWNER and not just a value. A literal outside every injector reports
+    `chapter=None`; it is still an id the build spends, but nothing can say whose it is.
+
+    Raises ValueError when `source` does not define the writer. An unresolvable signature
+    switches positional binding off in `callsites.scan`, which would leave this returning ()
+    for a file full of literals -- a scan that quietly stops scanning, which is the failure
+    #341 shipped and decisions.md 2026-09-02 names.
+    """
+    if source is None and path in _literal_cache:
+        return _literal_cache[path]
+    cache_key = None
+    if source is None:
+        with open(path, encoding='utf-8') as f:
+            source = f.read()
+        cache_key = path
+
+    callsites = _callsites()
+    params = callsites.signature(source, MESSAGE_WRITER, path)
+    if 'msg_id' not in params:
+        raise ValueError(
+            '%s does not define %s(.., msg_id, ..), so its call sites cannot be bound and '
+            'every bare literal in it would read as absent' % (path, MESSAGE_WRITER))
+
+    tree = ast.parse(source, path)
+    # Injectors never nest, so a line span is enough to say which one owns a call. A call in
+    # a module-level helper falls outside all of them and reports no chapter, which is the
+    # truth: the helper is called with an id, it does not choose one.
+    spans = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        match = _INJECTOR_RE.match(node.name)
+        if match:
+            spans.append((node.lineno, node.end_lineno or node.lineno,
+                          'ch00' if match.group(2) is None else match.group(1)))
+
+    found = []
+    for site in callsites.scan(source, MESSAGE_WRITER, path, params=params):
+        if site.kind != 'call':
+            continue
+        try:
+            value = int(site.bound.get('msg_id'), 0)
+        except (TypeError, ValueError):
+            continue          # a named constant or an expression: discovery by NAME owns it
+        chapter = next((c for lo, hi, c in spans if lo <= site.lineno <= hi), None)
+        found.append(MessageLiteral(value, chapter, site.lineno))
+    found = tuple(sorted(found, key=lambda lit: lit.lineno))
+    if cache_key is not None:
+        # ast.parse of a 14k-line module costs ~60ms; injector_message_ids is called from the
+        # build AND from a dozen tests. Keyed by path and skipped for a caller-supplied
+        # source, which is never the file on disk.
+        _literal_cache[cache_key] = found
+    return found

--- a/tools/test_check_message_literals.py
+++ b/tools/test_check_message_literals.py
@@ -127,12 +127,15 @@ class LiteralMessageIdScan(unittest.TestCase):
             hosts.literal_message_ids(source='def inject_ch07(c):\n    '
                                              'set_message_body(lines, 0xBF4, body)\n')
 
-    def test_the_live_tree_has_exactly_the_twelve_the_issue_names(self):
+    def test_the_live_tree_s_literals_are_all_attributed(self):
+        """Count-free on purpose: a hardcoded 12 fails the moment someone adds a THIRTEENTH
+        and registers it correctly, which is the behaviour this guard exists to permit."""
         found = hosts.literal_message_ids()
-        self.assertEqual(12, len(found), found)
-        self.assertEqual({'ch00': 8, 'ch01': 4},
-                         {c: len([l for l in found if l.chapter == c]) for c in ('ch00', 'ch01')})
-        self.assertIn(0xC25, [lit.msg_id for lit in found])
+        self.assertTrue(found, 'the live tree writes bare literals; finding none means a broken scan')
+        self.assertTrue(all(lit.chapter for lit in found),
+                        [l for l in found if not l.chapter])
+        self.assertIn(0xC25, [lit.msg_id for lit in found],
+                      "0xC25 is the id whose invisibility motivated #346")
 
     def test_injector_message_ids_folds_the_literals_in(self):
         """The deadness half. With this, a block drawn over 0xC25 is refused whether or not
@@ -148,38 +151,22 @@ class LiteralMessageIdScan(unittest.TestCase):
                         'a block over the prologue\'s 0xC25 literal must be refused')
 
 
-class MessageLiteralsAreRegistered(unittest.TestCase):
-    """The ownership half: discovery finds the id, but only the registry can OWN it."""
+class MessageLiteralDiscoveryGuard(unittest.TestCase):
+    """check.py owns DISCOVERY: the scan runs, and every hit can name an owner."""
 
     def _fail(self, source):
         fail = []
         check.check_message_literals_are_registered(fail, source=source)
         return fail
 
-    def test_a_registered_literal_passes(self):
-        self.assertEqual([], self._fail(REGISTERED))
-
-    def test_an_unregistered_bare_literal_is_caught(self):
-        bad = self._fail(UNREGISTERED)
-        self.assertEqual(1, len(bad), bad)
-        self.assertIn('0xBF4', bad[0])
-        self.assertIn('ch07', bad[0])
-
-    def test_the_complaint_names_the_tuple_to_add_it_to(self):
-        self.assertIn('CH07_LITERAL_MSGS', self._fail(UNREGISTERED)[0])
-
-    def test_the_prologue_complaint_names_PROLOGUE_LITERAL_MSGS(self):
-        """ch00's tuple is not CH00_-shaped, and a guard that told the author to create
-        CH00_LITERAL_MSGS would be inventing a second registry beside the one that works."""
-        bad = self._fail(PROLOGUE)
-        self.assertEqual(1, len(bad), bad)
-        self.assertIn('0xC25', bad[0])
-        self.assertIn('PROLOGUE_LITERAL_MSGS', bad[0])
+    def test_a_literal_inside_an_injector_is_not_this_guard_s_business(self):
+        """Ownership moved to build time (#356 review). Here, an attributed literal is fine."""
+        self.assertEqual([], self._fail(UNREGISTERED))
 
     def test_a_named_id_is_none_of_this_guards_business(self):
         self.assertEqual([], self._fail(NAMED_ONLY))
 
-    def test_a_literal_with_no_injector_must_at_least_have_a_NAME(self):
+    def test_a_literal_with_no_injector_is_caught(self):
         bad = self._fail(HOMELESS)
         self.assertEqual(1, len(bad), bad)
         self.assertIn('outside every injector', bad[0])
@@ -197,6 +184,14 @@ class MessageLiteralsAreRegistered(unittest.TestCase):
         self.assertTrue(fail)
         self.assertIn('vacuously', fail[0])
 
+    def test_a_malformed_source_is_REPORTED_not_raised(self):
+        """callsites.signature turns SyntaxError into callsites.ParseError, which is not a
+        SyntaxError -- so an `except (ValueError, SyntaxError)` let it escape and killed the
+        whole drift gate with a traceback, skipping every check after it (#356 review)."""
+        fail = self._fail('def inject_ch07(c):\n    set_message_body(lines, 0x1,\n')
+        self.assertEqual(1, len(fail), fail)
+        self.assertIn('cannot scan', fail[0])
+
     def test_the_check_is_registered_in_the_drift_gate(self):
         """Defined-but-unregistered is how check_tile_changes_outlive_the_retarget shipped:
         it ran only via the test subprocess, which check_tests_pass skips whenever
@@ -206,20 +201,60 @@ class MessageLiteralsAreRegistered(unittest.TestCase):
         self.assertIn('check_message_literals_are_registered',
                       inspect.getsource(check.main))
 
-    def test_the_static_registry_read_is_not_empty(self):
-        """The claims dict is names and splats, so `literal_eval` refuses it outright. If the
-        static read came back empty the guard would police nothing and say so."""
-        import ast
-        with open(os.path.join(check.REPO, 'tools', 'build_campaign.py'), encoding='utf-8') as fh:
-            tree = ast.parse(fh.read(), 'build_campaign.py')
-        claims = check._chapter_message_claims(tree, check._module_int_table(tree))
-        self.assertIn('ch00', claims)
-        self.assertIn(0xC25, claims['ch00'])
-
     def test_the_live_tree_is_clean(self):
         fail = []
         check.check_message_literals_are_registered(fail)
         self.assertEqual([], fail)
+
+
+class LiteralOwnershipAtBuildTime(unittest.TestCase):
+    """build_campaign owns OWNERSHIP, because there the registry is a real dict.
+
+    The static version died in #356's review: HOSTED_CHAPTER_MESSAGE_IDS is written as
+    generators, subscripts and tuple-unpacked constants, so an AST evaluator of it was wrong
+    in both directions -- it missed ch04's 0x9C3/0x9C6 and demanded a registration that makes
+    assert_message_ids_unique exit, and it over-collected ch05's box counts and passed an
+    unclaimed 0x13.
+    """
+
+    def setUp(self):
+        try:
+            import build_campaign as bc
+        except ImportError as exc:                # pragma: no cover - lean environment
+            self.skipTest('build_campaign does not import here: %s' % exc)
+        self.bc = bc
+        self.lit = hosts.MessageLiteral
+
+    def test_a_claimed_literal_passes(self):
+        self.bc.assert_literals_are_claimed(
+            literals=[self.lit(0xBF4, 'ch07', 10)], claims={'ch07': (0xBF4,)})
+
+    def test_an_unclaimed_literal_exits_the_BUILD(self):
+        with self.assertRaises(SystemExit) as caught:
+            self.bc.assert_literals_are_claimed(
+                literals=[self.lit(0xBF4, 'ch07', 10)], claims={'ch07': (0x1,)})
+        self.assertIn('0xBF4', str(caught.exception))
+        self.assertIn('CH07_LITERAL_MSGS', str(caught.exception))
+
+    def test_the_prologue_complaint_names_PROLOGUE_LITERAL_MSGS(self):
+        """ch00's tuple is not CH00_-shaped, and telling the author to create CH00_LITERAL_MSGS
+        would invent a second registry beside the one that works."""
+        with self.assertRaises(SystemExit) as caught:
+            self.bc.assert_literals_are_claimed(
+                literals=[self.lit(0xC25, 'ch00', 10)], claims={'ch00': ()})
+        self.assertIn('PROLOGUE_LITERAL_MSGS', str(caught.exception))
+
+    def test_an_unattributed_literal_is_left_to_the_discovery_guard(self):
+        self.bc.assert_literals_are_claimed(
+            literals=[self.lit(0xBF4, None, 10)], claims={})
+
+    def test_the_LIVE_tree_passes_against_the_REAL_registry(self):
+        """The whole point of moving here: ch04's tuple-unpacked claims resolve exactly."""
+        self.bc.assert_literals_are_claimed()
+
+    def test_it_runs_in_the_build(self):
+        import inspect
+        self.assertIn('assert_literals_are_claimed', inspect.getsource(self.bc.main))
 
 
 if __name__ == '__main__':

--- a/tools/test_check_message_literals.py
+++ b/tools/test_check_message_literals.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Tests for bare-literal message-id discovery (#346).
+
+The hole: `build_campaign.injector_message_ids` finds a message id by the NAME of the
+constant holding it, so an id written as hex AT the `set_message_body` call site has no
+name to be found by. Twelve exist on main -- the prologue's eight and ch01's four -- and
+they reached the deadness guard only because someone grepped for them once and
+hand-transcribed them into `PROLOGUE_LITERAL_MSGS` / `CH01_LITERAL_MSGS`. So the promise
+in that docstring ("registering a new one is enough -- there is no second list to
+remember") was false for exactly this class: the next bare literal was invisible until a
+human noticed it.
+
+`0xC25` is why it matters. It sits `0x33` above ch05's `0xBC5-0xBF2` pool, so extending
+that range upward -- the obvious next move -- would have been accepted by every guard and
+would have overwritten Scramsax's defeat quote.
+
+Two halves, tested here:
+  * `inject.hosts.literal_message_ids` DISCOVERS them from source, attributed to the
+    injector that writes them, and `injector_message_ids` folds them in -- so deadness is
+    checked with no human step at all.
+  * `check.check_message_literals_are_registered` still requires the id to be CLAIMED in
+    `HOSTED_CHAPTER_MESSAGE_IDS`, because discovery cannot invent an OWNER and ownership is
+    what `assert_message_ids_unique` and `make chapter` headroom read.
+
+Run: python3 tools/test_check_message_literals.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check
+from inject import hosts
+
+
+# A miniature build_campaign.py: the writer's definition (without it `callsites` cannot bind
+# a POSITIONAL msg_id, which is how all 71 real call sites pass it), one chapter's literal
+# tuple, and the claims registry that gives the id an owner.
+WRITER = """
+def set_message_body(lines, msg_id, body, create=False):
+    pass
+"""
+
+REGISTERED = WRITER + """
+CH07_LITERAL_MSGS = (0xBF3, 0xBF4)
+HOSTED_CHAPTER_MESSAGE_IDS = {
+    'ch07': (*CH07_LITERAL_MSGS,),
+}
+
+def inject_ch07(campaign):
+    set_message_body(lines, 0xBF3, body)
+    set_message_body(lines, msg_id=0xBF4, body=body)
+"""
+
+UNREGISTERED = WRITER + """
+CH07_LITERAL_MSGS = (0xBF3,)
+HOSTED_CHAPTER_MESSAGE_IDS = {
+    'ch07': (*CH07_LITERAL_MSGS,),
+}
+
+def inject_ch07(campaign):
+    set_message_body(lines, 0xBF3, body)
+    set_message_body(lines, 0xBF4, body)
+"""
+
+NAMED_ONLY = WRITER + """
+CH07_TAUNT_MSG = 0xBF3
+HOSTED_CHAPTER_MESSAGE_IDS = {
+    'ch07': (CH07_TAUNT_MSG,),
+}
+
+def inject_ch07(campaign):
+    set_message_body(lines, CH07_TAUNT_MSG, body)
+"""
+
+PROLOGUE = WRITER + """
+PROLOGUE_LITERAL_MSGS = (0x664,)
+HOSTED_CHAPTER_MESSAGE_IDS = {
+    'ch00': PROLOGUE_LITERAL_MSGS,
+}
+
+def inject_prologue(campaign):
+    set_message_body(lines, 0x664, body)
+    set_message_body(lines, 0xC25, body)
+"""
+
+HOMELESS = WRITER + """
+HOSTED_CHAPTER_MESSAGE_IDS = {'ch07': ()}
+
+def _some_helper(lines):
+    set_message_body(lines, 0xBF4, body)
+"""
+
+
+class LiteralMessageIdScan(unittest.TestCase):
+    """The discovery half: a bare literal registers ITSELF, with the chapter that writes it."""
+
+    def test_a_bare_literal_is_found_and_attributed(self):
+        found = hosts.literal_message_ids(source=REGISTERED)
+        self.assertEqual([(0xBF3, 'ch07'), (0xBF4, 'ch07')],
+                         [(lit.msg_id, lit.chapter) for lit in found])
+
+    def test_a_positional_id_is_bound_by_SIGNATURE_not_by_position_guessing(self):
+        """Every real call site passes msg_id POSITIONALLY, so `grep msg_id=` finds none of
+        them. `callsites` binds the argument against the definition instead."""
+        found = hosts.literal_message_ids(source=REGISTERED)
+        self.assertIn(0xBF3, [lit.msg_id for lit in found])
+
+    def test_a_NAMED_id_is_not_a_literal(self):
+        self.assertEqual((), hosts.literal_message_ids(source=NAMED_ONLY))
+
+    def test_the_prologue_is_ch00(self):
+        """HOSTED_CHAPTER_MESSAGE_IDS keys the prologue 'ch00' while its injector and its
+        constants say PROLOGUE, so the attribution has to translate or nothing lines up."""
+        self.assertEqual({'ch00'},
+                         {lit.chapter for lit in hosts.literal_message_ids(source=PROLOGUE)})
+
+    def test_a_literal_outside_every_injector_has_no_chapter(self):
+        found = hosts.literal_message_ids(source=HOMELESS)
+        self.assertEqual([None], [lit.chapter for lit in found])
+
+    def test_a_source_that_does_not_define_the_writer_fails_LOUDLY(self):
+        """An unresolvable signature switches positional binding OFF in `callsites.scan`, so
+        this would return () for a file full of literals -- a scan that quietly stops
+        scanning, which is the failure decisions.md 2026-09-02 names."""
+        with self.assertRaises(ValueError):
+            hosts.literal_message_ids(source='def inject_ch07(c):\n    '
+                                             'set_message_body(lines, 0xBF4, body)\n')
+
+    def test_the_live_tree_has_exactly_the_twelve_the_issue_names(self):
+        found = hosts.literal_message_ids()
+        self.assertEqual(12, len(found), found)
+        self.assertEqual({'ch00': 8, 'ch01': 4},
+                         {c: len([l for l in found if l.chapter == c]) for c in ('ch00', 'ch01')})
+        self.assertIn(0xC25, [lit.msg_id for lit in found])
+
+    def test_injector_message_ids_folds_the_literals_in(self):
+        """The deadness half. With this, a block drawn over 0xC25 is refused whether or not
+        anybody wrote the id down -- which is the whole ask of #346."""
+        try:
+            import build_campaign as bc
+        except ImportError as exc:                # pragma: no cover - lean environment
+            self.skipTest('build_campaign does not import here: %s' % exc)
+        spent = bc.injector_message_ids()
+        for lit in hosts.literal_message_ids():
+            self.assertIn(lit.msg_id, spent, hex(lit.msg_id))
+        self.assertTrue(bc.live_ids_in_declared_blocks(blocks={'zz': ((0xC25, 0xC25),)}),
+                        'a block over the prologue\'s 0xC25 literal must be refused')
+
+
+class MessageLiteralsAreRegistered(unittest.TestCase):
+    """The ownership half: discovery finds the id, but only the registry can OWN it."""
+
+    def _fail(self, source):
+        fail = []
+        check.check_message_literals_are_registered(fail, source=source)
+        return fail
+
+    def test_a_registered_literal_passes(self):
+        self.assertEqual([], self._fail(REGISTERED))
+
+    def test_an_unregistered_bare_literal_is_caught(self):
+        bad = self._fail(UNREGISTERED)
+        self.assertEqual(1, len(bad), bad)
+        self.assertIn('0xBF4', bad[0])
+        self.assertIn('ch07', bad[0])
+
+    def test_the_complaint_names_the_tuple_to_add_it_to(self):
+        self.assertIn('CH07_LITERAL_MSGS', self._fail(UNREGISTERED)[0])
+
+    def test_the_prologue_complaint_names_PROLOGUE_LITERAL_MSGS(self):
+        """ch00's tuple is not CH00_-shaped, and a guard that told the author to create
+        CH00_LITERAL_MSGS would be inventing a second registry beside the one that works."""
+        bad = self._fail(PROLOGUE)
+        self.assertEqual(1, len(bad), bad)
+        self.assertIn('0xC25', bad[0])
+        self.assertIn('PROLOGUE_LITERAL_MSGS', bad[0])
+
+    def test_a_named_id_is_none_of_this_guards_business(self):
+        self.assertEqual([], self._fail(NAMED_ONLY))
+
+    def test_a_literal_with_no_injector_must_at_least_have_a_NAME(self):
+        bad = self._fail(HOMELESS)
+        self.assertEqual(1, len(bad), bad)
+        self.assertIn('outside every injector', bad[0])
+
+    def test_a_broken_scan_fails_instead_of_passing_vacuously(self):
+        """The live scan finding zero literals means the scan broke, not that the campaign
+        stopped writing them -- and silence is what both look like from outside."""
+        real = hosts.literal_message_ids
+        hosts.literal_message_ids = lambda *a, **kw: ()
+        try:
+            fail = []
+            check.check_message_literals_are_registered(fail)
+        finally:
+            hosts.literal_message_ids = real
+        self.assertTrue(fail)
+        self.assertIn('vacuously', fail[0])
+
+    def test_the_check_is_registered_in_the_drift_gate(self):
+        """Defined-but-unregistered is how check_tile_changes_outlive_the_retarget shipped:
+        it ran only via the test subprocess, which check_tests_pass skips whenever
+        fireemblem8u/src is absent -- exactly the lightweight CI job it was meant to protect
+        (decisions.md 2026-09-02)."""
+        import inspect
+        self.assertIn('check_message_literals_are_registered',
+                      inspect.getsource(check.main))
+
+    def test_the_static_registry_read_is_not_empty(self):
+        """The claims dict is names and splats, so `literal_eval` refuses it outright. If the
+        static read came back empty the guard would police nothing and say so."""
+        import ast
+        with open(os.path.join(check.REPO, 'tools', 'build_campaign.py'), encoding='utf-8') as fh:
+            tree = ast.parse(fh.read(), 'build_campaign.py')
+        claims = check._chapter_message_claims(tree, check._module_int_table(tree))
+        self.assertIn('ch00', claims)
+        self.assertIn(0xC25, claims['ch00'])
+
+    def test_the_live_tree_is_clean(self):
+        fail = []
+        check.check_message_literals_are_registered(fail)
+        self.assertEqual([], fail)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #346.

## The problem

`injector_message_ids` finds a message id by the **name of the constant** holding it, and its
comment promised that "registering a new one is enough — there is no second list to remember".
That was false for an id passed as hex at the `set_message_body` call site. Twelve such bare
literals exist on `main` (8 prologue + 4 ch01) and they reached the deadness guard only because
somebody grepped for them once and hand-transcribed them into `PROLOGUE_LITERAL_MSGS` /
`CH01_LITERAL_MSGS`. The thirteenth would have been invisible.

**`0xC25` is the sharp case.** It sits `0x33` above ch05's `0xBC5-0xBF2` pool, so extending that
range upward — the obvious next move when ch05 runs out of ids, and `make chapter CH=ch05` already
reports that block as FULL — would have been accepted by every guard in the repo and would have
overwritten Scramsax's defeat quote.

## The fix — two halves, because #346 is two problems

**Discovery.** `inject.hosts.literal_message_ids` AST-scans `build_campaign.py`'s own source
through `tools/callsites.py` for `set_message_body` call sites with an integer-literal `msg_id`,
and attributes each to the injector that writes it (`inject_prologue` → ch00, `inject_chNN` →
chNN). It reads argument **bindings**, not text: `msg_id` is positional at all 71 call sites, so
`grep msg_id=` finds exactly none of them. `injector_message_ids` folds the result in, so the
build-time gate and `make chapter` headroom see a bare literal with **no human step at all**.

**Ownership.** Discovery cannot invent an owner, and ownership is what `assert_message_ids_unique`
collides on and what `make chapter` reads for headroom — an id spent but unclaimed reads as free
room that has already been spent. `check_message_literals_are_registered` still requires the claim
and names the tuple to add it to.

Split cleanly: **discovery makes the id safe, registration makes it accountable.**

## Anti-#341 measures

Per the 2026-09-02 ADR *"A guard that stops guarding fails silently, and green is what that looks
like"*:

- registered in `check.py`'s `main()` tuple, **pinned by a test** that reads
  `inspect.getsource(check.main)` — a check that is defined and unit-tested is still not *running*;
- **vacuity guard**: a live scan finding zero literals *fails*, because a broken scan and a clean
  tree are the same silence;
- `literal_message_ids` raises rather than returning `()` if the writer's signature can't be
  resolved, since an unresolvable signature silently disables positional binding in `callsites.scan`.

Reuse over new machinery: `callsites.scan` already does argument binding (same reason
`check_wrap_widths_are_pixels` reads bindings), and `inject/hosts.py` already source-scans
`build_campaign.py`, owns `_INJECTOR_RE`, and is stdlib-only — so the lean CI `checks` job runs this
guard for real instead of skipping it.

## Verification

| | |
|---|---|
| `python3 tools/test_check_message_literals.py` (18 tests) | **before: 17 errors + 1 failure · after: 18 pass** |
| `python3 tools/check.py` | `drift check: clean`, exit 0 |
| Bare literals discovered on `main` | **12, all already claimed** — the guard ships **strict, no allowlist** |
| Not vacuous | planting `set_message_body(lines, 0xBF3, …)` into `inject_ch05` produces the full complaint naming `CH05_LITERAL_MSGS` |

**No ROM build and no playtest are needed** — this is discovery plus a lint. Nothing here touches
injected data, the decomp, or anything the ROM contains.

## Review

Per the 2026-09-02 ADR *"`/code-review` is the review step, and the author never reviews their own
PR"* — **this has not been reviewed yet.** It was drafted by a subagent and independently verified by
me (I ran the before/after myself rather than taking the agent's word), but that is not a review.
Needs a fresh reviewer before merge.
