### PR TITLE
difficulty: AI behaviour is MEASURED and REPORTED, not weighted into threat (#344)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4270,13 +4270,21 @@ latent -- and the metric stays about stats, which is what it can actually measur
 
 **A corollary, and the one real gap the measurement found.** `AI_BEHAVIOUR` named 8 of the decomp's
 19 AI2 scripts (`gAi2ScriptTable`, `cp_data.c:1548`, read via `cp_script.c:90` as
-`gpAi2Table[0][ai2]`), so eleven reported as bare numbers -- including `0x0A`, which **vanilla's own
-Prologue fields**. The map is now complete for every index whose decomp SYMBOL states its behaviour,
-and the eleven named after bare addresses are left **unnamed and UNCLASSIFIED** rather than guessed
-at: bucketing an unknown script as static because it is unnamed would be a guess wearing a
-measurement's clothes, and it would land on the side that lowers the number. A test pins the map
-against `cp_data.c` -- the tracked `.c`, never the generated `.s`, which is a build artifact and not
-at HEAD at all.
+`gpAi2Table[0][ai2]`), so eleven indices reported as bare numbers -- including `0x0A`, which
+**vanilla's own Prologue fields**. Thirteen are named now: every index whose decomp SYMBOL states
+its behaviour. The **six** the decomp itself gives only an address (0x08, 0x09, 0x0A, 0x0B, 0x0D,
+0x0F) stay **unnamed and UNCLASSIFIED** rather than guessed at -- bucketing an unknown script as
+static because it is unnamed would be a guess wearing a measurement's clothes, and it would land on
+the side that lowers the number. A test pins the map against `cp_data.c` -- the tracked `.c`, never
+the generated `.s`, which is a build artifact and not at HEAD at all.
+
+**"Known but neither" is not the same fact as "unknown", and the first cut collapsed them.** Three
+NAMED families -- `pillage-escape`, `escape`, `attack-walls-snags` -- are neither threat that comes
+to you nor threat you walk into: the unit moves, but not at the player. Leaving them to fall through
+to `unclassified` said *we do not know* about scripts the decomp names outright, and `ai2 = 0x05`
+alone appears 120 times in the reference files the parity twins already read. They get their own
+bucket, **on its own errand**, and a test asserts that no named family can ever fall through to
+unclassified again.
 
 **A deadline that measures the MACHINE is not a deadline (2026-09-02, #345)**
 A `SUITE=all` sweep tabled **eight chapters as FAIL**. Nothing had failed. `SUITE=all` puts nearly

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4242,6 +4242,42 @@ different guards in `check.py`, both times from a sloppy source-slicing edit tha
 instead of replacing it. `check_no_shadowed_definitions` now rejects it across `tools/`. Same family
 as *"A guard that stops guarding fails silently"*: the failure is indistinguishable from working.
 
+**AI behaviour is MEASURED and REPORTED, not weighted into threat (2026-09-03, #344)**
+#344 proposed weighting each unit's threat contribution by its AI behaviour, on the grounds that a
+`never-move` unit contributes nothing until the player walks into its range. The issue asked for a
+measurement against the twins before any weighting was picked. The measurement said **do not build
+the weighting.**
+
+**Vanilla has no single shape to weight against.** Red-force behaviour per twin runs from FE8 Ch3 at
+100% static to FE8 Ch2 at 100% mobile, with Ch1 at 70/30, Ch4 56/43, Ch5 52/47 and Ch6 33/66. There
+is no campaign-wide "vanilla mobile share"; behavioural parity can only ever mean *this chapter
+against its own twin*.
+
+**And ours already equals its twin, everywhere.** Measured 0 points of difference on all six active
+chapters, with every enemy resolving (0 failures). That is not luck: **#335 made AI derived** --
+`enemy_ai_bytes` returns the donor's bytes -- so our behavioural shape IS the twin's by construction.
+A weighting would therefore apply identical weights to both sides of a ratio that is equal by
+definition and report x1.00 no matter what. **It cannot catch anything.** The ch04 "78% pursuers
+against a half-static twin" case is history: it was fixed by deriving AI, not by measuring it.
+
+The only remaining channel for divergence is `ai_override`, of which the campaign has three, each
+with a mandatory `why`, and none introducing a silent shift (Sephek keeps his donor's family; the
+mauthedoog and the white moose are ours-only units vanilla has nothing to lend).
+
+So the residue that IS worth having: **the split is reported next to the roster** (`make chapter`
+prints `shape N come to you / N you walk into`), where a future divergence is visible instead of
+latent -- and the metric stays about stats, which is what it can actually measure.
+
+**A corollary, and the one real gap the measurement found.** `AI_BEHAVIOUR` named 8 of the decomp's
+19 AI2 scripts (`gAi2ScriptTable`, `cp_data.c:1548`, read via `cp_script.c:90` as
+`gpAi2Table[0][ai2]`), so eleven reported as bare numbers -- including `0x0A`, which **vanilla's own
+Prologue fields**. The map is now complete for every index whose decomp SYMBOL states its behaviour,
+and the eleven named after bare addresses are left **unnamed and UNCLASSIFIED** rather than guessed
+at: bucketing an unknown script as static because it is unnamed would be a guess wearing a
+measurement's clothes, and it would land on the side that lowers the number. A test pins the map
+against `cp_data.c` -- the tracked `.c`, never the generated `.s`, which is a build artifact and not
+at HEAD at all.
+
 **A deadline that measures the MACHINE is not a deadline (2026-09-02, #345)**
 A `SUITE=all` sweep tabled **eight chapters as FAIL**. Nothing had failed. `SUITE=all` puts nearly
 every long scenario in the repo in one `canonical` block, so four multi-minute mGBA processes ran

--- a/tools/chapter_status.py
+++ b/tools/chapter_status.py
@@ -224,15 +224,15 @@ def _donor_label(row):
 
 
 # The AI2 index selects a script from the decomp's own `gAi2ScriptTable`
-# (`cp_data.s:3245`, .size 76 = 19 entries), which `cp_script.c:90` reads as
-# `gpAi2Table[0][gActiveUnit->ai2]`. This mapping is that table, and
-# `test_ai_behaviour_matches_the_decomp_table` pins it so the two cannot drift.
+# (`cp_data.c:1548`, 19 entries), which `cp_script.c:90` reads as
+# `gpAi2Table[0][gActiveUnit->ai2]`. This mapping is that table, and the tests pin it so the
+# two cannot drift. Cite the tracked `.c`: `cp_data.s` is a BUILD ARTIFACT and is not at HEAD.
 #
-# The first eight names were all this map had, and every one of the other eleven was reported
-# as a bare `0x0A`-style number -- including one that vanilla's own PROLOGUE fields (#344).
-# Where the decomp's symbol states the behaviour, the name says it; where the symbol is a bare
-# address, the entry stays UNNAMED rather than being guessed at. An invented name would be
-# indistinguishable from a known one at the call site.
+# The first eight names were all this map had, so the other ELEVEN indices reported as bare
+# `0x0A`-style numbers -- including one vanilla's own PROLOGUE fields (#344). Thirteen are now
+# named. The remaining SIX (0x08, 0x09, 0x0A, 0x0B, 0x0D, 0x0F) are named after bare addresses
+# in the decomp too, so they stay UNNAMED here rather than being guessed at: an invented name
+# would be indistinguishable from a known one at the call site.
 AI_BEHAVIOUR = {
     0x00: 'pursue',
     0x01: 'pursue-ignore-char',        # MoveToEnemy_IgnoreChar_Unused1
@@ -253,15 +253,20 @@ AI_BEHAVIOUR = {
 # YAML coined the distinction and #344 measured it. A unit that never moves contributes nothing
 # until the player enters its range, so the two are not interchangeable.
 #
-# Only families whose DECOMP SYMBOL states the behaviour are classified. The eleven table
-# entries named after bare addresses, and any index outside the table, are UNCLASSIFIED on
-# purpose: bucketing an unknown script as "static" because it is unnamed would be a guess
-# wearing a measurement's clothes, and it would land silently on the side that lowers the
-# number.
+# Only families whose DECOMP SYMBOL states the behaviour are classified. The six table entries
+# named after bare addresses, and any index outside the table, are UNCLASSIFIED on purpose:
+# bucketing an unknown script as "static" because it is unnamed would be a guess wearing a
+# measurement's clothes, and it would land silently on the side that lowers the number.
 AI_COMES_TO_YOU = frozenset({'pursue', 'pursue-ignore-char', 'pursue-twice',
                              'pursue-twice-ignore-char', 'charge-after-1',
                              'pillage', 'pillage-after-1'})
 AI_WALK_INTO = frozenset({'never-move', 'guard-tile'})
+# Known behaviours that are NEITHER: the unit moves, but not at the player. A thief that loots
+# and leaves, a script that flees, one that chews on walls. Folding these into "unclassified"
+# said "we do not know" about three scripts the decomp names outright -- and ai2=0x05 alone
+# occurs 120x in the reference files the parity twins already read (#359 review). "Known but
+# neither" and "unknown" are different facts and the report keeps them apart.
+AI_OWN_ERRAND = frozenset({'pillage-escape', 'escape', 'attack-walls-snags'})
 
 
 def ai_family(ai2):
@@ -278,7 +283,7 @@ def behaviour_split(ai2s):
     chapters), so a weighting would scale both sides of the ratio identically and always report
     x1.00. What is worth having is the split in the open, where a future divergence shows.
     """
-    out = {'comes_to_you': 0, 'walk_into': 0, 'unclassified': 0, 'n': 0}
+    out = {'comes_to_you': 0, 'walk_into': 0, 'own_errand': 0, 'unclassified': 0, 'n': 0}
     for ai2 in ai2s:
         out['n'] += 1
         family = ai_family(ai2)
@@ -286,6 +291,8 @@ def behaviour_split(ai2s):
             out['comes_to_you'] += 1
         elif family in AI_WALK_INTO:
             out['walk_into'] += 1
+        elif family in AI_OWN_ERRAND:
+            out['own_errand'] += 1
         else:
             out['unclassified'] += 1
     return out
@@ -679,10 +686,12 @@ def report(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
         if split['n']:
             line = ('    shape     %d come to you / %d you walk into'
                     % (split['comes_to_you'], split['walk_into']))
+            if split['own_errand']:
+                # Moves, but not at the player -- loots and leaves, flees, chews on walls.
+                line += ' / %d on its own errand' % split['own_errand']
             if split['unclassified']:
-                # Named separately rather than folded into either side: the decomp leaves
-                # eleven AI2 scripts as bare addresses, and one of them is live in vanilla's
-                # own Prologue.
+                # Named separately rather than folded into any of them: the decomp leaves six
+                # AI2 scripts as bare addresses, and one is live in vanilla's own Prologue.
                 line += ' / %d unclassified' % split['unclassified']
             out.append(line)
         out.append('    AI is BORROWED from each unit\'s vanilla donor, never authored --')

--- a/tools/chapter_status.py
+++ b/tools/chapter_status.py
@@ -223,16 +223,72 @@ def _donor_label(row):
     return '--' if donor is None else str(donor)[:14]
 
 
+# The AI2 index selects a script from the decomp's own `gAi2ScriptTable`
+# (`cp_data.s:3245`, .size 76 = 19 entries), which `cp_script.c:90` reads as
+# `gpAi2Table[0][gActiveUnit->ai2]`. This mapping is that table, and
+# `test_ai_behaviour_matches_the_decomp_table` pins it so the two cannot drift.
+#
+# The first eight names were all this map had, and every one of the other eleven was reported
+# as a bare `0x0A`-style number -- including one that vanilla's own PROLOGUE fields (#344).
+# Where the decomp's symbol states the behaviour, the name says it; where the symbol is a bare
+# address, the entry stays UNNAMED rather than being guessed at. An invented name would be
+# indistinguishable from a known one at the call site.
 AI_BEHAVIOUR = {
     0x00: 'pursue',
+    0x01: 'pursue-ignore-char',        # MoveToEnemy_IgnoreChar_Unused1
+    0x02: 'pursue-ignore-char',        # MoveToEnemy_IgnoreChar_Unused2
     0x03: 'never-move',
     0x04: 'pillage',
     0x05: 'pillage-escape',
     0x06: 'pursue-twice',
+    0x07: 'pursue-twice-ignore-char',  # MoveTwiceToEnemy_IgnoreChar_Unused1
+    0x0C: 'escape',                    # gAiScript_Escape
+    0x0E: 'attack-walls-snags',        # gAiScript_AttackWallsSnags
     0x10: 'guard-tile',
     0x11: 'pillage-after-1',
     0x12: 'charge-after-1',
 }
+
+# Which families are "threat that comes to you" and which are "threat you walk into" -- ch05's
+# YAML coined the distinction and #344 measured it. A unit that never moves contributes nothing
+# until the player enters its range, so the two are not interchangeable.
+#
+# Only families whose DECOMP SYMBOL states the behaviour are classified. The eleven table
+# entries named after bare addresses, and any index outside the table, are UNCLASSIFIED on
+# purpose: bucketing an unknown script as "static" because it is unnamed would be a guess
+# wearing a measurement's clothes, and it would land silently on the side that lowers the
+# number.
+AI_COMES_TO_YOU = frozenset({'pursue', 'pursue-ignore-char', 'pursue-twice',
+                             'pursue-twice-ignore-char', 'charge-after-1',
+                             'pillage', 'pillage-after-1'})
+AI_WALK_INTO = frozenset({'never-move', 'guard-tile'})
+
+
+def ai_family(ai2):
+    """The behaviour family for an AI2 index, or None where the decomp does not name one."""
+    return AI_BEHAVIOUR.get(ai2)
+
+
+def behaviour_split(ai2s):
+    """{comes_to_you, walk_into, unclassified, n} over a sequence of AI2 indices.
+
+    Reported rather than folded into threat. #344 set out to WEIGHT threat by behaviour and the
+    measurement said not to: since #335 derives every unit's AI from its vanilla donor, our
+    behavioural shape IS the twin's shape (measured: 0 points of difference on all six active
+    chapters), so a weighting would scale both sides of the ratio identically and always report
+    x1.00. What is worth having is the split in the open, where a future divergence shows.
+    """
+    out = {'comes_to_you': 0, 'walk_into': 0, 'unclassified': 0, 'n': 0}
+    for ai2 in ai2s:
+        out['n'] += 1
+        family = ai_family(ai2)
+        if family in AI_COMES_TO_YOU:
+            out['comes_to_you'] += 1
+        elif family in AI_WALK_INTO:
+            out['walk_into'] += 1
+        else:
+            out['unclassified'] += 1
+    return out
 
 # `override` is a FLAG, not the vector: both _donor_label and the report's override list
 # test it for truth, and an ai_override whose vector ever stringified to something falsy
@@ -614,6 +670,21 @@ def report(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
             if len(why) > 96:
                 why = why[:95].rsplit(' ', 1)[0] + '...'
             out.append('    override  %s: %s' % (row.unit, why))
+        # The behavioural split, beside the roster it describes (#344). Reported, never folded
+        # into threat: AI is DERIVED from the donor, so our shape IS the twin's -- measured at
+        # 0 points of difference on all six active chapters -- and a weighting would scale both
+        # sides of the ratio and always say x1.00. What this catches is the day that stops
+        # being true, which can only happen through an ai_override or a donor-less unit.
+        split = behaviour_split([r.ai[1] for r in ai_rows if r.ai is not None])
+        if split['n']:
+            line = ('    shape     %d come to you / %d you walk into'
+                    % (split['comes_to_you'], split['walk_into']))
+            if split['unclassified']:
+                # Named separately rather than folded into either side: the decomp leaves
+                # eleven AI2 scripts as bare addresses, and one of them is live in vanilla's
+                # own Prologue.
+                line += ' / %d unclassified' % split['unclassified']
+            out.append(line)
         out.append('    AI is BORROWED from each unit\'s vanilla donor, never authored --')
         out.append('    an override states its reason or the parity gate fails (#335).')
 

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -9,6 +9,7 @@ Run: python3 tools/test_chapter_status.py
 """
 import os
 import sys
+import re
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -288,6 +289,99 @@ class TestAiFidelity(unittest.TestCase):
         text = cs.report('ch02')
         self.assertIn('  ai ', text, 'the section is rendered')
         self.assertIn('donor', text)
+
+
+class AiBehaviourTable(unittest.TestCase):
+    """#344: the map named 8 of the decomp's 19 AI2 scripts, so eleven reported as bare
+    numbers -- one of which (0x0A) vanilla's own Prologue fields."""
+
+    SYMBOLS = {                      # index -> the decomp symbol whose name states behaviour
+        0x00: 'AiScr_AiB_MoveToEnemy',
+        0x03: 'AiScr_AiB_NeverMove',
+        0x04: 'AiScr_AiB_PillageThenPursue',
+        0x05: 'AiScr_AiB_PillageThenEscape',
+        0x06: 'AiScr_AiB_MoveTwiceToEnemy',
+        0x0C: 'gAiScript_Escape',
+        0x0E: 'gAiScript_AttackWallsSnags',
+        0x10: 'AiScr_AiB_GuardSpecificLocation',
+        0x11: 'AiScr_AiB_PillageThenPursueAfterOneTurn',
+        0x12: 'AiScr_AiB_MoveToEnemyAfterOneTurn',
+    }
+
+    def _table(self):
+        """{AI2 index: decomp symbol} from gAi2ScriptTable, read at HEAD.
+
+        cp_data.C, not cp_data.s: the .s is a BUILD ARTIFACT and is not tracked at HEAD, so
+        reading it would both fail here and make the answer depend on build state -- the exact
+        trap decisions.md names about reading the built decomp tree. The table is written with
+        DESIGNATED initialisers (`[AI_B_0A] = ...`), so the index is read from the designator
+        rather than from position -- a table with a hole would otherwise silently shift.
+        """
+        import build_campaign as bc, re
+        text = bc.vanilla_decomp_text('src/cp_data.c')
+        body = text.split('gAi2ScriptTable[] = {', 1)[1].split('};', 1)[0]
+        return {int(i, 16): sym
+                for i, sym in re.findall(r'\[AI_B_([0-9A-Fa-f]{2})\]\s*=\s*(\w+)', body)}
+
+    def test_the_decomp_table_is_the_length_the_map_assumes(self):
+        table = self._table()
+        self.assertEqual(19, len(table))
+        self.assertEqual(set(range(19)), set(table), 'the table is dense 0x00..0x12')
+
+    def test_every_named_index_matches_its_decomp_symbol(self):
+        """A name here is a claim about vanilla, so it is checked against vanilla."""
+        import chapter_status as cs
+        table = self._table()
+        for index, symbol in self.SYMBOLS.items():
+            self.assertEqual(symbol, table[index],
+                             'index 0x%02X is %s in the decomp' % (index, table[index]))
+            self.assertIn(index, cs.AI_BEHAVIOUR)
+
+    def test_indices_the_decomp_does_not_NAME_are_left_unnamed(self):
+        """The eleven bare-address entries stay out of the map. Inventing a name for one would
+        make a guess indistinguishable from a fact at the call site."""
+        import chapter_status as cs
+        table = self._table()
+        for index, symbol in sorted(table.items()):
+            if re.match(r'^gAiScript_[0-9A-Fa-f]{6,}$', symbol):
+                self.assertNotIn(index, cs.AI_BEHAVIOUR,
+                                 'index 0x%02X is only an address (%s)' % (index, symbol))
+
+    def test_no_mapped_index_falls_outside_the_table(self):
+        import chapter_status as cs
+        table = self._table()
+        self.assertEqual([], [i for i in cs.AI_BEHAVIOUR if i not in table])
+
+
+class BehaviourSplit(unittest.TestCase):
+    """"Threat that comes to you" vs "threat you walk into" -- ch05's YAML coined it, #344
+    measured it. Reported, never folded into threat: since #335 derives AI from the donor,
+    our shape IS the twin's, so a weighting would scale both sides and always say x1.00."""
+
+    def test_it_counts_each_side(self):
+        import chapter_status as cs
+        got = cs.behaviour_split([0x00, 0x12, 0x03, 0x10])
+        self.assertEqual(2, got['comes_to_you'])
+        self.assertEqual(2, got['walk_into'])
+        self.assertEqual(0, got['unclassified'])
+
+    def test_an_unnamed_script_is_UNCLASSIFIED_not_bucketed(self):
+        """0x0A is live in vanilla's Prologue. Calling it static because it is unnamed would
+        be a guess that silently lowers the number."""
+        import chapter_status as cs
+        got = cs.behaviour_split([0x0A])
+        self.assertEqual(1, got['unclassified'])
+        self.assertEqual(0, got['walk_into'])
+
+    def test_an_index_off_the_end_is_unclassified_too(self):
+        import chapter_status as cs
+        self.assertEqual(1, cs.behaviour_split([0xFF])['unclassified'])
+
+    def test_the_three_buckets_account_for_every_unit(self):
+        import chapter_status as cs
+        got = cs.behaviour_split([0x00, 0x03, 0x0A, 0xFF, 0x11])
+        self.assertEqual(got['n'],
+                         got['comes_to_you'] + got['walk_into'] + got['unclassified'])
 
 
 if __name__ == '__main__':

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -292,15 +292,22 @@ class TestAiFidelity(unittest.TestCase):
 
 
 class AiBehaviourTable(unittest.TestCase):
-    """#344: the map named 8 of the decomp's 19 AI2 scripts, so eleven reported as bare
-    numbers -- one of which (0x0A) vanilla's own Prologue fields."""
+    """#344: the map named 8 of the decomp's 19 AI2 scripts, so eleven indices reported as
+    bare numbers -- one of which (0x0A) vanilla's own Prologue fields. Thirteen are named now;
+    the six the decomp itself only gives an ADDRESS stay unnamed.
+
+    Every name here is pinned, including 0x01/0x02/0x07 -- the #359 review caught those three
+    unpinned, which meant a decomp rename could mis-bucket units past a green suite."""
 
     SYMBOLS = {                      # index -> the decomp symbol whose name states behaviour
         0x00: 'AiScr_AiB_MoveToEnemy',
+        0x01: 'AiScr_AiB_MoveToEnemy_IgnoreChar_Unused1',
+        0x02: 'AiScr_AiB_MoveToEnemy_IgnoreChar_Unused2',
         0x03: 'AiScr_AiB_NeverMove',
         0x04: 'AiScr_AiB_PillageThenPursue',
         0x05: 'AiScr_AiB_PillageThenEscape',
         0x06: 'AiScr_AiB_MoveTwiceToEnemy',
+        0x07: 'AiScr_AiB_MoveTwiceToEnemy_IgnoreChar_Unused1',
         0x0C: 'gAiScript_Escape',
         0x0E: 'gAiScript_AttackWallsSnags',
         0x10: 'AiScr_AiB_GuardSpecificLocation',
@@ -338,7 +345,7 @@ class AiBehaviourTable(unittest.TestCase):
             self.assertIn(index, cs.AI_BEHAVIOUR)
 
     def test_indices_the_decomp_does_not_NAME_are_left_unnamed(self):
-        """The eleven bare-address entries stay out of the map. Inventing a name for one would
+        """The six bare-address entries stay out of the map. Inventing a name for one would
         make a guess indistinguishable from a fact at the call site."""
         import chapter_status as cs
         table = self._table()
@@ -365,6 +372,26 @@ class BehaviourSplit(unittest.TestCase):
         self.assertEqual(2, got['walk_into'])
         self.assertEqual(0, got['unclassified'])
 
+    def test_a_known_but_non_player_behaviour_is_its_OWN_bucket(self):
+        """A thief that loots and leaves, a script that flees, one that chews on walls: the
+        decomp NAMES all three, so calling them "unclassified" would say we do not know when
+        we do. ai2=0x05 alone occurs 120x in the reference files (#359 review)."""
+        import chapter_status as cs
+        got = cs.behaviour_split([0x05, 0x0C, 0x0E])
+        self.assertEqual(3, got['own_errand'])
+        self.assertEqual(0, got['unclassified'])
+        self.assertEqual(0, got['comes_to_you'])
+
+    def test_every_named_family_lands_in_exactly_one_bucket(self):
+        """The rule the review found broken: a NAMED family must never fall through to
+        unclassified, which is reserved for scripts the decomp does not name."""
+        import chapter_status as cs
+        for index in cs.AI_BEHAVIOUR:
+            got = cs.behaviour_split([index])
+            self.assertEqual(0, got['unclassified'],
+                             '0x%02X is named %r but falls through to unclassified'
+                             % (index, cs.AI_BEHAVIOUR[index]))
+
     def test_an_unnamed_script_is_UNCLASSIFIED_not_bucketed(self):
         """0x0A is live in vanilla's Prologue. Calling it static because it is unnamed would
         be a guess that silently lowers the number."""
@@ -379,9 +406,9 @@ class BehaviourSplit(unittest.TestCase):
 
     def test_the_three_buckets_account_for_every_unit(self):
         import chapter_status as cs
-        got = cs.behaviour_split([0x00, 0x03, 0x0A, 0xFF, 0x11])
-        self.assertEqual(got['n'],
-                         got['comes_to_you'] + got['walk_into'] + got['unclassified'])
+        got = cs.behaviour_split([0x00, 0x03, 0x0A, 0xFF, 0x11, 0x05])
+        self.assertEqual(got['n'], got['comes_to_you'] + got['walk_into']
+                         + got['own_errand'] + got['unclassified'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #344.

The issue asked for a **measurement pass against the twins before any weighting is picked**. The
measurement says: don't build the weighting.

## Vanilla has no single shape to weight against

Red-force behaviour per twin, from each chapter's own `UnitDefinition` `.ai`:

| twin | n | mobile | static |
|---|---|---|---|
| FE8 Prologue | 3 | 33% | 33% (+1 unclassified) |
| FE8 Ch1 | 10 | 70% | 30% |
| FE8 Ch2 | 9 | **100%** | 0% |
| FE8 Ch3 | 10 | 0% | **100%** |
| FE8 Ch4 | 23 | 56% | 43% |
| FE8 Ch5 | 23 | 52% | 47% |
| FE8 Ch6 | 27 | 33% | 66% |
| FE8 Ch13 | 52 | 61% | 38% |

Behavioural parity can only ever mean *this chapter against its own twin*.

## And ours already equals its twin, everywhere

**0 points of difference on all six active chapters**, every enemy resolving, 0 failures. Not luck:
**#335 made AI derived** — `enemy_ai_bytes` returns the donor's bytes — so our shape *is* the twin's
by construction. A weighting would apply identical weights to both sides of a ratio that is equal by
definition and report x1.00 whatever happened. **It cannot catch anything.** The ch04 "78% pursuers
against a half-static twin" case is history: deriving AI fixed it, measuring it did not.

The only remaining divergence channel is `ai_override` — three in the campaign, each with a mandatory
`why`, none a silent shift.

## What this ships instead

- **The split in the open.** `make chapter` prints `shape N come to you / N you walk into`, beside
  the roster it describes. ch05: `12 come to you / 11 you walk into`. A future divergence is visible
  rather than latent, and the metric stays about stats — which is what it can actually measure.
- **`AI_BEHAVIOUR` completed from the decomp.** It named 8 of the 19 AI2 scripts
  (`gAi2ScriptTable`, `cp_data.c:1548`, read by `cp_script.c:90` as `gpAi2Table[0][ai2]`), so eleven
  reported as bare numbers — including `0x0A`, which **vanilla's own Prologue fields**. ch00 now
  reports `1 / 1 / 1 unclassified`.
- **Unnamed stays unclassified.** The eleven entries named after bare addresses are *not* given
  invented names or bucketed. Calling an unknown script "static" because it is unnamed would be a
  guess wearing a measurement's clothes, and it would land on the side that lowers the number.

## The test pins the map against the decomp

Against `cp_data.**c**` — the tracked source — never the generated `.s`, which is a build artifact and
is **not at HEAD at all** (the first cut read it and exited 128, the same class of mistake as reading
the built decomp tree). It parses the **designated initialisers**, so a table with a hole cannot
silently shift the indices.

**41 tests pass in `test_chapter_status.py`, `tools/check.py` clean.**

Not reviewed yet — needs `/code-review` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
