### PR TITLE
difficulty: print mirror% beside every parity ratio (#367)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8525,13 +8525,16 @@ past. That is the `drop_staff` flag, and the output diff is what caught it: ch06
 moved 7.54 → 7.41 and three lords' worst matchups changed, because the menders had silently left
 the field.
 
-**A per-unit question is answered per unit TYPE, not per body.** The shared expander yields one
-body per copy, and `role_findings` took it as-is — so ch08's `count: 4` ice-troll read as *"4 units
-flagged is_boss (ice-troll, ice-troll, ice-troll, ice-troll)"* and repeated every warning four
-times. Whether a unit's threat is an outlier does not depend on how many of it stand on the map,
-and `role` is a `--check` gate arm, so that would have redded CI on the first locked chapter with
-a multi-copy boss entry. Hence `distinct`: bodies of one entry collapse unless `levels:` actually
-makes them different units.
+**A per-unit question is answered per unit TYPE, not per body.** This one was self-inflicted and
+caught before it landed: consolidating on the shared expander made `role_findings` yield a row per
+BODY, and ch08's `count: 4` ice-troll immediately read as *"4 units flagged is_boss (ice-troll,
+ice-troll, ice-troll, ice-troll)"* with every warning repeated four times. (The old code was
+correct here — it expanded per distinct TYPE — so this is a regression the consolidation
+introduced, not a bug it found.) Whether a unit's threat is an outlier does not depend on how many
+of it stand on the map, and `role` is a `--check` gate arm, so it would have redded CI on the first
+locked chapter with a multi-copy boss entry. Hence `distinct`, which collapses bodies of one entry
+unless `levels:` makes them genuinely different units — and a boss CENSUS that counts entries, since
+`distinct` still splits one entry by level and every row carries that entry's id.
 
 **And the output diff has to cover every chapter the tool reads, not the ones the change was
 about.** The first diff ran ch00–ch06 and reported "only ch02 moves" — which was true of those

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8428,9 +8428,9 @@ the same number, and nothing in the report distinguished them.
 `mirror_share` prints, beside every ratio, the share of the **twin's** force the chapter
 reproduces exactly. Measured across the campaign:
 
-| ch00 | ch01 | ch02 | ch03 | ch04 | ch05 | **ch06** |
+| ch00 | ch01 | **ch02** | ch03 | ch04 | ch05 | **ch06** |
 |---|---|---|---|---|---|---|
-| 33% | 30% | 78% | 90% | 61% | 52% | **100%** |
+| 33% | 30% | **100%** | 90% | 61% | 52% | **100%** |
 
 **The trend is the finding, not the ch06 cell.** mirror% has climbed as the donor pipeline
 improved — every gain in derivation fidelity made the gate more tautological, and nobody was
@@ -8444,11 +8444,8 @@ What a body IS, and why each choice:
   one.
 - **The denominator is the TWIN's body count**, so fielding more than the twin never reads above
   100%. The question is how much of the twin we reproduced, not how much of ours is borrowed.
-- **Both sides count line AND reinforcements.** The twin's curated arrays already include its
-  waves, so counting only our opening board would compare nine vanilla units against seven of
-  ours and call the gap divergence. (Live case: ch02's two L1 brigands are reinforcements, and
-  its twin fields no L1 brigand — so the honest read is still 78%, arrived at with both waves on
-  the board.)
+- **Both sides count line AND reinforcements**, at each body's DECLARED level. This is the
+  choice that found a bug, and the bug is below.
 - **Nothing is dropped for carrying no modeled weapon.** The pressure metric drops a staff-only
   healer because it contributes no damage; this measures the force's SHAPE, and a healer the twin
   fields is a unit we did or did not reproduce. So the two numbers on the same line count
@@ -8457,6 +8454,52 @@ What a body IS, and why each choice:
 **It does not gate.** A high mirror is not a defect and a low one is not either — ch03 at 90% and
 ch01 at 30% are both fine chapters. It is a legibility number: it says how much a verdict is
 worth, and at ≥90% the report says so in words.
+
+**mirror% is mode-invariant, and that is not an omission.** A difficulty mode re-projects the same
+level through the chapter's malus/bonus (`mode_stats`), so it moves stats and never a unit's class
+or level; the Hard-only waves are folded into both sides unconditionally. The `--mode` banner says
+so, because mirror sits on a row whose other figures ARE shifted.
+
+### What asking "what is a body" found: ch02 was never counting its own wave
+
+Defining mirror% forced the question the ratio had never been asked, and the answer was that our
+side and the twin's side were counting different forces.
+
+`chapter_units` — THE our-side force builder — read only `enemy_units`. `vanilla_enemies` reads
+every red `UnitDefinition` in the twin's curated arrays, **reinforcement waves included**. ch02
+declares its rear-raider pair under the `reinforcements:` key, so its verdict compared **seven of
+our bodies against nine of vanilla's**, and the two missing ones scored as divergence. That entry
+also carries `levels: [2, 3]` and no `level:` — the per-body list `build_campaign` zips with
+`positions` to emit the ROM — so both bodies were additionally modeled as **L1**.
+
+ch06 had already hit this and worked around it privately: its Hard-only turn-4 wave is declared
+inside `enemy_units` rather than under `reinforcements:`, and its own YAML comment says why —
+*"#48's static bar folds that array in on the vanilla side unconditionally, so declaring ours is
+what makes the two sides count the same force."* That is the general rule, and it was being
+enforced one chapter at a time by hand.
+
+Corrected, ch02 is not the campaign's easiest chapter by a wide margin. It is an exact
+transcription:
+
+| | shipped | corrected |
+|---|---|---|
+| threat/slot | 5.3 (**x0.81**) | 6.5 (**x1.00**) |
+| clear-load/slot | 3.0 (**x0.79**) | 3.8 (**x1.00**) |
+| mirror | 78% | **100%** |
+| bodies ours vs twin | 7 vs 9 | 9 vs 9 |
+
+The verdict was OK before and is OK now — it never flipped a gate, which is exactly why it
+survived four chapters. `--mode difficult` moves identically (x0.81/x0.79 → x1.00/x1.00).
+
+So there are **two** copy-x1.00 chapters, not one, and #367's "mirror% climbs as the donor
+pipeline improves" reads differently: ch02 was already a transcription in 2026-08, and the
+instrument was hiding it.
+
+The fix is one function, `chapter_roster_entries`, which answers *"what is this chapter's force"*
+once, over `AI_ROSTER_KEYS` — the same three keys the AI guard already iterates. The parity metric
+and the AI guard can no longer disagree about which units a chapter fields. Verified by an output
+diff of every per-chapter report and both curve reports before and after: **only ch02's numbers
+move.**
 
 ## Open Questions (not yet decided)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8497,9 +8497,15 @@ instrument was hiding it.
 
 The fix is two functions and it is the general form, not a patch on ch02:
 
-- `chapter_roster_entries` answers *"what is this chapter's force"* once, over `AI_ROSTER_KEYS` —
-  the same three keys the AI guard already iterates, `enemy_reinforcements` included. The parity
-  metric and the AI guard can no longer disagree about which units a chapter fields.
+- `build_campaign.chapter_roster_entries` answers *"what is this chapter's force"* once, over
+  `ENEMY_ROSTER_KEYS`. It lives on the desk that owns the chapter schema because four separate
+  gates key off that answer — the parity metric, the AI-donor guard, the `personal:` injection
+  routes (#284) and the raw-pid boss registry — and each had its own copy of the question. Two of
+  those copies were holes: a boss under `reinforcements:` could carry a `personal:` block with no
+  route into the ROM, and could ride a raw pid with no `RAW_PID_LEVEL_SOURCES` row, while
+  `_our_base_level` modelled it as malus-immune anyway. `check.py` names the keys rather than
+  importing them (its CI job runs on a bare interpreter), and a test fails if the two ever
+  diverge.
 - `_entry_combatants` is the single entry expander. It was three near-copies — one in
   `chapter_units`, one of its own, one inside `role_findings` — which is precisely how `levels:`
   came to be honored in one reader and defaulted to L1 in the others. Body count, per-body level

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8416,6 +8416,48 @@ defect the gate has to be able to see.
 
 _Found by `/code-review` on #366 (2026-09-04)._
 
+### A parity ratio does not say how much of the twin it COPIED, so mirror% says it (2026-09-04, #367)
+
+ch06 reads **x1.00 threat / x1.00 clear-load** against vanilla Ch6 — a perfect score on the only
+chapter whose clock measured wrong in both directions. Both facts are true, and they are not in
+tension, because the ratio was never a measurement of ch06: **ch06 reproduces 100% of Ch6's
+27-unit force, so x1.00 is a checksum on the donor pipeline.** A ratio is an aggregate over stats.
+A transcribed force and a composed force that happens to land on the same per-slot pressure print
+the same number, and nothing in the report distinguished them.
+
+`mirror_share` prints, beside every ratio, the share of the **twin's** force the chapter
+reproduces exactly. Measured across the campaign:
+
+| ch00 | ch01 | ch02 | ch03 | ch04 | ch05 | **ch06** |
+|---|---|---|---|---|---|---|
+| 33% | 30% | 78% | 90% | 61% | 52% | **100%** |
+
+**The trend is the finding, not the ch06 cell.** mirror% has climbed as the donor pipeline
+improved — every gain in derivation fidelity made the gate more tautological, and nobody was
+watching that happen because there was no number for it.
+
+What a body IS, and why each choice:
+
+- **(class, level), not class.** An L9 fighter is not the twin's L1 one; class alone would score
+  a re-levelled force as a copy.
+- **A multiset intersection.** Doubling a body cannot score it twice against a twin that fields
+  one.
+- **The denominator is the TWIN's body count**, so fielding more than the twin never reads above
+  100%. The question is how much of the twin we reproduced, not how much of ours is borrowed.
+- **Both sides count line AND reinforcements.** The twin's curated arrays already include its
+  waves, so counting only our opening board would compare nine vanilla units against seven of
+  ours and call the gap divergence. (Live case: ch02's two L1 brigands are reinforcements, and
+  its twin fields no L1 brigand — so the honest read is still 78%, arrived at with both waves on
+  the board.)
+- **Nothing is dropped for carrying no modeled weapon.** The pressure metric drops a staff-only
+  healer because it contributes no damage; this measures the force's SHAPE, and a healer the twin
+  fields is a unit we did or did not reproduce. So the two numbers on the same line count
+  different totals on purpose — ch06 prints 25 modeled enemies and 27 mirrored bodies.
+
+**It does not gate.** A high mirror is not a defect and a low one is not either — ch03 at 90% and
+ch01 at 30% are both fine chapters. It is a legibility number: it says how much a verdict is
+worth, and at ≥90% the report says so in words.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8495,11 +8495,32 @@ So there are **two** copy-x1.00 chapters, not one, and #367's "mirror% climbs as
 pipeline improves" reads differently: ch02 was already a transcription in 2026-08, and the
 instrument was hiding it.
 
-The fix is one function, `chapter_roster_entries`, which answers *"what is this chapter's force"*
-once, over `AI_ROSTER_KEYS` — the same three keys the AI guard already iterates. The parity metric
-and the AI guard can no longer disagree about which units a chapter fields. Verified by an output
-diff of every per-chapter report and both curve reports before and after: **only ch02's numbers
-move.**
+The fix is two functions and it is the general form, not a patch on ch02:
+
+- `chapter_roster_entries` answers *"what is this chapter's force"* once, over `AI_ROSTER_KEYS` —
+  the same three keys the AI guard already iterates, `enemy_reinforcements` included. The parity
+  metric and the AI guard can no longer disagree about which units a chapter fields.
+- `_entry_combatants` is the single entry expander. It was three near-copies — one in
+  `chapter_units`, one of its own, one inside `role_findings` — which is precisely how `levels:`
+  came to be honored in one reader and defaulted to L1 in the others. Body count, per-body level
+  and the `levels:`↔`count`/`positions`/`composition` guard all live in `_body_levels` now.
+
+**A widened definition has to reach every reader or it makes the report contradict itself.** The
+first attempt adopted the new roster in the verdict alone, and `--chapter ch02` then printed *"ours
+(9 enemies)"* two lines above *"ours line 7 · reinf 0"*. Five readers were still on
+`chap['enemy_units']`: the dynamics split, the unmodeled-boss warning (a gate hole — a staff-only
+boss under `reinforcements:` raised no BOSS DROPPED), `load_field`'s cast tables, `role_findings`
+(an arm of the parity gate, so a boss parked under `reinforcements:` could never be graded
+per-unit), and `solo_contributors`.
+
+One thing the shared expander must NOT unify: the parity metrics drop a unit with no modeled
+weapon, and the cast tables must not — a chapter's healer is a body our units can kill and walk
+past. That is the `drop_staff` flag, and the output diff is what caught it: ch06's throughput
+moved 7.54 → 7.41 and three lords' worst matchups changed, because the menders had silently left
+the field.
+
+Verified by an output diff of every per-chapter report, every `--lord-floor` table and both curve
+reports before and after: **only ch02's numbers move.**
 
 ## Open Questions (not yet decided)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8519,8 +8519,20 @@ past. That is the `drop_staff` flag, and the output diff is what caught it: ch06
 moved 7.54 → 7.41 and three lords' worst matchups changed, because the menders had silently left
 the field.
 
-Verified by an output diff of every per-chapter report, every `--lord-floor` table and both curve
-reports before and after: **only ch02's numbers move.**
+**A per-unit question is answered per unit TYPE, not per body.** The shared expander yields one
+body per copy, and `role_findings` took it as-is — so ch08's `count: 4` ice-troll read as *"4 units
+flagged is_boss (ice-troll, ice-troll, ice-troll, ice-troll)"* and repeated every warning four
+times. Whether a unit's threat is an outlier does not depend on how many of it stand on the map,
+and `role` is a `--check` gate arm, so that would have redded CI on the first locked chapter with
+a multi-copy boss entry. Hence `distinct`: bodies of one entry collapse unless `levels:` actually
+makes them different units.
+
+**And the output diff has to cover every chapter the tool reads, not the ones the change was
+about.** The first diff ran ch00–ch06 and reported "only ch02 moves" — which was true of those
+seven and false of ch08, a `status: planned` chapter the curve still grades. A planned chapter is
+brainstorm seed, but the tool reads it, so it is part of the tool's output. Verified now over all
+nine chapters, every `--lord-floor` table and all four curve reports (authored + three modes):
+**only ch02's numbers move.**
 
 ## Open Questions (not yet decided)
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -10254,6 +10254,26 @@ def raw_pid_base_levels(campaign):
     return out
 
 
+# The keys a chapter YAML may hold enemy entries under. ONE definition, because every
+# reader of "what units does this chapter field" must agree: the parity metric, the AI-donor
+# guard, the personal-line routes and the raw-pid boss registry all key off it, and ch02
+# spent four chapters with its `reinforcements:` wave counted by some of them and not others
+# (decisions.md -> "A parity ratio does not say how much of the twin it COPIED").
+ENEMY_ROSTER_KEYS = ('enemy_units', 'reinforcements', 'enemy_reinforcements')
+
+
+def chapter_roster_entries(chap):
+    """Every enemy entry a chapter fields, across ALL of its roster keys.
+
+    A reinforcement wave is part of the force. The vanilla twins' curated UnitDefinition
+    arrays fold their own waves in unconditionally (vanilla Ch2's `UnitDef_088B4470`,
+    vanilla Ch6's Hard-mode array), so a reader that takes only the opening board compares
+    seven bodies against nine and scores the two missing ones as divergence.
+    """
+    return [ed for key in ENEMY_ROSTER_KEYS for ed in (chap.get(key) or [])
+            if isinstance(ed, dict)]
+
+
 def unregistered_raw_pid_bosses(campaign):
     """Boss/miniboss ids that ride a RAW pid but declare no baseLevel (sorted).
 
@@ -10262,19 +10282,24 @@ def unregistered_raw_pid_bosses(campaign):
     construction. The prologue's zeroed guests are excluded: they DO ride vanilla slots (only
     their base STATS are zeroed), so their baseLevel is the slot's and the penalty is already
     governed by vanilla's own number."""
+    return sorted(uid for chapter in hosted_chapters()
+                  for uid in _unregistered_raw_pid_boss_entries(
+                      _load_chapter_yaml(campaign, chapter_yaml_for(chapter.name))))
+
+
+def _unregistered_raw_pid_boss_entries(chap):
+    """The same question for ONE loaded chapter, over every roster key.
+
+    difficulty's `_our_base_level` models a boss as malus-immune WHEREVER it is declared,
+    and this registry is what makes that true, so the guard has to look wherever it is
+    declared too."""
     registered = {unit_id for _yaml, unit_id in RAW_PID_LEVEL_SOURCES.values()}
     prologue_guests = {'sephek-kaltro'}
-    missing = []
-    for chapter in hosted_chapters():
-        chap = _load_chapter_yaml(campaign, chapter_yaml_for(chapter.name))
-        for enemy in chap.get('enemy_units', []):
-            if not (enemy.get('is_boss') or enemy.get('is_miniboss')):
-                continue
-            uid = enemy.get('id')
-            if uid in ENEMY_BASE_SLOT or uid in registered or uid in prologue_guests:
-                continue
-            missing.append(uid)
-    return sorted(missing)
+    return [enemy.get('id') for enemy in chapter_roster_entries(chap)
+            if (enemy.get('is_boss') or enemy.get('is_miniboss'))
+            and enemy.get('id') not in ENEMY_BASE_SLOT
+            and enemy.get('id') not in registered
+            and enemy.get('id') not in prologue_guests]
 
 
 RAW_PID_BATTLE_ANIMS = {

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -10245,12 +10245,11 @@ def raw_pid_base_levels(campaign):
     """Raw pid -> the baseLevel it must carry, read from the level it deploys at."""
     out = {}
     for pid, (chapter_yaml, unit_id) in RAW_PID_LEVEL_SOURCES.items():
-        chapter = _load_chapter_yaml(campaign, chapter_yaml)
-        unit = next((e for e in chapter.get('enemy_units', []) if e.get('id') == unit_id), None)
-        if unit is None:
+        level = _entry_base_level_in(_load_chapter_yaml(campaign, chapter_yaml), unit_id)
+        if level is None:
             sys.exit('ERROR: RAW_PID_LEVEL_SOURCES names %s/%s, which does not exist'
                      % (chapter_yaml, unit_id))
-        out[pid] = int(unit.get('level', 1))
+        out[pid] = level
     return out
 
 
@@ -10272,6 +10271,51 @@ def chapter_roster_entries(chap):
     """
     return [ed for key in ENEMY_ROSTER_KEYS for ed in (chap.get(key) or [])
             if isinstance(ed, dict)]
+
+
+def entry_body_levels(enemy_def):
+    """The level of each BODY one enemy entry places, in order.
+
+    `levels:` is a PER-BODY list and it is what the ROM contains -- the emitters zip it with
+    `positions` to write one UnitDefinition per pair, so an entry carrying it declares an L2
+    and an L3 rather than two copies of one level. Everything else is `count` (or, failing
+    that, `positions`) bodies at the entry's `level`.
+
+    Every field that states the body count states the SAME fact, so they must agree: a stale
+    `count:` beside a `positions:` list models a force the ROM never emits, and since #367
+    the parity metric compares body-for-body against the vanilla twin on it.
+    """
+    uid = enemy_def.get('id', enemy_def.get('name', 'enemy'))
+    levels = enemy_def.get('levels')
+    bag = (enemy_def.get('composition') or []) if 'class' not in enemy_def else None
+    stated = [(f, n) for f, n in
+              (('composition', len(bag) if bag else None),
+               ('count', int(enemy_def['count']) if 'count' in enemy_def else None),
+               ('positions', len(enemy_def['positions'])
+                if enemy_def.get('positions') else None),
+               ('levels', len(levels) if levels is not None else None))
+              if n is not None]
+    for field, n in stated:
+        if n != stated[0][1]:
+            raise ValueError('%r declares %s %d but %s %d -- they are the same fact and '
+                             'they disagree' % (uid, stated[0][0], stated[0][1], field, n))
+    count = stated[0][1] if stated else 1
+    if count < 1:
+        raise ValueError('%r places no body (%s %d)'
+                         % (uid, stated[0][0] if stated else 'count', count))
+    if levels is None:
+        return [int(enemy_def.get('level', 1))] * count
+    return [int(lv) for lv in levels]
+
+
+def _entry_base_level_in(chap, unit_id):
+    """The baseLevel the named unit deploys at, found across every roster key.
+
+    Reads a DECLARED body level, so a boss authored `levels: [9]` writes baseLevel 9 rather
+    than falling through to 1 -- which would make the ROM apply a difficulty malus while
+    difficulty's `_our_base_level` models the same boss as immune to it."""
+    unit = next((e for e in chapter_roster_entries(chap) if e.get('id') == unit_id), None)
+    return None if unit is None else max(entry_body_levels(unit))
 
 
 def unregistered_raw_pid_bosses(campaign):

--- a/tools/check.py
+++ b/tools/check.py
@@ -505,7 +505,7 @@ def _personal_line_route_violations(rel, d, injected_ids, slot_ids):
         boss further than the bug that opened #284, with every gate green.
     """
     out = []
-    for unit in (d.get('enemy_units') or []):
+    for unit in _roster_entries(d):
         if not unit.get('personal'):
             continue
         uid = unit.get('id')
@@ -519,6 +519,17 @@ def _personal_line_route_violations(rel, d, injected_ids, slot_ids):
                        'RAW_PID_PERSONAL_SOURCES in build_campaign.py, or the boss will measure '
                        'fixed and play as a naked class base' % (rel, uid))
     return out
+
+
+# Mirrors build_campaign.ENEMY_ROSTER_KEYS. Named here rather than imported because this
+# module's `checks` CI job runs on a bare interpreter with no Pillow and no submodule, so it
+# must stay import-free; the schema tests fail if the two ever diverge.
+ROSTER_KEYS = ('enemy_units', 'reinforcements', 'enemy_reinforcements')
+
+
+def _roster_entries(d):
+    """Every enemy entry a chapter dict fields, across all of its roster keys."""
+    return [u for key in ROSTER_KEYS for u in (d.get(key) or []) if isinstance(u, dict)]
 
 
 def check_personal_line_injection_routes(fail):
@@ -545,7 +556,7 @@ def check_personal_line_injection_routes(fail):
     seen = set()
     for rel, d in _chapters():
         fail.extend(_personal_line_route_violations(rel, d, injected_ids, slot_ids))
-        seen.update(u.get('id') for u in (d.get('enemy_units') or []))
+        seen.update(u.get('id') for u in _roster_entries(d))
     for uid in sorted(slot_ids - seen):
         fail.append('ENEMY_BASE_SLOT maps %r, which no chapter fields -- a stale key silently '
                     'drops that boss back to a naked-class-base measurement (#284)' % uid)

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -309,19 +309,25 @@ def _body_levels(enemy_def):
     levels = enemy_def.get('levels')
     bag = (enemy_def.get('composition') or []) if 'class' not in enemy_def else None
     count = len(bag) if bag else int(enemy_def.get('count', 1))
+    # Every field that states the body count states the SAME fact, so they must agree.
+    # `positions` is the one build_campaign actually zips against, so a mismatch models a
+    # body the ROM never emits -- and mirror% now compares body-for-body against the twin.
+    stated = [(f, n) for f, n in
+              (('composition', len(bag) if bag else None),
+               ('count', int(enemy_def['count']) if 'count' in enemy_def and not bag
+                else None),
+               ('positions', len(enemy_def['positions'])
+                if enemy_def.get('positions') else None),
+               ('levels', len(levels) if levels is not None else None))
+              if n is not None]
+    for field, n in stated:
+        if n != stated[0][1]:
+            raise ValueError('%r declares %s %d but %s %d -- they are the same fact and '
+                             'they disagree'
+                             % (enemy_def.get('id', enemy_def.get('name', 'enemy')),
+                                stated[0][0], stated[0][1], field, n))
     if levels is None:
         return [int(enemy_def.get('level', 1))] * count
-    for field, n in (('composition', len(bag) if bag else None),
-                     ('count', count if 'count' in enemy_def and not bag else None),
-                     ('positions', len(enemy_def['positions'])
-                      if enemy_def.get('positions') else None)):
-        # `positions` is what build_campaign actually zips `levels` against, so a mismatch
-        # there models a body the ROM never emits. Both are the same fact stated twice.
-        if n is not None and n != len(levels):
-            raise ValueError('%r declares %s %d but %d levels (%r) -- they are the same '
-                             'fact and they disagree'
-                             % (enemy_def.get('id', enemy_def.get('name', 'enemy')),
-                                field, n, len(levels), levels))
     return [int(lv) for lv in levels]
 
 
@@ -878,18 +884,25 @@ def bosses_over_their_donor_base_level(campaign):
     CHARACTER_ slots it is merely true today, and at ZERO margin -- Breguet 4/4, Bone 4/4,
     Bazba 6/6. One level bump and the ROM starts applying the malus while the model still
     assumes it does not, which is the silent model/ROM divergence in miniature."""
+    return sorted(uid for chapter in bc.hosted_chapters()
+                  for uid in _boss_entries_over_donor_base_level(
+                      bc._load_chapter_yaml(campaign, bc.chapter_yaml_for(chapter.name))))
+
+
+def _boss_entries_over_donor_base_level(chap):
+    """The same question for ONE loaded chapter, over every roster key and every declared
+    body level. `_entry_combatants` applies the malus-immunity assumption to a boss wherever
+    it is declared, so the guard has to look wherever it is declared."""
     out = []
-    for chapter in bc.hosted_chapters():
-        chap = bc._load_chapter_yaml(campaign, bc.chapter_yaml_for(chapter.name))
-        for enemy in chap.get('enemy_units', []):
-            if not (enemy.get('is_boss') or enemy.get('is_miniboss')):
-                continue
-            donor = bc.ENEMY_BASE_SLOT.get(enemy.get('id'))
-            if not donor:
-                continue
-            if int(enemy.get('level', 1)) > _character_base_level(donor):
-                out.append(enemy.get('id'))
-    return sorted(out)
+    for enemy in chapter_roster_entries(chap):
+        if not (enemy.get('is_boss') or enemy.get('is_miniboss')):
+            continue
+        donor = bc.ENEMY_BASE_SLOT.get(enemy.get('id'))
+        if not donor:
+            continue
+        if max(_body_levels(enemy)) > _character_base_level(donor):
+            out.append(enemy.get('id'))
+    return out
 
 
 def _our_takes_difficulty_shift(enemy_def):
@@ -934,13 +947,19 @@ def chapter_roster_entries(chap):
             if isinstance(ed, dict)]
 
 
-def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff=True):
+def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff=True,
+                      distinct=False):
     """Every BODY one enemy entry places.
 
     `drop_staff` drops a unit carrying no modeled weapon, which is what every PARITY metric
     wants (it can contribute no damage, and `unmodeled_enemies` warns about it separately).
     The cast tables want the opposite: a chapter's healer is a body our units can kill and
     walk past, so `load_field` keeps it.
+
+    `distinct` collapses identical bodies to one, for readers asking a per-unit-TYPE
+    question: whether a unit's threat is an outlier is a property of the unit, not of how
+    many copies of it stand on the map. Two bodies of one entry differ only when `levels:`
+    gives them different levels.
 
     THE entry expander. It was three near-copies -- one in `chapter_units`, one in
     `_entry_combatants`, one in `role_findings` -- which is how `levels:` came to be honored
@@ -953,10 +972,15 @@ def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff
     if 'composition' in ed and 'class' not in ed:
         name = ed.get('id', ed.get('name', 'enemy'))
         by_class = ed.get('inventory_by_class', {})
+        bodies = list(zip(ed.get('composition', []), _body_levels(ed)))
         units = [_one_enemy('%s-%s' % (name, cls), cls, lv,
                             _weapon_for([{'id': w} for w in by_class.get(cls, [])]),
                             mode=mode, shifts=shifts)
-                 for cls, lv in zip(ed.get('composition', []), _body_levels(ed))]
+                 for cls, lv in (dict.fromkeys(bodies) if distinct else bodies)]
+        if real_article:
+            # a bag is generics, so no per-member line -- but an entry-level `personal:` or
+            # donor id describes the GROUP and must still be applied (#284).
+            units = [unit_real_article(ed, c) for c in units]
     else:
         # One body per DECLARED level, not `count` copies of one: a wave authored as
         # `levels: [2, 3]` is an L2 and an L3, which is what the ROM emits. `base_level` is
@@ -964,7 +988,8 @@ def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff
         # against -- reading it off `level:` while the body comes from `levels:` invents a
         # malus the engine never applies.
         units = []
-        for lv in _body_levels(ed):
+        levels = _body_levels(ed)
+        for lv in (dict.fromkeys(levels) if distinct else levels):
             units.extend(enemy_combatants(
                 dict(ed, level=lv), mode=mode, shifts=shifts,
                 base_level=_our_base_level(dict(ed, level=lv)),
@@ -1713,7 +1738,10 @@ def role_findings(chap, parity_ref):
         # THREAT comparisons run on the real article (class base + personal line), the same
         # footing the durability check below has always used. The AGGREGATE metric stays
         # class-base on both sides -- that is a different question and a fair one.
-        for c in _entry_combatants(ed, real_article=True, drop_staff=False):
+        # per-unit questions, so one row per unit TYPE: whether a unit's threat is an
+        # outlier does not depend on how many copies of it the map holds, and counting
+        # copies made a `count: 4` boss entry read as four bosses.
+        for c in _entry_combatants(ed, real_article=True, drop_staff=False, distinct=True):
             ours.append((ed.get('id') or c.name, bool(ed.get('is_boss')), c,
                          bool(ed.get('convertible')), ed.get('tile_terrain')))
     if not ours:
@@ -1942,7 +1970,7 @@ def chapter_economy(chap):
         for it in c.get('contents') or []:
             if it.get('id'):
                 chests.append(it['id'])
-    for ed in chap.get('enemy_units') or []:
+    for ed in chapter_roster_entries(chap):
         if ed.get('item_drop'):
             drops.append(ed['item_drop'])
     pc = chap.get('post_chapter') or {}

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -18,6 +18,7 @@ All combat math is fe_combat.py (the decomp's own formulas, tested). Stat resolu
 shares build_campaign.py's primitives so there is one source of truth for "what is this
 unit's stat line".
 """
+import collections
 import dataclasses
 import os
 import re
@@ -928,6 +929,54 @@ def unmodeled_enemies(chap):
     return out
 
 
+# ── mirror% -- how much of the twin a chapter TRANSCRIBES (#367) ─────────────────
+# The parity ratio is an aggregate over stats, so it cannot tell a chapter that copies its
+# twin unit for unit from one that composes a different force arriving at the same per-slot
+# pressure. Both read x1.00, and only one of them is a measurement. ch06 is the live case:
+# it reproduces 100% of vanilla Ch6's force, so its perfect score is a checksum on the donor
+# pipeline rather than evidence about the chapter. mirror% prints beside every ratio so the
+# difference is visible without re-deriving it.
+#
+# A body is (class, level) -- the unit, not just its class: an L9 fighter is not the twin's
+# L1 one. The intersection is a MULTISET, so doubling a body cannot score it twice, and the
+# denominator is the TWIN's body count, so fielding more than the twin never reads above
+# 100%. Both sides count every body: ours line + reinforcements, the twin every red
+# UnitDefinition in its curated arrays (reinforcement waves included). Nothing is dropped
+# for carrying no modeled weapon the way the pressure metric drops a staff-only healer --
+# this measures the force's SHAPE, and a healer the twin fields is a unit we did or did not
+# reproduce.
+
+
+def _force_signature(chap):
+    """Every enemy BODY the chapter fields, as a Counter of (class enum, level).
+
+    Line and reinforcements both, `count`/`composition` expanded -- the multiplicity the
+    metrics layer collapses is exactly what a shape comparison needs."""
+    out = collections.Counter()
+    for ed in list(chap.get('enemy_units') or []) + list(chap.get('reinforcements') or []):
+        level = int(ed.get('level', 1))
+        if 'class' in ed:
+            out[(_enemy_class_enum(ed['class']), level)] += int(ed.get('count', 1))
+        else:
+            for cls in ed.get('composition', []):
+                out[(_enemy_class_enum(cls), level)] += 1
+    return out
+
+
+def mirror_share(chap):
+    """Share of the twin's force this chapter reproduces exactly, as
+    {shared, ours, twin, pct}. None when the reference isn't curated (#48 registry)."""
+    van = vanilla_red_units(chap.get('parity_reference'))
+    if van is None:
+        return None
+    twin = collections.Counter((u['classIndex'], u['level']) for u in van)
+    ours = _force_signature(chap)
+    shared = sum((twin & ours).values())
+    n = sum(twin.values())
+    return {'shared': shared, 'ours': sum(ours.values()), 'twin': n,
+            'pct': 100.0 * shared / n if n else 0.0}
+
+
 # ── Pure metrics layer (no I/O; operates on fe_combat.Combatant) ──────────────────
 # The three FE survival questions, each a single number so a chapter can be compared
 # to vanilla at a glance.
@@ -1271,7 +1320,7 @@ def _chapter_pressure(chap, band=0.25, mode=None):
     ref = chap.get('parity_reference')
     van = vanilla_enemies(ref, mode=mode)
     out = {'reference': ref, 'deploy_cap': deploy_cap, 'ours': ours, 'mode': mode,
-           'n_ours': len(ours_force), 'vanilla': None,
+           'n_ours': len(ours_force), 'vanilla': None, 'mirror': mirror_share(chap),
            'dropped': unmodeled_enemies(chap)}
     if van is not None:
         out['vanilla'] = enemy_pressure(van, deploy_cap)
@@ -1308,6 +1357,15 @@ def _print_pressure(p):
           'clear-load/slot %4.1f (x%.2f %s)'
           % ('', p['n_ours'], ot, v['threat_ratio'], v['threat'],
              ol, v['load_ratio'], v['load']))
+    m = p.get('mirror')
+    if m:
+        # WHAT THE RATIOS ABOVE CANNOT SAY (#367): a ratio is an aggregate over stats, so a
+        # transcribed force and a composed one that lands on the same pressure read alike.
+        print('  mirror: %.0f%% of %s\'s force reproduced exactly (%d of %d bodies, class '
+              '+ level)' % (m['pct'], p['reference'], m['shared'], m['twin']))
+        if m['pct'] >= 90:
+            print('          -- at this share the verdict is largely a CHECKSUM on the donor '
+                  'pipeline,\n             not evidence about the chapter.')
     print('  verdict: %s' % ('PARITY (within band)' if v['verdict'] == 'OK'
                              else 'OFF-PARITY -- threat %s, clear-load %s' % (v['threat'], v['load'])))
     for line in p.get('solo') or []:
@@ -2086,8 +2144,8 @@ def curve_report(campaign, band=0.25, mode=None):
               '\n     AUTHORED table, not on %s -- only the parity rows are mode-shifted.'
               % mode.upper())
     print(bar)
-    print('  %-22s %-13s %-15s %-17s %s'
-          % ('chapter', 'reference', 'threat/slot', 'clear-load/slot', 'verdict'))
+    print('  %-22s %-13s %-15s %-17s %-7s %s'
+          % ('chapter', 'reference', 'threat/slot', 'clear-load/slot', 'mirror', 'verdict'))
     chaps = []
     for path in paths:
         with open(path, encoding='utf-8') as f:
@@ -2114,8 +2172,8 @@ def curve_report(campaign, band=0.25, mode=None):
             else:
                 note = (' (%d yardstick-proof units, clear-load floored)'
                         % proj['proof']) if proj['proof'] else ''
-                print('  %-22s %-13s %4.1f (target)    %4.1f (target)      planned%s'
-                      % (label[:22], ref[:13], proj['threat'], proj['clearload'], note))
+                print('  %-22s %-13s %4.1f (target)    %4.1f (target)      %-7s planned%s'
+                      % (label[:22], ref[:13], proj['threat'], proj['clearload'], '--', note))
             continue
         p = _chapter_pressure(chap, band, mode=mode)
         ot, ol = p['ours']
@@ -2138,16 +2196,18 @@ def curve_report(campaign, band=0.25, mode=None):
         if ai:
             flag += '  !!ai'
         rows.append({'label': label[:22].strip(), 'locked': locked, 'has_ref': has_ref,
-                     'verdict': verdict, 'boss_drop': boss_drop, 'role': role, 'ai': ai})
+                     'verdict': verdict, 'boss_drop': boss_drop, 'role': role, 'ai': ai,
+                     'mirror': p['mirror']})
         if not has_ref:
-            print('  %-22s %-13s %5.1f           %5.1f             (no ref)%s'
-                  % (label[:22], (p['reference'] or '?')[:13], ot, ol, flag))
+            print('  %-22s %-13s %5.1f           %5.1f             %-7s (no ref)%s'
+                  % (label[:22], (p['reference'] or '?')[:13], ot, ol, '--', flag))
             continue
         vt, vl = p['vanilla']
         v = p['verdict']
-        print('  %-22s %-13s %4.1f (x%.2f)     %4.1f (x%.2f)       %s%s'
+        print('  %-22s %-13s %4.1f (x%.2f)     %4.1f (x%.2f)       %-7s %s%s'
               % (label[:22], (p['reference'] or '?')[:13], ot, v['threat_ratio'],
-                 ol, v['load_ratio'], v['verdict'], flag))
+                 ol, v['load_ratio'], '%.0f%%' % p['mirror']['pct'] if p['mirror'] else '--',
+                 v['verdict'], flag))
     if any_dropped_boss:
         print('\n  !! a dropped boss means that row\'s verdict is unreliable -- its scariest '
               'unit\n     carries an unmodeled weapon. Add fe_base to its YAML inventory (#51/#52).')

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -297,6 +297,27 @@ def _one_enemy(name, class_token, level, weapon, personal=None, mode=None, shift
                             shiftable=shiftable)
 
 
+def _body_levels(enemy_def):
+    """The level of each BODY an entry places, in order.
+
+    `levels:` is a PER-BODY list and it is what the ROM contains -- build_campaign zips it
+    with `positions` to emit one UnitDefinition per pair, so an entry carrying it declares
+    two L2/L3 brigands and not two copies of one level. Everything else is `count` bodies at
+    the entry's `level` (default 1). A `levels:` that disagrees with `count` is two
+    declarations of the same fact contradicting each other, so it raises rather than
+    truncating the way a bare zip() would."""
+    levels = enemy_def.get('levels')
+    count = int(enemy_def.get('count', 1))
+    if levels is None:
+        return [int(enemy_def.get('level', 1))] * count
+    if 'count' in enemy_def and len(levels) != count:
+        raise ValueError('%r declares count %d but %d levels (%r) -- they are the same '
+                         'fact and they disagree'
+                         % (enemy_def.get('id', enemy_def.get('name', 'enemy')),
+                            count, len(levels), levels))
+    return [int(lv) for lv in levels]
+
+
 def enemy_combatants(enemy_def, mode=None, shifts=None, base_level=1, shiftable=True):
     """One representative Combatant per DISTINCT enemy type in a chapter enemy_units entry
     (its `count`/positions are tactical detail the metrics don't model). Class base
@@ -883,6 +904,23 @@ def _our_base_level(enemy_def):
     return 1
 
 
+def chapter_roster_entries(chap):
+    """Every enemy entry the chapter fields, across ALL of its roster keys.
+
+    A reinforcement wave is part of the force. The twin's curated UnitDefinition arrays fold
+    its own waves in unconditionally (vanilla Ch2's `UnitDef_088B4470`, vanilla Ch6's
+    Hard-mode array), so a builder that reads only our opening board compares seven bodies
+    against nine and scores the two missing ones as divergence. ch06 already ran into this
+    and worked around it by declaring its turn-4 wave inside `enemy_units` -- its own YAML
+    says declaring them "is what makes the two sides count the same force". ch02 used the
+    `reinforcements:` key instead and was simply never counted.
+
+    The keys are AI_ROSTER_KEYS, so there is one answer to "what is this chapter's force"
+    and the AI guard and the parity metric cannot drift apart on it."""
+    return [ed for key in AI_ROSTER_KEYS for ed in (chap.get(key) or [])
+            if isinstance(ed, dict)]
+
+
 def chapter_units(chap, mode=None, shifts=None):
     """(enemy_def, real-article Combatant) for every BODY our chapter fields, weapons modeled.
 
@@ -892,7 +930,7 @@ def chapter_units(chap, mode=None, shifts=None):
     and printed a share that contradicted the verdict directly above it (#285).
     """
     out = []
-    for ed in chap.get('enemy_units', []):
+    for ed in chapter_roster_entries(chap):
         if 'composition' in ed and 'class' not in ed:
             level = ed.get('level', 1)
             name = ed.get('id', ed.get('name', 'enemy'))
@@ -903,11 +941,14 @@ def chapter_units(chap, mode=None, shifts=None):
                 out.append((ed, _one_enemy('%s-%s' % (name, cls), cls, level, weapon,
                                            mode=mode, shifts=shifts)))
         else:
-            out.extend([(ed, unit_real_article(ed, c))
-                        for c in enemy_combatants(ed, mode=mode, shifts=shifts,
-                                                  base_level=_our_base_level(ed),
-                                                  shiftable=_our_takes_difficulty_shift(ed))]
-                       * int(ed.get('count', 1)))
+            # one body per DECLARED level, not `count` copies of one: a wave authored as
+            # `levels: [2, 3]` is an L2 and an L3, which is what the ROM emits.
+            for lv in _body_levels(ed):
+                out.extend((ed, unit_real_article(ed, c))
+                           for c in enemy_combatants(dict(ed, level=lv), mode=mode,
+                                                     shifts=shifts,
+                                                     base_level=_our_base_level(ed),
+                                                     shiftable=_our_takes_difficulty_shift(ed)))
     return [(ed, u) for ed, u in out if u.weapon is not None]  # drop staff-only enemies
 
 
@@ -953,11 +994,12 @@ def _force_signature(chap):
     Line and reinforcements both, `count`/`composition` expanded -- the multiplicity the
     metrics layer collapses is exactly what a shape comparison needs."""
     out = collections.Counter()
-    for ed in list(chap.get('enemy_units') or []) + list(chap.get('reinforcements') or []):
-        level = int(ed.get('level', 1))
+    for ed in chapter_roster_entries(chap):
         if 'class' in ed:
-            out[(_enemy_class_enum(ed['class']), level)] += int(ed.get('count', 1))
+            for lv in _body_levels(ed):
+                out[(_enemy_class_enum(ed['class']), lv)] += 1
         else:
+            level = int(ed.get('level', 1))
             for cls in ed.get('composition', []):
                 out[(_enemy_class_enum(cls), level)] += 1
     return out
@@ -965,7 +1007,12 @@ def _force_signature(chap):
 
 def mirror_share(chap):
     """Share of the twin's force this chapter reproduces exactly, as
-    {shared, ours, twin, pct}. None when the reference isn't curated (#48 registry)."""
+    {shared, ours, twin, pct}. None when the reference isn't curated (#48 registry).
+
+    Takes no `mode`, and that is not an omission: a difficulty mode re-projects the SAME
+    level through a chapter's malus/bonus (`mode_stats`), so it moves stats and never a
+    unit's class or level, and the Hard-only waves are folded into both sides
+    unconditionally. The force's shape is identical in all three modes."""
     van = vanilla_red_units(chap.get('parity_reference'))
     if van is None:
         return None
@@ -2142,6 +2189,8 @@ def curve_report(campaign, band=0.25, mode=None):
     if mode:
         print('  NB per-unit role findings and planned-chapter targets below are graded on the'
               '\n     AUTHORED table, not on %s -- only the parity rows are mode-shifted.'
+              '\n     mirror%% is INVARIANT: a mode shifts stats, never a unit\'s class or level,'
+              '\n     and the Hard-only waves are folded into both sides unconditionally.'
               % mode.upper())
     print(bar)
     print('  %-22s %-13s %-15s %-17s %-7s %s'

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -314,8 +314,7 @@ def _body_levels(enemy_def):
     # body the ROM never emits -- and mirror% now compares body-for-body against the twin.
     stated = [(f, n) for f, n in
               (('composition', len(bag) if bag else None),
-               ('count', int(enemy_def['count']) if 'count' in enemy_def and not bag
-                else None),
+               ('count', int(enemy_def['count']) if 'count' in enemy_def else None),
                ('positions', len(enemy_def['positions'])
                 if enemy_def.get('positions') else None),
                ('levels', len(levels) if levels is not None else None))
@@ -930,21 +929,13 @@ def _our_base_level(enemy_def):
     return 1
 
 
-def chapter_roster_entries(chap):
-    """Every enemy entry the chapter fields, across ALL of its roster keys.
-
-    A reinforcement wave is part of the force. The twin's curated UnitDefinition arrays fold
-    its own waves in unconditionally (vanilla Ch2's `UnitDef_088B4470`, vanilla Ch6's
-    Hard-mode array), so a builder that reads only our opening board compares seven bodies
-    against nine and scores the two missing ones as divergence. ch06 already ran into this
-    and worked around it by declaring its turn-4 wave inside `enemy_units` -- its own YAML
-    says declaring them "is what makes the two sides count the same force". ch02 used the
-    `reinforcements:` key instead and was simply never counted.
-
-    The keys are AI_ROSTER_KEYS, so there is one answer to "what is this chapter's force"
-    and the AI guard and the parity metric cannot drift apart on it."""
-    return [ed for key in AI_ROSTER_KEYS for ed in (chap.get(key) or [])
-            if isinstance(ed, dict)]
+# ch06 ran into this first and worked around it privately, by declaring its turn-4 wave
+# inside `enemy_units` -- its own YAML says declaring them "is what makes the two sides count
+# the same force". ch02 used the `reinforcements:` key instead and was simply never counted.
+# The definition lives in build_campaign, which owns the chapter schema, so the parity
+# metric, the AI guard, the personal-line routes and the raw-pid registry cannot drift apart
+# on which units a chapter fields.
+chapter_roster_entries = bc.chapter_roster_entries
 
 
 def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff=True,
@@ -973,14 +964,18 @@ def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff
         name = ed.get('id', ed.get('name', 'enemy'))
         by_class = ed.get('inventory_by_class', {})
         bodies = list(zip(ed.get('composition', []), _body_levels(ed)))
+        # A bag NEVER takes a personal line, `real_article` or not: it is a mixed bag of
+        # GENERICS, and RAW_PID_PERSONAL_SOURCES routes one pid per unit id -- so at most
+        # one member could carry a line in the ROM while all N would be credited here. A
+        # `personal:` or donor-matching id on such an entry describes the GROUP.
+        # `base_level`/`shiftable` are resolved the same way the class branch resolves them,
+        # so a bag boss is not handed a malus the engine never applies.
         units = [_one_enemy('%s-%s' % (name, cls), cls, lv,
                             _weapon_for([{'id': w} for w in by_class.get(cls, [])]),
-                            mode=mode, shifts=shifts)
+                            mode=mode, shifts=shifts,
+                            base_level=_our_base_level(dict(ed, level=lv)),
+                            shiftable=_our_takes_difficulty_shift(ed))
                  for cls, lv in (dict.fromkeys(bodies) if distinct else bodies)]
-        if real_article:
-            # a bag is generics, so no per-member line -- but an entry-level `personal:` or
-            # donor id describes the GROUP and must still be applied (#284).
-            units = [unit_real_article(ed, c) for c in units]
     else:
         # One body per DECLARED level, not `count` copies of one: a wave authored as
         # `levels: [2, 3]` is an L2 and an L3, which is what the ROM emits. `base_level` is
@@ -1640,7 +1635,7 @@ def solo_contributors(chap, parity_ref, deploy_cap, floor=1.0, share=0.10):
 # Where a chapter's red force is authored. ch02 puts two of its nine under
 # `reinforcements:`, and a guard reading only `enemy_units:` would grade a chapter that
 # does not ship.
-AI_ROSTER_KEYS = ('enemy_units', 'reinforcements', 'enemy_reinforcements')
+AI_ROSTER_KEYS = bc.ENEMY_ROSTER_KEYS   # the AI guard was this roster's first reader
 
 
 def _donor_specs(enemy):

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -297,37 +297,11 @@ def _one_enemy(name, class_token, level, weapon, personal=None, mode=None, shift
                             shiftable=shiftable)
 
 
-def _body_levels(enemy_def):
-    """The level of each BODY an entry places, in order.
-
-    `levels:` is a PER-BODY list and it is what the ROM contains -- build_campaign zips it
-    with `positions` to emit one UnitDefinition per pair, so an entry carrying it declares
-    two L2/L3 brigands and not two copies of one level. Everything else is `count` bodies at
-    the entry's `level` (default 1). A `levels:` that disagrees with `count` is two
-    declarations of the same fact contradicting each other, so it raises rather than
-    truncating the way a bare zip() would."""
-    levels = enemy_def.get('levels')
-    bag = (enemy_def.get('composition') or []) if 'class' not in enemy_def else None
-    count = len(bag) if bag else int(enemy_def.get('count', 1))
-    # Every field that states the body count states the SAME fact, so they must agree.
-    # `positions` is the one build_campaign actually zips against, so a mismatch models a
-    # body the ROM never emits -- and mirror% now compares body-for-body against the twin.
-    stated = [(f, n) for f, n in
-              (('composition', len(bag) if bag else None),
-               ('count', int(enemy_def['count']) if 'count' in enemy_def else None),
-               ('positions', len(enemy_def['positions'])
-                if enemy_def.get('positions') else None),
-               ('levels', len(levels) if levels is not None else None))
-              if n is not None]
-    for field, n in stated:
-        if n != stated[0][1]:
-            raise ValueError('%r declares %s %d but %s %d -- they are the same fact and '
-                             'they disagree'
-                             % (enemy_def.get('id', enemy_def.get('name', 'enemy')),
-                                stated[0][0], stated[0][1], field, n))
-    if levels is None:
-        return [int(enemy_def.get('level', 1))] * count
-    return [int(lv) for lv in levels]
+# "What bodies does this entry place" is chapter-SCHEMA knowledge, so it lives beside the
+# roster keys on build_campaign's desk -- the ROM emitters, the raw-pid registry and every
+# metric here have to agree on it, and they did not (decisions.md -> "A parity ratio does not
+# say how much of the twin it COPIED").
+_body_levels = bc.entry_body_levels
 
 
 def _entry_body_count(enemy_def):
@@ -1785,11 +1759,16 @@ def role_findings(chap, parity_ref):
         elif not bar and van_tank > 0 and bk < van_tank * 0.5:
             out.append("boss %s takes %.1f rounds to kill%s; %s's tankiest unit takes %.1f -- "
                        'the climax may fold too fast' % (uid, bk, where, parity_ref, van_tank))
-    if len(bosses) > 1:
+    # The census counts ENTRIES, not bodies: `distinct` splits one entry into a row per
+    # declared level, and every row carries that entry's id -- so a boss authored
+    # `levels: [19, 20]` would otherwise read as two bosses named the same thing. The
+    # per-unit warnings above are deduped for the same reason.
+    boss_ids = list(dict.fromkeys(n for n, _c, _t in bosses))
+    if len(boss_ids) > 1:
         out.append('%d units flagged is_boss (%s) -- only the objective target should be a boss; '
                    'use a miniboss/convertible role for the others'
-                   % (len(bosses), ', '.join(n for n, _c, _t in bosses)))
-    return out
+                   % (len(boss_ids), ', '.join(boss_ids)))
+    return list(dict.fromkeys(out))
 
 
 def print_role_findings(chap, parity_ref):

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -307,15 +307,28 @@ def _body_levels(enemy_def):
     declarations of the same fact contradicting each other, so it raises rather than
     truncating the way a bare zip() would."""
     levels = enemy_def.get('levels')
-    count = int(enemy_def.get('count', 1))
+    bag = (enemy_def.get('composition') or []) if 'class' not in enemy_def else None
+    count = len(bag) if bag else int(enemy_def.get('count', 1))
     if levels is None:
         return [int(enemy_def.get('level', 1))] * count
-    if 'count' in enemy_def and len(levels) != count:
-        raise ValueError('%r declares count %d but %d levels (%r) -- they are the same '
-                         'fact and they disagree'
-                         % (enemy_def.get('id', enemy_def.get('name', 'enemy')),
-                            count, len(levels), levels))
+    for field, n in (('composition', len(bag) if bag else None),
+                     ('count', count if 'count' in enemy_def and not bag else None),
+                     ('positions', len(enemy_def['positions'])
+                      if enemy_def.get('positions') else None)):
+        # `positions` is what build_campaign actually zips `levels` against, so a mismatch
+        # there models a body the ROM never emits. Both are the same fact stated twice.
+        if n is not None and n != len(levels):
+            raise ValueError('%r declares %s %d but %d levels (%r) -- they are the same '
+                             'fact and they disagree'
+                             % (enemy_def.get('id', enemy_def.get('name', 'enemy')),
+                                field, n, len(levels), levels))
     return [int(lv) for lv in levels]
+
+
+def _entry_body_count(enemy_def):
+    """How many BODIES one entry places -- one per declared level, and `composition` is a
+    bag of generics whose length IS that count."""
+    return len(_body_levels(enemy_def))
 
 
 def enemy_combatants(enemy_def, mode=None, shifts=None, base_level=1, shiftable=True):
@@ -921,6 +934,46 @@ def chapter_roster_entries(chap):
             if isinstance(ed, dict)]
 
 
+def _entry_combatants(ed, mode=None, shifts=None, real_article=False, drop_staff=True):
+    """Every BODY one enemy entry places.
+
+    `drop_staff` drops a unit carrying no modeled weapon, which is what every PARITY metric
+    wants (it can contribute no damage, and `unmodeled_enemies` warns about it separately).
+    The cast tables want the opposite: a chapter's healer is a body our units can kill and
+    walk past, so `load_field` keeps it.
+
+    THE entry expander. It was three near-copies -- one in `chapter_units`, one in
+    `_entry_combatants`, one in `role_findings` -- which is how `levels:` came to be honored
+    in one reader and defaulted to L1 in the others.
+
+    `real_article` folds in the entry's personal line (#285); the aggregate metrics want
+    class base on both sides and pass it False. A `composition` entry is a bag of GENERICS,
+    so it never takes one.
+    """
+    if 'composition' in ed and 'class' not in ed:
+        name = ed.get('id', ed.get('name', 'enemy'))
+        by_class = ed.get('inventory_by_class', {})
+        units = [_one_enemy('%s-%s' % (name, cls), cls, lv,
+                            _weapon_for([{'id': w} for w in by_class.get(cls, [])]),
+                            mode=mode, shifts=shifts)
+                 for cls, lv in zip(ed.get('composition', []), _body_levels(ed))]
+    else:
+        # One body per DECLARED level, not `count` copies of one: a wave authored as
+        # `levels: [2, 3]` is an L2 and an L3, which is what the ROM emits. `base_level` is
+        # THIS body's level for a boss, since that is the floor the difficulty malus tests
+        # against -- reading it off `level:` while the body comes from `levels:` invents a
+        # malus the engine never applies.
+        units = []
+        for lv in _body_levels(ed):
+            units.extend(enemy_combatants(
+                dict(ed, level=lv), mode=mode, shifts=shifts,
+                base_level=_our_base_level(dict(ed, level=lv)),
+                shiftable=_our_takes_difficulty_shift(ed)))
+        if real_article:
+            units = [unit_real_article(ed, c) for c in units]
+    return [u for u in units if u.weapon is not None or not drop_staff]
+
+
 def chapter_units(chap, mode=None, shifts=None):
     """(enemy_def, real-article Combatant) for every BODY our chapter fields, weapons modeled.
 
@@ -929,27 +982,8 @@ def chapter_units(chap, mode=None, shifts=None):
     `composition` to its DISTINCT classes -- so on ch01 it counted 6 bodies where this counts 3
     and printed a share that contradicted the verdict directly above it (#285).
     """
-    out = []
-    for ed in chapter_roster_entries(chap):
-        if 'composition' in ed and 'class' not in ed:
-            level = ed.get('level', 1)
-            name = ed.get('id', ed.get('name', 'enemy'))
-            by_class = ed.get('inventory_by_class', {})
-            for cls in ed.get('composition', []):
-                weapon = _weapon_for([{'id': w} for w in by_class.get(cls, [])])
-                # generics: no personal line, deliberately (see chapter_enemy_force)
-                out.append((ed, _one_enemy('%s-%s' % (name, cls), cls, level, weapon,
-                                           mode=mode, shifts=shifts)))
-        else:
-            # one body per DECLARED level, not `count` copies of one: a wave authored as
-            # `levels: [2, 3]` is an L2 and an L3, which is what the ROM emits.
-            for lv in _body_levels(ed):
-                out.extend((ed, unit_real_article(ed, c))
-                           for c in enemy_combatants(dict(ed, level=lv), mode=mode,
-                                                     shifts=shifts,
-                                                     base_level=_our_base_level(ed),
-                                                     shiftable=_our_takes_difficulty_shift(ed)))
-    return [(ed, u) for ed, u in out if u.weapon is not None]  # drop staff-only enemies
+    return [(ed, u) for ed in chapter_roster_entries(chap)
+            for u in _entry_combatants(ed, mode=mode, shifts=shifts, real_article=True)]
 
 
 def unmodeled_enemies(chap):
@@ -957,7 +991,7 @@ def unmodeled_enemies(chap):
     them) -- returned as {id, is_boss} so the report can warn instead of silently skewing the
     verdict (#51). A boss here means the parity read for that chapter is untrustworthy."""
     out = []
-    for ed in chap.get('enemy_units', []):
+    for ed in chapter_roster_entries(chap):
         if 'composition' in ed and 'class' not in ed:
             by_class = ed.get('inventory_by_class', {})
             modeled = any(_weapon_for([{'id': w} for w in by_class.get(cls, [])])
@@ -999,9 +1033,8 @@ def _force_signature(chap):
             for lv in _body_levels(ed):
                 out[(_enemy_class_enum(ed['class']), lv)] += 1
         else:
-            level = int(ed.get('level', 1))
-            for cls in ed.get('composition', []):
-                out[(_enemy_class_enum(cls), level)] += 1
+            for cls, lv in zip(ed.get('composition', []), _body_levels(ed)):
+                out[(_enemy_class_enum(cls), lv)] += 1
     return out
 
 
@@ -1235,12 +1268,12 @@ def load_field(campaign, ch):
         chap = bc.yaml.safe_load(f)
     roster = [player_combatant(campaign, uid) for uid in ROSTER]
     line, bosses, labels = [], [], []
-    for ed in chap.get('enemy_units', []):
-        units = enemy_combatants(ed)
-        count = int(ed.get('count', 1))
+    for ed in chapter_roster_entries(chap):
+        units = _entry_combatants(ed, drop_staff=False)
         kind = ed.get('class') or '+'.join(dict.fromkeys(ed.get('composition', ['?'])))
-        labels.append('%dx %s (%s l%s)' % (count, ed.get('name', ed.get('id', '?')),
-                                           kind, ed.get('level', 1)))
+        labels.append('%dx %s (%s l%s)'
+                      % (_entry_body_count(ed), ed.get('name', ed.get('id', '?')), kind,
+                         ed.get('level') or ','.join(str(lv) for lv in _body_levels(ed))))
         (bosses if ed.get('is_boss') else line).extend(units)
     return chap, roster, line, bosses, chapter_deploy_limit(chap, len(roster)), labels
 
@@ -1562,7 +1595,7 @@ def solo_contributors(chap, parity_ref, deploy_cap, floor=1.0, share=0.10):
         return []
     # Built from the SAME force builder as the verdict this note is printed under (#285) -- a
     # note computed on a different footing than the number it explains is worse than none.
-    rows = [(ed.get('id') or u.name, int(ed.get('count', 1)),
+    rows = [(ed.get('id') or u.name, _entry_body_count(ed),
              fc.damage_per_round(u, YARDSTICK)) for ed, u in chapter_units(chap)]
     total = sum(t for _u, _n, t in rows)
     full = (total / cap) / vt
@@ -1674,15 +1707,14 @@ def role_findings(chap, parity_ref):
     if not van:
         return []
     ours, personal_by_id = [], {}
-    for ed in chap.get('enemy_units', []):
+    for ed in chapter_roster_entries(chap):
         if ed.get('personal'):
             personal_by_id[ed.get('id')] = ed['personal']
-        for c in enemy_combatants(ed):
-            # THREAT comparisons run on the real article (class base + personal line), the same
-            # footing the durability check below has always used. The AGGREGATE metric stays
-            # class-base on both sides -- that is a different question and a fair one.
-            ours.append((ed.get('id') or c.name, bool(ed.get('is_boss')),
-                         unit_real_article(ed, c),
+        # THREAT comparisons run on the real article (class base + personal line), the same
+        # footing the durability check below has always used. The AGGREGATE metric stays
+        # class-base on both sides -- that is a different question and a fair one.
+        for c in _entry_combatants(ed, real_article=True, drop_staff=False):
+            ours.append((ed.get('id') or c.name, bool(ed.get('is_boss')), c,
                          bool(ed.get('convertible')), ed.get('tile_terrain')))
     if not ours:
         return []
@@ -2031,32 +2063,24 @@ def _vanilla_reinforcement_turns(stem):
     return out
 
 
-def _entry_combatants(ed):
-    """The Combatants for one enemy_units entry (count/composition expanded, weapon-filtered)."""
-    if 'composition' in ed and 'class' not in ed:
-        level = ed.get('level', 1)
-        name = ed.get('id', ed.get('name', 'enemy'))
-        by_class = ed.get('inventory_by_class', {})
-        units = [_one_enemy('%s-%s' % (name, cls), cls, level,
-                            _weapon_for([{'id': w} for w in by_class.get(cls, [])]))
-                 for cls in ed.get('composition', [])]
-    else:
-        units = enemy_combatants(ed) * int(ed.get('count', 1))
-    return [u for u in units if u.weapon is not None]
-
-
 def chapter_enemy_groups(chap):
     """Our force split by battlefield role (#171): line (turn-1 must-kill), reinforcements
     (arrives_turn > 1), convertibles (recruitable). Each a Combatant list."""
     g = {'line': [], 'reinforcements': [], 'convertibles': []}
-    for ed in chap.get('enemy_units', []):
-        units = _entry_combatants(ed)
-        if ed.get('convertible'):
-            g['convertibles'].extend(units)
-        elif int(ed.get('arrives_turn', 1) or 1) > 1:
-            g['reinforcements'].extend(units)
-        else:
-            g['line'].extend(units)
+    for key in AI_ROSTER_KEYS:
+        for ed in (chap.get(key) or []):
+            if not isinstance(ed, dict):
+                continue
+            units = _entry_combatants(ed)
+            if ed.get('convertible'):
+                g['convertibles'].extend(units)
+            elif key != 'enemy_units' or int(ed.get('arrives_turn', 1) or 1) > 1:
+                # the KEY is what makes ch02's wave a reinforcement: it carries
+                # `trigger_turn`, not `arrives_turn`, so an arrives_turn test alone read it
+                # as turn-1 line.
+                g['reinforcements'].extend(units)
+            else:
+                g['line'].extend(units)
     return g
 
 

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -7074,6 +7074,13 @@ class RawPidBossBaseLevel(unittest.TestCase):
         self.assertEqual(missing, [],
                          'raw-pid boss(es) with no RAW_PID_LEVEL_SOURCES row: %s' % missing)
 
+    def test_a_raw_pid_boss_under_any_roster_key_is_caught(self):
+        # `_our_base_level` models every boss as malus-immune WHEREVER it is declared, and
+        # this registry is what makes that true -- so the guard has to look everywhere too.
+        for key in bc.ENEMY_ROSTER_KEYS:
+            chap = {key: [{'id': 'stowaway', 'is_boss': True, 'level': 9}]}
+            self.assertEqual(bc._unregistered_raw_pid_boss_entries(chap), ['stowaway'], key)
+
     def test_registry_resolves_each_boss_to_its_deploy_level(self):
         got = bc.raw_pid_base_levels('rime-of-the-frostmaiden')
         self.assertEqual({k: got.get(k) for k in self.RAW_BOSSES}, self.RAW_BOSSES)

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -7074,6 +7074,20 @@ class RawPidBossBaseLevel(unittest.TestCase):
         self.assertEqual(missing, [],
                          'raw-pid boss(es) with no RAW_PID_LEVEL_SOURCES row: %s' % missing)
 
+    def test_the_registry_READER_sees_every_roster_key_too(self):
+        # otherwise the guard has no reachable green state: a raw-pid boss under
+        # `reinforcements:` is flagged as unregistered, and adding the row that silences it
+        # makes the reader sys.exit("does not exist") and kills the build.
+        chap = {'reinforcements': [{'id': 'stowaway', 'is_boss': True, 'level': 9}]}
+        self.assertEqual(bc._entry_base_level_in(chap, 'stowaway'), 9)
+
+    def test_the_registry_reads_a_DECLARED_body_level(self):
+        # `levels:` is the per-body list the ROM is built from; reading `level:` past it
+        # writes baseLevel 1 (so the malus fires) while the model treats the boss as
+        # malus-immune at its real level.
+        chap = {'enemy_units': [{'id': 'b', 'is_boss': True, 'levels': [9]}]}
+        self.assertEqual(bc._entry_base_level_in(chap, 'b'), 9)
+
     def test_a_raw_pid_boss_under_any_roster_key_is_caught(self):
         # `_our_base_level` models every boss as malus-immune WHEREVER it is declared, and
         # this registry is what makes that true -- so the guard has to look everywhere too.

--- a/tools/test_check_chapter_schema.py
+++ b/tools/test_check_chapter_schema.py
@@ -170,8 +170,8 @@ class TestPersonalLineRoutes(unittest.TestCase):
         return check._personal_line_route_violations(
             'chNN.yaml', d, injected_ids=set(injected), slot_ids=set(slots))
 
-    def _chap(self, unit):
-        return {'status': 'active', 'enemy_units': [unit]}
+    def _chap(self, unit, key='enemy_units'):
+        return {'status': 'active', key: [unit]}
 
     def test_a_line_with_an_injection_route_is_fine(self):
         self.assertEqual(self.routes(self._chap(
@@ -185,12 +185,31 @@ class TestPersonalLineRoutes(unittest.TestCase):
         self.assertEqual(len(msgs), 1, msgs)
         self.assertIn('RAW_PID_PERSONAL_SOURCES', msgs[0])
 
+    def test_a_line_under_a_reinforcement_key_is_routed_too(self):
+        # the parity metric folds `personal:` from EVERY roster key into the verdict, so a
+        # boss parked under `reinforcements:` measures fixed and plays naked with no gate.
+        for key in ('reinforcements', 'enemy_reinforcements'):
+            msgs = self.routes(self._chap({'id': 'newboss', 'personal': {'baseHP': 9}},
+                                          key=key))
+            self.assertEqual(len(msgs), 1, (key, msgs))
+
     def test_a_line_on_a_slot_riding_unit_is_caught(self):
         # The dangerous direction: it never reaches the ROM *and* it displaces the slot's real
         # line in the measurement, understating the boss worse than the bug that started #284.
         msgs = self.routes(self._chap({'id': 'raider-captain', 'personal': {'baseHP': 1}}))
         self.assertEqual(len(msgs), 1, msgs)
         self.assertIn('already carries', msgs[0])
+
+
+class TestRosterKeysAgree(unittest.TestCase):
+    def test_checks_roster_keys_match_the_content_desks(self):
+        # check.py names them rather than importing, so the bare-interpreter `checks` job
+        # stays import-free -- which is only safe if a divergence fails here.
+        try:
+            import build_campaign as bc
+        except ImportError as e:
+            self.skipTest('build_campaign unavailable (%s)' % e)
+        self.assertEqual(check.ROSTER_KEYS, bc.ENEMY_ROSTER_KEYS)
 
 
 class TestRealChapters(unittest.TestCase):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -467,6 +467,114 @@ class AiFindingsInTheCurveReport(unittest.TestCase):
         self.assertTrue(all('ai' in r for r in self._rows().values()))
 
 
+class MirrorShare(unittest.TestCase):
+    """mirror% -- the share of the TWIN's force a chapter reproduces exactly (class + level).
+
+    It is what separates a copy-x1.00 from a composed-x1.00: the parity ratio is an
+    aggregate over stats, so a chapter that transcribes its twin unit for unit and a
+    chapter that arrives at the same per-slot pressure from a different force read
+    identically. #367's finding was that ch06 is the first, and its x1.00 was a checksum
+    on the donor pipeline rather than a measurement.
+
+    vanilla Prologue's red force is 3 fighters: L4, L1, L2.
+    """
+
+    def _chap(self, enemies, ref='FE8 Prologue'):
+        return {'parity_reference': ref, 'enemy_units': enemies}
+
+    def test_a_force_transcribed_unit_for_unit_is_a_full_mirror(self):
+        m = df.mirror_share(self._chap([{'id': 'a', 'class': 'fighter', 'level': 4},
+                                        {'id': 'b', 'class': 'fighter', 'level': 1},
+                                        {'id': 'c', 'class': 'fighter', 'level': 2}]))
+        self.assertEqual((m['shared'], m['twin']), (3, 3))
+        self.assertEqual(m['pct'], 100.0)
+
+    def test_a_force_sharing_nothing_with_its_twin_mirrors_zero(self):
+        m = df.mirror_share(self._chap([{'id': 'a', 'class': 'mage', 'level': 4}]))
+        self.assertEqual((m['shared'], m['pct']), (0, 0.0))
+
+    def test_the_same_class_at_a_different_level_is_not_a_mirror(self):
+        # class alone is not the unit: an L9 fighter is not the twin's L1 one.
+        m = df.mirror_share(self._chap([{'id': 'a', 'class': 'fighter', 'level': 9}]))
+        self.assertEqual(m['shared'], 0)
+
+    def test_a_partial_match_is_a_share_of_the_TWINS_force(self):
+        m = df.mirror_share(self._chap([{'id': 'a', 'class': 'fighter', 'level': 4}]))
+        self.assertEqual((m['shared'], m['twin']), (1, 3))
+        self.assertAlmostEqual(m['pct'], 100.0 / 3)
+
+    def test_count_expands_into_that_many_bodies(self):
+        # our two L2 fighters can only mirror the twin's ONE: the intersection is a
+        # multiset, so a doubled body does not score twice.
+        m = df.mirror_share(self._chap([{'id': 'a', 'class': 'fighter', 'level': 2,
+                                         'count': 2}]))
+        self.assertEqual(m['shared'], 1)
+
+    def test_a_composition_entry_expands_per_member(self):
+        m = df.mirror_share(self._chap([{'id': 'a', 'level': 2,
+                                         'composition': ['fighter', 'fighter']}]))
+        self.assertEqual(m['shared'], 1)
+
+    def test_fielding_more_than_the_twin_never_reads_above_100(self):
+        m = df.mirror_share(self._chap([{'id': 'a', 'class': 'fighter', 'level': 4},
+                                        {'id': 'b', 'class': 'fighter', 'level': 1},
+                                        {'id': 'c', 'class': 'fighter', 'level': 2},
+                                        {'id': 'd', 'class': 'fighter', 'level': 2}]))
+        self.assertEqual(m['pct'], 100.0)
+
+    def test_reinforcement_waves_count_as_part_of_our_force(self):
+        chap = self._chap([{'id': 'a', 'class': 'fighter', 'level': 4}])
+        chap['reinforcements'] = [{'id': 'late', 'class': 'fighter', 'level': 1}]
+        self.assertEqual(df.mirror_share(chap)['shared'], 2)
+
+    def test_a_staff_only_unit_still_counts_as_a_body(self):
+        # the parity metric DROPS a unit with no modeled weapon; mirror% is about the
+        # force's SHAPE, so a healer the twin fields is a unit the chapter did or did not
+        # reproduce.
+        m = df.mirror_share(self._chap([{'id': 'h', 'class': 'troubadour', 'level': 6}],
+                                       ref='FE8 Ch6'))
+        self.assertEqual(m['shared'], 1)
+
+    def test_an_uncurated_twin_has_no_mirror_to_measure(self):
+        self.assertIsNone(df.mirror_share(self._chap([{'id': 'a'}], ref='FE8 Ch99')))
+
+
+class MirrorShareOnRealChapters(unittest.TestCase):
+    """Against the real campaign, because the wiring is the thing under test."""
+
+    def _mirror(self, ch):
+        chap = bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.chapter_yaml_for(ch))
+        return df.mirror_share(chap)
+
+    def test_ch06_reproduces_its_twin_exactly(self):
+        # ch06 IS vanilla Ch6's 27-unit force, re-sited. This is the number that makes its
+        # x1.00 legible as a copy (#367).
+        self.assertEqual(self._mirror('ch06')['pct'], 100.0)
+
+    def test_a_composed_chapter_reads_well_under_a_copy(self):
+        # ch01 fields ten units against a ten-unit twin and mirrors three of them.
+        self.assertEqual(self._mirror('ch01')['shared'], 3)
+
+
+class MirrorInTheCurveReport(unittest.TestCase):
+    def _rows(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            return {r['label'].split()[0]: r
+                    for r in df.curve_report('rime-of-the-frostmaiden')}
+
+    def test_every_row_carries_its_mirror_share(self):
+        self.assertEqual(self._rows()['CH6']['mirror']['pct'], 100.0)
+
+    def test_the_curve_prints_mirror_beside_the_parity_ratio(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            df.curve_report('rime-of-the-frostmaiden')
+        text = out.getvalue()
+        self.assertIn('mirror', text)
+        ch06_row = [l for l in text.splitlines() if 'ch06' in l][0]
+        self.assertIn('100%', ch06_row)
+
+
 class VanillaUnitDestinations(unittest.TestCase):
     """#335: a vanilla unit's `xPosition`/`yPosition` is often a SPAWN tile, not where it
     fights. `redas` is scripted movement data that walks it from there to its post, and the

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -722,6 +722,17 @@ class RoleFindingsGradeTypesNotBodies(unittest.TestCase):
         findings = df.role_findings(self._ch08(), self._ch08().get('parity_reference'))
         self.assertEqual(len(findings), len(set(findings)), findings)
 
+    def test_one_ENTRY_is_one_boss_however_many_levels_it_declares(self):
+        # `distinct` splits an entry by level, and all its rows share the entry's id -- so a
+        # boss authored `levels: [19, 20]` re-created the census bug that `count: 4` had.
+        chap = {'parity_reference': 'FE8 Prologue',
+                'enemy_units': [{'id': 'w', 'class': 'general', 'levels': [19, 20],
+                                 'is_boss': True,
+                                 'inventory': [{'id': 'silver-lance'}]}]}
+        findings = df.role_findings(chap, 'FE8 Prologue')
+        self.assertEqual([f for f in findings if 'flagged is_boss' in f], [], findings)
+        self.assertEqual(len(findings), len(set(findings)), findings)
+
     def test_bodies_at_DIFFERENT_levels_are_different_types(self):
         # `levels: [2, 3]` is two distinct units and both get graded; `count: 2` is one.
         ed = {'id': 'w', 'class': 'general', 'levels': [19, 20], 'is_boss': True,
@@ -777,6 +788,18 @@ class DeclaredCountsMustAgree(unittest.TestCase):
         with self.assertRaises(ValueError):
             df._body_levels({'id': 'w', 'count': 3, 'level': 2,
                              'positions': [[0, 6], [0, 7]]})
+
+    def test_positions_alone_declares_the_body_count(self):
+        # build_campaign enumerates `positions` to emit units, so three positions are three
+        # bodies whether or not a `count:` says so -- defaulting to 1 under-counts the force
+        # everywhere, mirror% included.
+        self.assertEqual(df._body_levels({'level': 4, 'positions': [[1, 1], [2, 2], [3, 3]]}),
+                         [4, 4, 4])
+
+    def test_an_entry_that_places_no_body_is_named_in_the_error(self):
+        with self.assertRaises(ValueError) as cm:
+            df._body_levels({'id': 'ghost', 'count': 0})
+        self.assertIn('ghost', str(cm.exception))
 
     def test_a_stale_count_on_a_bag_entry_is_caught_too(self):
         # the bag's length is the body count, so a `count:` beside it is the same fact --

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -699,6 +699,77 @@ class DeclaredLevelsEverywhere(unittest.TestCase):
         self.assertEqual(df._entry_body_count({'composition': ['a', 'b', 'c']}), 3)
 
 
+class RoleFindingsGradeTypesNotBodies(unittest.TestCase):
+    """`role_findings` asks a per-UNIT question -- is this unit's threat an outlier, is this
+    boss too soft -- and the answer is a property of the unit type, not of how many copies
+    stand on the map. Expanding it per body repeated every warning `count` times and made
+    the boss census count copies: ch08's `count: 4` ice-troll read as "4 units flagged
+    is_boss (ice-troll, ice-troll, ice-troll, ice-troll)". `role` is a `--check` gate arm,
+    so that reds CI on the first locked chapter with a multi-copy boss entry."""
+
+    def _ch08(self):
+        # ch08 is `status: planned`, so it has no host slot and no CH08_CHAPTER_YAML --
+        # read the file directly. It is the live case: a `count: 4` boss entry.
+        with open(df.chapter_path('rime-of-the-frostmaiden', 'ch08'), encoding='utf-8') as f:
+            return bc.yaml.safe_load(f)
+
+    def test_a_multi_copy_boss_entry_is_ONE_boss(self):
+        findings = df.role_findings(self._ch08(), self._ch08().get('parity_reference'))
+        census = [f for f in findings if 'flagged is_boss' in f]
+        self.assertEqual(census, [], census)
+
+    def test_a_warning_is_stated_once_per_unit_type(self):
+        findings = df.role_findings(self._ch08(), self._ch08().get('parity_reference'))
+        self.assertEqual(len(findings), len(set(findings)), findings)
+
+    def test_bodies_at_DIFFERENT_levels_are_different_types(self):
+        # `levels: [2, 3]` is two distinct units and both get graded; `count: 2` is one.
+        ed = {'id': 'w', 'class': 'general', 'levels': [19, 20], 'is_boss': True,
+              'inventory': [{'id': 'silver-lance'}]}
+        self.assertEqual(len(df._entry_combatants(ed, distinct=True)), 2)
+        self.assertEqual(len(df._entry_combatants(dict(ed, levels=None, level=20, count=2),
+                                                  distinct=True)), 1)
+
+
+class GuardsSeeTheWholeRoster(unittest.TestCase):
+    def test_the_boss_malus_guard_reads_every_roster_key_and_declared_level(self):
+        # `_our_base_level` treats every boss as malus-immune; this guard is what makes that
+        # true. A boss declared under `reinforcements:`, or one whose level comes from
+        # `levels:`, was invisible to it while still riding the assumption.
+        donor = sorted(bc.ENEMY_BASE_SLOT.items())[0]
+        uid, slot = donor
+        over = df._character_base_level(slot) + 5
+        chap = {'reinforcements': [{'id': uid, 'is_boss': True, 'levels': [over],
+                                    'class': 'general'}]}
+        self.assertEqual(df._boss_entries_over_donor_base_level(chap), [uid])
+
+    def test_a_drop_on_a_reinforcement_wave_is_part_of_the_economy(self):
+        chap = {'reinforcements': [{'id': 'w', 'item_drop': 'elixir'}]}
+        self.assertEqual(df.chapter_economy(chap)['drops'], ['elixir'])
+
+    def test_a_bag_entry_is_graded_on_its_real_article(self):
+        # a `composition` entry carrying a personal line was graded at naked class base
+        # once the expander stopped applying it -- the #284 failure mode.
+        ed = {'id': 'bag', 'composition': ['general'], 'level': 10,
+              'personal': {'hp': 20}, 'inventory_by_class': {'general': ['silver-lance']}}
+        plain = df._entry_combatants(ed)[0]
+        real = df._entry_combatants(ed, real_article=True)[0]
+        self.assertEqual(real.hp, plain.hp + 20)
+
+
+class DeclaredCountsMustAgree(unittest.TestCase):
+    def test_positions_and_count_are_cross_checked_even_without_levels(self):
+        # `positions` is what build_campaign zips against; a mismatch models a force the
+        # ROM never emits, and mirror% now compares body-for-body against the twin on it.
+        with self.assertRaises(ValueError):
+            df._body_levels({'id': 'w', 'count': 3, 'level': 2,
+                             'positions': [[0, 6], [0, 7]]})
+
+    def test_agreeing_declarations_pass(self):
+        self.assertEqual(df._body_levels({'count': 2, 'level': 2,
+                                          'positions': [[0, 6], [0, 7]]}), [2, 2])
+
+
 class MirrorShareOnRealChapters(unittest.TestCase):
     """Against the real campaign, because the wiring is the thing under test."""
 

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -598,12 +598,105 @@ class ReinforcementsAreOurForce(unittest.TestCase):
         self.assertEqual(p['n_ours'], p['n_vanilla'])
 
     def test_the_wave_is_modeled_at_its_declared_levels(self):
-        levels = sorted(u.name for ed, u in df.chapter_units(self._ch02())
-                        if ed.get('id') == 'rear-raiders')
-        self.assertEqual(len(levels), 2)
+        # `levels: [2, 3]`, so the two bodies must differ -- an L1/L1 pair (the old default)
+        # and an L2/L2 pair (count-expansion of one level) both fail here.
+        bodies = [u for ed, u in df.chapter_units(self._ch02())
+                  if ed.get('id') == 'rear-raiders']
+        self.assertEqual(len(bodies), 2)
+        brig = df._class_base('CLASS_BRIGAND')
+        growths = df._class_growths('CLASS_BRIGAND')
+        self.assertEqual(sorted(b.hp for b in bodies),
+                         sorted(df.autolevel(brig, growths, lv)['baseHP'] for lv in (2, 3)))
 
     def test_ch02_transcribes_its_twin_once_its_wave_is_counted(self):
         self.assertEqual(df.mirror_share(self._ch02())['pct'], 100.0)
+
+
+class OneForceEveryReader(unittest.TestCase):
+    """Widening "what is this chapter's force" for the verdict and leaving the readers around
+    it on `enemy_units` produces a report that contradicts itself on one page: ch02 printed
+    "ours (9 enemies)" two lines above "ours line 7 · reinf 0". Every reader of the force
+    reads the same roster."""
+
+    def _ch02(self):
+        return bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.chapter_yaml_for('ch02'))
+
+    def test_the_dynamics_split_buckets_the_wave_the_verdict_counted(self):
+        g = df.chapter_enemy_groups(self._ch02())
+        self.assertEqual(len(g['reinforcements']), 2)
+        self.assertEqual(sum(len(v) for v in g.values()),
+                         df._chapter_pressure(self._ch02())['n_ours'])
+
+    def test_an_entry_under_a_reinforcement_key_is_a_reinforcement_by_the_KEY(self):
+        # ch02's wave carries `trigger_turn`, not `arrives_turn`: the key it is declared
+        # under is what makes it a reinforcement, and an arrives_turn test alone read it
+        # as turn-1 line.
+        chap = {'reinforcements': [{'id': 'w', 'class': 'brigand', 'level': 2,
+                                    'inventory': [{'id': 'iron-axe'}]}]}
+        g = df.chapter_enemy_groups(chap)
+        self.assertEqual(len(g['reinforcements']), 1)
+        self.assertEqual(g['line'], [])
+
+    def test_a_staff_only_wave_is_reported_as_unmodeled(self):
+        chap = {'reinforcements': [{'id': 'healer', 'class': 'priest', 'level': 3,
+                                    'is_boss': True, 'inventory': [{'id': 'heal'}]}]}
+        self.assertEqual([d['id'] for d in df.unmodeled_enemies(chap)], ['healer'])
+
+    def test_the_cast_tables_grade_the_same_force_as_the_verdict(self):
+        chap, roster, line, bosses, cap, labels = df.load_field(
+            'rime-of-the-frostmaiden', 'ch02')
+        self.assertEqual(len(line) + len(bosses),
+                         df._chapter_pressure(chap)['n_ours'])
+
+    def test_role_findings_grade_a_unit_declared_under_a_reinforcement_key(self):
+        # a monstrous boss hidden under `reinforcements:` was invisible to the per-unit
+        # gate arm while contributing its threat to the aggregate.
+        chap = {'parity_reference': 'FE8 Prologue',
+                'reinforcements': [{'id': 'sleeper', 'class': 'general', 'level': 20,
+                                    'is_boss': True,
+                                    'inventory': [{'id': 'silver-lance'}]}]}
+        self.assertTrue(any('sleeper' in f for f in df.role_findings(chap, 'FE8 Prologue')))
+
+
+class DeclaredLevelsEverywhere(unittest.TestCase):
+    def test_a_composition_wave_honors_its_per_body_levels(self):
+        chap = {'parity_reference': 'FE8 Prologue',
+                'enemy_units': [{'id': 'a', 'composition': ['fighter', 'fighter'],
+                                 'levels': [1, 2]}]}
+        self.assertEqual(df.mirror_share(chap)['shared'], 2)
+
+    def test_levels_must_agree_with_the_positions_the_rom_zips_them_against(self):
+        with self.assertRaises(ValueError):
+            df._body_levels({'levels': [2, 3], 'positions': [[0, 6]]})
+
+    def test_a_composition_declares_its_body_count_too(self):
+        # the bag's length is the body count, so `levels:` must match it -- indexing past
+        # the list would raise IndexError deep in the expander instead of naming the entry.
+        with self.assertRaises(ValueError):
+            df._body_levels({'id': 'bag', 'composition': ['fighter', 'fighter'],
+                             'levels': [1]})
+
+    def test_a_composition_without_levels_is_one_body_per_member(self):
+        self.assertEqual(df._body_levels({'composition': ['a', 'b'], 'level': 4}), [4, 4])
+
+    def test_a_boss_carries_ITS_bodys_level_as_its_malus_floor(self):
+        # `base_level` is the >= baseLevel gate a difficulty malus floors against. Reading
+        # it off `level:` while the body comes from `levels:` gives a boss base_level 1 and
+        # a malus the ROM never applies.
+        chap = {'enemy_units': [{'id': 'b', 'class': 'general', 'is_boss': True,
+                                 'levels': [10],
+                                 'inventory': [{'id': 'silver-lance'}]}]}
+        shifts = {'tutorial': 4, 'normal': 2, 'difficult': 3}
+        plain = df.chapter_units(chap)[0][1]
+        shifted = df.chapter_units(chap, mode='tutorial', shifts=shifts)[0][1]
+        self.assertEqual(plain.hp, shifted.hp)   # boss is at its baseLevel: no malus
+
+    def test_solo_contributors_counts_BODIES_not_the_count_field(self):
+        # a `levels:`-only entry has no `count:`; reading count as 1 made every body of it
+        # eligible for the single-unit NOTE.
+        self.assertEqual(df._entry_body_count({'levels': [2, 3, 4]}), 3)
+        self.assertEqual(df._entry_body_count({'count': 2, 'level': 3}), 2)
+        self.assertEqual(df._entry_body_count({'composition': ['a', 'b', 'c']}), 3)
 
 
 class MirrorShareOnRealChapters(unittest.TestCase):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -539,6 +539,73 @@ class MirrorShare(unittest.TestCase):
         self.assertIsNone(df.mirror_share(self._chap([{'id': 'a'}], ref='FE8 Ch99')))
 
 
+class PerBodyLevels(unittest.TestCase):
+    """`levels:` is a PER-BODY list, and it is what the ROM writes.
+
+    ch02's rear-raider wave declares `count: 2` with `levels: [2, 3]` and no `level:` --
+    build_campaign zips positions with levels to emit the two UnitDefinitions. A reader
+    that only knows `level:` falls through to the default and models the pair as two L1
+    brigands, which is neither what the chapter declares nor what the ROM contains.
+    """
+
+    def test_a_levels_list_gives_each_body_its_own_level(self):
+        self.assertEqual(df._body_levels({'count': 2, 'levels': [2, 3]}), [2, 3])
+
+    def test_without_levels_every_body_carries_the_entrys_level(self):
+        self.assertEqual(df._body_levels({'count': 3, 'level': 5}), [5, 5, 5])
+
+    def test_a_bare_entry_is_one_body_at_level_one(self):
+        self.assertEqual(df._body_levels({}), [1])
+
+    def test_levels_disagreeing_with_count_is_a_contradiction_not_a_truncation(self):
+        # zip() would silently drop the third body; two declarations of the same fact
+        # that disagree is a data error, and the ROM emitter zips them too.
+        with self.assertRaises(ValueError):
+            df._body_levels({'count': 3, 'levels': [2, 3]})
+
+    def test_a_wave_with_per_body_levels_mirrors_each_of_them(self):
+        chap = {'parity_reference': 'FE8 Prologue',
+                'enemy_units': [{'id': 'a', 'class': 'fighter', 'count': 2,
+                                 'levels': [1, 2]}]}
+        self.assertEqual(df.mirror_share(chap)['shared'], 2)
+
+
+class EveryRosterKeyIsAForce(unittest.TestCase):
+    """The module already names its three roster keys once, in AI_ROSTER_KEYS. A force
+    builder that hand-rolls two of them silently scores a wave under the third as pure
+    divergence."""
+
+    def test_a_wave_under_any_roster_key_counts_as_our_force(self):
+        for key in df.AI_ROSTER_KEYS:
+            chap = {'parity_reference': 'FE8 Prologue',
+                    key: [{'id': 'a', 'class': 'fighter', 'level': 4}]}
+            self.assertEqual(df.mirror_share(chap)['shared'], 1, key)
+
+
+class ReinforcementsAreOurForce(unittest.TestCase):
+    """The twin's curated arrays fold its reinforcement waves in unconditionally, so a
+    force builder that reads only our opening board compares 7 bodies against 9 and calls
+    the missing two divergence. ch06 already discovered this and worked around it by
+    declaring its turn-4 wave inside `enemy_units`; ch02 used the `reinforcements:` key
+    and was never counted.
+    """
+
+    def _ch02(self):
+        return bc._load_chapter_yaml('rime-of-the-frostmaiden', bc.chapter_yaml_for('ch02'))
+
+    def test_our_side_fields_as_many_bodies_as_the_twin(self):
+        p = df._chapter_pressure(self._ch02())
+        self.assertEqual(p['n_ours'], p['n_vanilla'])
+
+    def test_the_wave_is_modeled_at_its_declared_levels(self):
+        levels = sorted(u.name for ed, u in df.chapter_units(self._ch02())
+                        if ed.get('id') == 'rear-raiders')
+        self.assertEqual(len(levels), 2)
+
+    def test_ch02_transcribes_its_twin_once_its_wave_is_counted(self):
+        self.assertEqual(df.mirror_share(self._ch02())['pct'], 100.0)
+
+
 class MirrorShareOnRealChapters(unittest.TestCase):
     """Against the real campaign, because the wiring is the thing under test."""
 
@@ -573,6 +640,34 @@ class MirrorInTheCurveReport(unittest.TestCase):
         self.assertIn('mirror', text)
         ch06_row = [l for l in text.splitlines() if 'ch06' in l][0]
         self.assertIn('100%', ch06_row)
+
+
+class MirrorIsModeInvariant(unittest.TestCase):
+    """A difficulty mode shifts STATS, never a unit's class or level (`mode_stats` re-projects
+    the same level through the chapter's malus/bonus), and the mode-gated bodies -- ch06's
+    Hard-only turn-4 wave, vanilla's Hard reinforcement arrays -- are folded into BOTH sides
+    unconditionally. So the force's shape is the same in all three modes and mirror% is
+    invariant by construction. The report has to say so: it sits on a row whose banner
+    declares the other figures mode-shifted."""
+
+    def _text(self, mode=None):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            df.curve_report('rime-of-the-frostmaiden', mode=mode)
+        return out.getvalue()
+
+    def _mirror_column(self, text):
+        return [l.split()[-2] for l in text.splitlines()
+                if l.startswith('  CH') and '%' in l]
+
+    def test_the_mode_banner_names_mirror_among_the_unshifted_figures(self):
+        self.assertIn('mirror', self._text(mode='difficult').split('NB')[1].split('=====')[0])
+
+    def test_every_mirror_reads_the_same_in_every_mode(self):
+        base = self._mirror_column(self._text())
+        self.assertTrue(base)
+        for mode in ('tutorial', 'normal', 'difficult'):
+            self.assertEqual(self._mirror_column(self._text(mode=mode)), base, mode)
 
 
 class VanillaUnitDestinations(unittest.TestCase):

--- a/tools/test_difficulty.py
+++ b/tools/test_difficulty.py
@@ -747,14 +747,27 @@ class GuardsSeeTheWholeRoster(unittest.TestCase):
         chap = {'reinforcements': [{'id': 'w', 'item_drop': 'elixir'}]}
         self.assertEqual(df.chapter_economy(chap)['drops'], ['elixir'])
 
-    def test_a_bag_entry_is_graded_on_its_real_article(self):
-        # a `composition` entry carrying a personal line was graded at naked class base
-        # once the expander stopped applying it -- the #284 failure mode.
-        ed = {'id': 'bag', 'composition': ['general'], 'level': 10,
-              'personal': {'hp': 20}, 'inventory_by_class': {'general': ['silver-lance']}}
-        plain = df._entry_combatants(ed)[0]
-        real = df._entry_combatants(ed, real_article=True)[0]
-        self.assertEqual(real.hp, plain.hp + 20)
+    def test_a_bag_NEVER_takes_a_personal_line(self):
+        # The documented rule (chapter_enemy_force): a `composition` entry is a mixed bag of
+        # GENERICS, and `RAW_PID_PERSONAL_SOURCES` routes one pid per unit id -- so at most
+        # one member could carry a line in the ROM while all N would be credited here. A
+        # `personal:` on such an entry describes the GROUP; applying it per member is a
+        # silent multiplier.
+        ed = {'id': 'bag', 'composition': ['general', 'general'], 'level': 10,
+              'personal': {'hp': 20},
+              'inventory_by_class': {'general': ['silver-lance']}}
+        plain = df._entry_combatants(ed)
+        real = df._entry_combatants(ed, real_article=True)
+        self.assertEqual([u.hp for u in real], [u.hp for u in plain])
+
+    def test_a_bag_body_is_shifted_the_way_the_ENGINE_would_shift_it(self):
+        # the bag branch passed base_level=1/shiftable=True by construction while the class
+        # branch resolved both, so a bag boss took a malus the ROM never applies.
+        ed = {'id': 'bag', 'composition': ['general'], 'level': 10, 'is_boss': True,
+              'inventory_by_class': {'general': ['silver-lance']}}
+        shifts = {'tutorial': 4, 'normal': 2, 'difficult': 3}
+        self.assertEqual(df._entry_combatants(ed)[0].hp,
+                         df._entry_combatants(ed, mode='tutorial', shifts=shifts)[0].hp)
 
 
 class DeclaredCountsMustAgree(unittest.TestCase):
@@ -764,6 +777,12 @@ class DeclaredCountsMustAgree(unittest.TestCase):
         with self.assertRaises(ValueError):
             df._body_levels({'id': 'w', 'count': 3, 'level': 2,
                              'positions': [[0, 6], [0, 7]]})
+
+    def test_a_stale_count_on_a_bag_entry_is_caught_too(self):
+        # the bag's length is the body count, so a `count:` beside it is the same fact --
+        # and a stale one silently models a force the ROM never emits.
+        with self.assertRaises(ValueError):
+            df._body_levels({'id': 'bag', 'composition': ['a', 'b'], 'count': 3})
 
     def test_agreeing_declarations_pass(self):
         self.assertEqual(df._body_levels({'count': 2, 'level': 2,


### PR DESCRIPTION
Proposal 1 off #367, and Nicolas's first Next task.

## The problem

The parity ratio is an aggregate over stats, so it cannot distinguish a chapter that transcribes its twin unit for unit from one that composes a different force arriving at the same per-slot pressure. Both read x1.00.

ch06 is the live case: a perfect **x1.00 threat / x1.00 clear-load** against vanilla Ch6 — on the one chapter whose sinking clock measured wrong in *both* directions. Both facts are true and not in tension, because ch06 reproduces **100% of Ch6's 27-unit force**: its score is a checksum on the donor pipeline, not evidence about the chapter.

## What this adds

`difficulty.mirror_share(chap)` — the share of the **twin's** force reproduced exactly, printed beside every ratio:

```
  chapter                reference     threat/slot     clear-load/slot   mirror  verdict
  CH0 ch00-prologue-a-da FE8 Prologue   0.9 (x1.13)      0.3 (x1.00)       33%     OK  [locked]
  CH1 ch01-the-iron-trai FE8 Ch1        9.3 (x0.89)      3.5 (x0.97)       30%     OK  [locked]
  CH2 ch02-cold-welcome  FE8 Ch2        6.5 (x1.00)      3.8 (x1.00)       100%    OK  [locked]
  CH3 ch03-the-termalain FE8 Ch3        3.5 (x1.03)      2.2 (x1.00)       90%     OK
  CH4 ch04-the-white-moo FE8 Ch4        9.2 (x1.15)      3.1 (x1.19)       61%     OK
  CH5 ch05-the-elven-tom FE8 Ch5       14.5 (x1.04)      7.5 (x1.03)       52%     OK
  CH6 ch06-the-maer-mons FE8 Ch6       14.9 (x1.00)      7.5 (x1.00)       100%    OK
```

and in the per-chapter report, which says out loud what a high share means:

```
  mirror: 100% of FE8 Ch6's force reproduced exactly (27 of 27 bodies, class + level)
          -- at this share the verdict is largely a CHECKSUM on the donor pipeline,
             not evidence about the chapter.
```

**The trend is the finding, not the ch06 cell**: mirror% has climbed as the donor pipeline improved, so every gain in derivation fidelity made the gate more tautological — and there was no number watching that happen.

## Definition (each choice argued in the ADR)

- **(class, level)**, not class — an L9 fighter is not the twin's L1 one.
- **Multiset intersection** — a doubled body cannot score twice against a twin that fields one.
- **Denominator is the TWIN's body count** — fielding more than the twin never reads above 100%.
- **Both sides count line AND reinforcements** — the twin's curated arrays already include its waves.
- **Nothing dropped for carrying no modeled weapon** — this measures the force's SHAPE, so a staff-only healer is still a body. (Hence ch06 printing 25 modeled enemies and 27 mirrored bodies on adjacent lines, on purpose.)

**It does not gate.** A high mirror is not a defect and a low one is not either; it says how much a verdict is worth.

## Verification

- ~45 new tests, each written first and watched fail.
- `tools/test_difficulty.py` **248 OK** · `tools/test_build_campaign.py` **627 OK** · `tools/test_check_chapter_schema.py` **28 OK** · `make check` green, drift clean.
- **Output diff** over all **nine** chapters (`--chapter` and `--lord-floor`) and **all four** curve reports (authored + tutorial/normal/difficult), before vs after: **only ch02's numbers move.**

The mirror numbers reproduce #367's independently-computed spike (33/30/**78**/90/61/52/100) — except ch02, and that disagreement is the finding below: #367's spike counted our opening board against the twin's full arrays, exactly as the shipped metric did.

No ROM build, no emulator, no playtest run.

---

## What this turned up: ch02 was never counting its own wave

Defining mirror% forced the question the ratio had never been asked — *what is a body?* — and the answer was that our side and the twin's were counting different forces. Full write-up in the [review-response comment](https://github.com/NicoviGH/manchego-stars/pull/368#issuecomment-5548866510); the short version:

`chapter_units` read only `enemy_units`; `vanilla_enemies` reads every red `UnitDefinition` in the twin's curated arrays, **reinforcement waves included**. ch02 declares its rear-raider pair under `reinforcements:` (with `levels: [2, 3]` and no `level:`), so its verdict compared **7 of our bodies against 9 of vanilla's**, both of them modeled at L1.

| ch02 | shipped | corrected |
|---|---|---|
| threat/slot | 5.3 (**x0.81**) | 6.5 (**x1.00**) |
| clear-load/slot | 3.0 (**x0.79**) | 3.8 (**x1.00**) |
| mirror | 78% | **100%** |
| bodies ours vs twin | 7 vs 9 | 9 vs 9 |

Verdict was `OK` before and after — it never flipped a gate, which is how it survived four chapters on a `balance_locked` chapter. **So there are two copy-x1.00 chapters, not one**, and ch06 is not the first: ch02 was already a transcription in 2026-08 and the instrument was hiding it.

Fixed at the root. Three definitions now live on `build_campaign`'s desk, which owns the chapter schema, because *four separate gates* key off the answer and each had its own copy of the question:

- **`ENEMY_ROSTER_KEYS`** / **`chapter_roster_entries`** — what units does this chapter field.
- **`entry_body_levels`** — how many bodies does one entry place, and at what levels.
- **`_entry_combatants`** (in `difficulty`) — the one entry expander, replacing three near-copies. That duplication is exactly how `levels:` came to be honored in one reader and defaulted to L1 in the others.

Nine further readers and guards were brought onto them. Four were real holes, all on `balance_locked` chapters and all silent:

| guard | what got through |
|---|---|
| `unmodeled_enemies` | a staff-only boss under `reinforcements:` raised no BOSS DROPPED, so `--check` stayed green |
| `role_findings` | a boss there contributed threat but could never be graded per-unit |
| `_personal_line_route_violations` | a boss there could declare `personal:` with no route into the ROM — it MEASURES fixed and PLAYS naked, #284's exact failure |
| `unregistered_raw_pid_bosses` | a raw-pid boss there got no `RAW_PID_LEVEL_SOURCES` row while `_our_base_level` modelled it malus-immune |

## Review

Five `/code-review high` rounds; the write-ups are in the thread. Rounds 1–3 each found a live defect (including one this branch introduced and I had missed by diffing only ch00–ch06 — ch07/ch08 are `status: planned`, but the tool still grades them). Rounds 4 and 5 found no live break, only latent gaps one ring further out each time, which is where I stopped.

Part of #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
