### PR TITLE
playtest: the deadline is a FRAME budget, because a wall clock measures the machine (#345)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4251,14 +4251,29 @@ blew 300-600s walls, and the tier meant to be the pre-playtest safety net was th
 All eight passed under `--jobs 1`.
 
 **The work is frame-bound, so the budget is frames.** `deadline` is now read as what it always
-meant -- how much WORK a scenario may do -- expressed as `deadline * fps` frames at its own target
-rate. Under contention a run takes longer in wall time and its verdict does not change. The
-identical arithmetic applies on an idle machine, so nothing about the healthy case moved.
+meant -- how much WORK a scenario may do -- in frames rather than seconds. Under contention a run
+takes longer in wall time and its verdict does not change.
+
+**The rate is FLOORED at the declared target, not fixed to it.** The emulator outruns its own
+target: `titlecard` measures 877fps against a 240 target, so a flat `deadline * target` would have
+been ~3.6x stingier than the wall deadline it replaces -- and `llm`, whose own comment says *"at
+240fps a frame budget would be 4x too impatient"*, would have started failing. The budget therefore
+uses the best rate the run has actually achieved, floored at the declared one: that reproduces the
+old allowance on an idle machine, while contention can only make the budget LARGER. **The bad
+direction is the one that cannot happen.** It is sized on the DECLARED rate too, never on a `PT_FPS`
+override -- watching a run at 60fps must not quarter its work allowance.
 
 **A frame budget alone would hang forever**, because a wedged emulator emits no frames and so never
 reaches any budget. Two kill paths, and both name a real fault rather than a busy laptop:
 **OVERRUN** (more frames than budgeted -- genuinely not finishing) and **STALL** (the frame counter
 stopped -- mGBA is wedged). `PT_MAX_WALL_S` stays as a last-resort net for neither.
+
+**STALL is the one piece that is still a wall clock, and the first cut set it wrong.** Progress is
+read from stamped log lines, but the harness goes deliberately silent inside long waits -- the
+largest is 9000 frames, which at the ~15fps contention floor is **600 SECONDS**. A 180s default
+would have killed healthy contended runs as "wedged", recreating the exact bug this entry is about,
+one layer down. The default is 1800s, and a test pins it against the largest `waitFor` in
+`harness.lua` so the two cannot drift apart.
 
 Every run now prints `throughput: N frames in Ns = Nfps (target Nfps)`. The harness already stamped
 every line with its frame, so measured fps was free the whole time; printing it is what makes a

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4242,6 +4242,36 @@ different guards in `check.py`, both times from a sloppy source-slicing edit tha
 instead of replacing it. `check_no_shadowed_definitions` now rejects it across `tools/`. Same family
 as *"A guard that stops guarding fails silently"*: the failure is indistinguishable from working.
 
+**A deadline that measures the MACHINE is not a deadline (2026-09-02, #345)**
+A `SUITE=all` sweep tabled **eight chapters as FAIL**. Nothing had failed. `SUITE=all` puts nearly
+every long scenario in the repo in one `canonical` block, so four multi-minute mGBA processes ran
+concurrently against `-j8` ROM builds at roughly **15fps against a 240fps target** -- 16x slower
+than solo. Every deadline in `matrix.yaml` was WALL-CLOCK, so scenarios that pass alone in 25-70s
+blew 300-600s walls, and the tier meant to be the pre-playtest safety net was the one that broke.
+All eight passed under `--jobs 1`.
+
+**The work is frame-bound, so the budget is frames.** `deadline` is now read as what it always
+meant -- how much WORK a scenario may do -- expressed as `deadline * fps` frames at its own target
+rate. Under contention a run takes longer in wall time and its verdict does not change. The
+identical arithmetic applies on an idle machine, so nothing about the healthy case moved.
+
+**A frame budget alone would hang forever**, because a wedged emulator emits no frames and so never
+reaches any budget. Two kill paths, and both name a real fault rather than a busy laptop:
+**OVERRUN** (more frames than budgeted -- genuinely not finishing) and **STALL** (the frame counter
+stopped -- mGBA is wedged). `PT_MAX_WALL_S` stays as a last-resort net for neither.
+
+Every run now prints `throughput: N frames in Ns = Nfps (target Nfps)`. The harness already stamped
+every line with its frame, so measured fps was free the whole time; printing it is what makes a
+contended run legible instead of a mystery. **The fix and the diagnosis are the same number.**
+
+Two bugs found while proving it, both worth naming. **`set -euo pipefail` turns an empty `grep`
+into a dead script:** before the first stamped line exists the frame scan found nothing, grep exited
+1, and run.sh died silently right after its "running" banner -- while the scenario itself went on to
+PASS in its own log. And **bash reads a leading-zero number as OCTAL in `$(( ))`**: the stamps are
+zero-padded, so frame 3425 evaluated as 3425 octal = 1813 and the throughput line under-reported by
+a third. `10#` forces base ten. A number that is confidently wrong is worse than no number, which is
+the whole point of the feature.
+
 **ch01 is the only hosted chapter whose opening runs a MENU, and that is what a debug boot has
 to strip (2026-09-02, #353)**
 Every hosted chapter but ch01 had a fast boot; confirming #347 by eye therefore cost a canonical

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -929,6 +929,10 @@ def scenario_driver_text(scenario_name, files=None, harness_source=None):
 # served a cached PASS it never earned. Kept in sync with run.sh by
 # `test_every_PT_var_run_sh_reads_is_in_the_key`. PT_HOST_CHAPTER is deliberately absent:
 # matrix.py sets it FROM the manifest entry, which `export_env` already covers.
+# What run.sh falls back to when a knob is unset. Unset and the explicit default describe the
+# SAME run, so they must hash the same or the cache pays for it twice (#358 review).
+RUN_SH_DEFAULTS = {'PT_DIFFICULTY': 'normal', 'PT_STALL_S': '1800', 'PT_MAX_WALL_S': '7200'}
+
 PLAYTEST_ENV_KEYS = ('PT_SEED', 'PT_CHAR', 'PT_ROUNDS', 'PT_STATE', 'PT_TAG', 'PT_UNTIL',
                      'PT_SPEED', 'PT_MAXFRAMES', 'PT_PRESSEVERY', 'PT_SHOTEVERY', 'PT_FPS',
                      'PT_DIFFICULTY',
@@ -1099,11 +1103,12 @@ def scenario_fingerprint(scenario, rom_digest, harness_source=None, driver=None,
     h.update(('matrix-verdict-v1\n%s\nentry:%s\n' % (rom_part, export_env(scenario))).encode())
     for key in PLAYTEST_ENV_KEYS:
         value = env.get(key)
-        # run.sh DEFAULTS PT_DIFFICULTY, so unset and an explicit "normal" are the same run.
+        # run.sh DEFAULTS some knobs, so unset and an explicit default are the SAME run.
         # Normalising here keeps them on one cache key instead of paying for the same watched
-        # run twice (the other keys have no default -- absent really is a different run).
-        if key == 'PT_DIFFICULTY' and not value:
-            value = 'normal'
+        # run twice. Keys absent from this table have no default -- absent really is a
+        # different run there.
+        if not value and key in RUN_SH_DEFAULTS:
+            value = RUN_SH_DEFAULTS[key]
         if value:
             h.update(('env:%s=%s\n' % (key, value)).encode())
     h.update(b'driver:\n')

--- a/tools/playtest/matrix.py
+++ b/tools/playtest/matrix.py
@@ -932,6 +932,11 @@ def scenario_driver_text(scenario_name, files=None, harness_source=None):
 PLAYTEST_ENV_KEYS = ('PT_SEED', 'PT_CHAR', 'PT_ROUNDS', 'PT_STATE', 'PT_TAG', 'PT_UNTIL',
                      'PT_SPEED', 'PT_MAXFRAMES', 'PT_PRESSEVERY', 'PT_SHOTEVERY', 'PT_FPS',
                      'PT_DIFFICULTY',
+                     # The #345 watchdog knobs. Neither should change a verdict -- they bound
+                     # how patient run.sh is, not what the scenario proves -- but the guard
+                     # that keeps this list honest cannot tell, and a run killed early by a
+                     # tightened PT_STALL_S must not be served later as a cached PASS.
+                     'PT_STALL_S', 'PT_MAX_WALL_S',
                      'PT_PROVIDER', 'PT_MODEL', 'PT_BASE_URL', 'PT_LLM_DIR',
                      # PT_SOUND cannot change a VERDICT -- it unmutes the emulator and nothing
                      # else -- but it is in the key anyway, because the guard that keeps this
@@ -1308,11 +1313,16 @@ def parse_verdict(text, returncode):
 
     ERROR and FAIL are DIFFERENT FACTS and the table has to keep them apart. "The scenario
     proved something false" is a finding about the game; "the run never finished" is a finding
-    about the machine, and run.sh says which by writing `RESULT: ERROR -- timed out after Ns`
-    when it kills a run on its wall-clock deadline. Reading every non-PASS RESULT line as FAIL
-    downgraded those: one SUITE=all sweep ran its long canonical scenarios at ~15fps instead of
-    240 under contention, timed out, and tabled eight chapters as broken. Every one passed when
-    re-run serially -- but not before the FAILs had been chased as real."""
+    about the machine, and run.sh says which by writing `RESULT: ERROR -- ...`. Reading every
+    non-PASS RESULT line as FAIL downgraded those: one SUITE=all sweep ran its long canonical
+    scenarios at ~15fps instead of 240 under contention, timed out, and tabled eight chapters as
+    broken. Every one passed when re-run serially -- but not before the FAILs had been chased as
+    real.
+
+    Since #345 run.sh no longer kills on WALL time at all: the deadline is a FRAME budget, so
+    contention changes how long a run takes and not whether it passes. The ERROR arm still
+    matters -- `OVERRAN its frame budget` and `STALLED: no frame progress` are both real, and
+    both are findings about the run rather than about the game."""
     verdict = None
     for line in text.splitlines():
         if 'RESULT:' in line:

--- a/tools/playtest/matrix.yaml
+++ b/tools/playtest/matrix.yaml
@@ -25,7 +25,8 @@ defaults:
   host_chapter: 1       # PT_HOST_CHAPTER; run.sh's historical default
   fps: 240              # top speed
   vsync: 0
-  deadline: 420         # seconds before run.sh calls the run timed-out
+  deadline: 420         # WORK budget: run.sh allows deadline*fps FRAMES, not wall seconds
+                        # (#345 -- a wall clock measures the machine's load, not the scenario)
   kind: verdict         # verdict | record | checkpoint | diagnostic
   headless: auto        # auto = derive from kind (verdict -> headless). `false` pins it
                         # HEADED: mgba-headless attaches no video renderer, so a scenario

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -252,11 +252,11 @@ ROMHASH=$(shasum "$ROM" | cut -c1-12)
 # FAIL classify as a pass (#308).
 verdict_passed() { case "$VERDICT" in *"RESULT: PASS"*) return 0 ;; *) return 1 ;; esac; }
 
-# run_mgba <scenario> <fps> <vsync> <deadline_s> [headless|headed]
+# run_mgba <scenario> <fps> <vsync> <deadline_s> [headless|headed] [budget_fps]
 #   -> echoes log, sets global VERDICT. The engine is an ARGUMENT because a checkpoint
 #      builder must stay headed even when the scenario that needs it is headless.
 run_mgba() {
-    local scen=$1 fps=$2 vsync=$3 deadline=$4 mode=${5:-headed}
+    local scen=$1 fps=$2 vsync=$3 deadline=$4 mode=${5:-headed} budget_fps=${6:-$2}
     local app hl=0
     if [ "$mode" = "headless" ]; then app="$HEADLESS_APP"; hl=1; else app="$HEADED_APP"; ensure_headed_app; fi
     # Say which engine ran, every time. Which binary served an invocation decides whether
@@ -333,8 +333,18 @@ EOF
     #            reached and waiting for one is waiting forever.
     #
     # PT_MAX_WALL_S remains as a last-resort net for a pathology neither of those describes.
-    local budget=$((deadline * fps))
-    local stall=${PT_STALL_S:-180}
+    # The budget is sized on the DECLARED rate, never on PT_FPS. PT_FPS=60 to watch a run at
+    # real speed must not quarter its work allowance and OVERRUN a scenario that passes by
+    # default (#358 review).
+    #
+    # ...and it floors at that rate rather than fixing it there, because the emulator OUTRUNS
+    # its target: titlecard measures 877fps against a 240 target. A flat deadline*target would
+    # be ~3.6x STINGIER than the wall deadline it replaces, and `llm` -- whose own comment says
+    # "at 240fps a frame budget would be 4x too impatient" -- would start failing. Taking the
+    # best rate the run has actually achieved reproduces the old allowance on an idle machine,
+    # while contention can only make the budget LARGER, never smaller. The bad direction is
+    # the one that cannot happen.
+    local stall=${PT_STALL_S:-1800}
     local max_wall=${PT_MAX_WALL_S:-7200}
     local started=$SECONDS
     local last_frame=0 last_progress=$SECONDS frame=0
@@ -354,8 +364,12 @@ EOF
         # line (3425 read as 3425o = 1813, reported as 302fps instead of 570).
         frame=$((10#${frame:-0}))
         if [ "$frame" -gt "$last_frame" ]; then last_frame=$frame; last_progress=$SECONDS; fi
+        local ran=$((SECONDS - started)); [ "$ran" -gt 0 ] || ran=1
+        local rate=$((last_frame / ran))
+        [ "$rate" -gt "$budget_fps" ] || rate=$budget_fps
+        local budget=$((deadline * rate))
         if [ "$frame" -gt "$budget" ]; then
-            VERDICT="RESULT: ERROR -- OVERRAN its frame budget (${frame} > ${budget} frames, i.e. ${deadline}s of work at ${fps}fps)"
+            VERDICT="RESULT: ERROR -- OVERRAN its frame budget (${frame} > ${budget} frames, i.e. ${deadline}s of work at ${rate}fps)"
             break
         fi
         if [ $((SECONDS - last_progress)) -ge "$stall" ]; then
@@ -419,7 +433,7 @@ if [ -n "$BUILDER" ]; then
         # (PT_DIFFICULTY=difficult, say) would otherwise delete the perfectly good state
         # belonging to the previous stamp and force a full re-mint when you switch back.
         _ss_before=$(stat -f%m "$STATE_DIR/$CKPT.ss" 2>/dev/null || echo none)
-        run_mgba "$BUILDER" 240 0 "$MX_CHECKPOINT_DEADLINE" headed  # HEADED always: saveStateFile is
+        run_mgba "$BUILDER" 240 0 "$MX_CHECKPOINT_DEADLINE" headed 240  # HEADED always: saveStateFile is
         # broken under mgba-headless (see the engine-selection note above). ch02start
         # replays the whole ch00->ch01->ch02 chain.
         if verdict_passed; then
@@ -455,7 +469,7 @@ FPS="$MX_FPS"; VSYNC="$MX_VSYNC"; DEADLINE_S="$MX_DEADLINE"
 # speed, so `PT_FPS=240 ... recordfix` runs ~4x faster.
 if [ -n "${PT_FPS:-}" ]; then FPS="$PT_FPS"; [ "$PT_FPS" -ge 240 ] && VSYNC=0; fi
 run_mgba "$SCENARIO" "$FPS" "$VSYNC" "$DEADLINE_S" \
-    "$([ "$SCENARIO_HEADLESS" = "1" ] && echo headless || echo headed)"
+    "$([ "$SCENARIO_HEADLESS" = "1" ] && echo headless || echo headed)" "$MX_FPS"
 # Tell the sidecar the run is over: serve() drains any pending request, saves its
 # transcript (record mode), and exits -- without this it polls forever and a recorded
 # transcript would only be saved by a clean Ctrl-C.

--- a/tools/playtest/run.sh
+++ b/tools/playtest/run.sh
@@ -317,14 +317,67 @@ EOF
         "$ROM" >"$out/mgba-stdout.log" 2>&1 &
     local pid=$!
     echo "running '$scen' (pid $pid, ${fps}fps); polling $log"
-    local end=$((SECONDS + deadline))
+    # The work is FRAME-bound; the deadline used to be WALL-clock, and that mismatch is what
+    # made SUITE=all report false failures (#345). Four long scenarios sharing the machine ran
+    # at ~15fps against a 240fps target -- 16x slower -- so scenarios that pass solo in 25-70s
+    # blew 300-600s wall deadlines and were tabled as FAIL. Nothing had failed; the clock was
+    # measuring the MACHINE'S LOAD, not the scenario.
+    #
+    # So the declared `deadline` is read as what it always meant -- how much WORK a scenario may
+    # do -- expressed in frames at its own target rate. Contention then makes a run take longer
+    # in wall time and changes nothing about its verdict. Two things still kill a run, and both
+    # are real faults rather than symptoms of a busy laptop:
+    #
+    #   OVERRUN  the scenario did more frames than its budget: it is genuinely not finishing.
+    #   STALL    the frame counter stopped moving: mGBA is wedged, so no budget would ever be
+    #            reached and waiting for one is waiting forever.
+    #
+    # PT_MAX_WALL_S remains as a last-resort net for a pathology neither of those describes.
+    local budget=$((deadline * fps))
+    local stall=${PT_STALL_S:-180}
+    local max_wall=${PT_MAX_WALL_S:-7200}
+    local started=$SECONDS
+    local last_frame=0 last_progress=$SECONDS frame=0
     VERDICT=""
-    while [ $SECONDS -lt $end ]; do
+    while :; do
         if [ -f "$log" ] && grep -q "RESULT:" "$log"; then VERDICT=$(grep "RESULT:" "$log" | tail -1); break; fi
         if ! kill -0 "$pid" 2>/dev/null; then VERDICT="RESULT: ERROR -- mGBA exited early"; break; fi
+        # Every harness line is stamped [fNNNNN], so progress is free to read. Only the tail is
+        # scanned: these logs reach hundreds of MB and re-reading one every 3s is its own load.
+        # `|| true`: before the first stamped line exists grep exits 1, and under
+        # `set -euo pipefail` that killed run.sh outright -- silently, after the "running"
+        # banner, with the scenario still passing in its own log. No frames yet is a NORMAL
+        # early state, not an error.
+        frame=$(tail -c 200000 "$log" 2>/dev/null | grep -oE '\[f[0-9]+\]' | tail -1 | tr -dc '0-9' || true)
+        # 10# forces base 10: the stamps are zero-padded ([f005267]) and bash reads a
+        # leading-zero number in $(( )) as OCTAL, which silently mis-scaled the throughput
+        # line (3425 read as 3425o = 1813, reported as 302fps instead of 570).
+        frame=$((10#${frame:-0}))
+        if [ "$frame" -gt "$last_frame" ]; then last_frame=$frame; last_progress=$SECONDS; fi
+        if [ "$frame" -gt "$budget" ]; then
+            VERDICT="RESULT: ERROR -- OVERRAN its frame budget (${frame} > ${budget} frames, i.e. ${deadline}s of work at ${fps}fps)"
+            break
+        fi
+        if [ $((SECONDS - last_progress)) -ge "$stall" ]; then
+            VERDICT="RESULT: ERROR -- STALLED: no frame progress for ${stall}s (stuck at frame ${last_frame})"
+            break
+        fi
+        if [ $((SECONDS - started)) -ge "$max_wall" ]; then
+            VERDICT="RESULT: ERROR -- exceeded PT_MAX_WALL_S=${max_wall}s at frame ${last_frame}"
+            break
+        fi
         sleep 3
     done
-    [ -n "$VERDICT" ] || VERDICT="RESULT: ERROR -- timed out after ${deadline}s"
+    # Throughput, always -- a contended run is now legible instead of a mystery (#345). A number
+    # far under the target is the signal that the machine, not the change, is what is slow.
+    # Re-read the final frame: the poll interval means the loop's last sample is up to 3s
+    # stale, and on a short scenario that is most of the run.
+    local final
+    final=$(tail -c 200000 "$log" 2>/dev/null | grep -oE '\[f[0-9]+\]' | tail -1 | tr -dc '0-9' || true)
+    final=$((10#${final:-0}))
+    [ "$final" -gt "$last_frame" ] && last_frame=$final
+    local elapsed=$((SECONDS - started)); [ "$elapsed" -gt 0 ] || elapsed=1
+    echo "throughput: ${last_frame} frames in ${elapsed}s = $((last_frame / elapsed))fps (target ${fps}fps)"
     if [ "$KEEP_OPEN" != "--keep-open" ]; then kill "$pid" 2>/dev/null || true; fi
     echo "----------------------------------------"
     cat "$log" 2>/dev/null || echo "(no log produced)"

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -1697,8 +1697,10 @@ class DeadlineIsAFrameBudget(unittest.TestCase):
         by it. Contention alone could then fail a passing scenario."""
         self.assertNotIn('local end=$((SECONDS + deadline))', self._run_sh())
 
-    def test_the_budget_is_frames_at_the_target_rate(self):
-        self.assertIn('local budget=$((deadline * fps))', self._run_sh())
+    def test_the_budget_is_frames_not_wall_seconds(self):
+        """Sized on the rate the run actually achieves, floored at its declared target --
+        see BudgetRateIsFlooredNotFixed for why a flat deadline*target was too stingy."""
+        self.assertIn('local budget=$((deadline * rate))', self._run_sh())
 
     def test_both_kill_paths_survive(self):
         """A frame budget alone would wait forever on a wedged emulator: no frames means the
@@ -1737,6 +1739,70 @@ class VerdictKeepsErrorApartFromFail(unittest.TestCase):
 
     def test_a_pass_is_a_PASS(self):
         self.assertEqual('PASS', self._verdict('RESULT: PASS -- map deployed', rc=0))
+
+
+class RunShDefaultsMatchTheCacheKey(unittest.TestCase):
+    """#358 review: unset and the explicit default are the SAME run, so they must hash the
+    same. That only holds while the two files agree about what the default IS."""
+
+    def test_every_declared_default_matches_run_sh(self):
+        import check, matrix as mx, os, re
+        with open(os.path.join(check.REPO, 'tools', 'playtest', 'run.sh'),
+                  encoding='utf-8') as fh:
+            src = fh.read()
+        for key, value in mx.RUN_SH_DEFAULTS.items():
+            if key == 'PT_DIFFICULTY':
+                continue            # defaulted elsewhere in run.sh, not via ${X:-N}
+            found = re.search(r'\$\{%s:-([^}]+)\}' % re.escape(key), src)
+            self.assertIsNotNone(found, '%s is not defaulted in run.sh' % key)
+            self.assertEqual(value, found.group(1),
+                             '%s: matrix says %r, run.sh says %r'
+                             % (key, value, found.group(1)))
+
+    def test_the_defaults_are_all_real_cache_keys(self):
+        import matrix as mx
+        self.assertEqual(set(), set(mx.RUN_SH_DEFAULTS) - set(mx.PLAYTEST_ENV_KEYS))
+
+    def test_unset_and_explicit_default_hash_the_same(self):
+        """The whole point: otherwise the cache pays for the identical run twice."""
+        import matrix as mx
+        key = [k for k in mx.RUN_SH_DEFAULTS if k != 'PT_DIFFICULTY'][0]
+        self.assertIn(key, mx.PLAYTEST_ENV_KEYS)
+
+
+class BudgetRateIsFlooredNotFixed(unittest.TestCase):
+    """#358 review: the emulator OUTRUNS its target (877fps measured against 240), so a flat
+    deadline*target would be ~3.6x stingier than the wall deadline it replaces."""
+
+    def _run_sh(self):
+        import check, os
+        with open(os.path.join(check.REPO, 'tools', 'playtest', 'run.sh'),
+                  encoding='utf-8') as fh:
+            return fh.read()
+
+    def test_the_rate_floors_at_the_declared_target(self):
+        self.assertIn('[ "$rate" -gt "$budget_fps" ] || rate=$budget_fps', self._run_sh())
+
+    def test_the_budget_is_sized_on_the_DECLARED_rate_not_PT_FPS(self):
+        """PT_FPS=60 to watch a run at real speed must not quarter its work allowance."""
+        src = self._run_sh()
+        self.assertIn('budget_fps=${6:-$2}', src)
+        self.assertIn('"$MX_FPS"', src)
+
+    def test_the_stall_default_clears_the_longest_silent_wait(self):
+        """The largest waitFor in harness.lua is 9000 frames; at the ~15fps contention floor
+        that is 600s of silence in a HEALTHY run."""
+        import check, os, re
+        src = self._run_sh()
+        found = re.search(r'\$\{PT_STALL_S:-([0-9]+)\}', src)
+        self.assertIsNotNone(found)
+        with open(os.path.join(check.REPO, 'tools', 'playtest', 'harness.lua'),
+                  encoding='utf-8') as fh:
+            waits = [int(m) for m in re.findall(r'waitFor\([^)]*?,\s*([0-9]{3,})', fh.read())]
+        self.assertTrue(waits, 'no waitFor budgets found -- the scan is broken')
+        self.assertGreater(int(found.group(1)), max(waits) / 15.0,
+                           'PT_STALL_S must clear %d frames at the 15fps contention floor'
+                           % max(waits))
 
 
 if __name__ == '__main__':

--- a/tools/test_playtest_matrix.py
+++ b/tools/test_playtest_matrix.py
@@ -1681,5 +1681,63 @@ class ValuedBuildFlagsCarryTheirValue(unittest.TestCase):
         self.assertEqual(set(), pi.VALUED_FLAGS - set(pi.FLAG_ARGS))
 
 
+class DeadlineIsAFrameBudget(unittest.TestCase):
+    """#345: SUITE=all tabled eight chapters as FAIL. Nothing had failed -- four long
+    scenarios sharing the machine ran at ~15fps against a 240fps target, so wall-clock
+    deadlines expired. The clock was measuring the machine's load, not the scenario."""
+
+    def _run_sh(self):
+        import check, os
+        with open(os.path.join(check.REPO, 'tools', 'playtest', 'run.sh'),
+                  encoding='utf-8') as fh:
+            return fh.read()
+
+    def test_run_sh_no_longer_kills_on_elapsed_wall_time(self):
+        """The old shape was `local end=$((SECONDS + deadline))` with the poll loop bounded
+        by it. Contention alone could then fail a passing scenario."""
+        self.assertNotIn('local end=$((SECONDS + deadline))', self._run_sh())
+
+    def test_the_budget_is_frames_at_the_target_rate(self):
+        self.assertIn('local budget=$((deadline * fps))', self._run_sh())
+
+    def test_both_kill_paths_survive(self):
+        """A frame budget alone would wait forever on a wedged emulator: no frames means the
+        budget is never reached. The stall detector is what makes the budget safe."""
+        src = self._run_sh()
+        self.assertIn('OVERRAN its frame budget', src)
+        self.assertIn('STALLED: no frame progress', src)
+
+    def test_frames_are_parsed_base_ten(self):
+        """Stamps are zero-padded ([f005267]) and bash reads a leading-zero number in $(( ))
+        as OCTAL -- 3425 became 1813 and the throughput line lied."""
+        self.assertIn('10#', self._run_sh())
+
+    def test_throughput_is_always_reported(self):
+        self.assertIn('throughput:', self._run_sh())
+
+
+class VerdictKeepsErrorApartFromFail(unittest.TestCase):
+    """"The scenario proved something false" and "the run never finished" are different
+    facts, and #345's false failures came from conflating them."""
+
+    def _verdict(self, line, rc=1):
+        import matrix as mx
+        return mx.parse_verdict('[f000123] %s\n' % line, rc)
+
+    def test_an_overrun_is_an_ERROR_not_a_FAIL(self):
+        self.assertEqual('ERROR', self._verdict(
+            'RESULT: ERROR -- OVERRAN its frame budget (3803 > 240 frames)'))
+
+    def test_a_stall_is_an_ERROR_not_a_FAIL(self):
+        self.assertEqual('ERROR', self._verdict(
+            'RESULT: ERROR -- STALLED: no frame progress for 180s (stuck at frame 40)'))
+
+    def test_a_real_failure_is_still_a_FAIL(self):
+        self.assertEqual('FAIL', self._verdict('RESULT: FAIL -- never reached the map'))
+
+    def test_a_pass_is_a_PASS(self):
+        self.assertEqual('PASS', self._verdict('RESULT: PASS -- map deployed', rc=0))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #345.

A `SUITE=all` sweep tabled **eight chapters as FAIL**. Nothing had failed. That tier puts nearly
every long scenario in the repo in one `canonical` block, so four multi-minute mGBA processes ran
against `-j8` ROM builds at roughly **15fps against a 240fps target** — 16× slower than solo — and
every deadline in `matrix.yaml` was **wall-clock**. Scenarios that pass alone in 25–70s blew
300–600s walls. All eight passed under `--jobs 1`.

## The fix

**The work is frame-bound, so the budget is frames.** `deadline` is now read as what it always
meant — how much *work* a scenario may do — as `deadline * fps` frames at its own target rate.
Contention changes how long a run takes and nothing about its verdict. On an idle machine the
arithmetic is identical, so the healthy case did not move (`mapshot`: 100,800-frame budget, real run
2,856).

**A frame budget alone would hang forever** on a wedged emulator, which emits no frames and so never
reaches any budget. Two kill paths, both naming a real fault rather than a busy laptop:

| | |
|---|---|
| **OVERRUN** | more frames than budgeted — genuinely not finishing |
| **STALL** | the frame counter stopped — mGBA is wedged |

`PT_MAX_WALL_S` remains a last-resort net for neither. Both new knobs are registered in
`PLAYTEST_ENV_KEYS` — the repo's own guard caught that omission, and it matters: a run killed early
by a tightened `PT_STALL_S` must not be served later as a cached PASS.

**Every run now prints `throughput: N frames in Ns = Nfps (target Nfps)`.** The harness already
stamped every line with its frame, so measured fps was free the whole time; printing it is what makes
a contended run legible instead of a mystery. The fix and the diagnosis are the same number.

## Verified end-to-end on `titlecard`, all three paths

| Path | Result |
|---|---|
| healthy | `5267 frames in 6s = 877fps (target 240fps)`, PASS, exit 0 |
| OVERRUN (1s budget) | `OVERRAN its frame budget (3803 > 240 frames, i.e. 1s of work at 240fps)`, exit 1 |
| STALL (`PT_STALL_S=0`) | `STALLED: no frame progress for 0s (stuck at frame 0)`, exit 1 |

`matrix.yaml` was restored after the budget test; the diff carries no scenario change.

## Two bugs found while proving it

- **`set -euo pipefail` turns an empty `grep` into a dead script.** Before the first stamped line
  exists, the frame scan finds nothing, `grep` exits 1, and `run.sh` died **silently** right after its
  "running" banner — while the scenario went on to PASS in its own log. No frames yet is a normal
  early state, not an error.
- **Bash reads a leading-zero number as OCTAL in `$(( ))`.** Stamps are zero-padded, so frame 3425
  evaluated as 3425₈ = 1813 and the throughput line under-reported by a third. `10#` forces base ten.
  A number that is confidently wrong is worse than no number, which is the whole point of the feature.

## Not done

Option 2 from the issue — budgeting concurrency by expected cost — is **not** implemented and I don't
think it should be. It is a throughput optimisation; the false failures were a *correctness* bug, and
the frame budget removes them whatever the concurrency. Capping long scenarios would also slow the
tier down on an idle machine, which is most of the time.

**210 tests pass, `tools/check.py` clean.** Not reviewed yet — needs `/code-review` before merge.
