### PR TITLE
difficulty: a gift is a gift whatever carries it (#26)

### DIFF
--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -1773,15 +1773,34 @@ def vanilla_economy(parity_ref):
 def chapter_economy(chap):
     """Our chapter's declared economy from its YAML: explicit gold + item ids by vehicle.
     Campaign item ids aren't valued here (they aren't vanilla enums) -- the vanilla bar is the
-    gold target; ours is listed alongside for a same-glance compare."""
+    gold target; ours is listed alongside for a same-glance compare.
+
+    Every DELIVERY VEHICLE we ship has to be listed here, not just the vanilla-shaped ones. ch06
+    hands out FE8 Ch6's own two rewards -- an Antitoxin and the Orion's Bolt gated on keeping
+    everyone alive -- through a Talk on a rescue boat and a save-them-all clear bonus, because it
+    has no villages at all. Counting only villages/chests/drops/post-chapter gold scored it at
+    400g against the twin's ~15,240g and reported a faithful chapter as an impoverished one
+    (#26). A vehicle the reader does not know reads as a reward we never gave.
+    """
     gold = 0
     gifts, chests, drops = [], [], []
-    for v in chap.get('villages') or []:
-        for r in v.get('visit_reward') or []:
+
+    def take(rewards):
+        """Fold one reward list into gold + gifts. Same shape wherever it is carried."""
+        nonlocal gold
+        for r in rewards or []:
             if r.get('id') == 'gold':
                 gold += int(r.get('amount') or 0)
             elif r.get('id'):
                 gifts.append(r['id'])
+
+    for v in chap.get('villages') or []:
+        take(v.get('visit_reward'))
+    for boat in chap.get('rescue_boats') or []:
+        take((boat.get('talk') or {}).get('reward'))
+    bonus = (chap.get('economy') or {}).get('save_all_bonus')
+    if bonus:
+        gifts.append(bonus)
     for c in chap.get('chests') or []:
         for it in c.get('contents') or []:
             if it.get('id'):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -1105,6 +1105,30 @@ class ItemEconomy(unittest.TestCase):
         self.assertEqual(ours['drops'], ['chest-key'])
         self.assertEqual(ours['shops'], ['termalaine'])
 
+    def test_chapter_economy_counts_non_village_delivery_vehicles(self):
+        """A gift is a gift whatever carries it (#26).
+
+        ch06 hands out vanilla Ch6's own two rewards -- the Antitoxin its village gives and the
+        Orion's Bolt its ending gates on CHECK_ALIVE -- but through vehicles this chapter
+        invented: a Talk on a rescue boat, and a save-them-all clear bonus. The reader only knew
+        villages, chests, drops and post_chapter gold, so it scored ch06 at 400g against the
+        twin's ~15,240g and made a faithful chapter look impoverished. The build already emits
+        both (ch05 ships save_all_bonus), so this was the REPORT lying, not the chapter."""
+        chap = {
+            'rescue_boats': [
+                {'id': 'boat-east', 'talk': {'reward': [{'id': 'antitoxin', 'amount': 1},
+                                                        {'id': 'gold', 'amount': 500}]}},
+                {'id': 'boat-west', 'talk': {'reward': []}},
+            ],
+            'economy': {'save_all_bonus': 'orions-bolt'},
+        }
+        ours = df.chapter_economy(chap)
+        self.assertEqual(ours['gold'], 500)
+        self.assertEqual(ours['gifts'], ['antitoxin', 'orions-bolt'])
+
+    def test_chapter_economy_survives_a_chapter_with_no_boats(self):
+        self.assertEqual(df.chapter_economy({})['gifts'], [])
+
 
 class BattlefieldDynamics(unittest.TestCase):
     """Recruit-flips + reinforcement timing (#171), auto-detected from HEAD for the twin and


### PR DESCRIPTION
The item-economy parity line scored ch06 at **400g** against FE8 Ch6's ~15,240g, and reported a faithful chapter as an impoverished one.

The chapter was not the problem. `chapter_economy()` knew four delivery vehicles - villages, chests, enemy drops and post-chapter gold - and **ch06 has no villages at all**. It hands out vanilla Ch6's own two rewards through vehicles it invented: an Antitoxin on a rescue boat's Talk, and the Orion's Bolt as a save-them-all clear bonus.

Both were already **built** (ch05 has shipped `save_all_bonus` since #254); only the report could not see them. A vehicle the reader does not know reads as a reward we never gave.

## After

- **ch06**: `gifts[antitoxin, orions-bolt]` against the twin's `ORIONSBOLT` + `ANTITOXIN`.
- **ch05**: its five gifts now land 1:1 on vanilla Ch5's five (`guiding-ring` was previously invisible for the same reason).

Folding a reward list is now one helper, so a fifth vehicle is one call rather than another copy of the gold-vs-gift branch.

Found while answering "are we meeting vanilla Ch6?" on #26 - the enemy pressure was x1.00 and only the economy line looked wrong, which is exactly how a blind spot presents.

`make check` clean - `make test` 1,829 cases, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
