### PR TITLE
map_sprite_editor: Finish for scratch characters, a preview that repaints on frame boundaries, and the two-pose rule bounded

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7658,6 +7658,13 @@ Established while sizing Messie for ch06, and every line of it applies to the ne
   nudged one pixel down with only the head or neck retouched. Measured counter-example, caught
   mid-authoring: a Messie draft with 141 of 415 inked cells differing between the two held frames
   read as jumpy, and **no timing change can fix that** — the engine snaps by design.
+- **What must not move is the SILHOUETTE, not every pixel** (refined 2026-09-03, the same day, by
+  the next draft). Messie's finished sheet differs by 77 of 321 inked cells between the held frames
+  and reads correctly, because every one of them is in the front FLIPPERS: body, neck and head are
+  pixel-identical, so the eye sees a plesiosaur paddling rather than a pose swapping. The test is
+  therefore *where* the cells differ, not how many — a localized moving part held against a fixed
+  body is the two-pose bob doing its job, and a whole-silhouette redraw is the failure. Diff the
+  two held frames and look at the map before judging the count.
 
 - **32x32 is a HARD ENGINE CEILING.** `UNIT_ICON_SIZE_*` has exactly three values (16x16, 16x32,
   32x32) and `bmudisp.c` switches on them in five places. Bigger means new enum cases plus SMS VRAM

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -7648,6 +7648,17 @@ suppressed, and that our own layouts were in the candidate pool._
 
 Established while sizing Messie for ch06, and every line of it applies to the next custom unit too.
 
+- **The idle is a TWO-POSE BOB, not three drawings** (added 2026-09-03). FE8 holds frame 0 for 32
+  ticks, frame 1 for 4, frame 2 for 32, frame 1 for 4 (`bmudisp.c`, the `GetGameClock() % 72`
+  ladder). Both long holds are 32 ticks, so if frames 0 and 2 are different drawings the sprite
+  SNAPS between two poses half a second apart and reads as jumpy. The cast's 32x32 beasts do not
+  do this: white-moose's frame 2 is within 12 cells of frame 0 and its frame 1 is the whole
+  silhouette shifted (0,+1) at **0.0% residual**; lupin and lycanroc-pack have frame 2 **byte-
+  identical** to frame 0. So the shape to paint is: frame 0, frame 2 = frame 0, frame 1 = frame 0
+  nudged one pixel down with only the head or neck retouched. Measured counter-example, caught
+  mid-authoring: a Messie draft with 141 of 415 inked cells differing between the two held frames
+  read as jumpy, and **no timing change can fix that** — the engine snaps by design.
+
 - **32x32 is a HARD ENGINE CEILING.** `UNIT_ICON_SIZE_*` has exactly three values (16x16, 16x32,
   32x32) and `bmudisp.c` switches on them in five places. Bigger means new enum cases plus SMS VRAM
   we do not have spare — the same VRAM that already bounds the TESTCH bench. Braulo, Meesmickle,

--- a/tools/map_sprite_editor.py
+++ b/tools/map_sprite_editor.py
@@ -217,11 +217,10 @@ class Doc:
         if not self.done_path:
             return
         if value:
-            # The marker lives beside the clean-recolour snapshot, and an --extra sheet has
-            # no snapshot -- so for a scratch character (Messie) the .base/ directory may not
-            # exist at all and Finish died on a missing parent. The flag is about THIS sheet,
-            # not about having a donor to reset to, so create the directory rather than
-            # refuse (Nicolas, 2026-09-03: "not sure if the finish button is broken").
+            # The marker lives beside the clean-recolour snapshot, and an --extra sheet has no
+            # snapshot -- so for a scratch character (Messie) the .base/ directory may not exist
+            # at all and Finish died on a missing parent. The flag is about THIS sheet, not about
+            # having a donor to reset to, so create the directory rather than fail.
             os.makedirs(os.path.dirname(self.done_path), exist_ok=True)
             open(self.done_path, 'w').close()
         elif os.path.exists(self.done_path):

--- a/tools/map_sprite_editor.py
+++ b/tools/map_sprite_editor.py
@@ -384,6 +384,9 @@ async function switchTo(uid, mode){
   await loadChar(uid, mode);
 }
 let undo=[], redo=[], playT=0, playStart=0;
+/* The preview repaints on a frame boundary, or when an edit/background change
+   invalidates what is on screen (previewDirty). */
+let lastPreviewFrame=-1, previewDirty=true;
 const BGS=[['grass',[104,152,56]],['snow',[224,232,240]],['grey',[96,96,96]],['black',[20,20,20]]];
 let bgIdx=0;
 const $=id=>document.getElementById(id);
@@ -534,15 +537,23 @@ function drawRef(){if(!REF){return;} const c=$('refCv');const cell=Math.max(2,(1
   const ref=REF[frame];for(let y=0;y<S.fh;y++)for(let x=0;x<S.fw;x++){const p=ref[y*S.fw+x];if(!p[3])continue;
     ctx.fillStyle=`rgb(${p[0]},${p[1]},${p[2]})`;ctx.fillRect(x*cell,y*cell,cell,cell);}}
 
-/* ---- live preview (decomp idle timing) ---- */
+/* ---- live preview (decomp idle timing) ----
+   The cadence is bmudisp.c's own ladder (see IDLE_SEQ) and must not be smoothed: the
+   engine SNAPS between held poses. What must not happen is repainting a pose that has
+   not changed -- 1024 fillRects and a canvas realloc on every one of 60 frames a second
+   made the preview stutter on a busy machine, which reads as a jumpy sprite and is not
+   one. Redraw on the frame BOUNDARIES only, which is exactly when the engine redraws. */
 function loop(ts){
   if(playing){const cycle=S.idleSeq.reduce((a,s)=>a+s[1],0)*S.tickMs;
     const t=((ts-playStart)%cycle)/S.tickMs; let acc=0,pf=S.idleSeq[0][0];
     for(const [fi,dur] of S.idleSeq){if(t<acc+dur){pf=fi;break;}acc+=dur;}
-    drawPreview(pf);}
+    if(pf!==lastPreviewFrame||previewDirty){lastPreviewFrame=pf;previewDirty=false;drawPreview(pf);}}
   requestAnimationFrame(loop);
 }
-function drawPreview(pf){const c=$('prevCv');const cell=6;c.width=S.fw*cell;c.height=S.fh*cell;
+function drawPreview(pf){const c=$('prevCv');const cell=6;
+  /* Assigning width/height RESETS the surface, so only do it when the geometry
+     actually changed (a different sheet), never once per animation frame. */
+  if(c.width!==S.fw*cell||c.height!==S.fh*cell){c.width=S.fw*cell;c.height=S.fh*cell;}
   const ctx=c.getContext('2d');const bg=BGS[bgIdx][1];
   ctx.fillStyle=`rgb(${bg[0]},${bg[1]},${bg[2]})`;ctx.fillRect(0,0,c.width,c.height);
   const fr=S.frames[Math.min(pf,S.n-1)];for(let y=0;y<S.fh;y++)for(let x=0;x<S.fw;x++){
@@ -617,7 +628,7 @@ window.addEventListener('load',()=>{
   $('followTgl').onclick=e=>{if(!MOTION)return;followMotion=!followMotion;if(followMotion)allFrames=false;syncModeBtns();};
   $('undoBtn').onclick=doUndo; $('redoBtn').onclick=doRedo;
   $('play').onclick=e=>{playing=!playing;e.target.textContent=playing?'⏸':'▶';if(playing)playStart=performance.now();};
-  $('bgCycle').onclick=e=>{bgIdx=(bgIdx+1)%BGS.length;e.target.textContent=BGS[bgIdx][0]+' ▸';};
+  $('bgCycle').onclick=e=>{bgIdx=(bgIdx+1)%BGS.length;previewDirty=true;e.target.textContent=BGS[bgIdx][0]+' ▸';};
   $('save').onclick=save;
   $('finishBtn').onclick=async()=>{
     const url = S.done ? 'unfinish' : 'finish';
@@ -637,7 +648,7 @@ window.addEventListener('load',()=>{
     if(map[k]){tool=map[k];[...document.querySelectorAll('.tool')].forEach(x=>x.classList.toggle('on',x.dataset.tool===tool));}});
   window.addEventListener('resize',()=>drawStage());
   window.addEventListener('beforeunload',e=>{if(dirty){e.preventDefault();e.returnValue='';}});
-  playStart=performance.now();
+  playStart=performance.now(); previewDirty=true;
 });
 function rebuildThumbs(){const cells=$('frames').children;
   for(let f=0;f<S.n;f++)if(cells[f])drawFrameInto(cells[f].querySelector('canvas').getContext('2d'),f,3,null);}
@@ -645,7 +656,8 @@ function syncModeBtns(){$('allTgl').classList.toggle('on',allFrames);
   $('followTgl').classList.toggle('on',followMotion);}
 function syncUndoBtns(){const u=$('undoBtn'),r=$('redoBtn');
   if(u)u.disabled=!undo.length; if(r)r.disabled=!redo.length;}
-function markDirty(){dirty=true; const b=$('save'); if(b&&!b.textContent.startsWith('● '))b.textContent='● '+b.textContent.replace(/^● /,'');}
+function markDirty(){dirty=true; previewDirty=true;   // every pixel edit lands here
+  const b=$('save'); if(b&&!b.textContent.startsWith('● '))b.textContent='● '+b.textContent.replace(/^● /,'');}
 function doUndo(){if(!undo.length)return;redo.push(snap());S.frames=undo.pop();drawStage();rebuildThumbs();syncUndoBtns();markDirty();}
 function doRedo(){if(!redo.length)return;undo.push(snap());S.frames=redo.pop();drawStage();rebuildThumbs();syncUndoBtns();markDirty();}
 async function save(){$('saveStat').querySelector('button')&&($('save').textContent='saving…');


### PR DESCRIPTION
Three changes to the map-sprite editor and its ADR, all shaken out while Nicolas painted Messie.

## 1. The Finish button could not mark a scratch character

The done-marker is written beside the clean-recolour snapshot (`.base/<uid>.png.done`), but an `--extra` sheet has no snapshot — so `.base/` may not exist at all, and `set_done()` died on the missing parent directory. Verified directly: with `.base/` absent, `open(path, 'w')` raises `FileNotFoundError`. It now creates the directory; `POST /finish` returns 200 and the flag sticks.

Save was never affected — only the marker.

## 2. The preview repainted on every rAF

`drawPreview` ran on every `requestAnimationFrame` — 1024 `fillRect`s **and a canvas reallocation** sixty times a second, redrawing a pose that had not changed. It now repaints on the four frame boundaries the engine itself redraws on, plus whenever an edit, background change or character load invalidates the canvas, so painting still updates instantly.

**The cadence was not the cause and is untouched.** `IDLE_SEQ`'s 32/4/32/4 over 72 ticks matches `bmudisp.c`'s `GetGameClock() % 72` ladder frame for frame, and the engine snaps between held poses by design. Nicolas has since confirmed the jumpiness he saw was the artwork, not the timing — this change stands on its own as a perf fix, not as the answer to that complaint.

## 3. The two-pose rule, stated and then bounded

Added to `docs/decisions.md` under *"A map sprite is 32x32 or it is nothing"*, then refined the same day by the next draft:

| sheet | held frames 0 vs 2 | frame 1 relative to frame 0 |
|---|---|---|
| white-moose | 12 cells differ | shifted (0,+1), **0.0% residual** |
| lupin / lycanroc | **identical** | shifted (0,+1), 7.8% residual |
| meesmickle | 30 cells differ | 8.1% residual |
| messie, first draft | 141 of 415 inked | not a clean shift — 36.6% |
| messie, finished | 77 of 321 inked | **all of them front flippers** |

Both of FE8's long holds are 32 ticks, so a whole-silhouette redraw snaps between two poses half a second apart. But the finished Messie differs by 77 cells and reads correctly, because body, neck and head are pixel-identical and only the flippers move — it paddles. **What must not move is the silhouette, not every pixel.** The ADR says so, so the rule can't be applied as dogma to the next beast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
