### PR TITLE
ch06: the clock is its declared pursuers, and the AI vector has two halves (#26)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -816,3 +816,27 @@ design_notes: >
 # map (`LoadUnit` has no death check; `GetUnitFromCharId` returns NULL for an absent unit, and
 # a CUMO/MOVE on NULL is the never-returns soft-lock assert_scripted_move_reachable exists for).
 cutscene_actors: [marty, braulo]
+
+# ── What proves it (D8) ─────────────────────────────────────────────────────────
+# A chapter DECLARES its own scenarios and `tools/playtest/declared.py` derives their matrix
+# rows from this block (#314) -- the ROM from `boot:`, PT_HOST_CHAPTER from the host-slot
+# registry. Nothing about them is written a second time in `matrix.yaml`.
+#
+# There is one case, and it is the one #360 could not run because ch06 had no debug boot when
+# it landed: the pockets are a claim about the ENGINE'S pathing, and `mapshot` photographs
+# turn 1 while the question needs several enemy phases. Everything else ch06 owes is a
+# DIALOGUE or ART dependency (the three cutscenes, the boarding pass, Messie's bust, the
+# merfolk reskins) and there is nothing to assert about a scene that has no text yet.
+playtest:
+  boot: ch06boot                  # CH06BOOT=1; host slot 7 comes from inject/hosts.py
+  cases:
+    # Hand-written Lua, and it names why rather than defaulting to it: the declared
+    # vocabulary is boot -> settle -> visit -> read items, and this case drives ENEMY PHASES
+    # and reads the red and green unit arrays. `deadline` is raised because twelve phases of
+    # twenty-four enemies is several times the work a village case does.
+    - name: ch06clock
+      proves: >
+        both pursuers path to their hull without stalling, and the range-1 crab attacks the
+        west boat only from its pocket door -- the single melee cell the pocket promises
+      lua: ch06clock
+      deadline: 900

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -145,6 +145,17 @@ difficulty_note: >
                        range 1, so it must occupy that one cell -- which also means the
                        player cannot BOARD until it is dead. Sinks the hull on turn 8.
 
+  THOSE TWO AND NOTHING ELSE, and enforcing it took a licence. Measured in-engine (#26): four of
+  the line's STRIKERS reached the east hull on enemy phase 1 and sank it on turn 4, because
+  `never-move` names only the APPROACH byte while the ACTION half steps out within a unit's own
+  movement to hit whatever it can reach. Vanilla Ch6 never has this problem -- ZERO of its
+  seventeen strikers can reach a villager in one turn, its rescue targets sit in a mountain ring,
+  and its clock is pursuers only. Our frozen lake has no mountain ring, so the protection is
+  bought with vanilla's own AI_A_08 instead: every unit that can reach a hull and is not declared
+  in `rescue_pursuers` carries a do-not-attack ACTION byte, and fights the player identically.
+  `check_rescue_targets` is the guard; decisions.md -> "AI_B is the APPROACH and AI_A is the
+  ACTION".
+
   Neither boat is answered by a body-block, and the #360 review is why that is written down:
   the crab reaches the door on turn 2 and the player's earliest arrival anywhere near it is
   Pinky on turn 3, so "race it to the door" was a lever that did not exist. What the west
@@ -153,7 +164,16 @@ difficulty_note: >
   outside melee. That asymmetry is what puts the plot-critical hint (Tali) on the boat a
   player is likeliest to save.
 
-  Against foot on turn 6 the east clock is vanilla's own slack of one turn. Nerra inherits Novala's
+  WHO CAN ACTUALLY GET THERE is `reached_on_contested:`, not `reached_on:` -- the latter is an
+  EMPTY-MAP walk, and a unit cannot move through an enemy body. With the line standing, the WEST
+  door is turn 6 for foot (vanilla Ch6's own foot number) after moving one corking body off the
+  channel, and the EAST door is a FLIER-and-Braulo objective: foot, cavalry and Trex cannot reach
+  it at all. That is deliberate and it is OURS, not parity -- vanilla's rescue is reachable by
+  everything except Cavalier and Armour. ch06 makes the east hull Pinky's beat the way vanilla
+  builds whole chapters around a flier or a thief; the west hull is the one the party saves
+  together.
+
+  Against foot on turn 6 the west clock is vanilla's own slack of one turn. Nerra inherits Novala's
   softness on purpose -- but note her Flux does 22 to a 19 HP hull, so she is kept on the
   centre shelf, far from both. Messie is a cutscene, not an encounter, so no route skips XP.
 
@@ -227,6 +247,19 @@ deployment:
 enemy_units:
   # ── The trident line (vanilla's 6 Soldiers) → merfolk, Mermaid `2. Lance` ─────
   - id: merfolk-trident
+    ai_override:
+      ai: '{0x8, 0x3, 0x0, 0x0}'   # AI_A_08 ActionInRange_ExceptCivilian + AI_B_03 NeverMove
+      why: >
+        Vanilla Ch6's line CANNOT touch a rescue target. Measured over Ch6Map with each class's
+        own movement-cost table: ZERO of its seventeen strikers can reach a villager in one
+        turn, and the clock is eight PURSUERS arriving turns 4-6. Ours can, because our map put
+        a hull inside the line instead of in a mountain-ringed corner -- its (18,14) body is two steps from the east hull, so it steps out and swings.
+        Only the ACTION half changes, to vanilla's own AI_A_08, whose do-not-attack list is
+        repointed at the two boat pids (repoint_boat_safe_ai_list, on ch05's AI_A_07
+        precedent). The donor's approach byte is kept, so this unit fights the player exactly
+        as its donor does and simply will not swing at a hull -- the behaviour vanilla gets
+        from terrain and our map cannot. decisions.md -> "AI_B is the APPROACH and AI_A is the
+        ACTION".
     name: "Mermaid"
     count: 4
     class: soldier              # vanilla: 4x Lv7 Soldier, Iron Lance
@@ -235,7 +268,11 @@ enemy_units:
     inventory:
       - id: iron-lance
     damage_type: piercing       # flavor label only
-    positions: [[18, 14], [2, 14], [13, 11], [7, 15]]
+    # (2,14) -> (3,14): ONE tile, and it is the whole west clock. That body corked the
+    # only foot channel to the west door -- contested foot arrival was turn 11 against a
+    # turn-8 fuse, i.e. unsaveable. At (3,14) it is turn 6, which is vanilla Ch6's own
+    # foot number. Derived, not eyeballed: `map_placement_preview.reached_on`.
+    positions: [[18, 14], [3, 14], [13, 11], [7, 15]]
     donor: [[14, 9], [15, 7], [20, 7], [19, 13]] # vanilla's four HOLDING L7 soldiers
     skin:
       look: "merfolk spear-guard; the anim's lance IS a trident"
@@ -288,6 +325,19 @@ enemy_units:
       look: "merfolk on a shark, boarding axe"
       source: "FE-Repo: Map Sprites/Mounted - Dismounted, Monsters, Misc/Shark Rider (M) {N426}, 16x16 (stand+walk); NO battle anim exists -- vanilla Fighter frames, repalletted"
   - id: shark-rider-steel
+    ai_override:
+      ai: '{0x8, 0x3, 0x0, 0x0}'   # AI_A_08 ActionInRange_ExceptCivilian + AI_B_03 NeverMove
+      why: >
+        Vanilla Ch6's line CANNOT touch a rescue target. Measured over Ch6Map with each class's
+        own movement-cost table: ZERO of its seventeen strikers can reach a villager in one
+        turn, and the clock is eight PURSUERS arriving turns 4-6. Ours can, because our map put
+        a hull inside the line instead of in a mountain-ringed corner -- (16,15) reaches the east door in one move.
+        Only the ACTION half changes, to vanilla's own AI_A_08, whose do-not-attack list is
+        repointed at the two boat pids (repoint_boat_safe_ai_list, on ch05's AI_A_07
+        precedent). The donor's approach byte is kept, so this unit fights the player exactly
+        as its donor does and simply will not swing at a hull -- the behaviour vanilla gets
+        from terrain and our map cannot. decisions.md -> "AI_B is the APPROACH and AI_A is the
+        ACTION".
     name: "Shark Rider"
     count: 1
     class: fighter              # vanilla: 1x Lv6 Fighter, Steel Axe
@@ -319,6 +369,14 @@ enemy_units:
 
   # ── The mounted block (vanilla's 3 Cavaliers) → crab-riders ──────────────────
   - id: crab-rider-blade
+    ai_override:
+      ai: '{0x8, 0x12, 0x0, 0x0}'  # AI_A_08 ExceptCivilian + the donor's charge-after-1
+      why: >
+        Its CHARGE is the donor's and is untouched -- only the ACTION half changes, so it comes
+        at the player exactly as vanilla's does. But it can path to the east hull, and this
+        chapter's clock is its two DECLARED pursuers (`rescue_pursuers`), not whatever else can
+        reach a boat. Vanilla Ch6 keeps its rescue targets out of reach with terrain; our map
+        cannot, so the licence is spent explicitly instead. `check_rescue_targets` is the guard.
     name: "Crab Rider"
     count: 1
     class: cavalier             # vanilla: 1x Lv7 Cavalier, Iron Blade
@@ -333,6 +391,14 @@ enemy_units:
       look: "merfolk astride a lake crab; the mount repainted from an arachnid to ice-blue shell"
       source: "FE-Repo: Battle Animations/Mounted - Dismounted, Monsters, Misc/[Spider-Variant] [M] Cavalier Rider by DATonDemand -> 1. Sword + 2. Lance; map sprite Cavalier (M) Spider Rider Sword {Zoramine} or Elder Bael Sword {Metalocif}, 16x32"
   - id: crab-rider-sword
+    ai_override:
+      ai: '{0x8, 0x12, 0x0, 0x0}'  # AI_A_08 ExceptCivilian + the donor's charge-after-1
+      why: >
+        Its CHARGE is the donor's and is untouched -- only the ACTION half changes, so it comes
+        at the player exactly as vanilla's does. But it can path to the east hull, and this
+        chapter's clock is its two DECLARED pursuers (`rescue_pursuers`), not whatever else can
+        reach a boat. Vanilla Ch6 keeps its rescue targets out of reach with terrain; our map
+        cannot, so the licence is spent explicitly instead. `check_rescue_targets` is the guard.
     name: "Crab Rider"
     count: 1
     class: cavalier             # vanilla: 1x Lv6 Cavalier, Iron Sword
@@ -345,6 +411,14 @@ enemy_units:
     donor: [7, 1]                   # vanilla L6 cavalier
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
   - id: crab-rider-lance
+    ai_override:
+      ai: '{0x8, 0x12, 0x0, 0x0}'  # AI_A_08 ExceptCivilian + the donor's charge-after-1
+      why: >
+        Its CHARGE is the donor's and is untouched -- only the ACTION half changes, so it comes
+        at the player exactly as vanilla's does. But it can path to the east hull, and this
+        chapter's clock is its two DECLARED pursuers (`rescue_pursuers`), not whatever else can
+        reach a boat. Vanilla Ch6 keeps its rescue targets out of reach with terrain; our map
+        cannot, so the licence is spent explicitly instead. `check_rescue_targets` is the guard.
     name: "Crab Rider"
     count: 1
     class: cavalier             # vanilla: 1x Lv6 Cavalier, Iron Lance
@@ -403,6 +477,19 @@ enemy_units:
       look: "a shelled thing plated like a knight, holding a bridge"
       source: "FE-Repo: Battle Animations/Infantry - Knights, Generals, Armors/[General-Variant] IronShell-Tiny General [U] by Alexsplode -> 2. Lance; map sprite General (U) IronShell_Tiny {Alexsplode}, 16x32. NB its anim preview keys on BLUE, not the usual green."
   - id: ironshell-horseslayer
+    ai_override:
+      ai: '{0x8, 0x3, 0x0, 0x0}'   # AI_A_08 ActionInRange_ExceptCivilian + AI_B_03 NeverMove
+      why: >
+        Vanilla Ch6's line CANNOT touch a rescue target. Measured over Ch6Map with each class's
+        own movement-cost table: ZERO of its seventeen strikers can reach a villager in one
+        turn, and the clock is eight PURSUERS arriving turns 4-6. Ours can, because our map put
+        a hull inside the line instead of in a mountain-ringed corner -- its JAVELIN reaches the east hull from (15,12), one step away.
+        Only the ACTION half changes, to vanilla's own AI_A_08, whose do-not-attack list is
+        repointed at the two boat pids (repoint_boat_safe_ai_list, on ch05's AI_A_07
+        precedent). The donor's approach byte is kept, so this unit fights the player exactly
+        as its donor does and simply will not swing at a hull -- the behaviour vanilla gets
+        from terrain and our map cannot. decisions.md -> "AI_B is the APPROACH and AI_A is the
+        ACTION".
     name: "Ironshell"
     count: 1
     class: armor-knight         # vanilla: 1x Lv6 Knight, Horseslayer + Javelin
@@ -473,6 +560,19 @@ enemy_units:
 
   # ── Bow and beast (vanilla's Archer and its one Bael) ────────────────────────
   - id: merfolk-bow
+    ai_override:
+      ai: '{0x8, 0x3, 0x0, 0x0}'   # AI_A_08 ActionInRange_ExceptCivilian + AI_B_03 NeverMove
+      why: >
+        Vanilla Ch6's line CANNOT touch a rescue target. Measured over Ch6Map with each class's
+        own movement-cost table: ZERO of its seventeen strikers can reach a villager in one
+        turn, and the clock is eight PURSUERS arriving turns 4-6. Ours can, because our map put
+        a hull inside the line instead of in a mountain-ringed corner -- an iron bow reaches the hull from (17,14), three steps from its post.
+        Only the ACTION half changes, to vanilla's own AI_A_08, whose do-not-attack list is
+        repointed at the two boat pids (repoint_boat_safe_ai_list, on ch05's AI_A_07
+        precedent). The donor's approach byte is kept, so this unit fights the player exactly
+        as its donor does and simply will not swing at a hull -- the behaviour vanilla gets
+        from terrain and our map cannot. decisions.md -> "AI_B is the APPROACH and AI_A is the
+        ACTION".
     name: "Mermaid"
     count: 1
     class: archer               # vanilla: 1x Lv6 Archer, Iron Bow
@@ -744,6 +844,14 @@ terrain_divergence:
 # entry per (deployable PC x boat), every entry for a boat sharing that boat's ONE flag:
 # the first boarding sets it and `SearchAvailableEvent` then skips the rest. Generated
 # from the roster, never hand-listed, or it silently rots when the roster changes.
+# The chapter's CLOCK, declared. `check_rescue_targets` proves nothing else on the board can
+# attack a hull: every other unit that can reach one carries an ACTION byte that cannot target
+# it. Vanilla Ch6 gets this from terrain -- zero of its seventeen strikers can reach a villager
+# in one turn, and its clock is pursuers only. Ours is the same shape, bought with the AI byte.
+rescue_pursuers:
+- id: merfolk-thrower           # east: JAVELIN, range 1-2, so the pocket door never stops it
+- id: ice-crab                  # west: range 1, so it must OCCUPY the door -- and it does
+
 rescue_boats:
 - id: boat-east
   fe_name: "Fishing Boat"       # <=12 chars (see decisions.md: long names garble the buffer)
@@ -787,7 +895,7 @@ rescue_boats:
   reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5, trex: 5}   # to the DOOR, EMPTY MAP
   # Contested, as boat-east. The cork here is merfolk-trident at (2,14): removing that one
   # body takes foot from turn 11 back to the declared 6.
-  reached_on_contested: {foot: 11, cavalry: 8, flier: 3, braulo: 6, trex: 9}
+  reached_on_contested: {foot: 6, cavalry: 5, flier: 3, braulo: 5, trex: 5}
   talk:
     background: bg_Boat
     ea_file: events/ch06-boat-west.ea

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -758,7 +758,13 @@ rescue_boats:
                                 # a range-2 weapon reaches the hull over the wall from 3 tiles
                                 # -- FE8 has no line of sight, so a wall never stops a javelin,
                                 # a bow or a tome. Placement is the only lever for those.
-  reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5, trex: 5}   # to the DOOR, re-measured
+  reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5, trex: 5}   # to the DOOR, EMPTY MAP
+  # ...and the same walk with the enemy LINE standing on it (turn-1 snapshot; derived by
+  # `map_placement_preview.reached_on`, never hand-kept). A unit cannot pass through an enemy
+  # body, and this map's channels are narrow enough that ONE body corks a route: removing
+  # shark-rider-halberd at (15,16) alone turns `null` into turn 12. The empty-map row above is
+  # what the chapter's clock was designed against, and it is not what a player walks.
+  reached_on_contested: {foot: null, cavalry: null, flier: 3, braulo: 6, trex: null}
   talk:
     background: bg_Boat         # vendored from FE-Repo; the boarding CG
     ea_file: events/ch06-boat-east.ea
@@ -778,7 +784,10 @@ rescue_boats:
   door: [4, 18]
   donor: [20, 5]                  # vanilla Ch6's boss (Novala) -- GuardTileAI, Ch6's own tail
   attackable_sides: 1           # as boat-east; a flier adds 3 cells, range-2 reaches from 2
-  reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5, trex: 5}   # to the DOOR, re-measured
+  reached_on: {foot: 6, cavalry: 5, flier: 3, braulo: 5, trex: 5}   # to the DOOR, EMPTY MAP
+  # Contested, as boat-east. The cork here is merfolk-trident at (2,14): removing that one
+  # body takes foot from turn 11 back to the declared 6.
+  reached_on_contested: {foot: 11, cavalry: 8, flier: 3, braulo: 6, trex: 9}
   talk:
     background: bg_Boat
     ea_file: events/ch06-boat-west.ea

--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -623,6 +623,17 @@ enemy_units:
       - id: iron-lance
     damage_type: piercing
     positions: [[0, 11]]
+    ai_override:
+      ai: '{0x8, 0x0, 0x1, 0x0}'   # AI_A_08 ExceptCivilian + the donor's own pursue approach
+      why: >
+        The same override the turn-1 line carries, for the same reason and with the same
+        discipline: only the ACTION byte changes, and the approach (0x0, pursue) is the donor's
+        own, untouched. These three spawn on the WEST EDGE, a short ride from the west hull's
+        pocket, and a pursuing approach walks them onto it -- so without this they are
+        undeclared pressure on a hull whose fuse is costed against one declared pursuer.
+        "The hulls' clock is its DECLARED pursuers and nothing else" is not a turn-1 rule, and
+        a Difficult-only wave is no less bound by it than the opening board. They were invisible
+        to `check_rescue_targets` until it stopped skipping reinforcements (#366 review).
     donor: [3, 11]
     # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
@@ -638,6 +649,17 @@ enemy_units:
       - id: iron-lance
     damage_type: piercing
     positions: [[0, 9]]
+    ai_override:
+      ai: '{0x8, 0x0, 0x1, 0x0}'   # AI_A_08 ExceptCivilian + the donor's own pursue approach
+      why: >
+        The same override the turn-1 line carries, for the same reason and with the same
+        discipline: only the ACTION byte changes, and the approach (0x0, pursue) is the donor's
+        own, untouched. These three spawn on the WEST EDGE, a short ride from the west hull's
+        pocket, and a pursuing approach walks them onto it -- so without this they are
+        undeclared pressure on a hull whose fuse is costed against one declared pursuer.
+        "The hulls' clock is its DECLARED pursuers and nothing else" is not a turn-1 rule, and
+        a Difficult-only wave is no less bound by it than the opening board. They were invisible
+        to `check_rescue_targets` until it stopped skipping reinforcements (#366 review).
     donor: [2, 9]
     # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}
@@ -654,6 +676,17 @@ enemy_units:
       - id: javelin
     damage_type: slashing
     positions: [[0, 13]]
+    ai_override:
+      ai: '{0x8, 0x0, 0x1, 0x0}'   # AI_A_08 ExceptCivilian + the donor's own pursue approach
+      why: >
+        The same override the turn-1 line carries, for the same reason and with the same
+        discipline: only the ACTION byte changes, and the approach (0x0, pursue) is the donor's
+        own, untouched. These three spawn on the WEST EDGE, a short ride from the west hull's
+        pocket, and a pursuing approach walks them onto it -- so without this they are
+        undeclared pressure on a hull whose fuse is costed against one declared pursuer.
+        "The hulls' clock is its DECLARED pursuers and nothing else" is not a turn-1 rule, and
+        a Difficult-only wave is no less bound by it than the opening board. They were invisible
+        to `check_rescue_targets` until it stopped skipping reinforcements (#366 review).
     donor: [2, 13]
     # the vanilla units that FIGHT on these tiles (their REDA destinations, not spawns)
     skin: {look: "merfolk astride a lake crab", source: "as crab-rider-blade"}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8368,6 +8368,54 @@ faithful. The difference is legibility: vanilla's restriction is TERRAIN, which 
 off the map before committing, and ours is ENEMY BODIES, which are dynamic, invisible as a
 constraint, and dissolve as you kill them.
 
+### Two do-not-attack lists are not one mechanism, and they have different invariants (2026-09-04, #26)
+
+`AI_A_07` and `AI_A_08` look interchangeable. Both run the standard offensive action through
+`AiIsUnitEnemyAndNotInScrList`, so a unit carrying either fights the player normally and simply
+will not swing at whatever its list names. `check_rescue_targets` accepted **either** as proof
+that a unit could not sink a hull.
+
+It is not proof, because the **lists are different and each names one thing**. AI_A_07's is
+repointed at ch05's escort (`repoint_escort_safe_ai_list`) and never at a boat pid, so a ch06
+unit carrying `{0x7, ...}` politely refuses to attack Basil — who is not in the chapter — and
+sinks the hull on schedule. The gate would have called it licensed. Only `AI_A_08` is repointed
+at the hulls, so only `AI_A_08` licenses anything here.
+
+**The invariants also differ, and the difference is not an oversight.** AI_A_07's is one **UNIT**:
+vanilla ships exactly one client (Ch5's Joshua), so a second silently inherits our escort's
+immunity — `assert_escort_safe_ai_has_one_client` sweeps every chapter for it. AI_A_08's is one
+**CHAPTER**: vanilla ships *no* clients at all, so the chapter that claims the list may spend it
+on as many of its own units as it likes (ch06 spends it on ten), and the hazard is a *different*
+chapter picking the byte up for its own reasons — inheriting immunity to pids it has never heard
+of, and standing in the way of the next chapter that wants the list for its own rescue targets.
+`assert_boat_safe_ai_is_single_chapter` is that sweep, and both now run through one
+`safe_ai_clients(ai_index)` implementation. Having only one of the two lists swept is exactly how
+the second came to be spent with no sweep at all.
+
+_Found by `/code-review` on #366 (2026-09-04)._
+
+### A reachability gate that skips reinforcements is grading the opening board, not the chapter (2026-09-04, #26)
+
+`units_reaching` dropped every enemy with an `arrives_turn`, reasoning that it is "not on the
+board when the clock starts". True, and irrelevant: a hull's fuse is costed against the units the
+chapter **declares** as its clock, and an undeclared unit that reaches a hull on turn 5 sinks it
+exactly as surely as one that reaches it on turn 1 — it just does it out of sight of a gate that
+only ever looked at turn 1.
+
+ch06's three Difficult-only turn-4 crab riders spawn on the WEST EDGE, a short ride from the west
+hull's pocket, and their donor's pursuing approach walks them onto it. They were invisible, so
+they carried no `ai_override` while their six turn-1 siblings all did — *"the hulls' clock is its
+declared pursuers and nothing else"* had been applied to the opening board and nowhere else. They
+now carry the same override, changing only the ACTION byte and leaving the donor's approach
+(`0x0`, pursue) untouched.
+
+The general form: **a guard scoped to turn 1 states a turn-1 fact, and difficulty is not a turn-1
+property.** The three shipped difficulty modes are all shipped (*"Vanilla ships three difficulty
+modes, so we ship three"*), so a hull that survives on Normal and sinks early on Difficult is a
+defect the gate has to be able to see.
+
+_Found by `/code-review` on #366 (2026-09-04)._
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8239,6 +8239,39 @@ both hulls sink on turn 7 and 8.** Same slack, arrived at from the other directi
 The lesson that outlives ch06: a parity claim about a vanilla chapter's *feel* is a measurement,
 not a memory. Both halves of this one had been asserted in a chapter YAML for weeks.
 
+### A rescue clock is a HIT RATE, so a scenario MEASURES it and never asserts it (2026-09-04, #26)
+
+ch06's chapter YAML declares its two hulls sinking on **turn 7 and turn 8**, and `ch06clock` was
+about to assert exactly that. It does not, and the reason generalises past this chapter.
+
+The west fuse is one Level 1 Bael swinging a venin claw at a 19 HP, 5 Def hull sitting in FOREST.
+Read off the decomp's own tables: 6 damage a connection, four connections to sink it, and a **47
+displayed hit** into the hull's +1 Def / +20 avoid cover — 45% true on 2RN. Seven phases of that
+sink the hull about **38%** of the time. "Turn 8" is not a turn number; it is the middle of a
+distribution, and one playtest is one sample of it. A scenario that asserted the declared turn
+would be a coin-flip verdict: green or red on the same unchanged ROM, which is worse than no
+coverage because it teaches the next session to re-run until it passes.
+
+So the case splits what it does by what is actually deterministic:
+
+- **Asserted** — the pathing. Neither pursuer stalls short of its hull; the range-1 attacker, once
+  in range, is standing on the pocket's single door cell and nowhere else; nothing reaches a hull
+  on enemy phase 1. Those are properties of the map and the AI, and they are the same every run.
+- **Measured and logged** — the sink turn, printed against the declared one. A run that disagrees
+  is a finding about the chapter's balance, not a broken scenario.
+
+The corollary for the instrument: **the first run of `ch06clock` watched two units and could not
+name a third.** An 11-damage hit landed on the east hull during enemy phase 1 while the only mover
+near it was three tiles out and nothing in the emitted `MS_Ch06Line` was in weapon range at all.
+That gap is not a bad guess, it is a scenario too narrow to distinguish "the AI did something
+surprising" from "what LOADED is not the table we emitted" — so it now dumps the whole red roster
+at turn 1 and every red within three tiles of a hull the moment the hull loses HP. A run costs the
+same either way; the reading is what varies (see *"Playtest runs are the most expensive thing in
+this repo"*).
+
+What that first run actually returned is on **#26**, and the response — retune the placement, or
+restate the budget the chapter claims — is not settled here.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8272,6 +8272,47 @@ this repo"*).
 What that first run actually returned is on **#26**, and the response — retune the placement, or
 restate the budget the chapter claims — is not settled here.
 
+### AI_B is the APPROACH and AI_A is the ACTION, and the moving half is AI_A (2026-09-04, #26)
+
+`ch06clock`'s first headed run found three enemies our tooling labels **never-move** standing around
+a boat they had walked to. They are not mislabelled data — they are a label that reports half a
+vector.
+
+From `cp_data.c`, a unit's AI is two scripts, not one:
+
+- `gAi2ScriptTable[AI_B_03] = AiScr_AiB_NeverMove` is `AI_NOP_0E`. It is the **approach** script and
+  it does nothing: all it suppresses is walking across the map at you.
+- `gAi1ScriptTable[AI_A_00] = gAiScript_ActionInRange` is `AI_ACTION(100)`. It is the **action**
+  script, and acting includes moving within the unit's own range to reach a target. The statue is
+  `AI_A_03 ActionStanding`.
+
+So `{0x00, 0x03}` — vanilla's most common pairing — means *"hold the line, but step out and hit
+anything you can reach."* Measured across the campaign: **94 of 99 enemies are `ActionInRange`,
+and 48 of the 51 units reported as "threat you walk into" will move.** Four units in the whole
+campaign are genuine statues.
+
+**What this does NOT invalidate.** `enemy_ai_bytes` emits all four donor bytes and `ai_bytes`
+resolves vanilla's symbolic macros (`GuardTileAI` -> `(0x3, 0x3)`, `DoNothing` -> `(0x6, 0x3)`),
+raising rather than defaulting on an unknown token. ch06's boats carry a live non-zero AI_A into the
+ROM, which is the proof the pipeline is whole. #335's derivation is sound and nothing needs
+re-deriving; *"AI behaviour is MEASURED and REPORTED, not weighted into threat"* still holds, since
+copied-wholesale bytes match the twin on both halves.
+
+**What it does invalidate** is the read-back. `AI_BEHAVIOUR`, `ai_family`, `behaviour_split` and
+`make chapter`'s behaviour column all key on `ai[1]` alone; `ai[0]` is read in exactly one place in
+the repo (ch05's escort). So the split's premise — *"a unit that never moves contributes nothing
+until the player enters its range"* — is false for 48 of 51 units, and #344's kept deliverable is
+the part that misreports. Note the shape of it: #344's own corollary was a coverage gap in this same
+table along the AI_B axis. Same bug class, one dimension over.
+
+**Why it surfaced on ch06 and not earlier.** It needs a killable unit parked inside a static's
+reach. Vanilla Ch6's entire red force is `ActionInRange x26 / ActionStanding x1` — **no
+`AI_A_08 ActionInRange_ExceptCivilian` anywhere** — so vanilla protects its villagers by PLACEMENT
+alone, which is what *"Vanilla Ch6's urgency is TRAVEL TIME"* measured independently. Our pockets
+moved a 19 HP hull into range of four statics. The bytes are faithful; the map is what changed.
+
+The ch06 response is not settled here — it is on #26.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8298,12 +8298,28 @@ ROM, which is the proof the pipeline is whole. #335's derivation is sound and no
 re-deriving; *"AI behaviour is MEASURED and REPORTED, not weighted into threat"* still holds, since
 copied-wholesale bytes match the twin on both halves.
 
-**What it does invalidate** is the read-back. `AI_BEHAVIOUR`, `ai_family`, `behaviour_split` and
-`make chapter`'s behaviour column all key on `ai[1]` alone; `ai[0]` is read in exactly one place in
-the repo (ch05's escort). So the split's premise — *"a unit that never moves contributes nothing
-until the player enters its range"* — is false for 48 of 51 units, and #344's kept deliverable is
-the part that misreports. Note the shape of it: #344's own corollary was a coverage gap in this same
-table along the AI_B axis. Same bug class, one dimension over.
+**What it invalidated** was the read-back, now fixed in the same change. `AI_BEHAVIOUR`,
+`ai_family`, `behaviour_split` and `make chapter`'s behaviour column all keyed on `ai[1]` alone, so
+the split's premise — *"a unit that never moves contributes nothing until the player enters its
+range"* — was false for 48 of 51 units, and #344's kept deliverable was the part that misreported.
+Note the shape of it: #344's own corollary was a coverage gap in this same table along the AI_B
+axis. Same bug class, one dimension over.
+
+The report now names both halves and derives a THREE-way shape from the pair, because two buckets
+could not express the case that actually shipped:
+
+- **pursuer** — the approach walks it across the map at you.
+- **striker** — it holds ground, but its ACTION steps out within its own move range. `{engage,
+  never-move}` is vanilla's commonest pairing and most of every roster; this is the bucket that did
+  not exist.
+- **statue** — it holds ground and does not move at all, even to attack. Four units campaign-wide.
+
+`AI_ACTION` is pinned against `gAi1ScriptTable` by a test on the same discipline `AI_BEHAVIOUR`
+follows: the twelve entries the decomp gives only an address (0x09–0x14) stay UNNAMED rather than
+guessed at. `ai_shape` takes the vector and **raises on a bare int**, because a stale
+`ai_shape(ai[1])` would classify a whole roster off half the information and look entirely correct
+— which is precisely how this defect survived. `map_placement_preview`'s `is_boss` special case is
+deleted: it was standing in for the AI_A half it could not see, and it was wrong in both directions.
 
 **Why it surfaced on ch06 and not earlier.** It needs a killable unit parked inside a static's
 reach. Vanilla Ch6's entire red force is `ActionInRange x26 / ActionStanding x1` — **no

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8329,6 +8329,45 @@ moved a 19 HP hull into range of four statics. The bytes are faithful; the map i
 
 The ch06 response is not settled here — it is on #26.
 
+### A reach number measured on an EMPTY MAP is a claim about terrain, not about the chapter (2026-09-04, #26)
+
+ch06's `reached_on:` block — *"foot reaches either door on turn 6, exactly as vanilla's does"* — is
+the number its entire rescue clock is tuned against. Nothing read it, nothing checked it, and it
+was measured by a Dijkstra (`map_placement_preview.foot_reach`) that did not know units exist.
+
+In FE a unit cannot move through an enemy body. Walking the same map with the line standing on it:
+
+| | foot | cavalry | flier | braulo | trex |
+|---|---|---|---|---|---|
+| **east door**, empty map | 6 | 5 | 3 | 5 | 5 |
+| **east door**, contested | **--** | **--** | 3 | 6 | **--** |
+| **west door**, empty map | 6 | 5 | 3 | 5 | 5 |
+| **west door**, contested | **11** | 8 | 3 | 6 | 9 |
+
+**Only the flier and Braulo can honour any clock.** Foot, cavalry and Trex cannot reach the east
+boat at all while the line stands, and reach the west one on turn 11 against a turn-8 fuse.
+
+**The channels are narrow enough that ONE body corks a route.** Removing `shark-rider-halberd` at
+(15,16) alone turns the east door from unreachable into turn 12; removing `merfolk-trident` at
+(2,14) takes the west door from turn 11 back to the declared 6. That is not a placement anyone
+would have predicted by eye, and it is why this is derived rather than reasoned about.
+
+`reached_on_contested:` now carries it, derived and pinned by a test, beside the empty-map row that
+is kept because it is what the clock was designed against — the two disagreeing IS the finding.
+
+**Stated limit.** The contested walk is a turn-1 SNAPSHOT: strikers step into the route on later
+phases, and the player kills bodies out of it. So it is a floor, a tighter one than the empty map,
+not the truth. What it cannot model is the cost of fighting, which depends on play — that stays a
+human playtest question, and a scenario that pretended to answer it would be measuring its own
+bot.
+
+**The vanilla parallel, and where it breaks.** Vanilla Ch6 also has classes that simply cannot make
+the rescue — MOUNTAIN is `--` for Cavalier and Armour, which is the guide's "send Seth"
+(*"Vanilla Ch6's urgency is TRAVEL TIME"*). So a rescue only some of the party can attempt is
+faithful. The difference is legibility: vanilla's restriction is TERRAIN, which the player reads
+off the map before committing, and ours is ENEMY BODIES, which are dynamic, invisible as a
+constraint, and dissolve as you kill them.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/fe8-pacing-reference.md
+++ b/docs/fe8-pacing-reference.md
@@ -195,6 +195,42 @@ post-MVP question — see `docs/roadmap.md`.)
 
 ---
 
+## Expected party level, by chapter — a stated PLANNING ASSUMPTION
+
+Not derived, and it cannot be: vanilla's ally `UnitDefinition` level is only read on a unit's
+FIRST load, so IS never declares what the party is by Ch6. It is a pacing fact, not a data fact.
+It is written down anyway, because every ABSOLUTE question needs it as a floor.
+
+| chapter | deployed-throughout unit, unpromoted |
+|---|---|
+| ch00–ch01 | 1–3 |
+| ch02–ch03 | 3–7 |
+| ch04–ch05 | 6–10 |
+| ch06–ch07 | **8–12** |
+| ch08 | 10–14 |
+
+**What this is for, and what it is NOT for.**
+
+`tools/difficulty.py` does not use it and should not. `player_combatant` resolves the cast *at
+base level* on purpose, and the parity ratio compares our chapter to its vanilla twin with the
+same understated party on both sides, so the bias cancels — the same argument
+`decisions.md` → *"AI behaviour is MEASURED and REPORTED"* makes for not weighting AI. Feeding a
+projected level into one side only would break that cancellation, not improve it.
+
+⚠️ The cancellation is first-order, not exact: `kills_per_round` and `durability` are threshold
+functions (doubling breakpoints, integer rounds-to-kill), so a party far below the enemies' level
+can saturate against both sides and flatten the ratio toward x1.00. The error is smallest at ch00
+and **grows with every chapter**. Tracked on #367.
+
+What the band IS for is sanity-checking any absolute claim before it becomes a design decision —
+*"can this unit survive that flight", "is this fuse long enough for a real party", "is this
+objective a coin flip"*. During #26 a ch06-era flier was assessed as fragile off her LEVEL 1 stat
+line and a chapter's design nearly turned on it. A number in a table would have stopped that.
+Absolute questions still end at tier 3 (`decisions.md` → *"Difficulty is checked in fidelity
+tiers"*): a chapter is not difficulty-verified until it has been played.
+
+---
+
 ## Open Items / deferred grounding
 
 - [x] **Pin exact promotion-item chapters** — done 2026-06-22: §3 is now a [decomp]-pinned

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -12748,6 +12748,55 @@ def repoint_escort_safe_ai_list(escort_char, why):
         f.write(source)
 
 
+#  AI_A_08's do-not-attack list, and the ch06 hulls it is repointed at. Vanilla declares it
+#  `u8 gUnknown_085A8B3C[] = { CHARACTER_CITIZEN, 0, 0, 0 }` and NOTHING in FE8 uses AI_A_08 --
+#  swept over events_udefs.c at decomp HEAD, `.ai = {0x8,` appears zero times -- so the index and
+#  its list are both free for us to spend.
+BOAT_SAFE_AI_INDEX = 0x8            # gAi1ScriptTable[AI_A_08] = gAiScript_ActionInRange_ExceptCivilian
+BOAT_SAFE_AI_LIST = 'gUnknown_085A8B3C'
+
+
+def repoint_boat_safe_ai_list(char_ids, why):
+    """Point AI_A_08's do-not-attack list at OUR rescue targets instead of vanilla's Citizen.
+
+    ch06's map puts a killable hull inside the merfolk line, which vanilla Ch6 never does: over
+    Ch6Map, with each class's own cost table, ZERO of its seventeen strikers can reach a
+    villager in one turn. Ours reach a boat on enemy phase 1, four of them, and a hull tuned as
+    a one-pursuer fuse sinks on turn 4 instead of 7. Vanilla buys that protection with TERRAIN
+    -- a mountain ring no Armour or Cavalier can cross -- and our frozen lake has no analogue,
+    so we buy it with the AI byte vanilla itself provides for exactly this job.
+
+    `AI_A_08` is `gAiScript_ActionInRange_ExceptCivilian`: the standard offensive action run
+    through `AiIsUnitEnemyAndNotInScrList`, which calls `AiIsInShortList(script->unk_08, ...)`
+    against each candidate's `pCharacterData->number`. `unk_08` is the list below. Copying the
+    byte alone does NOT protect our hulls, because the list holds a literal character id and
+    ours are raw pids of our own -- the same trap `repoint_escort_safe_ai_list` documents for
+    AI_A_07, and this is that function's twin.
+
+    THE LIST IS WIDENED, and that is not cosmetic. `AiIsInShortList` takes a `const u16*` and
+    stops on a zero entry, so vanilla's four BYTES are the two-entry u16 short list
+    `{ CHARACTER_CITIZEN, TERMINATOR }` -- it holds ONE id, not four. Writing both hull pids
+    into the byte slots would produce the single garbage id 0xBCBB and protect neither. Two ids
+    need six bytes: `{ id, 0, id, 0, 0, 0 }` reads as `{ id, id, TERMINATOR }`.
+
+    SAFE BECAUSE THE LIST HAS NO CLIENTS AT ALL. Unlike AI_A_07 (vanilla Ch5's Joshua), AI_A_08
+    is referenced by no vanilla UnitDefinition in the ROM, so repointing its list changes the
+    behaviour of nothing that vanilla ships.
+    """
+    with open(CP_DATA_C, encoding='utf-8') as f:
+        source = f.read()
+    body = ', '.join('%s, 0' % c for c in char_ids) + ', 0, 0'
+    pattern = (r'(u8 CONST_DATA %s\[\] = \{ )CHARACTER_CITIZEN, 0, 0, 0( \};)'
+               % BOAT_SAFE_AI_LIST)
+    source, count = re.subn(pattern, r'\g<1>%s\g<2>' % body, source, count=1)
+    if count != 1:
+        sys.exit('ERROR: %s is not vanilla\'s { CHARACTER_CITIZEN, 0, 0, 0 } in %s -- AI_A_08\'s '
+                 'do-not-attack list moved or was already patched, so %s would go unprotected'
+                 % (BOAT_SAFE_AI_LIST, CP_DATA_C, why))
+    with open(CP_DATA_C, 'w', encoding='utf-8') as f:
+        f.write(source)
+
+
 def escort_safe_ai_clients(campaign='rime-of-the-frostmaiden'):
     """`['chNN.enemy-id', ...]` for every enemy whose EMITTED AI1 is AI_A_07.
 
@@ -14218,6 +14267,12 @@ def inject_ch06(campaign, boot=False, verbose=True):
     declare_unit_table(CH06_BOAT_TABLE, boat_rows,
                        'ch06 the Burly Ram and the Pronged Goat: green hulls in their pockets, '
                        'and the chapter\'s real difficulty (#26)')
+    # ...and take the hulls off the MENU for every unit that is not their declared pursuer.
+    # Four of the line's strikers reach a hull on enemy phase 1 -- vanilla Ch6's line reaches
+    # its villagers NEVER -- so the chapter's overridden units carry AI_A_08 and this points
+    # its do-not-attack list at the two boat pids. See repoint_boat_safe_ai_list.
+    repoint_boat_safe_ai_list([CH06_BOAT_PIDS['boat-east'], CH06_BOAT_PIDS['boat-west']],
+                              'ch06 the two marooned hulls')
 
     # 3. Strip the host slot's event lists and wire ours. The list SYMBOLS are the only vanilla
     #    names left in this function, and they come from CH06_EVENT_LISTS.

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -12756,7 +12756,7 @@ BOAT_SAFE_AI_INDEX = 0x8            # gAi1ScriptTable[AI_A_08] = gAiScript_Actio
 BOAT_SAFE_AI_LIST = 'gUnknown_085A8B3C'
 
 
-def repoint_boat_safe_ai_list(char_ids, why):
+def repoint_boat_safe_ai_list(char_ids, why, owner):
     """Point AI_A_08's do-not-attack list at OUR rescue targets instead of vanilla's Citizen.
 
     ch06's map puts a killable hull inside the merfolk line, which vanilla Ch6 never does: over
@@ -12783,6 +12783,7 @@ def repoint_boat_safe_ai_list(char_ids, why):
     is referenced by no vanilla UnitDefinition in the ROM, so repointing its list changes the
     behaviour of nothing that vanilla ships.
     """
+    assert_boat_safe_ai_is_single_chapter(owner)
     with open(CP_DATA_C, encoding='utf-8') as f:
         source = f.read()
     body = ', '.join('%s, 0' % c for c in char_ids) + ', 0, 0'
@@ -12797,13 +12798,17 @@ def repoint_boat_safe_ai_list(char_ids, why):
         f.write(source)
 
 
-def escort_safe_ai_clients(campaign='rime-of-the-frostmaiden'):
-    """`['chNN.enemy-id', ...]` for every enemy whose EMITTED AI1 is AI_A_07.
+def safe_ai_clients(ai_index, campaign='rime-of-the-frostmaiden'):
+    """`['chNN.enemy-id', ...]` for every enemy whose EMITTED AI1 is `ai_index`.
 
     Reads what each chapter actually ships -- donor bytes or a declared override -- rather
     than a table of labels (#335). That is strictly wider than the label scan it replaced:
-    it also catches a unit that inherits AI_A_07 from its vanilla DONOR, which no scan of
-    our own vocabulary could ever see."""
+    it also catches a unit that inherits the byte from its vanilla DONOR, which no scan of
+    our own vocabulary could ever see.
+
+    One implementation for BOTH repointed do-not-attack lists. They have the same hazard --
+    a global list whose safety rests on knowing every client -- and having only AI_A_07's
+    swept is what let AI_A_08 be spent with no sweep at all."""
     import difficulty
     out = []
     for path in sorted(glob.glob(os.path.join(
@@ -12820,10 +12825,41 @@ def escort_safe_ai_clients(campaign='rime-of-the-frostmaiden'):
                         ai = difficulty.enemy_ai_bytes(chap, enemy, index)
                     except ValueError:
                         continue        # ungrounded: ai_donor_findings reports it, not us
-                    if ai[0] == ESCORT_SAFE_AI_INDEX:
+                    if ai[0] == ai_index:
                         out.append('%s.%s' % (stem, enemy.get('id')))
                         break
     return sorted(out)
+
+
+def escort_safe_ai_clients(campaign='rime-of-the-frostmaiden'):
+    """Every enemy carrying AI_A_07 -- ch05's escort byte."""
+    return safe_ai_clients(ESCORT_SAFE_AI_INDEX, campaign)
+
+
+def assert_boat_safe_ai_is_single_chapter(owner):
+    """Refuse the repoint if any chapter but `owner` has picked up AI_A_08.
+
+    `assert_escort_safe_ai_has_one_client`'s twin, and it exists because AI_A_08's list is
+    exactly as GLOBAL as AI_A_07's. Once repointed it names ch06's two hull pids, so ANY unit
+    anywhere carrying `{0x8, ...}` inherits "will not attack those pids".
+
+    The invariants differ, and the difference is the point. AI_A_07's is one UNIT, because
+    vanilla ships one client and a second would inherit our escort's immunity by accident.
+    AI_A_08's is one CHAPTER, because vanilla ships NO clients -- so the chapter that claims
+    the list may spend it on as many of its own units as it likes (ch06 spends it on ten), and
+    the hazard is a DIFFERENT chapter picking the byte up for its own reasons. That unit would
+    silently refuse to attack pids its chapter has never heard of, and the next chapter to want
+    this byte for its own rescue targets would repoint the list out from under ch06 with
+    nothing anywhere to say so.
+    """
+    strays = [c for c in safe_ai_clients(BOAT_SAFE_AI_INDEX)
+              if not c.startswith(owner + '.')]
+    if strays:
+        sys.exit('ERROR: AI_A_08 (%s) is claimed by %s, but %s also carry it. The '
+                 'do-not-attack list is GLOBAL and now names %s\'s rescue targets, so those '
+                 'units silently inherit an immunity to pids their own chapter never declared. '
+                 'Give them a different ACTION byte, or move the list to a second index.'
+                 % (BOAT_SAFE_AI_LIST, owner, ', '.join(strays), owner))
 
 
 def assert_escort_safe_ai_has_one_client(ai_bytes):
@@ -14272,7 +14308,7 @@ def inject_ch06(campaign, boot=False, verbose=True):
     # its villagers NEVER -- so the chapter's overridden units carry AI_A_08 and this points
     # its do-not-attack list at the two boat pids. See repoint_boat_safe_ai_list.
     repoint_boat_safe_ai_list([CH06_BOAT_PIDS['boat-east'], CH06_BOAT_PIDS['boat-west']],
-                              'ch06 the two marooned hulls')
+                              'ch06 the two marooned hulls', owner='ch06')
 
     # 3. Strip the host slot's event lists and wire ours. The list SYMBOLS are the only vanilla
     #    names left in this function, and they come from CH06_EVENT_LISTS.

--- a/tools/chapter_status.py
+++ b/tools/chapter_status.py
@@ -249,18 +249,38 @@ AI_BEHAVIOUR = {
     0x12: 'charge-after-1',
 }
 
-# Which families are "threat that comes to you" and which are "threat you walk into" -- ch05's
-# YAML coined the distinction and #344 measured it. A unit that never moves contributes nothing
-# until the player enters its range, so the two are not interchangeable.
-#
-# Only families whose DECOMP SYMBOL states the behaviour are classified. The six table entries
-# named after bare addresses, and any index outside the table, are UNCLASSIFIED on purpose:
-# bucketing an unknown script as "static" because it is unnamed would be a guess wearing a
-# measurement's clothes, and it would land silently on the side that lowers the number.
+# The ACTION half, `gAi1ScriptTable` (cp_data.c). This is the half that MOVES, and reading only
+# AI_B is what let a chapter be designed against the word "never-move": `AI_B_03 NeverMove` is
+# `AI_NOP_0E` -- it only suppresses crossing the map -- while `AI_A_00 ActionInRange` is
+# `AI_ACTION(100)`, and acting includes stepping within the unit's own range to reach a target.
+# Measured when this landed: 94 of 99 campaign enemies are ActionInRange, and 48 of the 51 units
+# reported as "threat you walk into" will move (decisions.md -> "AI_B is the APPROACH and AI_A is
+# the ACTION"). Same naming discipline as AI_BEHAVIOUR: the twelve entries the decomp gives only
+# an address (0x09..0x14) stay UNNAMED rather than guessed at.
+AI_ACTION = {
+    0x00: 'engage',                   # ActionInRange
+    0x01: 'engage-80',                # ActionInRange_80Perc
+    0x02: 'engage-50',                # ActionInRange_50Perc
+    0x03: 'hold',                     # ActionStanding -- vanilla Ch6's Novala, and a true statue
+    0x04: 'hold-80',                  # ActionStanding_80Perc
+    0x05: 'hold-50',                  # ActionStanding_50Perc
+    0x06: 'inert',                    # DoNothing -- vanilla Ch6's three green villagers
+    0x07: 'engage-except-char',       # ActionInRange_ExceptNatasha (ch05's escort rides this)
+    0x08: 'engage-except-civilian',   # ActionInRange_ExceptCivilian
+}
+# Whether the ACTION reaches for a target. `engage*` walks within its own move range to attack;
+# `hold*` strikes only what is already adjacent; `inert` does nothing at all.
+AI_ACTION_MOVES = frozenset({'engage', 'engage-80', 'engage-50',
+                             'engage-except-char', 'engage-except-civilian'})
+AI_ACTION_HOLDS = frozenset({'hold', 'hold-80', 'hold-50', 'inert'})
+
+# Which APPROACH families cross the map at you, and which hold ground. Note this is no longer the
+# whole story on its own -- a holding APPROACH still moves if its ACTION engages, which is what
+# `ai_shape` exists to express.
 AI_COMES_TO_YOU = frozenset({'pursue', 'pursue-ignore-char', 'pursue-twice',
                              'pursue-twice-ignore-char', 'charge-after-1',
                              'pillage', 'pillage-after-1'})
-AI_WALK_INTO = frozenset({'never-move', 'guard-tile'})
+AI_HOLDS_GROUND = frozenset({'never-move', 'guard-tile'})
 # Known behaviours that are NEITHER: the unit moves, but not at the player. A thief that loots
 # and leaves, a script that flees, one that chews on walls. Folding these into "unclassified"
 # said "we do not know" about three scripts the decomp names outright -- and ai2=0x05 alone
@@ -270,31 +290,62 @@ AI_OWN_ERRAND = frozenset({'pillage-escape', 'escape', 'attack-walls-snags'})
 
 
 def ai_family(ai2):
-    """The behaviour family for an AI2 index, or None where the decomp does not name one."""
+    """The APPROACH family for an AI2 index, or None where the decomp does not name one."""
     return AI_BEHAVIOUR.get(ai2)
 
 
-def behaviour_split(ai2s):
-    """{comes_to_you, walk_into, unclassified, n} over a sequence of AI2 indices.
+def ai_action(ai1):
+    """The ACTION family for an AI1 index, or None where the decomp does not name one."""
+    return AI_ACTION.get(ai1)
+
+
+def ai_shape(ai):
+    """The three-way shape a FULL 4-byte vector describes, or None if either half is unnamed.
+
+        pursuer     -- the approach walks it across the map at you
+        striker     -- it holds ground, but its ACTION steps out within its own move range
+        statue      -- it holds ground and does not move at all, even to attack
+        own-errand  -- it moves, but not at the player (loots, flees, chews on walls)
+
+    Two buckets could not express the middle one, and the middle one is most of the campaign:
+    `{engage, never-move}` is vanilla's commonest pairing. ch06's clock was designed as though
+    it meant `statue`, and four merfolk walked to a boat the design had them nowhere near.
+
+    Takes the vector, never a single byte: a stale `ai_shape(ai[1])` would classify a whole
+    roster off half the information and look entirely correct, so an int RAISES.
+    """
+    if isinstance(ai, int) or not hasattr(ai, '__len__') or len(ai) < 2:
+        raise TypeError('ai_shape takes the 4-byte AI vector, not one byte -- the ACTION half '
+                        '(ai[0]) is what decides whether the unit moves (got %r)' % (ai,))
+    action, approach = ai_action(ai[0]), ai_family(ai[1])
+    if action is None or approach is None:
+        return None
+    if approach in AI_OWN_ERRAND:
+        return 'own-errand'
+    if approach in AI_COMES_TO_YOU:
+        return 'pursuer'
+    if approach in AI_HOLDS_GROUND:
+        return 'striker' if action in AI_ACTION_MOVES else 'statue'
+    return None
+
+
+def behaviour_split(ais):
+    """{pursuer, striker, statue, own_errand, unclassified, n} over a sequence of AI VECTORS.
 
     Reported rather than folded into threat. #344 set out to WEIGHT threat by behaviour and the
     measurement said not to: since #335 derives every unit's AI from its vanilla donor, our
-    behavioural shape IS the twin's shape (measured: 0 points of difference on all six active
-    chapters), so a weighting would scale both sides of the ratio identically and always report
-    x1.00. What is worth having is the split in the open, where a future divergence shows.
+    behavioural shape IS the twin's, so a weighting would scale both sides of the ratio
+    identically and always report x1.00. What is worth having is the split in the open, where a
+    future divergence shows -- which only works if the split describes the whole vector.
     """
-    out = {'comes_to_you': 0, 'walk_into': 0, 'own_errand': 0, 'unclassified': 0, 'n': 0}
-    for ai2 in ai2s:
+    out = {'pursuer': 0, 'striker': 0, 'statue': 0, 'own_errand': 0, 'unclassified': 0, 'n': 0}
+    for ai in ais:
         out['n'] += 1
-        family = ai_family(ai2)
-        if family in AI_COMES_TO_YOU:
-            out['comes_to_you'] += 1
-        elif family in AI_WALK_INTO:
-            out['walk_into'] += 1
-        elif family in AI_OWN_ERRAND:
-            out['own_errand'] += 1
-        else:
+        shape = ai_shape(ai)
+        if shape is None:
             out['unclassified'] += 1
+        else:
+            out[shape.replace('-', '_')] += 1
     return out
 
 # `override` is a FLAG, not the vector: both _donor_label and the report's override list
@@ -661,14 +712,19 @@ def report(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
     out.append('')
     ai_rows = ai(name, campaign)
     if ai_rows:
-        out.append('  ai        behaviour        borrowed from  unit')
+        out.append('  ai        action/approach          shape      borrowed from  unit')
         for row in ai_rows:
             if row.ai is None:
-                out.append('    %-16s %-14s %s' % ('UNGROUNDED', '--', row.unit))
+                out.append('    %-24s %-10s %-14s %s'
+                           % ('UNGROUNDED', '--', '--', row.unit))
                 continue
-            out.append('    %-16s %-14s %s'
-                       % (AI_BEHAVIOUR.get(row.ai[1], '0x%02X' % row.ai[1]),
-                          _donor_label(row), row.unit))
+            # BOTH halves. The approach alone reads "never-move" for a unit that steps out to
+            # strike, which is what ch06's clock was designed against (decisions.md -> "AI_B is
+            # the APPROACH and AI_A is the ACTION").
+            pair = '%s/%s' % (AI_ACTION.get(row.ai[0], '0x%02X' % row.ai[0]),
+                              AI_BEHAVIOUR.get(row.ai[1], '0x%02X' % row.ai[1]))
+            out.append('    %-24s %-10s %-14s %s'
+                       % (pair, ai_shape(row.ai) or '?', _donor_label(row), row.unit))
         overrides = [r for r in ai_rows if r.override]
         for row in overrides:
             # First sentence only: the reason is authored in full in the chapter YAML, and this
@@ -682,10 +738,13 @@ def report(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
         # 0 points of difference on all six active chapters -- and a weighting would scale both
         # sides of the ratio and always say x1.00. What this catches is the day that stops
         # being true, which can only happen through an ai_override or a donor-less unit.
-        split = behaviour_split([r.ai[1] for r in ai_rows if r.ai is not None])
+        split = behaviour_split([r.ai for r in ai_rows if r.ai is not None])
         if split['n']:
-            line = ('    shape     %d come to you / %d you walk into'
-                    % (split['comes_to_you'], split['walk_into']))
+            # THREE, not two. A `striker` holds ground but steps out within its own move range,
+            # and it is most of every roster -- collapsing it into "you walk into" is what let a
+            # chapter be planned as though the line would stand still.
+            line = ('    shape     %d come to you / %d hold and STRIKE / %d never move'
+                    % (split['pursuer'], split['striker'], split['statue']))
             if split['own_errand']:
                 # Moves, but not at the player -- loots and leaves, flees, chews on walls.
                 line += ' / %d on its own errand' % split['own_errand']

--- a/tools/check.py
+++ b/tools/check.py
@@ -932,7 +932,9 @@ def check_gate_chapter_window(fail):
 # YAML ids of a different shape (`north` vs `reliquary-north`), and matching those would mean
 # renaming a shipped chapter's constants rather than catching a bug.
 _LUA_ROW = re.compile(r'\{[^{}]*\bid\s*=\s*"([^"]+)"[^{}]*\}')
-_LUA_FIELD = re.compile(r'\b(\w+)\s*=\s*(-?\d+|0x[0-9A-Fa-f]+)')
+# NB the hex branch comes FIRST: Python's alternation is ordered, so `-?\d+` would match the
+# leading `0` of `0x11` and the field would silently read as 0.
+_LUA_FIELD = re.compile(r'\b(\w+)\s*=\s*(0x[0-9A-Fa-f]+|-?\d+)')
 
 
 def _chapter_lua_coords(doc):
@@ -1013,11 +1015,16 @@ def check_chapter_lua_facts(fail):
         fail.extend(_chapter_lua_fact_violations(rel, text, chapter_rel, doc))
 
 
-# The ACTION bytes that cannot target a listed character. AI_A_08 is the one ch06 spends
-# (`repoint_boat_safe_ai_list`); AI_A_07 is ch05's escort. Both run the standard offensive
-# action through `AiIsUnitEnemyAndNotInScrList`, so a unit carrying either fights the player
-# normally and simply will not swing at whatever the repointed list names.
-RESCUE_SAFE_ACTIONS = (0x07, 0x08)
+# The ACTION byte that cannot target a rescue target. AI_A_08 is the one ch06 spends
+# (`repoint_boat_safe_ai_list`), and it is the ONLY one that licenses a unit here.
+#
+# AI_A_07 deliberately is NOT in this tuple, though it has the same shape. Both run the
+# standard offensive action through `AiIsUnitEnemyAndNotInScrList`, so both refuse to swing at
+# whatever their list names -- but the LISTS are different and each names one thing. AI_A_07's
+# is repointed at ch05's escort (`repoint_escort_safe_ai_list`), never at a boat pid, so a
+# ch06 unit carrying `{0x7, ...}` refuses to attack Basil and sinks the hull happily. Treating
+# the two as interchangeable made this gate accept exactly that unit as proven safe.
+RESCUE_SAFE_ACTIONS = (0x08,)
 
 
 def _rescue_target_violations(short, reachers, pursuers):

--- a/tools/check.py
+++ b/tools/check.py
@@ -927,6 +927,92 @@ def check_gate_chapter_window(fail):
     fail.extend(_gate_window_violations(boots, hosts.hosted_chapters()))
 
 
+# A row in a chapter Lua chunk: `{ id = "boat-east", x = 17, y = 12, doorX = 17, ... }`.
+# Only rows keyed by `id` are in scope -- ch05.lua's reliquaries are keyed by `name` against
+# YAML ids of a different shape (`north` vs `reliquary-north`), and matching those would mean
+# renaming a shipped chapter's constants rather than catching a bug.
+_LUA_ROW = re.compile(r'\{[^{}]*\bid\s*=\s*"([^"]+)"[^{}]*\}')
+_LUA_FIELD = re.compile(r'\b(\w+)\s*=\s*(-?\d+|0x[0-9A-Fa-f]+)')
+
+
+def _chapter_lua_coords(doc):
+    """{id: {'xy': (x, y), 'door': (x, y) or None}} for everything a chapter YAML places."""
+    out = {}
+    for boat in (doc.get('rescue_boats') or ()):
+        if boat.get('id') and _int_pair(boat.get('tile')):
+            door = boat.get('door')
+            out[boat['id']] = {'xy': tuple(boat['tile']),
+                               'door': tuple(door) if _int_pair(door) else None}
+    for enemy in (doc.get('enemy_units') or ()):
+        spots = enemy.get('positions') or ()
+        if enemy.get('id') and spots and _int_pair(spots[0]):
+            out[enemy['id']] = {'xy': tuple(spots[0]), 'door': None}
+    for village in (doc.get('villages') or ()):
+        if village.get('id') and _int_pair(village.get('tile')):
+            out[village['id']] = {'xy': tuple(village['tile']), 'door': None}
+    return out
+
+
+def _chapter_lua_fact_violations(rel, text, chapter_rel, doc):
+    """A chapter Lua chunk's coordinates must be the chapter YAML's own.
+
+    A chunk restates what the YAML declares -- ch06.lua carries both hulls' pocket cells and
+    both pocket DOORS, and ch06clock's verdict is that a melee attacker stands on one of those
+    doors. A stale coordinate there does not crash: it produces a scenario that runs, reads
+    the wrong cell, and FAILs blaming the engine for a constant nobody updated. Same failure
+    `check_declared_cases` stops for a `visit` step's tile, one file over.
+    """
+    placed = _chapter_lua_coords(doc)
+    problems = []
+    for row in _LUA_ROW.finditer(text):
+        body = row.group(0)
+        uid = row.group(1)
+        fields = dict((k, int(v, 0)) for k, v in _LUA_FIELD.findall(body))
+        if 'x' not in fields or 'y' not in fields:
+            continue
+        want = placed.get(uid)
+        if want is None:
+            problems.append(
+                '%s places %r at (%d,%d), and %s declares nothing by that id -- a chapter '
+                'chunk that names a unit the chapter does not field cannot be found at run '
+                'time, so the scenario fails at its precondition'
+                % (rel, uid, fields['x'], fields['y'], chapter_rel))
+            continue
+        if (fields['x'], fields['y']) != want['xy']:
+            problems.append(
+                '%s puts %r at (%d,%d); %s declares (%d,%d). The Lua is not the authority'
+                % (rel, uid, fields['x'], fields['y'], chapter_rel, want['xy'][0],
+                   want['xy'][1]))
+        if 'doorX' in fields and 'doorY' in fields:
+            got = (fields['doorX'], fields['doorY'])
+            if want['door'] is None:
+                problems.append('%s gives %r a door at (%d,%d); %s declares none'
+                                % (rel, uid, got[0], got[1], chapter_rel))
+            elif got != want['door']:
+                problems.append(
+                    '%s puts %r\'s door at (%d,%d); %s declares (%d,%d). The door is the one '
+                    'ground cell the pocket can be attacked from, and it IS the verdict'
+                    % (rel, uid, got[0], got[1], chapter_rel, want['door'][0],
+                       want['door'][1]))
+    return problems
+
+
+def check_chapter_lua_facts(fail):
+    """Every `tools/playtest/chNN.lua` agrees with the chapter YAML it speaks for (#26)."""
+    docs = {}
+    for rel, d in _chapters():
+        docs[os.path.basename(rel).split('-')[0]] = (rel, d)
+    for path in sorted(glob.glob(os.path.join(REPO, 'tools/playtest/ch*.lua'))):
+        rel = os.path.relpath(path, REPO)
+        short = os.path.basename(path).split('.')[0]
+        if short not in docs:
+            continue                        # ch02check.lua and friends speak for no chapter
+        with open(path, encoding='utf-8') as fh:
+            text = fh.read()
+        chapter_rel, doc = docs[short]
+        fail.extend(_chapter_lua_fact_violations(rel, text, chapter_rel, doc))
+
+
 def _re_local_git_env(text, name):
     """True if `name` is bound to git_env() in this file -- `env = git_env()` then `env=env`."""
     import re as _re
@@ -2263,7 +2349,8 @@ def main():
                   check_playtest_matrix, check_rom_configs_reach_the_build,
                   check_decomp_git_calls_strip_the_env,
                   check_no_shadowed_definitions, check_gate_chapter_window,
-                  check_declared_cases, check_harness_local_ratchet,
+                  check_declared_cases, check_chapter_lua_facts,
+                  check_harness_local_ratchet,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,
                   check_tool_refs_exist, check_no_dead_concepts,

--- a/tools/check.py
+++ b/tools/check.py
@@ -1013,6 +1013,63 @@ def check_chapter_lua_facts(fail):
         fail.extend(_chapter_lua_fact_violations(rel, text, chapter_rel, doc))
 
 
+# The ACTION bytes that cannot target a listed character. AI_A_08 is the one ch06 spends
+# (`repoint_boat_safe_ai_list`); AI_A_07 is ch05's escort. Both run the standard offensive
+# action through `AiIsUnitEnemyAndNotInScrList`, so a unit carrying either fights the player
+# normally and simply will not swing at whatever the repointed list names.
+RESCUE_SAFE_ACTIONS = (0x07, 0x08)
+
+
+def _rescue_target_violations(short, reachers, pursuers):
+    """Every unit that can reach a rescue target without being licensed to.
+
+    `reachers` is [(enemy id, its 4 AI bytes)] for units that can attack a hull; `pursuers` is
+    the ids the chapter DECLARES as its clock. A chapter with rescue targets has costed exactly
+    those, and anything else reaching one is a mob it did not plan for -- ch06 shipped four, and
+    a hull tuned as a one-pursuer fuse sank on turn 4 instead of 7 (#26).
+
+    Two ways to be legitimate, and the finding names both: be the declared clock, or carry an
+    ACTION byte that cannot target the hull at all.
+    """
+    out = []
+    for uid, ai in reachers:
+        if uid in pursuers or (ai and ai[0] in RESCUE_SAFE_ACTIONS):
+            continue
+        out.append(
+            '%s: %r can attack a rescue target but is neither a declared pursuer nor carries '
+            'a do-not-attack ACTION byte. Vanilla protects its rescue targets with TERRAIN no '
+            'striker can cross; where our map cannot, the unit needs an `ai_override` to '
+            'AI_A_08 (0x8) -- or the chapter must declare it a pursuer and cost its clock'
+            % (short, uid))
+    return out
+
+
+def check_rescue_targets(fail):
+    """A chapter's rescue targets are reachable only by units it declared (#26)."""
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    try:
+        import difficulty
+        import map_placement_preview as pp
+        import chapter_status as cs
+    except ImportError as exc:      # Pillow / submodule absent on the lightweight checks job
+        print('check_rescue_targets: skipping (%s; the build job\'s `make test` covers it)' % exc)
+        return
+    for rel, doc in _chapters():
+        boats = doc.get('rescue_boats') or []
+        if not boats:
+            continue
+        short = str(doc.get('id', '')).split('-')[0]
+        try:
+            terrain = pp.terrain_grid(doc)
+        except Exception as exc:    # noqa: BLE001 -- an unbuilt map is not this gate's business
+            print('check_rescue_targets: skipping %s (%s)' % (short, exc))
+            continue
+        hulls = [tuple(b['tile']) for b in boats]
+        pursuers = {p['id'] for p in (doc.get('rescue_pursuers') or [])}
+        fail.extend(_rescue_target_violations(
+            short, pp.units_reaching(doc, terrain, hulls), pursuers))
+
+
 def _re_local_git_env(text, name):
     """True if `name` is bound to git_env() in this file -- `env = git_env()` then `env=env`."""
     import re as _re
@@ -2350,6 +2407,7 @@ def main():
                   check_decomp_git_calls_strip_the_env,
                   check_no_shadowed_definitions, check_gate_chapter_window,
                   check_declared_cases, check_chapter_lua_facts,
+                  check_rescue_targets,
                   check_harness_local_ratchet,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -12,8 +12,8 @@ for its confirmation preview -- and overlays:
 
   * a coordinate ruler, because every placement conversation is in map coordinates
   * the deploy block, the crossings and the boats, read from the chapter YAML
-  * one marker per placed unit, coloured by AI behaviour (the thing placement decides:
-    a never-move unit is furniture, a pursuer is a clock)
+  * one marker per placed unit, coloured by AI SHAPE (the thing placement decides:
+    a statue is furniture, a striker holds but strikes, a pursuer is a clock)
   * optional per-cell shading -- turn-reach bands, or the cells a placement threatens
 
 Placements come from the chapter YAML's own `positions:` once they are authored, or from
@@ -76,14 +76,25 @@ def mov_cost_row(table='TerrainTable_MovCost_CommonT1Normal'):
 
 FOOT_COST = mov_cost_row()
 
-# Marker colours by AI behaviour, because behaviour is what a placement decides: a
-# never-move unit is furniture the player walks into, a pursuer is a clock.
+# Marker colours by AI SHAPE (`chapter_status.ai_shape`), because shape is what a placement
+# decides: a statue is furniture, a striker holds its ground but steps out to hit whatever
+# comes close, a pursuer is a clock.
+#
+# Keyed on the SHAPE and never on the approach family. `never-move` names only the approach
+# byte, and a unit carrying it still steps out to strike -- which is exactly how four merfolk
+# mobbed a hull the chapter had nowhere near them (`decisions.md` -> "AI_B is the APPROACH and
+# AI_A is the ACTION"). These keys must stay in step with `ai_shape`'s return values;
+# `test_map_placement_preview` pins that.
 BEHAVIOUR_COLOUR = {
-    'never-move':     (206, 74, 74),      # red
-    'charge-after-1': (232, 138, 46),     # orange
-    'pursue':         (240, 208, 62),     # yellow
-    'hold-position':  (150, 46, 140),     # purple -- the boss on its tile
+    'pursuer':    (240, 208, 62),      # yellow -- the approach walks it at you
+    'striker':    (232, 138, 46),      # orange -- holds, but its ACTION steps out to strike
+    'statue':     (206, 74, 74),       # red    -- does not move at all, even to attack
+    'own-errand': (150, 46, 140),      # purple -- moves, but not at you (loots, flees)
 }
+# `ai_shape` returns None when either half of the vector is unnamed in the decomp. Draw that
+# as its own colour rather than guessing a shape: an unclassified unit is a fact, and the
+# marker should say so instead of borrowing a neighbour's meaning.
+UNCLASSIFIED_COLOUR = (140, 148, 170)
 BOAT_COLOUR = (86, 196, 120)
 DEPLOY_COLOUR = (74, 138, 226)
 
@@ -203,7 +214,13 @@ def _classes_text():
 
 
 def units_reaching(chapter, terrain, targets):
-    """[(enemy id, ai bytes)] for every turn-1 unit that can ATTACK one of `targets`.
+    """[(enemy id, ai bytes)] for every unit that can ATTACK one of `targets`.
+
+    REINFORCEMENTS ARE INCLUDED. They are not on the opening board, but a hull's fuse is costed
+    against the units a chapter DECLARES as its clock, and an undeclared unit that reaches a
+    hull on turn 5 sinks it exactly as surely as one that reaches it on turn 1 -- it just does
+    it out of sight of a gate that only ever looked at turn 1. Skipping them hid ch06's three
+    Difficult-only turn-4 crab riders, which spawn on the west edge and do reach the west hull.
 
     The two shapes reach differently, and conflating them is what made the first cut of this
     analysis wrong by three units:
@@ -221,8 +238,6 @@ def units_reaching(chapter, terrain, targets):
     import chapter_status as cs
     out = []
     for enemy in chapter.get('enemy_units') or ():
-        if enemy.get('arrives_turn'):
-            continue                      # not on the board when the clock starts
         # MAX range over the whole inventory, not the first weapon. FE8's AI equips whatever
         # lets it attack, and ch06's ironshell-horseslayer proved it in-engine: its items[0] is
         # a range-1 Horseslayer, and it threw its JAVELIN at the hull from two tiles away.
@@ -437,7 +452,7 @@ def render(chapter, stem, out_png, concept=None, shade=None, zoom=3):
 
     for tile, code, behaviour, eid, late in units:
         x, y = tile
-        colour = BEHAVIOUR_COLOUR.get(behaviour, (200, 200, 200))
+        colour = BEHAVIOUR_COLOUR.get(behaviour, UNCLASSIFIED_COLOUR)
         cx, cy = pad + x * cell + cell // 2, head + y * cell + cell // 2
         r = cell // 2 - 2
         if late:
@@ -456,10 +471,11 @@ def render(chapter, stem, out_png, concept=None, shade=None, zoom=3):
     d.text((pad, ly), 'behaviour, borrowed from each unit\'s vanilla donor (#335):',
            fill=(210, 210, 216), font=f_small)
     lx = pad + 390
-    for name, colour in (('never-move -- you walk into it', BEHAVIOUR_COLOUR['never-move']),
-                         ('charge after turn 1', BEHAVIOUR_COLOUR['charge-after-1']),
-                         ('pursue from turn 1', BEHAVIOUR_COLOUR['pursue']),
-                         ('B = boss, guards its tile', BEHAVIOUR_COLOUR['hold-position']),
+    for name, colour in (('pursuer -- comes to you', BEHAVIOUR_COLOUR['pursuer']),
+                         ('striker -- holds, steps out to strike', BEHAVIOUR_COLOUR['striker']),
+                         ('statue -- never moves, even to attack', BEHAVIOUR_COLOUR['statue']),
+                         ('own errand -- moves, not at you', BEHAVIOUR_COLOUR['own-errand']),
+                         ('AI not classified', UNCLASSIFIED_COLOUR),
                          ('hollow = arrives turn 4, Hard only', (150, 150, 158))):
         d.ellipse([lx, ly, lx + 15, ly + 15], fill=colour, outline=(16, 16, 18))
         d.text((lx + 22, ly), name, fill=(210, 210, 216), font=f_small)

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -161,7 +161,10 @@ def placed_units(chapter, concept=None):
         tiles = override.get(eid, enemy.get('positions') or [])
         for i, tile in enumerate(tiles):
             ai = dif.enemy_ai_bytes(chapter, enemy, i)
-            behaviour = 'hold-position' if enemy.get('is_boss') else cs.ai_family(ai[1])
+            # Derived from the WHOLE vector, never patched by role: `is_boss` was standing in
+            # for the AI_A half this could not see, and it was wrong in both directions -- a
+            # non-boss statue read as mobile, and a boss with an engaging action read as static.
+            behaviour = cs.ai_shape(ai) or cs.ai_family(ai[1]) or '?'
             code = 'B' if enemy.get('is_boss') else ROLE_CODE.get(enemy.get('class'), '??')
             late = enemy.get('arrives_turn') or enemy.get('hard_mode_only')
             out.append((tuple(tile), code, behaviour, eid, late))

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -109,10 +109,37 @@ def load_map(stem):
     return grid, terrain, ts
 
 
-def foot_reach(terrain, sources):
-    """Movement-point distance from any source cell, for a walking class."""
+# The movement profiles `reached_on:` is declared in. Each is (decomp cost table, baseMov) --
+# the table names are the decomp's own, and the two named entries are the PCs whose class makes
+# the crossing question different for them than for the rest of the party.
+REACH_ROLES = {
+    'foot':    ('TerrainTable_MovCost_CommonT1Normal', 5),
+    'cavalry': ('TerrainTable_MovCost_HorseT1Normal', 7),
+    'flier':   ('TerrainTable_MovCost_FlyNormal', 7),
+    'braulo':  ('TerrainTable_MovCost_PirateNormal', 5),
+    'trex':    ('TerrainTable_MovCost_CommonT1Normal', 6),
+}
+
+
+def foot_reach(terrain, sources, blocked=(), cost=None):
+    """Movement-point distance from any source cell.
+
+    `blocked` is cells a unit may not enter or pass through -- in FE that is every ENEMY body,
+    with no phasing and no swapping. Leaving it empty measures an EMPTY MAP, which is how
+    ch06's `reached_on:` came to claim "foot reaches either door on turn 6" for a boat sitting
+    behind a merfolk line: true of the terrain, untrue of the chapter. A source cell is never
+    blocked -- the walker is standing there.
+
+    `cost` is a terrain-id -> points table (see REACH_ROLES); it defaults to the foot row.
+
+    LIMIT, stated rather than implied: this is a turn-1 SNAPSHOT. Strikers step into the route
+    on later phases, so the contested number is still a floor -- a tighter one than the empty
+    map, not the truth. What it cannot model is the cost of fighting, which depends on play.
+    """
     import heapq
+    cost = FOOT_COST if cost is None else cost
     h, w = len(terrain), len(terrain[0])
+    blocked = set(blocked) - set(sources)
     dist, pq = {}, []
     for s in sources:
         dist[s] = 0
@@ -123,15 +150,65 @@ def foot_reach(terrain, sources):
             continue
         for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
             nx, ny = x + dx, y + dy
-            if not (0 <= nx < w and 0 <= ny < h):
+            if not (0 <= nx < w and 0 <= ny < h) or (nx, ny) in blocked:
                 continue
-            step = FOOT_COST.get(terrain[ny][nx])
+            step = cost.get(terrain[ny][nx])
             if step is None:
                 continue
             if c + step < dist.get((nx, ny), 1 << 30):
                 dist[(nx, ny)] = c + step
                 heapq.heappush(pq, (c + step, (nx, ny)))
     return dist
+
+
+def arrival_turn(points, mov):
+    """Movement points -> the turn a unit spending `mov` a turn first stands there."""
+    if points is None:
+        return None
+    return max(1, -(-points // mov))
+
+
+def enemy_bodies(chapter):
+    """Every turn-1 enemy tile. Reinforcements are excluded: they are not on the board yet."""
+    out = set()
+    for enemy in chapter.get('enemy_units') or ():
+        if enemy.get('arrives_turn'):
+            continue
+        for tile in enemy.get('positions') or ():
+            out.add(tuple(tile))
+    return out
+
+
+def load_chapter(prefix):
+    """The chapter doc whose id starts with `prefix`. One resolver, so `main` and every caller
+    that needs a chapter agree about what "ch06" means."""
+    match = [c for c in campaign_chapters.load_all()
+             if str(c.get('id', '')).startswith(prefix)]
+    if not match:
+        sys.exit('ERROR: no chapter id starts with %r' % prefix)
+    return match[0]
+
+
+def terrain_grid(chapter):
+    """The chapter's compiled terrain, by the map its YAML names."""
+    stem = os.path.splitext(os.path.basename(chapter['map']['file']))[0]
+    return load_map(stem)[1]
+
+
+def reached_on(chapter, terrain, target, contested=True):
+    """{role: turn} for reaching `target` from the deploy block, per movement profile.
+
+    `contested=True` walks the map with the enemy line standing on it, which is the reading
+    a chapter's clock actually needs. `contested=False` reproduces the empty-map number the
+    hand-written `reached_on:` blocks were measured with, so the two can be compared.
+    """
+    blocked = enemy_bodies(chapter) if contested else ()
+    out = {}
+    for role, (table, mov) in REACH_ROLES.items():
+        dist = foot_reach(terrain, deploy_cells(chapter, terrain), blocked=blocked,
+                          cost=mov_cost_row(table))
+        out[role] = arrival_turn(dist.get(tuple(target)), mov)
+    return out
 
 
 def deploy_cells(chapter, terrain):

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -179,6 +179,78 @@ def enemy_bodies(chapter):
     return out
 
 
+def class_movement(class_token):
+    """('cost table symbol', baseMov) for one of our chapter YAML class tokens.
+
+    Read off the ENGINE's class row, never a hand-kept table: a chapter whose whole shape is
+    who-can-cross-what cannot afford a second opinion about a class's movement.
+    """
+    import difficulty
+    enum = difficulty._enemy_class_enum(class_token)
+    src = _classes_text()
+    block = re.search(r'\[%s - 1\] = \{(.*?)\n    \},' % enum, src, re.S)
+    if not block:
+        raise KeyError('no class row for %r' % enum)
+    table = re.search(r'\.pMovCostTable\s*=\s*(\w+)', block.group(1))
+    mov = re.search(r'\.baseMov\s*=\s*(\d+)', block.group(1))
+    return (table.group(1) if table else 'TerrainTable_MovCost_CommonT1Normal',
+            int(mov.group(1)))
+
+
+def _classes_text():
+    import build_campaign as bc
+    return bc.vanilla_decomp_text('src/data_classes.c')
+
+
+def units_reaching(chapter, terrain, targets):
+    """[(enemy id, ai bytes)] for every turn-1 unit that can ATTACK one of `targets`.
+
+    The two shapes reach differently, and conflating them is what made the first cut of this
+    analysis wrong by three units:
+
+      * a STRIKER acts only on what it can reach THIS turn -- `AI_A` moves within the unit's
+        own movement to a firing cell or the unit does nothing at all. Vanilla Ch6's Soldier
+        nine points from a villager therefore never moves, which is why its line never mobs
+        them.
+      * a PURSUER accumulates movement across turns, so ANY path to a firing cell counts.
+
+    Weapon range comes from `difficulty._weapon_for`, so a staff-only unit is correctly no
+    threat and a javelin correctly reaches two.
+    """
+    import difficulty
+    import chapter_status as cs
+    out = []
+    for enemy in chapter.get('enemy_units') or ():
+        if enemy.get('arrives_turn'):
+            continue                      # not on the board when the clock starts
+        # MAX range over the whole inventory, not the first weapon. FE8's AI equips whatever
+        # lets it attack, and ch06's ironshell-horseslayer proved it in-engine: its items[0] is
+        # a range-1 Horseslayer, and it threw its JAVELIN at the hull from two tiles away.
+        ranges = [w.rng[1] for w in
+                  (difficulty._weapon_for([item]) for item in (enemy.get('inventory') or ()))
+                  if w is not None]
+        if not ranges:
+            continue                      # a staff is not a threat to a hull
+        reach = max(ranges)
+        table, mov = class_movement(enemy.get('deploy_class') or enemy['class'])
+        cost = mov_cost_row(table)
+        for index, (x, y) in enumerate(enemy.get('positions') or ()):
+            ai = difficulty.enemy_ai_bytes(chapter, enemy, index)
+            dist = foot_reach(terrain, [(x, y)], cost=cost)
+            # A STATUE cannot move at all, even to attack -- its reach is its weapon and
+            # nothing more. Giving it a pursuer's unlimited budget reported ch06's Nerra as a
+            # threat to a hull seven tiles away that she can never leave her tile to touch.
+            shape = cs.ai_shape(ai)
+            budget = 0 if shape == 'statue' else (mov if shape == 'striker' else None)
+            for cell, points in dist.items():
+                if budget is not None and points > budget:
+                    continue
+                if any(abs(cell[0] - t[0]) + abs(cell[1] - t[1]) <= reach for t in targets):
+                    out.append((enemy['id'], ai))
+                    break
+    return out
+
+
 def load_chapter(prefix):
     """The chapter doc whose id starts with `prefix`. One resolver, so `main` and every caller
     that needs a chapter agree about what "ch06" means."""

--- a/tools/playtest/ch06.lua
+++ b/tools/playtest/ch06.lua
@@ -1,0 +1,35 @@
+-- ch06.lua -- ch06's chapter-scoped playtest facts, in ITS OWN chunk (#314).
+--
+-- Same reason ch05.lua exists: harness.lua is one chunk at Lua's 200-local ceiling, so a
+-- chapter's facts live in a chapter chunk with its own fresh budget and are `dofile`d INSIDE
+-- the scenario that needs them (function-scoped, costing harness.lua no top-level slot).
+-- `LUA_CHUNKS` is globbed, so `check_lua_chunks_load` covers this file the day it exists.
+--
+-- WHAT BELONGS HERE: facts about ch06 that a scenario reads and the chapter YAML declares --
+-- the two hulls, the two pursuers, and the ONE ground cell each hull can be swung at from.
+-- `check_ch06_lua_matches_yaml` pins every coordinate and pid below against
+-- `ch06-the-maer-monster.yaml`, so this file cannot drift into asserting a map we do not ship.
+return {
+    -- The two marooned boats: GREEN CLASS_FLEET units on raw pids of our own
+    -- (CH06_BOAT_PIDS in build_campaign). `door` is the single ground cell adjacent to the
+    -- hull -- the pocket's only entrance, and the whole subject of ch06clock.
+    --
+    -- `sinks_on` is the chapter YAML's DECLARED fuse. It is logged, never asserted: the fuse
+    -- is a hit rate, not a turn number (see the scenario's header), so a single run is one
+    -- sample of a distribution and an equality check on it would be a coin-flip verdict.
+    BOATS = {
+        { id = "boat-east", pid = 0xbb, x = 17, y = 12, doorX = 17, doorY = 13, sinks_on = 7 },
+        { id = "boat-west", pid = 0xbc, x = 4,  y = 17, doorX = 4,  doorY = 18, sinks_on = 8 },
+    },
+
+    -- The two pursuers, by the tile each STARTS on. Every ch06 enemy is the same generic pid
+    -- (CH06_GENERIC_PID 0x80), so a pursuer cannot be found by charId -- it is identified by
+    -- its turn-1 position and then tracked by its index in gUnitArrayRed, which is stable.
+    --
+    -- They are deliberately different problems. The crab is range 1, so it must OCCUPY the
+    -- door; the thrower is range 1-2, so the pocket never stops it and it has to be killed.
+    PURSUERS = {
+        { id = "merfolk-thrower", boat = "boat-east", x = 14, y = 9,  range = 2 },
+        { id = "ice-crab",        boat = "boat-west", x = 7,  y = 20, range = 1 },
+    },
+}

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -9587,6 +9587,14 @@ scenarios.ch06clock = function()
             if hp < h.hp then
                 log(string.format("ch06clock: %s took %d on enemy phase %d -- reds within 3:",
                     b.id, h.hp - hp, t))
+                -- Put the CAMERA on the hull before the frame. Headless this is a no-op and
+                -- the roster dump below is the whole reading; headed (PT_HEADED=1 PT_FPS=60)
+                -- it photographs who is actually standing around the boat, which is the
+                -- question the emitted unit table could not answer.
+                cursorTo(b.x, b.y)
+                wait(90)                -- the map scrolls to the cursor; shooting before it
+                                        -- arrives photographs wherever the fight happened to be
+                shot(string.format("%s-hit-turn%d", b.id, t))
                 for i = 0, 49 do
                     local r = unitAt(SYM.gUnitArrayRed, i)
                     if r and not isDead(r) and r.onMap and dist(r.x, r.y, b.x, b.y) <= 3 then

--- a/tools/playtest/harness.lua
+++ b/tools/playtest/harness.lua
@@ -9448,6 +9448,233 @@ scenarios.recordch02ending = function()
     result("PASS", atTitle and "ch02 ending recorded (reached title)" or "ch02 ending recorded")
 end
 
+-- ch06clock (#26): the run #360 could not do, because ch06 had no debug boot when it landed.
+--
+-- WHAT IT SETTLES. ch06's two hulls sit in POCKETS: an impassable TILE_2E body plus ONE
+-- ground cell you can stand on to swing at them (decisions.md -> "ch06's boats sit in
+-- POCKETS"). That is a claim about the ENGINE'S pathing, not about our map data, and no
+-- static tool can answer it -- `mapshot` photographs turn 1 and the question needs several
+-- enemy phases. So this drives the enemy phases and reads memory:
+--
+--   * neither pursuer STALLS -- it closes on its hull every phase until it is in range,
+--     rather than parking because the approach is one tile wide;
+--   * the range-1 crab, once in range of the west hull, is standing on the DOOR and nowhere
+--     else. That is the pocket's whole promise: exactly one melee tile;
+--   * the range-2 thrower reaches the east hull ANYWAY -- FE8 has no line of sight, so the
+--     wall never stops a javelin. Its throwing tile is logged, because that is placement
+--     evidence rather than a pass/fail;
+--   * nothing touches a hull on turn 1, which is vanilla Ch6's own placement claim.
+--
+-- WHAT IT DELIBERATELY DOES NOT ASSERT: the sink TURN. The chapter YAML declares turns 7 and
+-- 8, but a fuse made of attacks is a hit RATE, not a turn number -- the crab shows a 47
+-- displayed hit into the hull's forest cover and needs four connections, so "turn 8" is a
+-- distribution and one run is one sample of it. Asserting it would make this a coin-flip
+-- verdict. It is measured and LOGGED against the declared turn instead, and a run that
+-- disagrees is a finding for the chapter's balance, not a broken scenario.
+--
+-- The party is held at full HP every turn. That is isolation, not a cheat: a dead PC ends
+-- the run in a game over long before the clock resolves, and the subject here is the two
+-- pursuers rather than whether the fight is winnable. Same control ch02aidiag used.
+--
+-- CONTENTION for the door -- two units wanting the same single tile -- does NOT exist on
+-- normal, where the only pursuers are these two and they want different hulls. It exists on
+-- DIFFICULT, whose turn-4 crab-rider trio also pursues from the west edge. Declared cases
+-- run on normal, so that arm is not covered here and is not claimed to be.
+scenarios.ch06clock = function()
+    local CH06 = dofile(PLAYTEST_DIR .. "/ch06.lua")     -- ch06's shared facts (#314)
+    local TURNS = 12                                     -- past both declared fuses, with slack
+    if not bootToMap() then return result("FAIL", "never reached the ch06 map") end
+    pokeFastConfig()
+    waitFor(function() return faction() == 0 and not menuOpen()
+        and not procActive(SYM.ProcScr_StdEventEngine) end, 6000, true)
+
+    local function dist(ax, ay, bx, by) return math.abs(ax - bx) + math.abs(ay - by) end
+    local function indexOf(base, count, match)
+        for i = 0, count - 1 do
+            local u = unitAt(base, i)
+            if u and not isDead(u) and match(u) then return i, u end
+        end
+        return nil
+    end
+
+    -- The hulls, by the raw pid each boat owns (CH06_BOAT_PIDS). Tracked by INDEX and
+    -- re-read every phase: a unit snapshot is a copy, and the whole subject is what changes.
+    local hulls = {}
+    for _, b in ipairs(CH06.BOATS) do
+        local i, u = indexOf(SYM.gUnitArrayGreen, 20, function(g) return g.charId == b.pid end)
+        if not i then
+            return result("FAIL", string.format(
+                "%s (pid 0x%02X) is not on the map -- the chapter's clock is two GREEN units "
+                .. "and one of them never loaded", b.id, b.pid))
+        end
+        if u.x ~= b.x or u.y ~= b.y then
+            return result("FAIL", string.format(
+                "%s loaded at (%d,%d), not the pocket cell (%d,%d) its chapter YAML declares",
+                b.id, u.x, u.y, b.x, b.y))
+        end
+        hulls[b.id] = { boat = b, index = i, hp = u.hp, maxhp = u.maxhp, sank = nil }
+        log(string.format("ch06clock: %s hull at (%d,%d) %d/%d HP, door (%d,%d), declared "
+            .. "fuse turn %d", b.id, u.x, u.y, u.hp, u.maxhp, b.doorX, b.doorY, b.sinks_on))
+    end
+
+    -- The pursuers. Every ch06 enemy shares one generic pid, so a pursuer is identified by
+    -- the tile it STARTS on and then tracked by its stable index in gUnitArrayRed.
+    local chase = {}
+    for _, p in ipairs(CH06.PURSUERS) do
+        local i, u = indexOf(SYM.gUnitArrayRed, 50,
+            function(r) return r.x == p.x and r.y == p.y end)
+        if not i then
+            return result("FAIL", string.format(
+                "no living enemy on (%d,%d) at turn 1 -- %s is the pursuer that makes the %s "
+                .. "clock exist, and the placement this scenario reads is gone",
+                p.x, p.y, p.id, p.boat))
+        end
+        local lo, hi = unitAttackRange(u)
+        chase[#chase + 1] = { spec = p, index = i, x = u.x, y = u.y, arrived = nil }
+        log(string.format("ch06clock: %s at (%d,%d), weapon range %s-%s (declared max %d), "
+            .. "chasing %s -- %d tiles from its door",
+            p.id, u.x, u.y, tostring(lo), tostring(hi), p.range, p.boat,
+            dist(u.x, u.y, hulls[p.boat].boat.doorX, hulls[p.boat].boat.doorY)))
+    end
+
+    -- The turn-1 red roster, once. The first run of this scenario measured an 11-damage hit
+    -- on a hull during enemy phase 1 and could not name what threw it: nothing in the EMITTED
+    -- unit table (`MS_Ch06Line`) is within weapon range of that hull at load, and the only
+    -- mover near it was still three tiles out. A scenario that watches two units cannot tell
+    -- "the AI did something surprising" from "the loaded map is not the table we emitted", so
+    -- it dumps what actually LOADED -- which is the reading the next run needs and the one
+    -- this scenario was too narrow to take (decisions.md -> one INSTRUMENTED run, not one run
+    -- per guess).
+    for i = 0, 49 do
+        local u = unitAt(SYM.gUnitArrayRed, i)
+        if u and not isDead(u) and u.onMap then
+            local lo, hi = unitAttackRange(u)
+            log(string.format("ch06clock: roster red[%02d] (%2d,%2d) lvl %2d hp %2d range %s-%s",
+                i, u.x, u.y, u.level, u.hp, tostring(lo), tostring(hi)))
+        end
+    end
+
+    -- Findings are COLLECTED, not returned on sight. This is the one run ch06 gets for the
+    -- question (decisions.md -> "Playtest runs are the most expensive thing in this repo"), so
+    -- a turn-1 contact must not abandon the pathing evidence the same run was going to
+    -- produce. Only a wedged phase or a game over ends it early, because neither leaves
+    -- anything left to read.
+    local stalls, offdoor, early = {}, {}, {}
+    for t = 1, TURNS do
+        -- Isolation: the party is not the subject, and a game over ends the run before the
+        -- clock resolves. Never visits, never fights -- it only gives the turns back.
+        for i = 0, 61 do
+            local u = unitAt(SYM.gUnitArrayBlue, i)
+            if u and not isDead(u) then emu:write8(u.addr + 0x13, u.maxhp) end
+        end
+        local phase = runEnemyPhase()
+        if phase == nil then
+            return result("FAIL", string.format("the enemy phase never returned on turn %d", t))
+        end
+        if phase == "gameover" then
+            return result("FAIL", string.format(
+                "game over on turn %d despite the party being held at full HP", t))
+        end
+
+        for _, b in ipairs(CH06.BOATS) do
+            local h = hulls[b.id]
+            local u = unitAt(SYM.gUnitArrayGreen, h.index)
+            local hp = (u and not isDead(u)) and u.hp or 0
+            if hp == 0 and not h.sank then h.sank = t end
+            -- Name the attacker. A hull losing HP with no pursuer in range is the reading the
+            -- first run could not explain, so every red that could plausibly have reached it
+            -- is dumped at the moment the damage lands rather than reconstructed afterwards.
+            if hp < h.hp then
+                log(string.format("ch06clock: %s took %d on enemy phase %d -- reds within 3:",
+                    b.id, h.hp - hp, t))
+                for i = 0, 49 do
+                    local r = unitAt(SYM.gUnitArrayRed, i)
+                    if r and not isDead(r) and r.onMap and dist(r.x, r.y, b.x, b.y) <= 3 then
+                        local lo, hi = unitAttackRange(r)
+                        log(string.format("ch06clock:   red[%02d] (%2d,%2d) d=%d range %s-%s",
+                            i, r.x, r.y, dist(r.x, r.y, b.x, b.y), tostring(lo), tostring(hi)))
+                    end
+                end
+            end
+            if t == 1 and hp < h.maxhp then
+                early[#early + 1] = string.format("%s took %d on enemy phase 1", b.id,
+                                                  h.maxhp - hp)
+            end
+            h.hp = hp
+        end
+
+        for _, c in ipairs(chase) do
+            local h = hulls[c.spec.boat]
+            local u = unitAt(SYM.gUnitArrayRed, c.index)
+            local x, y = (u and not isDead(u)) and u.x or -1, (u and not isDead(u)) and u.y or -1
+            local d = (x >= 0) and dist(x, y, h.boat.x, h.boat.y) or -1
+            local inRange = d >= 0 and d <= c.spec.range
+            log(string.format(
+                "ch06clock: turn %2d (engine %2d)  %-16s (%2d,%2d) d=%2d %-9s | %-9s %2d/%2d HP",
+                t, turn(), c.spec.id, x, y, d, inRange and "IN RANGE" or "closing",
+                c.spec.boat, h.hp, h.maxhp))
+            if h.hp > 0 and x >= 0 then
+                if inRange then
+                    if not c.arrived then c.arrived = t end
+                    -- The pocket's whole promise. A range-1 attacker in range of the hull is
+                    -- standing on the door or the pocket does not shape melee at all.
+                    if c.spec.range == 1 and not (x == h.boat.doorX and y == h.boat.doorY) then
+                        offdoor[#offdoor + 1] = string.format(
+                            "%s reached %s from (%d,%d) on turn %d, not the door (%d,%d)",
+                            c.spec.id, c.spec.boat, x, y, t, h.boat.doorX, h.boat.doorY)
+                    end
+                elseif x == c.x and y == c.y then
+                    stalls[#stalls + 1] = string.format(
+                        "%s did not move on turn %d -- still (%d,%d), %d tiles from %s",
+                        c.spec.id, t, x, y, d, c.spec.boat)
+                end
+            end
+            c.x, c.y = x, y
+        end
+    end
+
+    if #early > 0 then
+        return result("FAIL", "something reached a hull on enemy phase 1. ch06's whole "
+            .. "travel-time budget is measured from vanilla Ch6's claim that nothing can: "
+            .. table.concat(early, "; "))
+    end
+    if #stalls > 0 then
+        return result("FAIL", "a pursuer STALLED short of its hull, so the one-tile approach "
+            .. "is not pathable for it: " .. table.concat(stalls, "; "))
+    end
+    if #offdoor > 0 then
+        return result("FAIL", "a melee pursuer attacked a hull from outside its pocket door, "
+            .. "so the pocket is not one tile wide: " .. table.concat(offdoor, "; "))
+    end
+    for _, c in ipairs(chase) do
+        if not c.arrived then
+            return result("FAIL", string.format(
+                "%s never came within %d of %s in %d turns -- it retargeted or the pocket has "
+                .. "no path, and that boat has no clock",
+                c.spec.id, c.spec.range, c.spec.boat, TURNS))
+        end
+    end
+
+    -- The fuse: measured, reported, not asserted. See the header.
+    local told = {}
+    for _, b in ipairs(CH06.BOATS) do
+        local h = hulls[b.id]
+        local got = h.sank and string.format("turn %d", h.sank)
+            or string.format("still afloat at turn %d on %d HP", TURNS, h.hp)
+        told[#told + 1] = string.format("%s declared turn %d, measured %s", b.id, b.sinks_on, got)
+        if h.sank ~= b.sinks_on then
+            log(string.format("ch06clock: FUSE DIFFERS -- %s", told[#told]))
+        end
+    end
+    log("ch06clock: " .. table.concat(told, " | "))
+    return result("PASS", string.format(
+        "both pursuers pathed to their hull and neither stalled (%s); the melee pursuer "
+        .. "attacked only from its pocket door. Fuse measured, not asserted: %s",
+        table.concat({ chase[1].spec.id .. " in range turn " .. chase[1].arrived,
+                       chase[2].spec.id .. " in range turn " .. chase[2].arrived }, ", "),
+        table.concat(told, " | ")))
+end
+
 -- ---------------------------------------------------------------- runner
 -- A DECLARED case (#314) has no function here: its chapter YAML declares what it proves,
 -- `declared.py` emits it as a Lua table into the run directory, and cases.lua runs it. The

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -360,54 +360,158 @@ class AiBehaviourTable(unittest.TestCase):
         self.assertEqual([], [i for i in cs.AI_BEHAVIOUR if i not in table])
 
 
-class BehaviourSplit(unittest.TestCase):
-    """"Threat that comes to you" vs "threat you walk into" -- ch05's YAML coined it, #344
-    measured it. Reported, never folded into threat: since #335 derives AI from the donor,
-    our shape IS the twin's, so a weighting would scale both sides and always say x1.00."""
+class Ai1Table(unittest.TestCase):
+    """`AI_ACTION` is a claim about `gAi1ScriptTable`, so it is checked against it.
 
-    def test_it_counts_each_side(self):
+    The AI_A half is the one that MOVES: `AI_A_00 ActionInRange` is `AI_ACTION(100)` and acting
+    includes stepping within the unit's own range to reach a target, while `AI_B_03 NeverMove`
+    is `AI_NOP_0E` and only suppresses crossing the map. Reading AI_B alone reported 48 of 51
+    units as static when they step out (decisions.md -> "AI_B is the APPROACH and AI_A is the
+    ACTION"), which is the same coverage gap #344 fixed one axis over."""
+
+    SYMBOLS = {0x00: 'gAiScript_ActionInRange',
+               0x01: 'gAiScript_ActionInRange_80Perc',
+               0x02: 'gAiScript_ActionInRange_50Perc',
+               0x03: 'gAiScript_ActionStanding',
+               0x04: 'gAiScript_ActionStanding_80Perc',
+               0x05: 'gAiScript_ActionStanding_50Perc',
+               0x06: 'gAiScript_DoNothing',
+               0x07: 'gAiScript_ActionInRange_ExceptNatasha',
+               0x08: 'gAiScript_ActionInRange_ExceptCivilian'}
+
+    def _table(self):
+        import build_campaign as bc
+        body = re.search(r'gAi1ScriptTable\[\] = \{(.*?)\n\};',
+                         bc.vanilla_decomp_text('src/cp_data.c'), re.S).group(1)
+        return {int(i, 16): sym
+                for i, sym in re.findall(r'\[AI_A_([0-9A-Fa-f]{2})\]\s*=\s*(\w+)', body)}
+
+    def test_the_decomp_table_is_the_length_the_map_assumes(self):
+        table = self._table()
+        self.assertEqual(21, len(table))
+        self.assertEqual(set(range(21)), set(table), 'the table is dense 0x00..0x14')
+
+    def test_every_named_index_matches_its_decomp_symbol(self):
         import chapter_status as cs
-        got = cs.behaviour_split([0x00, 0x12, 0x03, 0x10])
-        self.assertEqual(2, got['comes_to_you'])
-        self.assertEqual(2, got['walk_into'])
+        table = self._table()
+        for index, symbol in self.SYMBOLS.items():
+            self.assertEqual(symbol, table[index],
+                             'index 0x%02X is %s in the decomp' % (index, table[index]))
+            self.assertIn(index, cs.AI_ACTION)
+
+    def test_indices_the_decomp_does_not_NAME_are_left_unnamed(self):
+        """Twelve bare-address entries (0x09..0x14) stay out, on the same rule AI_BEHAVIOUR
+        follows: a guess must not be indistinguishable from a fact at the call site."""
+        import chapter_status as cs
+        for index, symbol in sorted(self._table().items()):
+            if re.match(r'^gAiScript_[0-9A-Fa-f]{6,}$', symbol):
+                self.assertNotIn(index, cs.AI_ACTION,
+                                 'index 0x%02X is only an address (%s)' % (index, symbol))
+
+    def test_no_mapped_index_falls_outside_the_table(self):
+        import chapter_status as cs
+        table = self._table()
+        self.assertEqual([], [i for i in cs.AI_ACTION if i not in table])
+
+    def test_every_named_action_is_classified_as_moving_or_holding(self):
+        import chapter_status as cs
+        for index, name in cs.AI_ACTION.items():
+            self.assertTrue(name in cs.AI_ACTION_MOVES or name in cs.AI_ACTION_HOLDS,
+                            '0x%02X (%s) is named but neither moves nor holds' % (index, name))
+
+
+class AiShape(unittest.TestCase):
+    """The three-way shape a FULL vector describes. Two buckets could not express the case
+    that actually shipped: a unit that holds its ground but steps out to strike."""
+
+    def test_a_pursuer_crosses_the_map(self):
+        import chapter_status as cs
+        self.assertEqual('pursuer', cs.ai_shape((0x00, 0x00, 0, 0)))
+
+    def test_engage_plus_never_move_is_a_STRIKER_not_a_statue(self):
+        """The whole finding. ch06's merfolk are exactly this, and were read as statues."""
+        import chapter_status as cs
+        self.assertEqual('striker', cs.ai_shape((0x00, 0x03, 0, 0)))
+
+    def test_hold_plus_never_move_is_a_statue(self):
+        """vanilla Ch6's Novala -- GuardTileAI, the only non-ActionInRange unit in that force."""
+        import chapter_status as cs
+        self.assertEqual('statue', cs.ai_shape((0x03, 0x03, 0, 0)))
+
+    def test_inert_plus_never_move_is_a_statue_too(self):
+        """DoNothing -- vanilla Ch6's three green villagers."""
+        import chapter_status as cs
+        self.assertEqual('statue', cs.ai_shape((0x06, 0x03, 0, 0)))
+
+    def test_an_own_errand_is_neither(self):
+        import chapter_status as cs
+        self.assertEqual('own-errand', cs.ai_shape((0x00, 0x05, 0, 0)))
+
+    def test_an_unnamed_approach_is_unclassified(self):
+        import chapter_status as cs
+        self.assertIsNone(cs.ai_shape((0x00, 0x0A, 0, 0)))
+
+    def test_an_unnamed_ACTION_is_unclassified_even_when_the_approach_is_named(self):
+        """The half that decides movement is AI_A, so an unknown there is unknown overall --
+        bucketing it by AI_B alone is the exact error this change exists to end."""
+        import chapter_status as cs
+        self.assertIsNone(cs.ai_shape((0x09, 0x03, 0, 0)))
+
+    def test_a_bare_int_is_REFUSED_rather_than_misread(self):
+        """A stale `ai_shape(ai[1])` call would classify a whole roster off half a vector and
+        look perfectly correct. It raises instead."""
+        import chapter_status as cs
+        self.assertRaises(TypeError, cs.ai_shape, 0x03)
+
+
+class BehaviourSplit(unittest.TestCase):
+    """Reported, never folded into threat: since #335 derives AI from the donor, our shape IS
+    the twin's, so a weighting would scale both sides and always say x1.00 (#344)."""
+
+    def test_it_counts_each_shape(self):
+        import chapter_status as cs
+        got = cs.behaviour_split([(0x00, 0x00, 0, 0), (0x00, 0x12, 0, 0),
+                                  (0x00, 0x03, 0, 0), (0x03, 0x10, 0, 0)])
+        self.assertEqual(2, got['pursuer'])
+        self.assertEqual(1, got['striker'])
+        self.assertEqual(1, got['statue'])
         self.assertEqual(0, got['unclassified'])
 
     def test_a_known_but_non_player_behaviour_is_its_OWN_bucket(self):
-        """A thief that loots and leaves, a script that flees, one that chews on walls: the
-        decomp NAMES all three, so calling them "unclassified" would say we do not know when
-        we do. ai2=0x05 alone occurs 120x in the reference files (#359 review)."""
         import chapter_status as cs
-        got = cs.behaviour_split([0x05, 0x0C, 0x0E])
+        got = cs.behaviour_split([(0x00, 0x05, 0, 0), (0x00, 0x0C, 0, 0), (0x00, 0x0E, 0, 0)])
         self.assertEqual(3, got['own_errand'])
         self.assertEqual(0, got['unclassified'])
-        self.assertEqual(0, got['comes_to_you'])
+        self.assertEqual(0, got['pursuer'])
 
-    def test_every_named_family_lands_in_exactly_one_bucket(self):
-        """The rule the review found broken: a NAMED family must never fall through to
-        unclassified, which is reserved for scripts the decomp does not name."""
+    def test_every_named_pair_lands_in_exactly_one_bucket(self):
+        """A NAMED family must never fall through to unclassified -- the rule #344's review
+        found broken, now enforced across BOTH halves."""
         import chapter_status as cs
-        for index in cs.AI_BEHAVIOUR:
-            got = cs.behaviour_split([index])
-            self.assertEqual(0, got['unclassified'],
-                             '0x%02X is named %r but falls through to unclassified'
-                             % (index, cs.AI_BEHAVIOUR[index]))
+        for a in cs.AI_ACTION:
+            for b in cs.AI_BEHAVIOUR:
+                got = cs.behaviour_split([(a, b, 0, 0)])
+                self.assertEqual(0, got['unclassified'],
+                                 '(0x%02X, 0x%02X) is named on both halves but falls through'
+                                 % (a, b))
 
     def test_an_unnamed_script_is_UNCLASSIFIED_not_bucketed(self):
-        """0x0A is live in vanilla's Prologue. Calling it static because it is unnamed would
-        be a guess that silently lowers the number."""
         import chapter_status as cs
-        got = cs.behaviour_split([0x0A])
+        got = cs.behaviour_split([(0x00, 0x0A, 0, 0)])
         self.assertEqual(1, got['unclassified'])
-        self.assertEqual(0, got['walk_into'])
+        self.assertEqual(0, got['statue'])
 
     def test_an_index_off_the_end_is_unclassified_too(self):
         import chapter_status as cs
-        self.assertEqual(1, cs.behaviour_split([0xFF])['unclassified'])
+        self.assertEqual(1, cs.behaviour_split([(0xFF, 0xFF, 0, 0)])['unclassified'])
 
-    def test_the_three_buckets_account_for_every_unit(self):
+    def test_the_buckets_account_for_every_unit(self):
         import chapter_status as cs
-        got = cs.behaviour_split([0x00, 0x03, 0x0A, 0xFF, 0x11, 0x05])
-        self.assertEqual(got['n'], got['comes_to_you'] + got['walk_into']
+        vectors = [(0x00, 0x00, 0, 0), (0x00, 0x03, 0, 0), (0x03, 0x03, 0, 0),
+                   (0x00, 0x0A, 0, 0), (0xFF, 0xFF, 0, 0), (0x00, 0x11, 0, 0),
+                   (0x00, 0x05, 0, 0)]
+        got = cs.behaviour_split(vectors)
+        self.assertEqual(got['n'], got['pursuer'] + got['striker'] + got['statue']
                          + got['own_errand'] + got['unclassified'])
 
 

--- a/tools/test_check_chapter_lua.py
+++ b/tools/test_check_chapter_lua.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for check.py's chapter-Lua-chunk coordinate guard (#26).
+
+A chapter chunk (`tools/playtest/chNN.lua`) restates coordinates the chapter YAML already
+declares -- ch06.lua carries both hulls' pocket cells and both pocket DOORS, and ch06clock's
+whole verdict is that a melee attacker stands on one of those doors. A stale door there does
+not crash: it produces a scenario that runs, reads the wrong cell, and FAILs blaming the
+engine. That is the same failure `check_declared_cases` exists to stop for `visit` steps.
+
+The pure half is tested against synthetic inputs, both directions -- clean input produces
+nothing, drifted input produces the finding -- because a guard that cannot fail is not one.
+
+Run: python3 tools/test_check_chapter_lua.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check                                            # noqa: E402
+
+DOC = {
+    'rescue_boats': [{'id': 'boat-east', 'tile': [17, 12], 'door': [17, 13]}],
+    'enemy_units': [{'id': 'ice-crab', 'positions': [[7, 20]]}],
+}
+CLEAN = '''return {
+    BOATS = {
+        { id = "boat-east", pid = 0xbb, x = 17, y = 12, doorX = 17, doorY = 13, sinks_on = 7 },
+    },
+    PURSUERS = {
+        { id = "ice-crab", boat = "boat-west", x = 7, y = 20, range = 1 },
+    },
+}
+'''
+
+
+def run(text=CLEAN, doc=None):
+    return check._chapter_lua_fact_violations('tools/playtest/ch06.lua', text,
+                                              'ch06.yaml', doc if doc is not None else DOC)
+
+
+class TestChapterLuaFacts(unittest.TestCase):
+    def test_matching_coordinates_are_clean(self):
+        self.assertEqual(run(), [])
+
+    def test_a_drifted_tile_is_reported(self):
+        found = run(CLEAN.replace('x = 17, y = 12', 'x = 17, y = 11'))
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('boat-east', found[0])
+        self.assertIn('(17,11)', found[0])
+
+    def test_a_drifted_door_is_reported(self):
+        # The one that matters most: ch06clock's verdict is a door cell, so a stale door
+        # reads as a broken pocket rather than as a stale constant.
+        found = run(CLEAN.replace('doorX = 17, doorY = 13', 'doorX = 16, doorY = 13'))
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('door', found[0])
+
+    def test_a_drifted_enemy_start_tile_is_reported(self):
+        # A pursuer is FOUND by its start tile (every ch06 enemy shares one generic pid), so
+        # this coordinate is not decoration -- a stale one finds no unit and fails at boot.
+        found = run(CLEAN.replace('x = 7, y = 20', 'x = 7, y = 19'))
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('ice-crab', found[0])
+
+    def test_an_id_the_chapter_does_not_declare_is_reported(self):
+        found = run(CLEAN.replace('"ice-crab"', '"ice-krab"'))
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('ice-krab', found[0])
+
+    def test_every_drifted_row_is_reported_not_just_the_first(self):
+        bad = CLEAN.replace('x = 17, y = 12', 'x = 0, y = 0').replace('x = 7, y = 20',
+                                                                     'x = 1, y = 1')
+        self.assertEqual(len(run(bad)), 2, run(bad))
+
+    def test_a_row_without_an_id_is_out_of_scope_rather_than_a_crash(self):
+        # ch05.lua's reliquaries are keyed by `name`, not `id`, and its chapter YAML calls
+        # them `reliquary-north`. Matching those would mean renaming a shipped chapter's
+        # constants, so they are deliberately not in scope -- and must not raise here.
+        self.assertEqual(run('return { X = { { name = "north", x = 5, y = 1 } } }'), [])
+
+    def test_a_chunk_with_no_coordinate_rows_is_clean(self):
+        self.assertEqual(run('return { MSG = { OPENING = 0x9F6 } }'), [])
+
+    def test_a_missing_chapter_doc_is_reported_rather_than_passing_vacuously(self):
+        found = run(doc=None if False else {})
+        self.assertTrue(found)
+        self.assertIn('boat-east', found[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_check_rescue_targets.py
+++ b/tools/test_check_rescue_targets.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Tests for check.py's rescue-target guard (#26).
+
+A chapter with `rescue_boats:` declares which units are the clock. Everything ELSE that can
+reach a hull is a mob the chapter did not plan for, and ch06 shipped four of them: the fuse was
+tuned as a one-pursuer clock and the hull sank on turn 4 instead of 7.
+
+The pure half is tested against synthetic input, both directions, because a guard that cannot
+fail is not a guard.
+
+Run: python3 tools/test_check_rescue_targets.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check                                            # noqa: E402
+
+SAFE = (0x08, 0x03, 0, 0)      # ActionInRange_ExceptCivilian -- cannot target a hull
+MOB = (0x00, 0x03, 0, 0)       # plain ActionInRange -- steps out and swings
+PURSUER = (0x00, 0x00, 0, 0)
+
+
+def run(reachers, pursuers=('ice-crab',)):
+    return check._rescue_target_violations('ch06', reachers, set(pursuers))
+
+
+class RescueTargetsHaveOnlyTheirDeclaredClock(unittest.TestCase):
+    def test_a_declared_pursuer_may_reach_a_hull(self):
+        self.assertEqual([], run([('ice-crab', PURSUER)]))
+
+    def test_a_unit_carrying_the_safe_ACTION_may_reach_a_hull(self):
+        self.assertEqual([], run([('merfolk-bow', SAFE)]))
+
+    def test_an_UNDECLARED_striker_that_reaches_a_hull_is_reported(self):
+        found = run([('merfolk-bow', MOB)])
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('merfolk-bow', found[0])
+
+    def test_every_offender_is_reported_not_just_the_first(self):
+        self.assertEqual(2, len(run([('merfolk-bow', MOB), ('shark-rider-steel', MOB)])))
+
+    def test_a_pursuer_that_is_not_declared_is_still_reported(self):
+        """A pursuer walks to the hull over several turns, which is a clock -- but an
+        UNdeclared one is a second clock nobody costed."""
+        found = run([('crab-rider-hard-lance', PURSUER)])
+        self.assertEqual(len(found), 1, found)
+
+    def test_nothing_reaching_a_hull_is_clean(self):
+        self.assertEqual([], run([]))
+
+    def test_the_finding_names_the_two_ways_out(self):
+        """The message has to say what to DO, because the fix is a design choice between
+        declaring the unit as a pursuer and giving it the safe action byte."""
+        text = run([('merfolk-bow', MOB)])[0]
+        self.assertIn('ai_override', text)
+        self.assertIn('pursuer', text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -217,5 +217,42 @@ class ReachedOnIsDerived(unittest.TestCase):
                                  % (boat['id'], role, declared, got[role]))
 
 
+class BehaviourColour(unittest.TestCase):
+    """The legend must not promise a colour the render never draws.
+
+    `ai_shape` replaced the approach-family vocabulary and `BEHAVIOUR_COLOUR` kept the old
+    keys, so every one of ch06's 27 markers fell through to the default grey while the legend
+    still advertised red/orange/yellow/purple. Nothing caught it because nothing tested the
+    key set -- and a placement picture that mis-states behaviour is exactly the picture ch06's
+    clock was designed against.
+    """
+
+    def test_every_shape_has_a_colour(self):
+        import chapter_status as cs
+        shapes = set()
+        for action in cs.AI_ACTION:
+            for approach in cs.AI_BEHAVIOUR:
+                shape = cs.ai_shape((action, approach, 0, 0))
+                if shape is not None:
+                    shapes.add(shape)
+        self.assertTrue(shapes, 'ai_shape named nothing -- the sweep is not reaching it')
+        self.assertEqual(shapes - set(pp.BEHAVIOUR_COLOUR), set(),
+                         'ai_shape returns a shape the render has no colour for')
+
+    def test_no_colour_for_a_shape_that_does_not_exist(self):
+        """The other direction: a stale key is a legend entry nothing can ever draw."""
+        import chapter_status as cs
+        shapes = {cs.ai_shape((a, b, 0, 0))
+                  for a in cs.AI_ACTION for b in cs.AI_BEHAVIOUR}
+        self.assertEqual(set(pp.BEHAVIOUR_COLOUR) - shapes, set(),
+                         'BEHAVIOUR_COLOUR names a behaviour `ai_shape` never returns')
+
+    def test_ch06_markers_all_resolve(self):
+        """The regression itself: no ch06 unit renders as unclassified."""
+        grey = sorted(u[3] for u in pp.placed_units(ch06())
+                      if u[2] not in pp.BEHAVIOUR_COLOUR)
+        self.assertEqual(grey, [], 'ch06 units with no derived shape: %r' % (grey,))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -76,10 +76,18 @@ class Board(unittest.TestCase):
         units = pp.placed_units(self.chap)
         self.assertEqual(len(units), sum(int(e.get('count', 1))
                                          for e in self.chap['enemy_units']))
+        # SHAPES, derived from the whole AI vector, not the approach byte alone. `striker` is
+        # the one the old two-label vocabulary could not say: holds ground, but steps out
+        # within its own move range to strike. It is most of this roster, and reading those
+        # units as `never-move` is what let ch06's clock be designed around a line that in
+        # fact walks to the boats (decisions.md -> "AI_B is the APPROACH and AI_A is the
+        # ACTION"). The boss is `statue` because his VECTOR says so -- GuardTileAI, inherited
+        # from Novala -- rather than because an `is_boss` flag patched the label.
         behaviours = {b for _, _, b, _, _ in units}
-        self.assertIn('never-move', behaviours)
-        self.assertIn('pursue', behaviours)
-        self.assertIn('hold-position', behaviours)          # the boss, flagged by is_boss
+        self.assertIn('striker', behaviours)
+        self.assertIn('pursuer', behaviours)
+        self.assertIn('statue', behaviours)
+        self.assertNotIn('hold-position', behaviours)
 
     def test_no_enemy_stands_where_its_class_cannot(self):
         """The failure this tool exists to make impossible: a coordinate that looks fine on

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -133,5 +133,89 @@ class Board(unittest.TestCase):
             self.assertEqual(placed['nerra'], (9, 12))
 
 
+class ContestedReach(unittest.TestCase):
+    """`reached_on:` is the number ch06's whole clock rests on, and until now nothing read it.
+
+    It was also measured on an EMPTY MAP: `foot_reach` was a Dijkstra over terrain that did not
+    know units exist. In FE a unit cannot move through an enemy body, so a line standing across
+    a channel is a wall -- and ch06's east boat sits behind exactly such a line. An uncontested
+    number flatters our map more than it flatters vanilla's, whose rescue route peels away from
+    the fight entirely (decisions.md -> "Vanilla Ch6's urgency is TRAVEL TIME").
+    """
+
+    def _grid(self):
+        # 5x1 corridor of plain, cost 1 per step.
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        return [[plain] * 5]
+
+    def test_an_open_corridor_costs_one_point_per_step(self):
+        dist = pp.foot_reach(self._grid(), [(0, 0)])
+        self.assertEqual(4, dist[(4, 0)])
+
+    def test_a_body_in_the_corridor_makes_the_far_side_UNREACHABLE(self):
+        """The whole point: FE has no phasing through an enemy."""
+        dist = pp.foot_reach(self._grid(), [(0, 0)], blocked={(2, 0)})
+        self.assertNotIn((4, 0), dist)
+        self.assertEqual(1, dist[(1, 0)])
+
+    def test_a_body_ON_the_source_does_not_break_the_walk(self):
+        dist = pp.foot_reach(self._grid(), [(0, 0)], blocked={(0, 0)})
+        self.assertEqual(4, dist[(4, 0)])
+
+    def test_blocked_defaults_to_empty_so_the_old_reading_is_still_available(self):
+        self.assertEqual(pp.foot_reach(self._grid(), [(0, 0)]),
+                         pp.foot_reach(self._grid(), [(0, 0)], blocked=set()))
+
+    def test_turns_is_ceiling_of_points_over_move(self):
+        """A unit spends up to `mov` points a turn, so 6 points at mov 5 is two turns."""
+        self.assertEqual(1, pp.arrival_turn(5, 5))
+        self.assertEqual(2, pp.arrival_turn(6, 5))
+        self.assertEqual(2, pp.arrival_turn(10, 5))
+        self.assertIsNone(pp.arrival_turn(None, 5))
+
+
+class ReachedOnIsDerived(unittest.TestCase):
+    """ch06 declares `reached_on:` per class. It is now derived and compared, because a hand-kept
+    number that nothing reads is how "foot reaches either door on turn 6" survived as the
+    chapter's load-bearing claim without ever being true under fire."""
+
+    def test_every_declared_class_is_one_the_deriver_knows(self):
+        chap = pp.load_chapter('ch06')
+        for boat in chap['rescue_boats']:
+            for role in (boat.get('reached_on') or {}):
+                self.assertIn(role, pp.REACH_ROLES,
+                              '%r is declared but has no movement profile' % role)
+
+    def test_the_contested_walk_reproduces_the_declared_numbers(self):
+        """`reached_on_contested:` is the row that describes what a player actually walks, so
+        it is derived and pinned. Nothing may hand-edit it away from the map."""
+        chap = pp.load_chapter('ch06')
+        terrain = pp.terrain_grid(chap)
+        for boat in chap['rescue_boats']:
+            got = pp.reached_on(chap, terrain, tuple(boat['door']), contested=True)
+            for role, declared in (boat.get('reached_on_contested') or {}).items():
+                self.assertEqual(declared, got[role],
+                                 '%s %s: declared %s, derived %s'
+                                 % (boat['id'], role, declared, got[role]))
+
+    def test_a_contested_row_is_declared_for_every_boat(self):
+        """The empty-map row alone is what let "foot reaches either door on turn 6" stand as
+        the chapter's load-bearing claim while being false for every ground class."""
+        for boat in pp.load_chapter('ch06')['rescue_boats']:
+            self.assertIn('reached_on_contested', boat, boat['id'])
+
+    def test_the_uncontested_walk_reproduces_the_declared_numbers(self):
+        """The declared block was measured this way, so deriving it the same way must agree --
+        that is what makes the CONTESTED number a finding rather than a tooling difference."""
+        chap = pp.load_chapter('ch06')
+        terrain = pp.terrain_grid(chap)
+        for boat in chap['rescue_boats']:
+            got = pp.reached_on(chap, terrain, tuple(boat['door']), contested=False)
+            for role, declared in (boat.get('reached_on') or {}).items():
+                self.assertEqual(declared, got[role],
+                                 '%s %s: declared turn %s, derived %s'
+                                 % (boat['id'], role, declared, got[role]))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
ch06 was the only hosted chapter no scenario covered. It declares one now — and the run it enabled found a defect that turned out to be campaign-wide, not ch06's.

## What it found

`ch06clock` drives twelve enemy phases and reads memory. First run: **four enemies our tooling labelled `never-move` had walked to a boat and sunk it on turn 4 against a declared turn 7.**

Root cause, from `cp_data.c`: a unit's AI is two scripts, not one. `AI_B_03 NeverMove` is `AI_NOP_0E` — the **approach**, and it only suppresses crossing the map. `AI_A_00 ActionInRange` is `AI_ACTION(100)` — the **action**, and acting includes stepping within the unit's own movement to reach a target. Every AI view in the repo read `ai[1]` alone, so **48 of the 51 units reported as "threat you walk into" will in fact move.**

That single cause explained all three findings: the phase-1 damage, the collapsed fuse, and the pursuer that "walked away" (all four cells inside its javelin range were occupied by its own allies, so it stalled — which also answers the queue-vs-stall question the scenario was written for).

## What it changes

**The AI read-back reads both halves**, and derives a three-way shape, because two buckets could not express the case that shipped:

```
before:  shape  9 come to you / 18 you walk into
after:   shape  9 come to you / 17 hold and STRIKE / 1 never move
```

`AI_ACTION` is pinned against `gAi1ScriptTable` by a test on the discipline `AI_BEHAVIOUR` already follows. `ai_shape` takes the vector and **raises on a bare int** — a stale half-vector call would classify a whole roster and look correct, which is how this survived; the guard caught the one internal caller during the change.

**Reach is measured with the enemy line standing on it.** `reached_on:` was the number ch06's clock rested on, nothing read it, and it came from a Dijkstra that did not know units exist:

| | foot | cavalry | flier | braulo | trex |
|---|---|---|---|---|---|
| east door, empty map | 6 | 5 | 3 | 5 | 5 |
| east door, contested | — | — | 3 | 6 | — |
| west door, contested (before) | 11 | 8 | 3 | 6 | 9 |

The channels are narrow enough that **one body corks a route**. Moving `merfolk-trident` (2,14) → (3,14) takes the west door from turn 11 to **turn 6** — vanilla Ch6's own foot number.

**The hulls' clock is the chapter's declared pursuers and nothing else.** Seven entries take `ai_override` to vanilla's own `AI_A_08 ActionInRange_ExceptCivilian`, keeping the donor's approach byte, so they fight the player identically and cannot target a hull. `repoint_boat_safe_ai_list` points that script's do-not-attack list at both boat pids — twin of ch05's `AI_A_07` escort hack, and **widened to six bytes**, because `AiIsInShortList` takes a `u16*` and stops on zero: vanilla's four bytes are a one-id list, and two hulls need `{ 0xbb, 0, 0xbc, 0, 0, 0 }`.

Vanilla needs none of this. Measured over `Ch6Map` with each class's own cost table: **zero of its seventeen strikers can reach a villager in one turn**, its rescue targets sit in a mountain ring, and its clock is pursuers only. Our frozen lake has no mountain ring, so the protection is bought with the AI byte instead.

## Confirmation run

**PASS.** Every striker stayed on its start tile; the east hull is untouched until phase 5 and only by the declared pursuer; and the thrower finally lands its first throw on **enemy phase 2** exactly as the chapter always claimed — it could not before, because the strikers had taken all four of its firing cells.

## Guards added

- `check_rescue_targets` — nothing reaches a rescue target without being a declared pursuer or carrying a do-not-attack byte. It caught two modelling bugs during its own construction (weapon range is the max over the inventory, not `items[0]`; a statue's reach is its weapon and nothing more) and three undeclared pursuers.
- `check_chapter_lua_facts` — a chapter Lua chunk's coordinates must be the chapter YAML's own.

## Known and deliberately NOT fixed here

**The east fuse is now too slack** — measured still afloat at turn 12 against a declared 7 (the west sank turn 5 against 8). Both are the hit-rate problem the ADR predicts: a fuse made of attacks is a distribution, not a turn number. Tuning it is parked behind **#367**, because the difficulty model's trustworthiness is under review and the tuning levers (HP, a second pursuer) are exactly what that review affects. The fix in this PR does not depend on that model — it is grounded in measured vanilla behaviour.

## Verification

`make check` clean · `make test` **1,869+ cases, exit 0** · `ch06clock` **PASS** · ROM builds green with the repoint verified in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
