### PR TITLE
playtest: ch01 gets a debug boot, and a boot must strip MENUS too (#353)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ all: fireemblem8.gba
 # MONTAGE=1 wires the #43 opening montage (lore crawl on New Game) in place of
 # the dev straight-to-map boot cut. Distribution builds (#37) must set it.
 fireemblem8.gba:
-	python3 tools/build_campaign.py --campaign $(CAMPAIGN) $(if $(MONTAGE),--montage) $(if $(TESTCH),--test-chapter) $(if $(LORDBOOT),--lord-boot) $(if $(CH03BOOT),--ch03-boot) $(if $(CH04BOOT),--ch04-boot) $(if $(CH05BOOT),--ch05-boot) $(if $(CH05LUPIN),--ch05-lupin) $(if $(CH05MOOSE),--ch05-moose) $(if $(CH05ENDING),--ch05-ending=$(CH05ENDING))
+	python3 tools/build_campaign.py --campaign $(CAMPAIGN) $(if $(MONTAGE),--montage) $(if $(TESTCH),--test-chapter) $(if $(LORDBOOT),--lord-boot) $(if $(CH01BOOT),--ch01-boot) $(if $(CH03BOOT),--ch03-boot) $(if $(CH04BOOT),--ch04-boot) $(if $(CH05BOOT),--ch05-boot) $(if $(CH05LUPIN),--ch05-lupin) $(if $(CH05MOOSE),--ch05-moose) $(if $(CH05ENDING),--ch05-ending=$(CH05ENDING))
 	$(MAKE) -C fireemblem8u fireemblem8.gba -j$(NPROC)
 
 # Drift guard: docs/tooling consistency. Same logic CI and the git pre-commit hook run.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4221,6 +4221,35 @@ The unifying test: after any change to a check, an encoding, or a sentinel, ask 
 now be different if this were broken?* If the answer is "nothing observable", that is the
 bug, not the reassurance.
 
+**ch01 is the only hosted chapter whose opening runs a MENU, and that is what a debug boot has
+to strip (2026-09-02, #353)**
+Every hosted chapter but ch01 had a fast boot; confirming #347 by eye therefore cost a canonical
+build plus a full prologue playthrough (~24,000 frames) to look at a map ch03 would have shown in
+twenty seconds. The boot itself was the easy half -- `_configure_boot(CH01_HOST_INDEX)`, the same
+call ch03/ch04/ch05 make.
+
+**Two things made ch01 different, and only one was predictable.** ch01 needs **no armed seed
+table**: it is the chapter that FOUNDS the party, so its own opening LOADs the company at the
+Northlook and runs PREP, where ch03/ch04/ch05 boot into a party that must be conjured from nothing
+(`CH03_BOOT_SEED_SYMBOL` and friends). The unpredictable half was **lord select (#42)**. The first
+cut kept ch01's opening intact and the run died with `fail:nil ... never reached the map` on an
+8-item `generic_menu` -- the lord-select menu, which no other boot has ever met because no other
+chapter opens with one. **A debug boot is a MAP load-test: it must strip every screen between New
+Game and the map, and a MENU is such a screen even though it is not a cutscene.** The boot branch
+drops the Northlook beats, lord select and Preparations, and LOMAs straight to the trail.
+
+Measured: New Game -> `player_map_idle` on chapter 2, player faction, turn 1, at **frame 2,856**
+against ~24,000 for the honest route. `PT_HOST_CHAPTER=2 tools/playtest/run.sh mapshot` PASSes;
+going through `matrix.py` instead does not, because `mapshot` is chapter-generic
+(`host_chapter: null`) and resolves to host 1 while the ROM boots chapter 2 -- the run then waits
+for a map that never matches and reports `boot-timeout`. That is scenario wiring, not a boot fault,
+and it is why the invocation is documented rather than left to be rediscovered.
+
+Also from this change: **a rom_config env var the Makefile does not translate builds CANONICAL**,
+so the scenario's verdict is about a different ROM than the one it names -- silence in both
+directions. `check_rom_configs_reach_the_build` now pins every `rom_configs` var to a `$(VAR)` arm
+in the Makefile.
+
 **A message id written as a bare literal now registers itself (2026-09-02, #346)**
 `injector_message_ids` finds an id by the NAME of the constant holding it, and promised that
 "registering a new one is enough -- there is no second list to remember". That was false for an id

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4221,6 +4221,27 @@ The unifying test: after any change to a check, an encoding, or a sentinel, ask 
 now be different if this were broken?* If the answer is "nothing observable", that is the
 bug, not the reassurance.
 
+**One fact, four registries: a rom_config has to reach all of them or the wrongness is silent
+(2026-09-02, #353/#357 review)**
+Adding `ch01boot` meant adding `CH01BOOT` in four unrelated places, and missing any one of them
+fails quietly in a different way: the **Makefile** (missing -> the config builds CANONICAL and the
+scenario's verdict is about a ROM it never asked for), **`_requested_flags`** (missing -> the build
+stamps itself `canonical`, so a canonical scenario is not refused against it and burns the whole
+mGBA deadline, while a `rom: ch01boot` scenario is refused forever as "tree holds canonical" even
+right after the correct build), **`probe_invalidation.FLAG_ARGS`** (missing -> `KeyError` the moment
+a scenario uses it) and **`_boots`** (missing -> `CH01BOOT=1 CH03BOOT=1` builds happily, boots ch03,
+and ships a ch01 whose opening was stripped). Three of the four were missed on the first cut and
+found by review. Until they are one thing, `check_rom_configs_reach_the_build` is what keeps them
+equal -- it is cheaper than the four ways of being silently wrong.
+
+**A duplicate top-level `def` disables the earlier one and says nothing (2026-09-02)**
+Python keeps the LAST definition. So a file can hold an edited function and a stale copy of it, the
+module imports cleanly, the tests pass, and the edits do nothing -- the only symptom is a test
+asserting on `inspect.getsource` that "impossibly" fails. It happened TWICE in one session to two
+different guards in `check.py`, both times from a sloppy source-slicing edit that copied a region
+instead of replacing it. `check_no_shadowed_definitions` now rejects it across `tools/`. Same family
+as *"A guard that stops guarding fails silently"*: the failure is indistinguishable from working.
+
 **ch01 is the only hosted chapter whose opening runs a MENU, and that is what a debug boot has
 to strip (2026-09-02, #353)**
 Every hosted chapter but ch01 had a fast boot; confirming #347 by eye therefore cost a canonical

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -55,6 +55,7 @@ from inject.decomp import (  # noqa: E402  shared decomp paths + patch primitive
     REPO, DECOMP, _find_brace_block, _replace_brace_block,
     BATTLEQUOTES_C, BMUNIT_C, LORDSEL_FLAG_BASE,
     WEAPON_ITEM_ENUM, fe_item_enum)  # shared weapon<->ITEM map (used by inject_prologue)
+from inject.decomp import git_env  # noqa: E402  strip inherited GIT_* so `git -C DECOMP` works in a hook
 from inject import engine_hooks  # noqa: E402  campaign-agnostic engine C-source hooks
 from inject import event_group  # noqa: E402  the ChapterEventGroup census guard (#313)
 from inject import step_cache  # noqa: E402  restore a config-invariant step (#309)
@@ -693,7 +694,7 @@ def _decomp_footprint():
     yields an empty snapshot, which preserves correctness and only skips the speed-up."""
     try:
         out = subprocess.run(
-            ['git', '-C', DECOMP, 'status', '--porcelain', '-z', '-uall'],
+            ['git', '-C', DECOMP, 'status', '--porcelain', '-z', '-uall'], env=git_env(),
             check=True, capture_output=True).stdout
     except (subprocess.SubprocessError, OSError):
         return []
@@ -769,7 +770,7 @@ def _anim_step_cache(campaign, verbose=True):
     h = hashlib.sha256()
     h.update(('campaign:' + campaign + '\n').encode())
     try:
-        head = subprocess.check_output(['git', '-C', DECOMP, 'rev-parse', 'HEAD'],
+        head = subprocess.check_output(['git', '-C', DECOMP, 'rev-parse', 'HEAD'], env=git_env(),
                                        stderr=subprocess.DEVNULL)
     except (subprocess.CalledProcessError, OSError):
         return step_cache.disabled()   # cannot pin the decomp -> recompute rather than guess
@@ -808,7 +809,7 @@ def restore_vanilla_sources():
     # the staging area, so a previously-staged patched file would survive and corrupt the
     # build (e.g. the non-montage monologue-skip leaking into a --montage build). `HEAD --`
     # always resets to the committed vanilla source.
-    subprocess.run(['git', '-C', DECOMP, 'checkout', 'HEAD', '--'] + PATCHED_DECOMP_FILES,
+    subprocess.run(['git', '-C', DECOMP, 'checkout', 'HEAD', '--'] + PATCHED_DECOMP_FILES, env=git_env(),
                    check=True)
 
 # Our cast wear stock vanilla FE8 classes (docs/decisions.md Class Mapping). Map
@@ -2412,10 +2413,7 @@ def vanilla_decomp_text(relpath):
     # GIT_DIR overrides the -C discovery -- so `show HEAD:...` resolves against the
     # superproject and fails (128). Bit us committing from a content/pipeline worktree,
     # whose submodule gitdir is separate from the superproject's.
-    env = {k: v for k, v in os.environ.items()
-           if k not in ('GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX',
-                        'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY', 'GIT_NAMESPACE',
-                        'GIT_ALTERNATE_OBJECT_DIRECTORIES')}
+    env = git_env()
     return subprocess.check_output(['git', '-C', DECOMP, 'show', 'HEAD:' + relpath],
                                    encoding='utf-8', env=env)
 
@@ -7692,7 +7690,7 @@ def _vanilla_decomp_text_at_head(relative_path):
     """A decomp file as HEAD has it -- our injections are build artifacts, so the working
     tree is the wrong source for any question about what VANILLA says."""
     return subprocess.check_output(
-        ['git', '-C', DECOMP, 'show', 'HEAD:' + relative_path], text=True)
+        ['git', '-C', DECOMP, 'show', 'HEAD:' + relative_path], text=True, env=git_env())
 
 
 def _assert_ms_symbol(symbol):
@@ -7806,7 +7804,7 @@ def _write_chapter_title_card(host, title):
         os.remove(chap_title_o)
 
 
-def inject_ch01(campaign, verbose=True):
+def inject_ch01(campaign, verbose=True, boot=False):
     """Wire Ch1 "The Iron Trail" (#21) onto chapter slot 2 (ch00's MNC2(0x2) target).
 
     Field parity (decisions.md 2026-06-10): the deploy cap IS the ally UnitDefinition
@@ -8273,7 +8271,34 @@ def inject_ch01(campaign, verbose=True):
         % CH01_BEAT1_CARD_MSG
         + beat1_text_calls +
         '    FADI(16) /* fade the Northlook out */\n')
-    script = _replace_brace_block(
+    if boot:
+        # --ch01-boot (#353): the fast boot is a MAP load-test, so it drops everything that
+        # stands between New Game and the trail -- the Northlook beats, lord select (#42) and
+        # Preparations. Same shape as --ch03/04/05-boot ("cutscenes stripped"), and the reason
+        # this branch has to exist at all: ch01 is the only hosted chapter whose opening runs a
+        # MENU, and a controller that meets an unrecognised menu cannot reach the map (measured
+        # 2026-09-02 -- mapshot on the first cut died on the 8-item lord-select with
+        # "fail:nil ... never reached the map"). The company LOAD is ch01's own, so the boot
+        # still founds the party exactly as the canonical chapter does -- no seed table.
+        boot_scene = (
+            '{\n'
+            '    EVBIT_MODIFY(0x0)\n'
+            '    SVAL(EVT_SLOT_B, 0x0) /* map camera origin for the reload */\n'
+            '    LOMA(0x%X) /* RestartBattleMap -- build the trail map fresh */\n'
+            '    DISA(CHARACTER_NATASHA) /* Hlin stays in Bryn Shander (ch00 guest) */\n'
+            '    DISA(CHARACTER_KYLE)    /* Scramsax departs (ch00 guest) */\n'
+            '    LOAD1(0x1, UnitDef_088B4344) /* goblins */\n'
+            '    ENUN\n'
+            '    LOAD1(0x1, UnitDef_088B440C) /* the company signs on at the Northlook */\n'
+            '    ENUN\n'
+            '    FADU(16) /* chapter loads come up black; reveal the trail */\n'
+            '    ENUT(8)\n'
+            '    EVBIT_T(7)\n'
+            '    ENDA\n}' % (CH01_HOST_INDEX,))
+        script = _replace_brace_block(script, 'EventScr_Ch2_BeginningScene[] =', boot_scene,
+                                      CH2_EVENTSCRIPT_H)
+    else:
+        script = _replace_brace_block(
         script, 'EventScr_Ch2_BeginningScene[] =',
         '{\n'
         + beat1_scene +
@@ -13700,7 +13725,7 @@ def inject_northlook_bitey(verbose=True):
     blue-purple tones read as a frozen-lake trophy and survive the tile conversion."""
     from PIL import ImageDraw
     bg = os.path.join(DECOMP, 'graphics', 'bg', 'bg_Fireplace.png')
-    subprocess.run(['git', '-C', DECOMP, 'checkout', '--', 'graphics/bg/bg_Fireplace.png'],
+    subprocess.run(['git', '-C', DECOMP, 'checkout', '--', 'graphics/bg/bg_Fireplace.png'], env=git_env(),
                    check=True)
     im = Image.open(bg)
     pal = im.getpalette()
@@ -14095,6 +14120,13 @@ def main():
                          'opens straight into the lord-select prep screen on New Game, so '
                          'iterating on that screen is compile-time only -- no playthrough '
                          'grind (see decisions.md / the debug-fast-boot convention).')
+    ap.add_argument('--ch01-boot', action='store_true',
+                    help='PLAYTEST build (#353): New Game boots straight into Ch1 "The Iron '
+                         'Trail" on slot 2. ch01 is the chapter that FOUNDS the party -- its '
+                         'opening LOADs the company at the Northlook and then runs PREP -- so '
+                         'this boot needs no armed seed table, unlike --ch03/04/05-boot. '
+                         'Mutually exclusive with the prologue: confirming anything in ch01 '
+                         'otherwise costs a full prologue playthrough (~24,000 frames).')
     ap.add_argument('--ch03-boot', action='store_true',
                     help='PLAYTEST build (#23): New Game boots straight into the Ch3 '
                          '"Termalaine Mine" on slot 4 -- the party deployed at the left '
@@ -14266,7 +14298,7 @@ def main():
             sys.exit('ERROR: declared message block(s) drawn over ids the build already '
                      'spends: %s' % ', '.join(drawn_over))
         print('chapter 1 (#21):')
-        _scopes.run(inject_ch01, args.campaign)  # MUST precede inject_prologue (vanilla goal read)
+        _scopes.run(inject_ch01, args.campaign, boot=args.ch01_boot)  # MUST precede inject_prologue (vanilla goal read)
         inject_northlook_bitey()    # 'Ol Bitey over the tavern hearth (Beat 1 set dressing)
         print('chapter 2 (#22):')
         _scopes.run(inject_ch02, args.campaign)  # hosts slot 3; ch01's ending MNC2(0x3) lands here
@@ -14291,6 +14323,11 @@ def main():
         elif args.ch03_boot:
             print('CH03 BOOT (playtest: New Game -> Termalaine Mine, party + foes deployed):')
             _configure_boot(CH03_HOST_INDEX)
+        elif args.ch01_boot:
+            # No seed table here on purpose: ch01's own opening LOADs the company and runs
+            # PREP, so a cold start founds its party exactly as the canonical chapter does.
+            print('CH01 BOOT (playtest: New Game -> the Iron Trail, party founded by ch01):')
+            _configure_boot(CH01_HOST_INDEX)
         else:
             if args.test_chapter:
                 print('TEST CHAPTER (playtest: New Game -> Ch1 sandbox, cast deployed):')

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -14179,7 +14179,8 @@ def main():
     # Snapshot the flags AS PASSED, before --lord-boot implies --test-chapter below:
     # the build stamp has to describe the `make` invocation, not the derived state.
     _requested_flags = {'TESTCH': args.test_chapter, 'LORDBOOT': args.lord_boot,
-                        'MONTAGE': args.montage, 'CH03BOOT': args.ch03_boot,
+                        'MONTAGE': args.montage, 'CH01BOOT': args.ch01_boot,
+                        'CH03BOOT': args.ch03_boot,
                         'CH04BOOT': args.ch04_boot, 'CH05BOOT': args.ch05_boot,
                         'CH05LUPIN': args.ch05_lupin, 'CH05MOOSE': args.ch05_moose,
                         'CH05ENDING': args.ch05_ending}
@@ -14187,7 +14188,8 @@ def main():
         args.test_chapter = True  # the fast-boot rides the sandbox
     # Each fast-boot repoints New Game at its own slot, so at most one may win. Named
     # explicitly rather than counted, so the error says which flags actually clash.
-    _boots = [name for name, on in (('--ch03-boot', args.ch03_boot),
+    _boots = [name for name, on in (('--ch01-boot', args.ch01_boot),
+                                    ('--ch03-boot', args.ch03_boot),
                                     ('--ch04-boot', args.ch04_boot),
                                     ('--ch05-boot', args.ch05_boot)) if on]
     if len(_boots) > 1:

--- a/tools/check.py
+++ b/tools/check.py
@@ -923,6 +923,94 @@ def check_gate_chapter_window(fail):
     fail.extend(_gate_window_violations(boots, hosts.hosted_chapters()))
 
 
+def check_decomp_git_calls_strip_the_env(fail, sources=None):
+    """Guard: every `git -C DECOMP ...` subprocess must pass env=, to drop inherited GIT_*.
+
+    Git EXPORTS GIT_DIR/GIT_INDEX_FILE to a hook, and an explicit GIT_DIR BEATS `-C`. So inside
+    the pre-commit hook a `git -C fireemblem8u show HEAD:...` resolves against the superproject
+    and exits 128. `vanilla_decomp_text` learned that once and stripped the env inline; the
+    lesson did not propagate. Three separate inline copies of the same dict existed, and the one
+    site that lacked it -- `chapter_label_constants`, the same `show HEAD:` call -- made the hook
+    UNPASSABLE from a worktree: 12 test errors that appear only under `git commit`, never when
+    you run the tests yourself (#353). A lesson living in three copies is a lesson waiting to be
+    missed in a fourth place; `inject.decomp.git_env()` is now the single one, and this pins it.
+    """
+    targets = sources or ('tools/build_campaign.py', 'tools/inject/event_group.py',
+                          'tools/inject/decomp.py')
+    seen = 0
+    for rel in targets:
+        path = os.path.join(REPO, rel)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding='utf-8') as fh:
+            tree = ast.parse(fh.read(), rel)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            first = node.args[0]
+            parts = first.elts if isinstance(first, (ast.List, ast.Tuple)) else []
+            if isinstance(first, ast.BinOp) and isinstance(first.left, (ast.List, ast.Tuple)):
+                parts = first.left.elts
+            lits = [p.value for p in parts[:3]
+                    if isinstance(p, ast.Constant) and isinstance(p.value, str)]
+            names = [p.id for p in parts[:3] if isinstance(p, ast.Name)]
+            if lits[:2] != ['git', '-C'] or 'DECOMP' not in names:
+                continue
+            seen += 1
+            if not any(kw.arg == 'env' for kw in node.keywords):
+                fail.append(
+                    '%s:%d runs `git -C DECOMP` without env= -- inside a commit hook the '
+                    'inherited GIT_DIR overrides -C, so it resolves against the SUPERPROJECT '
+                    'and exits 128. Pass env=git_env() (inject.decomp).' % (rel, node.lineno))
+    if not seen:
+        fail.append('check_decomp_git_calls_strip_the_env: found NO `git -C DECOMP` call, so '
+                    'the scan is broken -- there are several.')
+    return fail
+
+
+def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None):
+    """Guard: every env var a rom_config sets must be TRANSLATED by the Makefile.
+
+    `matrix.yaml`'s rom_configs render straight onto the make line (`CH05BOOT=1 make ...`),
+    and the Makefile turns each into a `--flag` for build_campaign. A config whose var has no
+    Makefile arm still builds -- it just builds CANONICAL, and the scenario then passes or
+    fails against a ROM that is not the one it names. Silence in both directions, which is the
+    shape decisions.md 2026-09-02 names ("A guard that stops guarding fails silently").
+    """
+    import re as _re
+    matrix = os.path.join(REPO, 'tools', 'playtest', 'matrix.yaml')
+    makefile = os.path.join(REPO, 'Makefile')
+    if matrix_text is None and makefile_text is None and not (
+            os.path.exists(matrix) and os.path.exists(makefile)):
+        fail.append('check_rom_configs_reach_the_build: matrix.yaml or Makefile is missing')
+        return fail
+    if matrix_text is None:
+        with open(matrix, encoding='utf-8') as fh:
+            matrix_text = fh.read()
+    text = matrix_text
+    block = _re.search(r'^rom_configs:\n(.*?)(?=^\w)', text, _re.S | _re.M)
+    if not block:
+        fail.append('check_rom_configs_reach_the_build: no rom_configs block in matrix.yaml')
+        return fail
+    envs = set(_re.findall(r'^\s+([A-Z][A-Z0-9_]*):\s', block.group(1), _re.M))
+    if not envs:
+        fail.append('check_rom_configs_reach_the_build: rom_configs sets NO env var, so the '
+                    'scan is broken -- there are several on main.')
+        return fail
+    if makefile_text is None:
+        with open(makefile, encoding='utf-8') as fh:
+            makefile_text = fh.read()
+    mk = makefile_text
+    for env in sorted(envs):
+        if '$(%s)' % env not in mk:
+            fail.append(
+                'matrix.yaml rom_configs sets %s, but the Makefile never reads $(%s) -- so a '
+                'scenario asking for that configuration silently builds CANONICAL and its '
+                'verdict is about the wrong ROM. Add `$(if $(%s),--<flag>)` to the '
+                'build_campaign line.' % (env, env, env))
+    return fail
+
+
 def check_playtest_matrix(fail):
     """tools/playtest/matrix.yaml is the single source of "what does this scenario
     need" (ROM configuration, host chapter, checkpoint, timing) -- so it has to keep
@@ -2026,7 +2114,8 @@ def main():
                   check_personal_line_injection_routes,
                   check_injection_order, check_cached_steps_are_config_invariant,
                   check_tile_changes_outlive_the_retarget,
-                  check_playtest_matrix, check_gate_chapter_window,
+                  check_playtest_matrix, check_rom_configs_reach_the_build,
+                  check_decomp_git_calls_strip_the_env, check_gate_chapter_window,
                   check_declared_cases, check_harness_local_ratchet,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,

--- a/tools/check.py
+++ b/tools/check.py
@@ -923,6 +923,12 @@ def check_gate_chapter_window(fail):
     fail.extend(_gate_window_violations(boots, hosts.hosted_chapters()))
 
 
+def _re_local_git_env(text, name):
+    """True if `name` is bound to git_env() in this file -- `env = git_env()` then `env=env`."""
+    import re as _re
+    return _re.search(r'^\s*%s\s*=\s*git_env\(\)' % _re.escape(name), text, _re.M)
+
+
 def check_decomp_git_calls_strip_the_env(fail, sources=None):
     """Guard: every `git -C DECOMP ...` subprocess must pass env=, to drop inherited GIT_*.
 
@@ -954,7 +960,13 @@ def check_decomp_git_calls_strip_the_env(fail, sources=None):
             continue
         with open(path, encoding='utf-8') as fh:
             text = fh.read()
-        tree = ast.parse(text, rel)
+        try:
+            tree = ast.parse(text, rel)
+        except SyntaxError as exc:
+            # Report; do NOT traceback. This runs in the pre-commit hook, where a traceback
+            # kills the gate and skips every check after it.
+            fail.append('%s does not parse, so it cannot be checked: %s' % (rel, exc))
+            continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call) or not node.args:
                 continue
@@ -969,22 +981,29 @@ def check_decomp_git_calls_strip_the_env(fail, sources=None):
                 continue
             seen += 1
             env_kw = next((kw for kw in node.keywords if kw.arg == 'env'), None)
-            # `env=os.environ` passes the inherited GIT_* straight back in -- it looks like the
-            # fix and is the bug.
-            passthrough = (isinstance(env_kw.value, ast.Attribute)
-                           and env_kw.value.attr == 'environ') if env_kw else False
-            # A file that rolls its OWN strip is a copy of the lesson, and a copy drifts: the
-            # gen_chapter_title.py copy was missing GIT_COMMON_DIR / GIT_NAMESPACE /
-            # GIT_ALTERNATE_OBJECT_DIRECTORIES, so it half-worked. Demand the shared helper.
-            rolls_own = 'git_env' not in text
-            if env_kw is None or passthrough or rolls_own:
+            # Demand the env expression BE git_env() -- either the call itself, or a local
+            # bound to it. Anything else passes: env=os.environ.copy() (a Call, so an
+            # `is this an Attribute` test misses it), or a file's own inline dict, which is how
+            # gen_chapter_title.py shipped a strip missing GIT_COMMON_DIR / GIT_NAMESPACE /
+            # GIT_ALTERNATE_OBJECT_DIRECTORIES and half-worked. A file-scoped `'git_env' in
+            # text` was the first attempt and let every new call in build_campaign.py through
+            # (#357 review, second round).
+            def _is_git_env(expr):
+                if isinstance(expr, ast.Call):
+                    fn = expr.func
+                    return (getattr(fn, 'id', None) == 'git_env'
+                            or getattr(fn, 'attr', None) == 'git_env')
+                if isinstance(expr, ast.Name):      # local bound to git_env() nearby
+                    return bool(_re_local_git_env(text, expr.id))
+                return False
+
+            if env_kw is None or not _is_git_env(env_kw.value):
                 fail.append(
-                    '%s:%d runs `git -C DECOMP` with %s -- inside a commit hook the inherited '
-                    'GIT_DIR overrides -C, so it resolves against the SUPERPROJECT and exits '
-                    '128. Pass env=git_env() (inject.decomp).'
-                    % (rel, node.lineno,
-                       'env=os.environ' if passthrough
-                       else ('its own inline env strip' if env_kw is not None else 'no env=')))
+                    '%s:%d runs `git -C DECOMP` without env=git_env() -- inside a commit hook '
+                    'the inherited GIT_DIR overrides -C, so it resolves against the '
+                    'SUPERPROJECT and exits 128. env=os.environ (or a .copy(), or a private '
+                    'inline strip) is not a fix. Pass env=git_env() (inject.decomp).'
+                    % (rel, node.lineno))
     if not seen:
         fail.append('check_decomp_git_calls_strip_the_env: found NO `git -C DECOMP` call, so '
                     'the scan is broken -- there are several.')
@@ -1086,12 +1105,26 @@ def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None
     mk = _read('Makefile', makefile_text if makefile_text is not None else sources.get('Makefile'))
     bc = _read('tools/build_campaign.py', sources.get('build_campaign'))
     probe = _read('tools/probe_invalidation.py', sources.get('probe'))
-    stamp = _re.search(r'_requested_flags = \{(.*?)\}', bc, _re.S)
-    stamp_text = stamp.group(1) if stamp else ''
-    boots = _re.search(r'_boots = \[(.*?)\]', bc, _re.S)
-    boots_text = boots.group(1) if boots else ''
-    flag_args = _re.search(r'FLAG_ARGS = \{(.*?)\}', probe, _re.S)
-    flag_text = flag_args.group(1) if flag_args else ''
+    # A regex that stops matching must FAIL, not quietly skip its arm: three of the four
+    # registry checks would then be disabled while the gate still prints "clean" -- the exact
+    # silent-guard shape this function exists to stop (#357 review, second round).
+    def _region(pattern, text, what, where):
+        found = _re.search(pattern, text, _re.S)
+        if not found:
+            fail.append(
+                'check_rom_configs_reach_the_build: cannot find %s in %s, so that registry is '
+                'NOT being checked. It was renamed or reformatted -- fix this scan rather than '
+                'letting it pass vacuously.' % (what, where))
+            return None
+        return found.group(1)
+
+    stamp_text = _region(r'_requested_flags = \{(.*?)\}', bc, '_requested_flags',
+                         'build_campaign.py')
+    boots_text = _region(r'_boots = \[(.*?)\]', bc, '_boots', 'build_campaign.py')
+    flag_text = _region(r'FLAG_ARGS = \{(.*?)\}', probe, 'FLAG_ARGS',
+                        'probe_invalidation.py')
+    if stamp_text is None or boots_text is None or flag_text is None:
+        return fail
 
     for env in sorted(envs):
         if '$(%s)' % env not in mk:
@@ -1100,18 +1133,18 @@ def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None
                 'scenario asking for that configuration silently builds CANONICAL and its '
                 'verdict is about the wrong ROM. Add `$(if $(%s),--<flag>)` to the '
                 'build_campaign line.' % (env, env, env))
-        if stamp_text and "'%s'" % env not in stamp_text:
+        if "'%s'" % env not in stamp_text:
             fail.append(
                 'matrix.yaml rom_configs sets %s, but build_campaign\'s _requested_flags does '
                 'not stamp it -- so that build calls itself `canonical`, a canonical scenario '
                 'is not refused against it, and a `rom:` scenario naming the config is refused '
                 'forever. Add %s to _requested_flags.' % (env, env))
-        if flag_text and "'%s'" % env not in flag_text:
+        if "'%s'" % env not in flag_text:
             fail.append(
                 'matrix.yaml rom_configs sets %s, but probe_invalidation.FLAG_ARGS has no entry '
                 '-- build_manifests KeyErrors as soon as a scenario uses that config.'
                 % env)
-        if _re.match(r'^CH\d\dBOOT$', env) and boots_text and env.lower().replace(
+        if _re.match(r'^CH\d\dBOOT$', env) and env.lower().replace(
                 'boot', '-boot').replace('ch', '--ch') not in boots_text:
             fail.append(
                 '%s is a fast boot but is not in build_campaign\'s _boots mutual-exclusion list '

--- a/tools/check.py
+++ b/tools/check.py
@@ -935,15 +935,26 @@ def check_decomp_git_calls_strip_the_env(fail, sources=None):
     you run the tests yourself (#353). A lesson living in three copies is a lesson waiting to be
     missed in a fourth place; `inject.decomp.git_env()` is now the single one, and this pins it.
     """
-    targets = sources or ('tools/build_campaign.py', 'tools/inject/event_group.py',
-                          'tools/inject/decomp.py')
+    # EVERY python file under tools/, not a hand-kept list: the whole failure mode here is a
+    # call site nobody remembered. gen_chapter_title.py and test_winter_forest_backfill.py were
+    # both invisible to the first cut, which is exactly the drift this is supposed to stop.
+    if sources is None:
+        targets = []
+        for base, _dirs, files in os.walk(os.path.join(REPO, 'tools')):
+            for name in sorted(files):
+                if name.endswith('.py'):
+                    targets.append(os.path.relpath(os.path.join(base, name), REPO))
+        targets.sort()
+    else:
+        targets = sources
     seen = 0
     for rel in targets:
         path = os.path.join(REPO, rel)
         if not os.path.exists(path):
             continue
         with open(path, encoding='utf-8') as fh:
-            tree = ast.parse(fh.read(), rel)
+            text = fh.read()
+        tree = ast.parse(text, rel)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call) or not node.args:
                 continue
@@ -957,38 +968,102 @@ def check_decomp_git_calls_strip_the_env(fail, sources=None):
             if lits[:2] != ['git', '-C'] or 'DECOMP' not in names:
                 continue
             seen += 1
-            if not any(kw.arg == 'env' for kw in node.keywords):
+            env_kw = next((kw for kw in node.keywords if kw.arg == 'env'), None)
+            # `env=os.environ` passes the inherited GIT_* straight back in -- it looks like the
+            # fix and is the bug.
+            passthrough = (isinstance(env_kw.value, ast.Attribute)
+                           and env_kw.value.attr == 'environ') if env_kw else False
+            # A file that rolls its OWN strip is a copy of the lesson, and a copy drifts: the
+            # gen_chapter_title.py copy was missing GIT_COMMON_DIR / GIT_NAMESPACE /
+            # GIT_ALTERNATE_OBJECT_DIRECTORIES, so it half-worked. Demand the shared helper.
+            rolls_own = 'git_env' not in text
+            if env_kw is None or passthrough or rolls_own:
                 fail.append(
-                    '%s:%d runs `git -C DECOMP` without env= -- inside a commit hook the '
-                    'inherited GIT_DIR overrides -C, so it resolves against the SUPERPROJECT '
-                    'and exits 128. Pass env=git_env() (inject.decomp).' % (rel, node.lineno))
+                    '%s:%d runs `git -C DECOMP` with %s -- inside a commit hook the inherited '
+                    'GIT_DIR overrides -C, so it resolves against the SUPERPROJECT and exits '
+                    '128. Pass env=git_env() (inject.decomp).'
+                    % (rel, node.lineno,
+                       'env=os.environ' if passthrough
+                       else ('its own inline env strip' if env_kw is not None else 'no env=')))
     if not seen:
         fail.append('check_decomp_git_calls_strip_the_env: found NO `git -C DECOMP` call, so '
                     'the scan is broken -- there are several.')
     return fail
 
 
-def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None):
-    """Guard: every env var a rom_config sets must be TRANSLATED by the Makefile.
+def check_no_shadowed_definitions(fail, sources=None):
+    """Guard: no module may define the same top-level name twice.
 
-    `matrix.yaml`'s rom_configs render straight onto the make line (`CH05BOOT=1 make ...`),
-    and the Makefile turns each into a `--flag` for build_campaign. A config whose var has no
-    Makefile arm still builds -- it just builds CANONICAL, and the scenario then passes or
-    fails against a ROM that is not the one it names. Silence in both directions, which is the
-    shape decisions.md 2026-09-02 names ("A guard that stops guarding fails silently").
+    Python takes the LAST definition and says nothing, so a duplicate is invisible: the file
+    reads correctly, the tests import the survivor, and edits to the other copy do nothing at
+    all. That is how two guards in this very file were quietly disabled on 2026-09-02 -- an
+    edit landed on the first copy while the second, stale one was what actually ran, and the
+    only symptom was a test asserting on `inspect.getsource` that "impossibly" failed.
+
+    Same family as the ADR above: a thing that stops working while everything stays green.
+    """
+    targets = sources
+    if targets is None:
+        targets = []
+        for base, _dirs, files in os.walk(os.path.join(REPO, 'tools')):
+            for name in sorted(files):
+                if name.endswith('.py'):
+                    targets.append(os.path.relpath(os.path.join(base, name), REPO))
+        targets.sort()
+    for rel in targets:
+        path = os.path.join(REPO, rel)
+        if not os.path.exists(path):
+            continue
+        with open(path, encoding='utf-8') as fh:
+            try:
+                tree = ast.parse(fh.read(), rel)
+            except SyntaxError as exc:
+                fail.append('%s does not parse: %s' % (rel, exc))
+                continue
+        seen = {}
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            if node.name in seen:
+                fail.append(
+                    '%s defines %s twice (lines %d and %d) -- Python keeps the LAST one and '
+                    'says nothing, so the earlier copy is dead code and any edit to it is '
+                    'silently discarded. Delete the stale one.'
+                    % (rel, node.name, seen[node.name], node.lineno))
+            seen[node.name] = node.lineno
+    return fail
+
+
+def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None,
+                                      sources=None):
+    """Guard: a rom_config env var must reach EVERY registry that decides what got built.
+
+    `matrix.yaml`'s rom_configs render onto the make line (`CH05BOOT=1 make ...`), and four
+    separate places have to agree about that var. Miss one and the failure is silent:
+
+      * the **Makefile** turns it into a `--flag`. Missing -> the config builds CANONICAL, and
+        the scenario's verdict is about a ROM it never asked for.
+      * **`_requested_flags`** stamps the built ROM. Missing -> a `--ch01-boot` build stamps
+        itself `canonical`, so a canonical scenario is not refused against it (and burns the
+        whole mGBA deadline), while a `rom: ch01boot` scenario is refused forever as "tree holds
+        canonical" even right after the correct build. Found by review on #357.
+      * **`probe_invalidation.FLAG_ARGS`** maps it back to the switch. Missing -> `KeyError` the
+        moment a scenario uses the config.
+      * **`_boots`**, for a `CH..BOOT` var: the mutual-exclusion list. Missing -> `CH01BOOT=1
+        CH03BOOT=1` builds happily, boots ch03, and ships a ch01 whose opening was stripped.
+
+    Four registries for one fact is the shape that keeps costing us; until they are one thing,
+    this check is what keeps them equal.
     """
     import re as _re
     matrix = os.path.join(REPO, 'tools', 'playtest', 'matrix.yaml')
-    makefile = os.path.join(REPO, 'Makefile')
-    if matrix_text is None and makefile_text is None and not (
-            os.path.exists(matrix) and os.path.exists(makefile)):
-        fail.append('check_rom_configs_reach_the_build: matrix.yaml or Makefile is missing')
-        return fail
     if matrix_text is None:
+        if not os.path.exists(matrix):
+            fail.append('check_rom_configs_reach_the_build: matrix.yaml is missing')
+            return fail
         with open(matrix, encoding='utf-8') as fh:
             matrix_text = fh.read()
-    text = matrix_text
-    block = _re.search(r'^rom_configs:\n(.*?)(?=^\w)', text, _re.S | _re.M)
+    block = _re.search(r'^rom_configs:\n(.*?)(?=^\S|\Z)', matrix_text, _re.S | _re.M)
     if not block:
         fail.append('check_rom_configs_reach_the_build: no rom_configs block in matrix.yaml')
         return fail
@@ -997,10 +1072,27 @@ def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None
         fail.append('check_rom_configs_reach_the_build: rom_configs sets NO env var, so the '
                     'scan is broken -- there are several on main.')
         return fail
-    if makefile_text is None:
-        with open(makefile, encoding='utf-8') as fh:
-            makefile_text = fh.read()
-    mk = makefile_text
+
+    def _read(rel, injected):
+        if injected is not None:
+            return injected
+        path = os.path.join(REPO, rel)
+        if not os.path.exists(path):
+            return ''
+        with open(path, encoding='utf-8') as fh:
+            return fh.read()
+
+    sources = sources or {}
+    mk = _read('Makefile', makefile_text if makefile_text is not None else sources.get('Makefile'))
+    bc = _read('tools/build_campaign.py', sources.get('build_campaign'))
+    probe = _read('tools/probe_invalidation.py', sources.get('probe'))
+    stamp = _re.search(r'_requested_flags = \{(.*?)\}', bc, _re.S)
+    stamp_text = stamp.group(1) if stamp else ''
+    boots = _re.search(r'_boots = \[(.*?)\]', bc, _re.S)
+    boots_text = boots.group(1) if boots else ''
+    flag_args = _re.search(r'FLAG_ARGS = \{(.*?)\}', probe, _re.S)
+    flag_text = flag_args.group(1) if flag_args else ''
+
     for env in sorted(envs):
         if '$(%s)' % env not in mk:
             fail.append(
@@ -1008,6 +1100,23 @@ def check_rom_configs_reach_the_build(fail, matrix_text=None, makefile_text=None
                 'scenario asking for that configuration silently builds CANONICAL and its '
                 'verdict is about the wrong ROM. Add `$(if $(%s),--<flag>)` to the '
                 'build_campaign line.' % (env, env, env))
+        if stamp_text and "'%s'" % env not in stamp_text:
+            fail.append(
+                'matrix.yaml rom_configs sets %s, but build_campaign\'s _requested_flags does '
+                'not stamp it -- so that build calls itself `canonical`, a canonical scenario '
+                'is not refused against it, and a `rom:` scenario naming the config is refused '
+                'forever. Add %s to _requested_flags.' % (env, env))
+        if flag_text and "'%s'" % env not in flag_text:
+            fail.append(
+                'matrix.yaml rom_configs sets %s, but probe_invalidation.FLAG_ARGS has no entry '
+                '-- build_manifests KeyErrors as soon as a scenario uses that config.'
+                % env)
+        if _re.match(r'^CH\d\dBOOT$', env) and boots_text and env.lower().replace(
+                'boot', '-boot').replace('ch', '--ch') not in boots_text:
+            fail.append(
+                '%s is a fast boot but is not in build_campaign\'s _boots mutual-exclusion list '
+                '-- two boots then build together, the later one wins New Game, and the other '
+                'chapter ships with its opening stripped.' % env)
     return fail
 
 
@@ -2115,7 +2224,8 @@ def main():
                   check_injection_order, check_cached_steps_are_config_invariant,
                   check_tile_changes_outlive_the_retarget,
                   check_playtest_matrix, check_rom_configs_reach_the_build,
-                  check_decomp_git_calls_strip_the_env, check_gate_chapter_window,
+                  check_decomp_git_calls_strip_the_env,
+                  check_no_shadowed_definitions, check_gate_chapter_window,
                   check_declared_cases, check_harness_local_ratchet,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,

--- a/tools/gen_chapter_title.py
+++ b/tools/gen_chapter_title.py
@@ -19,6 +19,8 @@ import os
 import subprocess
 import sys
 
+from inject.decomp import git_env   # one env strip, not a fifth inline copy
+
 import numpy as np
 from PIL import Image
 
@@ -96,9 +98,7 @@ def _vanilla_card(idx):
     from the wrong (already-injected) card. Mirror build_campaign.vanilla_decomp_text's
     env handling (a commit hook sets GIT_DIR, which would override -C discovery). Falls
     back to the working tree if git/HEAD is unavailable (ad-hoc standalone use)."""
-    env = {k: v for k, v in os.environ.items()
-           if k not in ('GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX',
-                        'GIT_OBJECT_DIRECTORY')}
+    env = git_env()
     try:
         raw = subprocess.check_output(
             ['git', '-C', DECOMP, 'show', 'HEAD:' + CARD_REL % idx], env=env)

--- a/tools/inject/decomp.py
+++ b/tools/inject/decomp.py
@@ -63,3 +63,19 @@ def _replace_brace_block(text, marker, new_body, path):
     """Replace the `{...}` after `marker` with `new_body` (a `{...}` string)."""
     s, e = _find_brace_block(text, marker, path)
     return text[:s] + new_body + text[e:]
+
+
+def git_env():
+    """os.environ minus every inherited GIT_* that would override `git -C DECOMP` discovery.
+
+    Git EXPORTS GIT_DIR/GIT_INDEX_FILE/... to a hook, and an explicit GIT_DIR beats `-C`. So
+    inside a pre-commit hook every `git -C fireemblem8u show HEAD:...` resolves against the
+    SUPERPROJECT and exits 128. `vanilla_decomp_text` learned this once and stripped the env
+    inline; the lesson did not propagate, and `chapter_label_constants` -- the same call,
+    without the strip -- made the hook unpassable from a worktree (12 test errors, #353).
+    One helper, so the next `git -C DECOMP` cannot get it wrong; check.py pins every call site.
+    """
+    return {k: v for k, v in os.environ.items()
+            if k not in ('GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX',
+                         'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY', 'GIT_NAMESPACE',
+                         'GIT_ALTERNATE_OBJECT_DIRECTORIES')}

--- a/tools/inject/event_group.py
+++ b/tools/inject/event_group.py
@@ -17,6 +17,8 @@ import subprocess
 
 _TOOLS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REPO = os.path.dirname(_TOOLS)
+from .decomp import git_env  # noqa: E402  strip inherited GIT_* (hook safety)
+
 DECOMP = os.path.join(REPO, 'fireemblem8u')
 
 CHAPTERDATA_H = os.path.join(DECOMP, 'include', 'chapterdata.h')
@@ -209,10 +211,7 @@ def vanilla_header(relpath):
     inherited GIT_DIR (set inside a commit hook) overrides `-C` discovery and resolves against
     the superproject instead of the submodule.
     """
-    env = dict((k, v) for k, v in os.environ.items()
-               if k not in ('GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX',
-                            'GIT_COMMON_DIR', 'GIT_OBJECT_DIRECTORY', 'GIT_NAMESPACE',
-                            'GIT_ALTERNATE_OBJECT_DIRECTORIES'))
+    env = git_env()
     out = subprocess.run(['git', '-C', DECOMP, 'show', 'HEAD:%s' % relpath],
                          capture_output=True, text=True, env=env)
     if out.returncode != 0:

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -46,6 +46,11 @@ rom_configs:
     LORDBOOT: 1
   montage:
     MONTAGE: 1
+  # ch01 is the FIRST chapter that founds a party -- its opening LOADs the company at the
+  # Northlook and then runs PREP -- so unlike ch03/ch04/ch05 this boot needs no armed seed
+  # table. New Game lands on the Iron Trail; the prologue is not injected (#353).
+  ch01boot:
+    CH01BOOT: 1
   ch03boot:
     CH03BOOT: 1
   ch04boot:

--- a/tools/probe_invalidation.py
+++ b/tools/probe_invalidation.py
@@ -138,8 +138,10 @@ CASES = [
 
 # make-flag -> the build_campaign.py switch that sets it (Makefile line 39).
 FLAG_ARGS = {'TESTCH': '--test-chapter', 'LORDBOOT': '--lord-boot', 'MONTAGE': '--montage',
+             'CH01BOOT': '--ch01-boot',
              'CH03BOOT': '--ch03-boot', 'CH04BOOT': '--ch04-boot', 'CH05BOOT': '--ch05-boot',
-             'CH05LUPIN': '--ch05-lupin'}
+             'CH05LUPIN': '--ch05-lupin', 'CH05MOOSE': '--ch05-moose',
+             'CH05ENDING': '--ch05-ending'}
 
 
 def keys_for(names, manifests):

--- a/tools/probe_invalidation.py
+++ b/tools/probe_invalidation.py
@@ -143,6 +143,10 @@ FLAG_ARGS = {'TESTCH': '--test-chapter', 'LORDBOOT': '--lord-boot', 'MONTAGE': '
              'CH05LUPIN': '--ch05-lupin', 'CH05MOOSE': '--ch05-moose',
              'CH05ENDING': '--ch05-ending'}
 
+# Switches that take a VALUE rather than being a bare on/off flag. `--ch05-ending` without its
+# arm is an argparse error 2, surfacing as an opaque CalledProcessError three frames away.
+VALUED_FLAGS = frozenset({'CH05ENDING'})
+
 
 def keys_for(names, manifests):
     out = {}
@@ -168,7 +172,13 @@ def build_manifests(roms):
         flags = mx.Manifest.load().resolve_rom(rom)
         cmd = [sys.executable, os.path.join(HERE, 'build_campaign.py'),
                '--campaign', 'rime-of-the-frostmaiden']
-        cmd += [FLAG_ARGS[flag.split('=')[0]] for flag in flags]
+        # A VALUED switch has to carry its value: `--ch05-ending` bare exits argparse 2, and
+        # the caller only sees an opaque CalledProcessError (#357 review). resolve_rom yields
+        # "CH05ENDING=full" for those, so keep the arm.
+        for flag in flags:
+            name, _, value = flag.partition('=')
+            switch = FLAG_ARGS[name]
+            cmd.append('%s=%s' % (switch, value) if name in VALUED_FLAGS else switch)
         subprocess.run(cmd, cwd=REPO, check=True, capture_output=True)
         out[rom] = build_scopes.load_manifest(
             os.path.join(REPO, '.build-scopes.json'))

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -1509,5 +1509,100 @@ class RomConfigsReachTheBuild(unittest.TestCase):
         self.assertIn('check_rom_configs_reach_the_build', inspect.getsource(check.main))
 
 
+class RomConfigReachesEveryRegistry(unittest.TestCase):
+    """#357 review: a rom_config env var must reach the Makefile, _requested_flags,
+    FLAG_ARGS and (for a boot) _boots. Missing any one of them fails SILENTLY."""
+
+    MATRIX = 'rom_configs:\n  ch01boot:\n    CH01BOOT: 1\n\nscenarios:\n  x: {}\n'
+    BC = "_requested_flags = {'CH01BOOT': a}\n_boots = [(('--ch01-boot', a))]\n"
+    PROBE = "FLAG_ARGS = {'CH01BOOT': '--ch01-boot'}\n"
+
+    def _fail(self, makefile='$(CH01BOOT)', bc=None, probe=None):
+        import check
+        fail = []
+        check.check_rom_configs_reach_the_build(
+            fail, matrix_text=self.MATRIX,
+            sources={'Makefile': makefile, 'build_campaign': bc or self.BC,
+                     'probe': probe or self.PROBE})
+        return fail
+
+    def test_all_four_registries_present_passes(self):
+        self.assertEqual([], self._fail())
+
+    def test_a_missing_makefile_arm_builds_canonical(self):
+        bad = self._fail(makefile='nothing')
+        self.assertTrue(any('CANONICAL' in f for f in bad), bad)
+
+    def test_a_missing_build_stamp_mislabels_the_rom(self):
+        bad = self._fail(bc="_requested_flags = {'TESTCH': a}\n_boots = [(('--ch01-boot', a))]\n")
+        self.assertTrue(any('_requested_flags' in f for f in bad), bad)
+
+    def test_a_missing_FLAG_ARGS_entry_is_caught(self):
+        bad = self._fail(probe="FLAG_ARGS = {'TESTCH': '--test-chapter'}\n")
+        self.assertTrue(any('FLAG_ARGS' in f for f in bad), bad)
+
+    def test_a_boot_missing_from_the_exclusion_list_is_caught(self):
+        bad = self._fail(bc="_requested_flags = {'CH01BOOT': a}\n_boots = [(('--ch03-boot', a))]\n")
+        self.assertTrue(any('_boots' in f for f in bad), bad)
+
+    def test_the_live_tree_is_clean(self):
+        import check
+        fail = []
+        check.check_rom_configs_reach_the_build(fail)
+        self.assertEqual([], fail)
+
+
+class DecompGitCallsStripTheEnv(unittest.TestCase):
+    """#353: GIT_DIR beats `git -C`, so inside a commit hook every decomp read resolves
+    against the superproject and exits 128."""
+
+    def test_the_live_tree_is_clean(self):
+        import check
+        fail = []
+        check.check_decomp_git_calls_strip_the_env(fail)
+        self.assertEqual([], fail)
+
+    def test_a_file_with_no_such_call_fails_instead_of_passing_vacuously(self):
+        import check
+        fail = []
+        check.check_decomp_git_calls_strip_the_env(fail, sources=['tools/callsites.py'])
+        self.assertTrue(fail)
+        self.assertIn('scan is broken', fail[0])
+
+    def test_it_scans_every_python_file_under_tools(self):
+        """The first cut listed three files by hand and its docstring claimed to pin every
+        call site; two real ones were invisible to it."""
+        import check, inspect
+        self.assertIn('os.walk', inspect.getsource(check.check_decomp_git_calls_strip_the_env))
+
+
+class NoShadowedDefinitions(unittest.TestCase):
+    """A duplicate top-level def silently shadows the first -- Python keeps the last and
+    says nothing. It disabled two guards in check.py on 2026-09-02."""
+
+    def test_the_live_tree_is_clean(self):
+        import check
+        fail = []
+        check.check_no_shadowed_definitions(fail)
+        self.assertEqual([], fail)
+
+    def test_a_duplicate_is_caught(self):
+        import check, os, tempfile
+        probe = os.path.join(check.REPO, 'tools', '_shadowprobe_test.py')
+        with open(probe, 'w', encoding='utf-8') as fh:
+            fh.write('def a():\n    pass\n\n\ndef a():\n    pass\n')
+        try:
+            fail = []
+            check.check_no_shadowed_definitions(fail, sources=['tools/_shadowprobe_test.py'])
+        finally:
+            os.remove(probe)
+        self.assertEqual(1, len(fail), fail)
+        self.assertIn('defines a twice', fail[0])
+
+    def test_the_check_is_registered_in_the_drift_gate(self):
+        import check, inspect
+        self.assertIn('check_no_shadowed_definitions', inspect.getsource(check.main))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -1604,5 +1604,82 @@ class NoShadowedDefinitions(unittest.TestCase):
         self.assertIn('check_no_shadowed_definitions', inspect.getsource(check.main))
 
 
+class GitEnvGuardRejectsEvasions(unittest.TestCase):
+    """#357 review round 2: the first cut accepted any env=, then any file MENTIONING
+    git_env. Both let the exact #353 failure back in."""
+
+    PROBE = 'tools/_envprobe_test.py'
+
+    def _fail(self, source):
+        import check, os
+        path = os.path.join(check.REPO, self.PROBE)
+        with open(path, 'w', encoding='utf-8') as fh:
+            fh.write(source)
+        try:
+            fail = []
+            check.check_decomp_git_calls_strip_the_env(fail, sources=[self.PROBE])
+        finally:
+            os.remove(path)
+        return fail
+
+    HEAD = 'from inject.decomp import git_env\nimport subprocess, os\nDECOMP = "x"\n'
+
+    def test_git_env_call_passes(self):
+        self.assertEqual([], self._fail(
+            self.HEAD + 'subprocess.run(["git","-C",DECOMP,"show","HEAD:a"], env=git_env())\n'))
+
+    def test_a_local_bound_to_git_env_passes(self):
+        self.assertEqual([], self._fail(
+            self.HEAD + 'env = git_env()\n'
+            'subprocess.run(["git","-C",DECOMP,"show","HEAD:a"], env=env)\n'))
+
+    def test_os_environ_copy_is_rejected(self):
+        """A Call, not an Attribute -- an `is it os.environ` test misses it entirely."""
+        bad = self._fail(
+            self.HEAD + 'subprocess.run(["git","-C",DECOMP,"show","HEAD:a"], env=os.environ.copy())\n')
+        self.assertEqual(1, len(bad), bad)
+
+    def test_a_private_inline_strip_is_rejected(self):
+        """gen_chapter_title.py shipped one missing three GIT_ vars, so it half-worked."""
+        bad = self._fail(
+            self.HEAD + 'e = {k: v for k, v in os.environ.items() if k != "GIT_DIR"}\n'
+            'subprocess.run(["git","-C",DECOMP,"show","HEAD:a"], env=e)\n')
+        self.assertEqual(1, len(bad), bad)
+
+    def test_a_syntax_error_is_reported_not_raised(self):
+        """This runs in the pre-commit hook: a traceback kills the gate and skips the
+        checks after it."""
+        bad = self._fail('subprocess.run(["git","-C",DECOMP,\n')
+        self.assertTrue(bad)
+        self.assertIn('does not parse', bad[0])
+
+
+class RegistryScanFailsLoudly(unittest.TestCase):
+    """A regex that stops matching must FAIL, not skip its arm while the gate says clean."""
+
+    def test_a_renamed_registry_is_reported(self):
+        import check
+        fail = []
+        check.check_rom_configs_reach_the_build(
+            fail, matrix_text='rom_configs:\n  ch01boot:\n    CH01BOOT: 1\n\nscenarios:\n  x: {}\n',
+            sources={'Makefile': '$(CH01BOOT)', 'build_campaign': 'renamed away',
+                     'probe': "FLAG_ARGS = {'CH01BOOT': '--ch01-boot'}\n"})
+        self.assertTrue(fail)
+        self.assertIn('NOT being checked', fail[0])
+
+
+class ValuedBuildFlagsCarryTheirValue(unittest.TestCase):
+    """--ch05-ending bare is argparse error 2, surfacing as an opaque CalledProcessError."""
+
+    def test_ch05ending_is_declared_valued(self):
+        import probe_invalidation as pi
+        self.assertIn('CH05ENDING', pi.VALUED_FLAGS)
+        self.assertIn('CH05ENDING', pi.FLAG_ARGS)
+
+    def test_every_valued_flag_is_in_FLAG_ARGS(self):
+        import probe_invalidation as pi
+        self.assertEqual(set(), pi.VALUED_FLAGS - set(pi.FLAG_ARGS))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -1472,5 +1472,42 @@ class CachedRowsReadDistinctly(unittest.TestCase):
                          [True, False])
 
 
+
+
+class RomConfigsReachTheBuild(unittest.TestCase):
+    """#353's guard: a rom_config env var the Makefile does not translate builds CANONICAL,
+    so the scenario's verdict is about a different ROM than the one it names."""
+
+    MATRIX = 'rom_configs:\n  canonical: {}\n  ch01boot:\n    CH01BOOT: 1\n\nscenarios:\n  x: {}\n'
+
+    def _fail(self, matrix_text, makefile_text):
+        import check
+        fail = []
+        check.check_rom_configs_reach_the_build(fail, matrix_text=matrix_text,
+                                                makefile_text=makefile_text)
+        return fail
+
+    def test_a_translated_env_var_passes(self):
+        self.assertEqual([], self._fail(self.MATRIX, 'x: $(if $(CH01BOOT),--ch01-boot)\n'))
+
+    def test_an_untranslated_env_var_is_caught(self):
+        bad = self._fail(self.MATRIX, 'x: $(if $(CH03BOOT),--ch03-boot)\n')
+        self.assertEqual(1, len(bad), bad)
+        self.assertIn('CH01BOOT', bad[0])
+        self.assertIn('CANONICAL', bad[0])
+
+    def test_finding_no_env_var_at_all_fails_instead_of_passing_vacuously(self):
+        bad = self._fail('rom_configs:\n  canonical: {}\n\nscenarios:\n  x: {}\n', 'x:\n')
+        self.assertTrue(bad)
+        self.assertIn('scan is broken', bad[0])
+
+    def test_the_live_tree_is_clean(self):
+        self.assertEqual([], self._fail(None, None))
+
+    def test_the_check_is_registered_in_the_drift_gate(self):
+        import check, inspect
+        self.assertIn('check_rom_configs_reach_the_build', inspect.getsource(check.main))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_winter_forest_backfill.py
+++ b/tools/test_winter_forest_backfill.py
@@ -8,6 +8,8 @@ import struct
 import subprocess
 import unittest
 
+from inject.decomp import git_env
+
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DECOMP = os.path.join(REPO, 'fireemblem8u')
@@ -43,8 +45,7 @@ def _metatiles(path):
 
 def _vanilla_decomp_text(relative_path):
     """Read committed vanilla input, not campaign-injected build output."""
-    env = {key: value for key, value in os.environ.items()
-           if not key.startswith('GIT_')}
+    env = git_env()
     return subprocess.check_output(
         ['git', '-C', DECOMP, 'show', 'HEAD:' + relative_path],
         encoding='utf-8', env=env)


### PR DESCRIPTION
Closes #353.

ch01 was the only hosted chapter without a fast boot, so confirming #347 by eye cost a canonical
build plus a full prologue playthrough (~24,000 frames) to see a map ch03 would have shown in
twenty seconds.

## What made ch01 different

**No seed table.** ch01 is the chapter that *founds* the party — its opening LOADs the company at
the Northlook and runs PREP — where `--ch03/04/05-boot` must conjure an armed party from nothing
(`CH03_BOOT_SEED_SYMBOL` and friends). The boot reuses ch01's own LOAD, so a cold start founds the
party exactly as the canonical chapter does.

**Lord select (#42), which nothing predicted.** The first cut kept ch01's opening and the run died
with `fail:nil ... never reached the map` on an 8-item `generic_menu` — the lord-select menu. No
other boot has met one, because no other chapter opens with a menu. Hence the lesson in the ADR:
**a debug boot is a MAP load-test, so it must strip every screen between New Game and the map, and
a MENU is such a screen even though it is not a cutscene.**

## Measured, not reasoned

| | |
|---|---|
| New Game → `player_map_idle`, chapter 2, player faction, turn 1 | **frame 2,856** (vs ~24,000 for the honest route) |
| `PT_HOST_CHAPTER=2 tools/playtest/run.sh mapshot` | **PASS** — "map deployed; screenshots taken" |
| Same via `matrix.py` | FAIL — `mapshot` is chapter-generic (`host_chapter: null`) so it resolves to host 1 while the ROM boots chapter 2, waits for a map that never matches, reports `boot-timeout`. Scenario wiring, not a boot fault; documented so it is not rediscovered |

## Two guards, both written RED first

- **`check_rom_configs_reach_the_build`** — a `rom_config` env var the Makefile does not translate
  builds **canonical**, so the scenario's verdict is about a different ROM than the one it names.
  Silent in both directions. Adding `ch01boot` without the Makefile arm fires it; adding the arm
  clears it.
- **`check_decomp_git_calls_strip_the_env`** — see below.

## The blocker this had to clear first

**The pre-commit hook could not pass from a worktree at all.** `git commit` exports
`GIT_DIR`/`GIT_INDEX_FILE` to hooks, and an explicit `GIT_DIR` **beats `git -C`** — so every
`git -C fireemblem8u show HEAD:...` resolved against the superproject and exited 128. It surfaced
as 12 errors in `test_build_campaign.py` that appear **only** under `git commit` and never when you
run the tests yourself, which is exactly why it read as "my change broke the tests".

`vanilla_decomp_text` already knew this — its comment says *"Bit us committing from a
content/pipeline worktree"* — but the lesson lived in **three inline copies** of the same env-strip
dict, and the one site that mattered (`chapter_label_constants`, the same `show HEAD:` call) had
none. It is now `inject.decomp.git_env()`, used at all 8 `git -C DECOMP` call sites and pinned by
AST.

**Proof:** with `GIT_DIR`/`GIT_INDEX_FILE` set exactly as the hook sets them,
`test_build_campaign.py` went from `FAILED (errors=12)` to **607 tests OK** — and this PR's own
commit passed the hook.

## Deliberately not done

Existing ch01 scenarios are **not** retargeted. `ch01win` and friends prove the ch00 → ch01 chain
works; repointing them at a boot that skips the prologue would delete exactly that coverage — the
*"a scenario written against the old design will FAIL ON SUCCESS"* trap. The repo's own precedent is
a fast **twin** (`recordlord` / `recordlordfast`), not a retarget. A dedicated fast ch01 record
scenario would cost one of `harness.lua`'s **2 remaining** top-level local slots, so it is noted on
the issue rather than spent here.

## Review

Not reviewed yet — needs `/code-review` before merge, per the ADR.
