### PR TITLE
rescue_forecast: which pursuer can actually engage its hull, and when (#367, #26)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8543,6 +8543,93 @@ brainstorm seed, but the tool reads it, so it is part of the tool's output. Veri
 nine chapters, every `--lord-floor` table and all four curve reports (authored + three modes):
 **only ch02's numbers move.**
 
+### A rescue-fuse FORECAST is the reusable question, and it is not a danger grid (2026-09-05, #367, #26)
+
+#367 asked whether the difficulty model has a spatial element that was designed and never
+wired. The answer for a full per-tile danger grid is: not built, and deliberately out of
+scope here -- that is a different, much larger tool. What chapters actually need, repeatedly,
+is narrower: *for a protected tile (a rescue boat, a defend objective, a fragile NPC), which
+enemies can get a firing position on it, on what turn, for how much damage per phase, and
+therefore when does it die?* `tools/rescue_forecast.py` answers exactly that, reusing (never
+reinventing) three things that already existed on three different desks:
+
+- `map_placement_preview.foot_reach` -- the contested (turn-1-body-blocked) Dijkstra
+  `reached_on_contested:` already uses.
+- `difficulty`'s stat resolution (`_entry_combatants`, `_class_base`, `on_terrain`) --
+  the SAME donor-derived numbers the parity gate grades a chapter's force on.
+- `fe_combat.damage_per_round` -- the decomp's own combat math, never a second model.
+
+**The five pieces.** (1) `firing_cells(terrain, target, weapon_range)`: every cell at
+Manhattan distance 1..range that a foot unit can stand on -- FE8 has no line of sight, so
+this is pure distance, not a walk (`decisions.md` -> "What terrain cannot do is stop a
+ranged weapon"). (2) `arrival_to_cells`: the turn an enemy first stands on ANY of those
+cells, walking the CONTESTED map -- `None` (never engages) is a first-class result, not an
+error. (3) damage/phase is `fe_combat.damage_per_round` with the target resolved on its
+real terrain. (4) `sink_band`: HP / damage-per-phase is a MEAN, not a fact (`decisions.md`
+-> "A rescue clock is a HIT RATE"), so the sink turn is reported as a band -- modeled as the
+first-passage time of a random walk with the phase's own mean and variance (the Wald /
+inverse-Gaussian approximation: `E[phases] = hp/mu`, `Var[phases] = hp*sigma2/mu**3`), a
+heuristic width stated as exactly that in the docstring, not a claimed percentile. (5)
+`concurrent_attacker_cap`: when several enemies can reach one target, how many can attack
+it in the SAME phase is a bipartite MATCHING between attackers and the firing cells each
+one's own range reaches, not a single number split between them.
+
+**Validated against ch06's own measured numbers, not synthetic stand-ins.** boat-east's
+javelin-range firing cells are exactly `(15,12) (17,10) (17,13) (17,14)`, one melee cell
+`(17,13)`; boat-west's are `(2,17) (4,18) (4,19)`, one melee cell `(4,18)` -- both match
+their declared `door`. `merfolk-thrower` (soldier L7, javelin) computes to 2.76 dmg/phase
+against the hull's real fighting stats (19 HP / 6 Def in FOREST cover / +20 avoid) and
+**cannot reach any east firing cell on the contested snapshot -- its own allies cork all
+four.** `ice-crab` (bael L1, venin claw) computes to 2.82 dmg/phase, reaches its door on
+turn 2, forecast sink band ~turn 6-12 (expected 9) against a declared 8 -- inside the band.
+
+**The finding this reproduces, in one number: ch06's declared "sinks the hull on turn 7"
+(east) describes a unit that never arrives.** That prose lives in `difficulty_note:`, not a
+schema field -- nothing was asserting it, so nothing broke when it stopped being true. This
+is the SAME shape as the already-confirmed #26 bug (`decisions.md` -> "AI_B is the APPROACH
+and AI_A is the ACTION"): the tooling that measures a chapter's clock did not exist, so the
+design note was never checked against the map it now sits on.
+
+**The guard is ADVISORY, not a gate, on purpose.** `check.check_rescue_fuse_forecast` prints
+(never appends to `fail`) when a declared `rescue_pursuers:` id cannot reach a firing cell
+for any of its chapter's `rescue_boats`, and would check a declared numeric fuse against the
+forecast band if a chapter ever adopts an (currently unused, forward-looking) `declared_fuse:`
+field. Flipping the reachability half to a hard gate is a follow-up left for Nicolas once
+ch06's east pursuer is resettled (move the pursuer, or re-declare which hull is its clock) --
+this PR does not touch ch06's YAML to make the guard pass, because the finding is real and
+the fix is a design call, not a bug in the tool. `chapter_status.loose_ends` surfaces the
+identical finding for `make chapter CH=ch06`, sharing `check._fuse_forecast_findings` so the
+two never drift into two different opinions about the same chapter.
+
+**Same code path, two latent bugs fixed alongside it (map_placement_preview.py, not
+rescue_forecast.py's own code).** `units_reaching` iterated `chapter['enemy_units']` only,
+though its docstring claimed reinforcements were included -- true only because ch06 happens
+to keep its Difficult-only wave inside `enemy_units`. It now reads
+`build_campaign.chapter_roster_entries`, every roster key. `enemy_bodies` never read past
+`enemy_units:` at all, so a `reinforcements:`/`enemy_reinforcements:` entry's body was
+invisible to the contested Dijkstra's blockers regardless of timing -- and a naive fix that
+widened the loop without ALSO fixing the timing test would have flipped the bug rather than
+closed it, since those keys carry `trigger_turn`, not `arrives_turn` (ch02's `rear-raiders`
+wave): testing `arrives_turn` alone reads an absent field as falsy, i.e. turn-1. The one
+correct predicate -- "is this entry's body on the board at turn 1" -- was already living
+correctly, but only, inside `difficulty.chapter_enemy_groups`; it is now
+`build_campaign.entry_is_turn1(key, enemy_def)`, and both readers share it.
+
+**Output diff, over all nine chapters (ch00..ch08), because a previous PR on this exact area
+got burned diffing only seven of them (`decisions.md` -> "only ch02's numbers move").**
+`enemy_bodies`, `units_reaching` (with each chapter's own `rescue_boats` as targets, `[]`
+where none are declared) and `difficulty.chapter_enemy_groups`'s counts/names: byte-identical
+before and after, on every chapter. This is a real, checked result, not an assumption --
+ch02 is the only chapter using a `reinforcements:` key today, and its wave was invisible to
+`enemy_bodies` both before (never read) and after (correctly excluded as not-turn-1); no
+chapter besides ch06 declares `rescue_boats`, so `units_reaching`'s target list is `[]`
+everywhere else and its output cannot move. The FIX has zero live-chapter impact today and
+is still worth shipping: it closes two latent traps for the day a chapter fields a
+reinforcement-key pursuer against a rescue target, which #367's own forecast model now makes
+newly possible to author correctly. `chapter_status.report()` moves on exactly one chapter
+(ch06) and by exactly one line -- the new advisory loose-end -- everywhere else
+byte-identical.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8630,6 +8630,36 @@ newly possible to author correctly. `chapter_status.report()` moves on exactly o
 (ch06) and by exactly one line -- the new advisory loose-end -- everywhere else
 byte-identical.
 
+**Review found two more crash paths the roster-widening opened, both fixed before merge.**
+`/code-review high`, four independent angles, three of which converged on the same defect
+from different directions: `_fuse_forecast_findings`'s declared-fuse loop compared
+`r.sink_low <= declared <= r.sink_high` over every row that reaches its target, but
+`pursuer_forecast` returns exactly `arrival_turn` set with every sink field `None` when the
+attacker reaches a firing cell yet deals zero true damage there (`sink_band`'s own `None`
+case) -- unreached today because no chapter has adopted `declared_fuse:` yet, but a raw
+`TypeError` the day one does, inside the function whose own docstring and dedicated test
+promise it never fails the build. Fixed by requiring `sink_low is not None` too. Second: the
+now-widened `units_reaching` calls `difficulty.enemy_ai_bytes` on every roster key, which
+RAISES on an entry with neither `donor:` nor `ai_override:` -- a normal mid-draft state --
+and `check_rescue_targets` called it with no guard, inside a `main()` that runs every check
+with zero exception isolation between them. One ungrounded `reinforcements:` entry on a
+future rescue chapter would have crashed the ENTIRE `check.py`, every other gate along with
+it. Fixed with the same try/except-and-skip idiom the function already used two lines above
+for an unbuilt map. Both reproduced with a failing test before the fix -- the second via a
+`check._chapters` monkeypatch, the first such precedent in that test file.
+
+Left as follow-up rather than fixed here (all latent, none affect a gate or a live chapter's
+numbers, and the change was already large): `target_combatant` bypasses
+`difficulty._one_enemy`'s autolevel/class-tag/personal-line handling (a no-op today, since
+ch06's boats are level-1 no-personal `CLASS_FLEET`, but silently wrong the day a boat entry
+adopts any of those); `firing_cells`/`arrival_to_cells`/`_boat_terrain_name` each re-glue
+primitives that already exist inlined elsewhere rather than sharing one implementation;
+`chapter_status.py` grew a third copy of the same `try: import X except ImportError: None`
+template; and `map_placement_preview.placed_units` (the tool's PNG *render* path, not any
+of its data-consumed-by-gates path) still reads `enemy_units` alone, so a
+`reinforcements:`-key wave renders invisibly on a concept PNG even though every gate now
+accounts for it correctly.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8648,17 +8648,50 @@ it. Fixed with the same try/except-and-skip idiom the function already used two 
 for an unbuilt map. Both reproduced with a failing test before the fix -- the second via a
 `check._chapters` monkeypatch, the first such precedent in that test file.
 
-Left as follow-up rather than fixed here (all latent, none affect a gate or a live chapter's
-numbers, and the change was already large): `target_combatant` bypasses
-`difficulty._one_enemy`'s autolevel/class-tag/personal-line handling (a no-op today, since
-ch06's boats are level-1 no-personal `CLASS_FLEET`, but silently wrong the day a boat entry
-adopts any of those); `firing_cells`/`arrival_to_cells`/`_boat_terrain_name` each re-glue
-primitives that already exist inlined elsewhere rather than sharing one implementation;
-`chapter_status.py` grew a third copy of the same `try: import X except ImportError: None`
-template; and `map_placement_preview.placed_units` (the tool's PNG *render* path, not any
-of its data-consumed-by-gates path) still reads `enemy_units` alone, so a
-`reinforcements:`-key wave renders invisibly on a concept PNG even though every gate now
-accounts for it correctly.
+**The review's other half was reuse, and "it's only latent" was the wrong bar.** The same
+pass flagged five places where this work had grown its own copy of something that already
+existed. The first instinct was to leave them — all latent, none touching a gate or a live
+chapter's numbers. That reasoning does not survive contact with where the code actually
+lives: these are not pre-existing debt the PR walked past, they are code the PR itself wrote,
+or the third instance of a bug in a file whose other two instances it already claims to have
+fixed. A change that says "same code path, two latent bugs fixed alongside it" and leaves the
+third copy of that same bug in that same file has not fixed the pattern, it has fixed two
+thirds of it.
+
+- **`placed_units` was that third copy.** `enemy_units` alone, plus a `late` flag testing
+  `arrives_turn` alone — which reads a `trigger_turn` wave as turn-1, exactly backwards. Now
+  iterates `ENEMY_ROSTER_KEYS` and asks `entry_is_turn1`, OR'd with `hard_mode_only` (a MODE
+  gate, a different axis `entry_is_turn1` deliberately does not model).
+- **`target_combatant` bypassed `difficulty._one_enemy`**, the path every other enemy
+  resolves through, so it skipped autolevel, `CLASS_TAGS` (which `fe_combat` reads to resolve
+  effective weapons) and any personal line. A no-op while ch06's boats are level-1
+  no-personal `CLASS_FLEET`; silently wrong the day a `rescue_boats:` entry declares
+  otherwise.
+- **`firing_cells` was a second copy of the Manhattan-range check `units_reaching` already
+  ran inline.** It is a terrain/range primitive, the same family as `foot_reach`, so it moved
+  to `map_placement_preview`; `units_reaching` calls it and `rescue_forecast` aliases it.
+- **`reached_on` and `arrival_to_cells` were mirror-image glue** over the same two
+  primitives — Dijkstra, then points-to-turn — differing only in which end was plural.
+  `arrival_turn_to` takes both ends as lists and serves either direction.
+- **`chapter_status` grew a third `try: import X except ImportError: None`.** Extracted
+  `_try_import`; the three wrappers stay separately named because tests monkeypatch them
+  individually.
+
+**One flagged "duplicate" was refused, and the reason is the general rule.**
+`_boat_terrain_name` was called a duplicate of `difficulty.vanilla_terrain_at`. It is not:
+`vanilla_terrain_at` resolves a tile on a VANILLA DONOR layout by name, `_boat_terrain_name`
+reads OUR OWN compiled grid already in hand. Those differ by construction — see *"ch06
+departs from its donor's terrain in 21 declared cells"* above, and both boat tiles are among
+those 21 (`TILE_2E`/`VILLAGE_REGULAR` → `FOREST` by `terrain_divergence`). Unifying them
+would swap the hull's cover for the donor's terrain and move every sink band. **A shared
+shape is not a shared question**, and a dedup that changes an answer is a regression wearing
+a cleanup's clothes.
+
+Verified by output diff across all nine chapters over `placed_units`, `reached_on` (contested
+and uncontested), `units_reaching` and the whole `chapter_forecast`: the only change anywhere
+is ch02's `placed_units` gaining its two `rear-raiders` bodies, correctly marked late — which
+is simultaneously the proof that the four refactors are behaviour-preserving and that the
+fifth was a real bug.
 
 ## Open Questions (not yet decided)
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -10273,6 +10273,23 @@ def chapter_roster_entries(chap):
             if isinstance(ed, dict)]
 
 
+def entry_is_turn1(key, enemy_def):
+    """Is this entry's body standing on the board at TURN 1, before the player's first move?
+
+    The KEY decides it, not `arrives_turn` alone: only `enemy_units` is the opening-board
+    array, and even then only unconditionally -- an entry there may still declare its OWN
+    `arrives_turn > 1` (ch06's Difficult-only crab-rider wave stays inside `enemy_units` for
+    exactly this reason, so its own field is what excludes it). A `reinforcements:` or
+    `enemy_reinforcements:` entry is never turn-1 regardless of what it carries, and that
+    matters because those entries use a DIFFERENT field for their own timing --
+    `trigger_turn`, not `arrives_turn` (ch02's `rear-raiders`). Two readers tested
+    `arrives_turn` alone against every key and both read a `trigger_turn` wave as turn-1,
+    which is backwards: a reinforcement key is the one shape definitely not on the opening
+    board (`difficulty.chapter_enemy_groups`'s dynamics split, and
+    `map_placement_preview.enemy_bodies`'s Dijkstra blockers, #367)."""
+    return key == 'enemy_units' and int(enemy_def.get('arrives_turn', 1) or 1) <= 1
+
+
 def entry_body_levels(enemy_def):
     """The level of each BODY one enemy entry places, in order.
 

--- a/tools/chapter_status.py
+++ b/tools/chapter_status.py
@@ -67,6 +67,36 @@ def _build_campaign():
         return None
 
 
+def _rescue_forecast_module():
+    """`rescue_forecast`, or None where it cannot be imported (same Pillow dependency as
+    `_preview_module`, through `map_placement_preview`)."""
+    try:
+        import rescue_forecast
+        return rescue_forecast
+    except ImportError:
+        return None
+
+
+def _rescue_clock_findings(name, campaign=campaign_chapters.CAMPAIGN):
+    """Advisory findings for a chapter's rescue clock (#367), for `loose_ends` and the
+    report -- the same pure logic `check.py check_rescue_fuse_forecast` runs, read here so
+    a fresh session sees ch06's confirmed #26 finding (the east pursuer cannot engage)
+    without leaving the terminal. `[]` on a chapter with no rescue clock, or where the
+    forecast module could not be imported -- silence, never a false "clean"."""
+    rf = _rescue_forecast_module()
+    if rf is None:
+        return []
+    chapter = load(name, campaign)
+    if not (chapter.get('rescue_boats') and chapter.get('rescue_pursuers')):
+        return []
+    try:
+        rows = rf.chapter_forecast(chapter)
+    except Exception:                # noqa: BLE001 -- an unbuilt map is not this report's business
+        return []
+    import check
+    return check._fuse_forecast_findings(chapter, rows)
+
+
 def _boxes(script):
     """Authored boxes in a script -- stage directions are not boxes.
 
@@ -615,6 +645,8 @@ def loose_ends(name, campaign=campaign_chapters.CAMPAIGN, cache_dir=None):
     for row in art(name, campaign):
         if row.missing:
             out.append('%s (%s) has no %s' % (row.unit, row.role, ', '.join(row.missing)))
+
+    out.extend(_rescue_clock_findings(name, campaign))
 
     if host_slot(name, campaign) is None:
         out.append('not hosted: no slot declared in inject/hosts.py, so nothing loads it')

--- a/tools/chapter_status.py
+++ b/tools/chapter_status.py
@@ -26,6 +26,17 @@ SceneRow = collections.namedtuple('SceneRow', 'trigger slot declared boxes previ
 Room = collections.namedtuple('Room', 'claimed block used_in_block borrowed free')
 
 
+def _try_import(name):
+    """`name`, imported, or `None` where it cannot be -- the one implementation behind
+    `_preview_module`/`_build_campaign`/`_rescue_forecast_module`, which were three copies
+    of this exact template. Each stays its own module-level function (not a single
+    parameterized one) because callers monkeypatch them individually by name in tests."""
+    try:
+        return __import__(name)
+    except ImportError:
+        return None
+
+
 def _preview_module():
     """`scene_preview`, or None where it cannot be imported.
 
@@ -33,11 +44,7 @@ def _preview_module():
     CI job that installs pyyaml and nothing else this is absent, and a status report is still
     worth printing without its preview column. Everything else here is stdlib + pyyaml.
     """
-    try:
-        import scene_preview
-        return scene_preview
-    except ImportError:
-        return None
+    return _try_import('scene_preview')
 
 
 def _previews_by_event(chapter_short):
@@ -60,21 +67,13 @@ def _previews_by_event(chapter_short):
 
 def _build_campaign():
     """`build_campaign`, or None where Pillow is absent (see `_preview_module`)."""
-    try:
-        import build_campaign
-        return build_campaign
-    except ImportError:
-        return None
+    return _try_import('build_campaign')
 
 
 def _rescue_forecast_module():
     """`rescue_forecast`, or None where it cannot be imported (same Pillow dependency as
     `_preview_module`, through `map_placement_preview`)."""
-    try:
-        import rescue_forecast
-        return rescue_forecast
-    except ImportError:
-        return None
+    return _try_import('rescue_forecast')
 
 
 def _rescue_clock_findings(name, campaign=campaign_chapters.CAMPAIGN):

--- a/tools/check.py
+++ b/tools/check.py
@@ -1088,6 +1088,82 @@ def check_rescue_targets(fail):
             short, pp.units_reaching(doc, terrain, hulls), pursuers))
 
 
+def _fuse_forecast_findings(chapter, rows=None):
+    """Advisory findings for one chapter's rescue clock (#367).
+
+    Two things the fuse-forecast model can say that `check_rescue_targets` cannot -- that
+    guard proves nothing UNDECLARED can attack a hull; this asks whether the DECLARED clock
+    actually gets there:
+
+      * every `rescue_pursuers:` id should reach a firing cell for AT LEAST ONE of the
+        chapter's `rescue_boats` (mirroring `check_rescue_targets`'s own "any hull"
+        reading -- a chapter does not wire which pursuer clocks which boat, only that each
+        declared pursuer is somebody's clock);
+      * a boat's optional `declared_fuse:` (no shipped chapter has adopted this field yet --
+        ch06's "sinks on turn 7/8" lives as PROSE in `difficulty_note:`) should fall inside
+        the forecast band of whatever pursuer reaches it.
+
+    `rows` is `rescue_forecast.chapter_forecast(chapter)`'s output, threaded in for
+    testability; the caller computes it once per chapter and passes it here.
+    """
+    findings = []
+    for pursuer in chapter.get('rescue_pursuers') or []:
+        pid = pursuer['id']
+        mine = [r for r in (rows or []) if r.enemy_id == pid]
+        if mine and not any(r.arrival_turn is not None for r in mine):
+            findings.append(
+                '%s: declared a rescue_pursuer but cannot reach a firing cell for any '
+                'rescue target on the contested snapshot -- its fuse describes a unit '
+                'that never arrives' % pid)
+    for boat in chapter.get('rescue_boats') or []:
+        declared = boat.get('declared_fuse')
+        if declared is None:
+            continue
+        reaching = [r for r in (rows or [])
+                   if r.boat_id == boat['id'] and r.arrival_turn is not None]
+        if not reaching:
+            continue                  # already reported above, once, by the pursuer loop
+        if not any(r.sink_low <= declared <= r.sink_high for r in reaching):
+            findings.append(
+                '%s: declared_fuse %s falls outside every reaching pursuer\'s forecast '
+                'band (%s)' % (boat['id'], declared,
+                              ', '.join('%s %s-%s' % (r.enemy_id, r.sink_low, r.sink_high)
+                                        for r in reaching)))
+    return findings
+
+
+def check_rescue_fuse_forecast(fail):
+    """ADVISORY, not a gate (#367): does a chapter's DECLARED rescue clock actually reach
+    its target, and does a declared fuse sit inside the forecast band.
+
+    Deliberately never appends to `fail`. ch06's east pursuer (`merfolk-thrower`) fails the
+    reachability half TODAY -- a real, already-confirmed bug (#26): its own line corks
+    every one of its four javelin firing cells on the contested snapshot, so the chapter's
+    declared "sinks on turn 7" describes a unit that never arrives. The fix is a design
+    call (move the pursuer, or re-declare which hull is the east clock) that belongs to
+    Nicolas, not to this PR, so this prints rather than reddens `main`. Flip the
+    `_fuse_forecast_findings` call below to `fail.extend(...)` once that pursuer is
+    settled -- see `docs/decisions.md` for the dated ADR."""
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    try:
+        import rescue_forecast as rf
+    except ImportError as exc:      # Pillow / submodule absent on the lightweight checks job
+        print('check_rescue_fuse_forecast: skipping (%s; the build job\'s `make test` '
+             'covers it)' % exc)
+        return
+    for rel, doc in _chapters():
+        if not (doc.get('rescue_boats') and doc.get('rescue_pursuers')):
+            continue
+        short = str(doc.get('id', '')).split('-')[0]
+        try:
+            rows = rf.chapter_forecast(doc)
+        except Exception as exc:    # noqa: BLE001 -- an unbuilt map is not this gate's business
+            print('check_rescue_fuse_forecast: skipping %s (%s)' % (short, exc))
+            continue
+        for finding in _fuse_forecast_findings(doc, rows):
+            print('check_rescue_fuse_forecast: %s: %s' % (short, finding))
+
+
 def _re_local_git_env(text, name):
     """True if `name` is bound to git_env() in this file -- `env = git_env()` then `env=env`."""
     import re as _re
@@ -2425,7 +2501,7 @@ def main():
                   check_decomp_git_calls_strip_the_env,
                   check_no_shadowed_definitions, check_gate_chapter_window,
                   check_declared_cases, check_chapter_lua_facts,
-                  check_rescue_targets,
+                  check_rescue_targets, check_rescue_fuse_forecast,
                   check_harness_local_ratchet,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,

--- a/tools/check.py
+++ b/tools/check.py
@@ -1084,8 +1084,15 @@ def check_rescue_targets(fail):
             continue
         hulls = [tuple(b['tile']) for b in boats]
         pursuers = {p['id'] for p in (doc.get('rescue_pursuers') or [])}
-        fail.extend(_rescue_target_violations(
-            short, pp.units_reaching(doc, terrain, hulls), pursuers))
+        try:
+            reachers = pp.units_reaching(doc, terrain, hulls)
+        except Exception as exc:    # noqa: BLE001 -- an ungrounded roster entry (no donor/
+            # ai_override, a normal mid-draft state -- #369 widened `units_reaching` to every
+            # roster key, so a `reinforcements:`/`enemy_reinforcements:` entry authored ahead
+            # of its AI can reach here) is #335's business, not this gate's.
+            print('check_rescue_targets: skipping %s (%s)' % (short, exc))
+            continue
+        fail.extend(_rescue_target_violations(short, reachers, pursuers))
 
 
 def _fuse_forecast_findings(chapter, rows=None):
@@ -1119,8 +1126,14 @@ def _fuse_forecast_findings(chapter, rows=None):
         declared = boat.get('declared_fuse')
         if declared is None:
             continue
+        # `sink_low is not None` too: `pursuer_forecast` returns a row with `arrival_turn`
+        # SET but every sink field None when the attacker reaches a firing cell yet deals
+        # no true damage there (`sink_band`'s own None case -- 0 hit chance or an
+        # effectiveness mismatch). Comparing `None <= declared` crashes the very guard whose
+        # whole contract is that it never fails the build.
         reaching = [r for r in (rows or [])
-                   if r.boat_id == boat['id'] and r.arrival_turn is not None]
+                   if r.boat_id == boat['id'] and r.arrival_turn is not None
+                   and r.sink_low is not None]
         if not reaching:
             continue                  # already reported above, once, by the pursuer loop
         if not any(r.sink_low <= declared <= r.sink_high for r in reaching):

--- a/tools/difficulty.py
+++ b/tools/difficulty.py
@@ -2076,10 +2076,11 @@ def chapter_enemy_groups(chap):
             units = _entry_combatants(ed)
             if ed.get('convertible'):
                 g['convertibles'].extend(units)
-            elif key != 'enemy_units' or int(ed.get('arrives_turn', 1) or 1) > 1:
+            elif not bc.entry_is_turn1(key, ed):
                 # the KEY is what makes ch02's wave a reinforcement: it carries
                 # `trigger_turn`, not `arrives_turn`, so an arrives_turn test alone read it
-                # as turn-1 line.
+                # as turn-1 line. `entry_is_turn1` is the one place that now knows it
+                # (#367) -- `map_placement_preview.enemy_bodies` shares it too.
                 g['reinforcements'].extend(units)
             else:
                 g['line'].extend(units)

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -180,13 +180,24 @@ def arrival_turn(points, mov):
 
 
 def enemy_bodies(chapter):
-    """Every turn-1 enemy tile. Reinforcements are excluded: they are not on the board yet."""
+    """Every turn-1 enemy tile, across every roster key a body may be declared under.
+
+    Reinforcements are excluded -- they are not on the board yet -- but "reinforcement" is
+    not simply "an `enemy_units` entry with a truthy `arrives_turn`": a `reinforcements:` or
+    `enemy_reinforcements:` entry carries `trigger_turn` instead (ch02's `rear-raiders`), so
+    testing `arrives_turn` alone against a bare `chapter.get('enemy_units')` loop both missed
+    those entries' bodies AND, on a naive widen-the-loop fix, would have read them as turn-1
+    (`arrives_turn` absent reads as falsy) -- exactly backwards, since a reinforcement KEY is
+    the one shape definitely not on the opening board. `build_campaign.entry_is_turn1` is the
+    one place that now decides this, shared with `difficulty.chapter_enemy_groups` (#367)."""
+    import build_campaign as bc
     out = set()
-    for enemy in chapter.get('enemy_units') or ():
-        if enemy.get('arrives_turn'):
-            continue
-        for tile in enemy.get('positions') or ():
-            out.add(tuple(tile))
+    for key in bc.ENEMY_ROSTER_KEYS:
+        for enemy in chapter.get(key) or ():
+            if not isinstance(enemy, dict) or not bc.entry_is_turn1(key, enemy):
+                continue
+            for tile in enemy.get('positions') or ():
+                out.add(tuple(tile))
     return out
 
 
@@ -216,11 +227,15 @@ def _classes_text():
 def units_reaching(chapter, terrain, targets):
     """[(enemy id, ai bytes)] for every unit that can ATTACK one of `targets`.
 
-    REINFORCEMENTS ARE INCLUDED. They are not on the opening board, but a hull's fuse is costed
+    REINFORCEMENTS ARE INCLUDED, across every roster key (`build_campaign.chapter_roster_entries`)
+    -- not just `enemy_units`. They are not on the opening board, but a hull's fuse is costed
     against the units a chapter DECLARES as its clock, and an undeclared unit that reaches a
     hull on turn 5 sinks it exactly as surely as one that reaches it on turn 1 -- it just does
     it out of sight of a gate that only ever looked at turn 1. Skipping them hid ch06's three
-    Difficult-only turn-4 crab riders, which spawn on the west edge and do reach the west hull.
+    Difficult-only turn-4 crab riders, which spawn on the west edge and do reach the west hull;
+    this docstring's claim was only ever TRUE of ch06, because ch06 happens to keep that wave
+    inside `enemy_units` -- a chapter whose wave lives under `reinforcements:` or
+    `enemy_reinforcements:` (ch02's own `rear-raiders`) was invisible here until now (#367).
 
     The two shapes reach differently, and conflating them is what made the first cut of this
     analysis wrong by three units:
@@ -234,10 +249,11 @@ def units_reaching(chapter, terrain, targets):
     Weapon range comes from `difficulty._weapon_for`, so a staff-only unit is correctly no
     threat and a javelin correctly reaches two.
     """
+    import build_campaign as bc
     import difficulty
     import chapter_status as cs
     out = []
-    for enemy in chapter.get('enemy_units') or ():
+    for enemy in bc.chapter_roster_entries(chapter):
         # MAX range over the whole inventory, not the first weapon. FE8's AI equips whatever
         # lets it attack, and ch06's ironshell-horseslayer proved it in-engine: its items[0] is
         # a range-1 Horseslayer, and it threw its JAVELIN at the hull from two tiles away.

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -132,6 +132,31 @@ REACH_ROLES = {
 }
 
 
+def firing_cells(terrain, target, weapon_range):
+    """Every cell at Manhattan distance 1..`weapon_range` from `target` that a foot unit can
+    stand on -- the set of tiles an attacker could occupy to hit it. FE8 has no line of
+    sight (decisions.md -> "What terrain cannot do is stop a ranged weapon"), so this is
+    pure Manhattan distance, not a walk: a range-2 firing cell three tiles out through a
+    wall is exactly as live as the door directly beside the target.
+
+    Standability is FOOT passability (`FOOT_COST`), a generic ground proxy rather than any
+    one attacker's own class -- the cell has to exist for SOME ground unit to occupy it
+    before who specifically reaches it is asked. The target's own tile (distance 0) is
+    never a firing cell.
+
+    `units_reaching` uses this for the same range check it always ran inline; `rescue_forecast`
+    aliases it rather than keeping its own copy."""
+    tx, ty = target
+    h, w = len(terrain), len(terrain[0])
+    out = []
+    for y in range(h):
+        for x in range(w):
+            d = abs(x - tx) + abs(y - ty)
+            if 1 <= d <= weapon_range and FOOT_COST.get(terrain[y][x]) is not None:
+                out.append((x, y))
+    return sorted(out)
+
+
 def foot_reach(terrain, sources, blocked=(), cost=None):
     """Movement-point distance from any source cell.
 
@@ -177,6 +202,28 @@ def arrival_turn(points, mov):
     if points is None:
         return None
     return max(1, -(-points // mov))
+
+
+def arrival_turn_to(terrain, sources, cost_table, mov, targets, blocked=()):
+    """The turn a unit moving from ANY of `sources` (at `mov` points/turn on `cost_table`, a
+    `pMovCostTable` symbol per `class_movement`) first stands on ANY of `targets`, walking
+    the map with `blocked` cells excluded. `None` if no target is reachable at all -- a
+    first-class outcome, not an error (ch06's merfolk-thrower: its own line corks every one
+    of its four javelin cells).
+
+    ONE Dijkstra + arrival-turn conversion, shared by two call shapes that are otherwise
+    mirror images of each other: `reached_on` walks MANY sources (the deploy block) to ONE
+    target; `rescue_forecast.arrival_to_cells` walks ONE source (an enemy) to MANY candidate
+    firing cells. Passing both ends as lists covers either direction without the caller
+    having to know which side is plural."""
+    if not targets:
+        return None
+    cost = mov_cost_row(cost_table)
+    dist = foot_reach(terrain, [tuple(s) for s in sources], blocked=blocked, cost=cost)
+    reachable = [dist[c] for c in (tuple(t) for t in targets) if c in dist]
+    if not reachable:
+        return None
+    return arrival_turn(min(reachable), mov)
 
 
 def enemy_bodies(chapter):
@@ -265,6 +312,7 @@ def units_reaching(chapter, terrain, targets):
         reach = max(ranges)
         table, mov = class_movement(enemy.get('deploy_class') or enemy['class'])
         cost = mov_cost_row(table)
+        fire = {cell for t in targets for cell in firing_cells(terrain, t, reach)}
         for index, (x, y) in enumerate(enemy.get('positions') or ()):
             ai = difficulty.enemy_ai_bytes(chapter, enemy, index)
             dist = foot_reach(terrain, [(x, y)], cost=cost)
@@ -276,7 +324,7 @@ def units_reaching(chapter, terrain, targets):
             for cell, points in dist.items():
                 if budget is not None and points > budget:
                     continue
-                if any(abs(cell[0] - t[0]) + abs(cell[1] - t[1]) <= reach for t in targets):
+                if cell in fire:
                     out.append((enemy['id'], ai))
                     break
     return out
@@ -306,12 +354,9 @@ def reached_on(chapter, terrain, target, contested=True):
     hand-written `reached_on:` blocks were measured with, so the two can be compared.
     """
     blocked = enemy_bodies(chapter) if contested else ()
-    out = {}
-    for role, (table, mov) in REACH_ROLES.items():
-        dist = foot_reach(terrain, deploy_cells(chapter, terrain), blocked=blocked,
-                          cost=mov_cost_row(table))
-        out[role] = arrival_turn(dist.get(tuple(target)), mov)
-    return out
+    sources = deploy_cells(chapter, terrain)
+    return {role: arrival_turn_to(terrain, sources, table, mov, [target], blocked=blocked)
+            for role, (table, mov) in REACH_ROLES.items()}
 
 
 def deploy_cells(chapter, terrain):
@@ -326,28 +371,40 @@ def deploy_cells(chapter, terrain):
 
 
 def placed_units(chapter, concept=None):
-    """[(tile, label, behaviour)] for every unit a placement puts on the map.
+    """[(tile, label, behaviour, id, late)] for every unit a placement puts on the map.
 
     From a concept JSON when one is given -- `{"units": {"<enemy id>": [[x, y], ...]}}` --
     and otherwise from each enemy entry's own `positions:`. Behaviour comes from the
     chapter's own AI resolution either way, so a concept cannot drift from what the
-    build would emit."""
+    build would emit.
+
+    Reads every roster key (#367/#369) -- was `enemy_units` alone, the THIRD copy of the
+    same bug `enemy_bodies` and `units_reaching` were fixed for: a `reinforcements:`/
+    `enemy_reinforcements:` wave was simply absent from the picture. `late` (drawn as a
+    hollow ring) is `build_campaign.entry_is_turn1`'s KEY-aware answer OR'd with
+    `hard_mode_only` -- a separate, MODE-gated axis `entry_is_turn1` does not model, since
+    ch06's Difficult-only crab riders declare it while staying inside `enemy_units`."""
+    import build_campaign as bc
     import difficulty as dif
     import chapter_status as cs
     override = (json.load(open(concept))['units'] if concept else {})
     out = []
-    for enemy in chapter.get('enemy_units') or []:
-        eid = enemy.get('id')
-        tiles = override.get(eid, enemy.get('positions') or [])
-        for i, tile in enumerate(tiles):
-            ai = dif.enemy_ai_bytes(chapter, enemy, i)
-            # Derived from the WHOLE vector, never patched by role: `is_boss` was standing in
-            # for the AI_A half this could not see, and it was wrong in both directions -- a
-            # non-boss statue read as mobile, and a boss with an engaging action read as static.
-            behaviour = cs.ai_shape(ai) or cs.ai_family(ai[1]) or '?'
-            code = 'B' if enemy.get('is_boss') else ROLE_CODE.get(enemy.get('class'), '??')
-            late = enemy.get('arrives_turn') or enemy.get('hard_mode_only')
-            out.append((tuple(tile), code, behaviour, eid, late))
+    for key in bc.ENEMY_ROSTER_KEYS:
+        for enemy in chapter.get(key) or ():
+            if not isinstance(enemy, dict):
+                continue
+            eid = enemy.get('id')
+            tiles = override.get(eid, enemy.get('positions') or [])
+            for i, tile in enumerate(tiles):
+                ai = dif.enemy_ai_bytes(chapter, enemy, i)
+                # Derived from the WHOLE vector, never patched by role: `is_boss` was standing
+                # in for the AI_A half this could not see, and it was wrong in both directions
+                # -- a non-boss statue read as mobile, and a boss with an engaging action read
+                # as static.
+                behaviour = cs.ai_shape(ai) or cs.ai_family(ai[1]) or '?'
+                code = 'B' if enemy.get('is_boss') else ROLE_CODE.get(enemy.get('class'), '??')
+                late = not bc.entry_is_turn1(key, enemy) or bool(enemy.get('hard_mode_only'))
+                out.append((tuple(tile), code, behaviour, eid, late))
     return out
 
 

--- a/tools/rescue_forecast.py
+++ b/tools/rescue_forecast.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Rescue-fuse forecast: for a protected tile (a rescue boat, a defend objective, a fragile
+NPC), which enemies can get a firing position on it, on what turn, for how much damage per
+phase, and therefore when does it die.
+
+This is deliberately NOT a full per-tile danger grid -- #367 asked whether the difficulty
+model has an unwired spatial element, and a whole-map danger grid was explicitly cut from
+this answer's scope. What is built instead is the narrower, reusable question every chapter
+with a rescue clock actually asks, proven against ch06's two boats and meant to carry
+forward to the campaign's other ~20 chapters unchanged.
+
+Nothing here is a new combat model: every damage/hit number comes straight from
+`fe_combat.py` (the decomp's own math), every stat resolution from `difficulty.py`, and
+every walk from `map_placement_preview.foot_reach` (a Dijkstra over the engine's own
+per-class movement-cost tables). This module is the GLUE between them:
+
+  1. `firing_cells` -- every cell within a weapon's range that a foot unit can stand on.
+     The throughput bound: at most one attacker per cell per phase, allies block each other.
+  2. `arrival_to_cells` -- the turn an enemy first stands on ANY of those cells, walking the
+     CONTESTED map (turn-1 enemy bodies block, same as `map_placement_preview.reached_on`'s
+     own reading). `None` if no firing cell is reachable at all -- a first-class result, not
+     an error: ch06's merfolk-thrower is exactly this case, corked by its own line.
+  3. `fe_combat.damage_per_round` -- damage per phase, target resolved on its real terrain
+     via `difficulty.on_terrain`.
+  4. `sink_band` -- HP / damage-per-phase is a MEAN, not a fact, because a phase either
+     connects or it does not (`docs/decisions.md` -> "A rescue clock is a HIT RATE, so a
+     scenario MEASURES it and never asserts it"). Reported as a band; see its own docstring
+     for exactly what the band means and how it's built.
+  5. `concurrent_attacker_cap` -- when several enemies can reach one target, how many can
+     attack it in the SAME phase is capped by the number of distinct firing cells a MATCHING
+     can assign them to. ch06's two hulls each have exactly one melee door, so this is not
+     load-bearing there yet -- it is built in for the wider targets later chapters will ship.
+
+HONEST LIMITS, inherited from what this reuses: a turn-1 CONTESTED SNAPSHOT (strikers can
+still step into the route on later phases, and the player kills bodies out of it -- see
+`map_placement_preview.foot_reach`'s own docstring), and a static per-hit damage/hit-chance
+read with no positioning or AI beyond "does it path to a firing cell" (`fe_combat`'s own
+warning). It is a forecast, not a prophecy -- a real playtest is still the arbiter.
+
+    python3 tools/rescue_forecast.py ch06
+"""
+import argparse
+import dataclasses
+import math
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'tools'))
+import build_campaign as bc                                          # noqa: E402
+import difficulty as dif                                             # noqa: E402
+import fe_combat as fc                                                # noqa: E402
+import map_placement_preview as pp                                   # noqa: E402
+
+
+def firing_cells(terrain, target, weapon_range):
+    """Every cell at Manhattan distance 1..`weapon_range` from `target` that a foot unit can
+    stand on -- the set of tiles an attacker could occupy to hit it. FE8 has no line of
+    sight (decisions.md -> "What terrain cannot do is stop a ranged weapon"), so this is
+    pure Manhattan distance, not a walk: a range-2 firing cell three tiles out through a
+    wall is exactly as live as the door directly beside the target.
+
+    Standability is FOOT passability (`map_placement_preview.FOOT_COST`), a generic ground
+    proxy rather than any one attacker's own class -- the cell has to exist for SOME ground
+    unit to occupy it before who specifically reaches it is asked. The target's own tile
+    (distance 0) is never a firing cell."""
+    tx, ty = target
+    h, w = len(terrain), len(terrain[0])
+    out = []
+    for y in range(h):
+        for x in range(w):
+            d = abs(x - tx) + abs(y - ty)
+            if 1 <= d <= weapon_range and pp.FOOT_COST.get(terrain[y][x]) is not None:
+                out.append((x, y))
+    return sorted(out)
+
+
+def arrival_to_cells(terrain, source, cost_table, mov, cells, blocked=()):
+    """The turn an enemy at `source` (moving `mov` a turn on `cost_table`, a
+    `pMovCostTable` symbol per `map_placement_preview.class_movement`) first stands on ANY
+    of `cells`, walking the CONTESTED map (`blocked` -- turn-1 enemy bodies, which a unit
+    may not enter or pass through). `None` if none of `cells` is reachable at all -- the
+    enemy never gets a firing position, which is a first-class outcome (ch06's
+    merfolk-thrower: its own line corks every one of its four javelin cells)."""
+    if not cells:
+        return None
+    cost = pp.mov_cost_row(cost_table)
+    dist = pp.foot_reach(terrain, [tuple(source)], blocked=blocked, cost=cost)
+    reachable = [dist[c] for c in cells if c in dist]
+    if not reachable:
+        return None
+    return pp.arrival_turn(min(reachable), mov)
+
+
+@dataclasses.dataclass(frozen=True)
+class SinkBand:
+    """Phases FROM ARRIVAL, not turns -- the caller adds the arrival turn. See `sink_band`."""
+    low: int
+    expected: int
+    high: int
+
+
+def sink_band(hp, attacker, target, terrain_avoid=0, z=1.0):
+    """How many PHASES of continuous attack it takes `attacker` to sink a `hp`-HP target,
+    as a band, not a point -- because a phase either connects or it does not, and "HP /
+    damage-per-phase" is the MEAN of a random variable, not its value
+    (`docs/decisions.md` -> "A rescue clock is a HIT RATE").
+
+    Modeled as the first-passage time of a random walk with the phase's own mean and
+    variance (the Wald / inverse-Gaussian approximation for a Brownian motion with drift):
+    a phase deals `hits` (1, or 2 on a follow-up) independent Bernoulli(p) connects worth
+    `dmg` each, so its damage has mean `mu = dmg * hits * p` (exactly
+    `fe_combat.damage_per_round` -- the point estimate this band is built around IS that
+    number, per the literal spec "forecast sink turn = arrival + HP / damage_per_phase") and
+    variance `sigma2 = dmg**2 * hits * p * (1-p)`. For a target needing `hp` total damage:
+
+        E[phases]   = hp / mu
+        Var[phases] = hp * sigma2 / mu**3
+
+    `z` widens or narrows the band (default 1.0: mean +/- one modeled standard deviation).
+    This is a HEURISTIC width, not a claimed exact percentile -- HP is discrete and the true
+    process is closer to a negative binomial than a Brownian motion, but that is the same
+    order of approximation `damage_per_round` itself already is (a static, mean-only combat
+    proxy the rest of this codebase accepts). The low end is additionally floored at the
+    deterministic BEST case -- every attack connects -- since no amount of luck sinks a
+    target faster than that.
+
+    Returns `None` if `attacker` cannot damage `target` at all (no weapon, or 0 true
+    damage): "never sinks it" is a fact worth a `None`, not a divide-by-zero.
+    """
+    if attacker.weapon is None:
+        return None                                 # a weaponless body threatens nothing
+    dmg = fc.damage(attacker, target)
+    p = fc.hit_chance(attacker, target, terrain_avoid) / 100.0
+    if dmg <= 0 or p <= 0:
+        return None
+    hits = 2 if fc.doubles(attacker, target) else 1
+    mu = dmg * hits * p
+    sigma2 = dmg ** 2 * hits * p * (1 - p)
+    hits_needed = -(-hp // dmg)                     # ceil(hp / dmg)
+    floor_phases = -(-hits_needed // hits)          # every hit connects -- the fastest case
+    mean_phases = hp / mu
+    var_phases = hp * sigma2 / mu ** 3
+    sd_phases = var_phases ** 0.5
+    low = max(floor_phases, math.ceil(mean_phases - z * sd_phases))
+    high = math.ceil(mean_phases + z * sd_phases)
+    expected = math.ceil(mean_phases)
+    return SinkBand(low=low, expected=expected, high=max(high, expected))
+
+
+def _bipartite_matching_size(adjacency):
+    """Maximum bipartite matching (Kuhn's algorithm) between `adjacency`'s left nodes
+    (indices into it) and whatever right-side tokens its lists name. Small inputs only --
+    a chapter's simultaneous attackers and a target's firing cells are a handful, never a
+    graph this needs to be fast on."""
+    match_right = {}
+
+    def augment(u, seen):
+        for v in adjacency[u]:
+            if v in seen:
+                continue
+            seen.add(v)
+            if v not in match_right or augment(match_right[v], seen):
+                match_right[v] = u
+                return True
+        return False
+
+    count = 0
+    for u in range(len(adjacency)):
+        if augment(u, set()):
+            count += 1
+    return count
+
+
+def concurrent_attacker_cap(terrain, target, weapon_ranges):
+    """How many attackers, with these `weapon_ranges` (one entry per attacker), can occupy
+    DISTINCT firing cells for `target` in the SAME phase.
+
+    Not every attacker can use every cell -- a melee attacker needs the one door, a range-2
+    attacker can use any of the wider ring -- so this is a bipartite MATCHING between
+    attackers and the cells within each one's own range, not a single number divided
+    between them. ch06's two hulls each have exactly one melee door (cap 1 for any group of
+    melee attackers), so this has nothing to prove there yet; it exists for the wider
+    targets later chapters will field, and is pinned on synthetic mixed-range groups for
+    that reason (`test_rescue_forecast.py`)."""
+    if not weapon_ranges:
+        return 0
+    cells_by_range = {r: firing_cells(terrain, target, r) for r in set(weapon_ranges)}
+    adjacency = [cells_by_range[r] for r in weapon_ranges]
+    return _bipartite_matching_size(adjacency)
+
+
+@dataclasses.dataclass(frozen=True)
+class PursuerForecast:
+    """One (enemy, boat) pair's whole forecast. `arrival_turn` and the `sink_*` fields are
+    `None` when the enemy cannot reach any firing cell for this boat -- "never engages" is
+    the finding, not a missing number."""
+    enemy_id: str
+    boat_id: str
+    weapon_range: int
+    arrival_turn: object
+    damage_per_phase: object
+    sink_low: object
+    sink_expected: object
+    sink_high: object
+
+
+def target_combatant(boat):
+    """The Combatant a `rescue_boats:` entry fights as: its declared class's base stats,
+    unarmed (a rescue target never attacks back -- FE8's civilian hulls carry no weapon)."""
+    enum = dif._enemy_class_enum(boat['class'])
+    base = dif._class_base(enum)
+    return dif._stats_to_combatant(boat.get('id', 'target'), base, weapon=None)
+
+
+def _boat_terrain_name(terrain, boat):
+    tx, ty = boat['tile']
+    return pp.NAME_BY_TERRAIN.get(terrain[ty][tx])
+
+
+def pursuer_forecast(chapter, terrain, enemy_def, index, boat):
+    """The full forecast for one enemy BODY (`enemy_def`'s `index`'th position) against one
+    `rescue_boats:` entry -- arrival, damage/phase, and the sink band, or all `None` past
+    `arrival_turn` when the enemy never gets a firing position at all."""
+    combatants = dif._entry_combatants(enemy_def, real_article=True)
+    attacker = combatants[index]
+    weapon_range = attacker.weapon.rng[1] if attacker.weapon else 0
+    boat_tile = tuple(boat['tile'])
+    none_row = PursuerForecast(enemy_def.get('id'), boat['id'], weapon_range,
+                               None, None, None, None, None)
+    if weapon_range <= 0:
+        return none_row                          # a staff/unarmed body threatens nothing
+    positions = enemy_def.get('positions') or ()
+    if index >= len(positions):
+        return none_row
+    source = positions[index]
+    table, mov = pp.class_movement(enemy_def.get('deploy_class') or enemy_def['class'])
+    blocked = pp.enemy_bodies(chapter)
+    cells = firing_cells(terrain, boat_tile, weapon_range)
+    arrival = arrival_to_cells(terrain, source, table, mov, cells, blocked)
+    if arrival is None:
+        return none_row
+    terrain_name = _boat_terrain_name(terrain, boat)
+    target, terrain_avoid = dif.on_terrain(target_combatant(boat), terrain_name)
+    dpr = fc.damage_per_round(attacker, target, terrain_avoid)
+    band = sink_band(target.hp, attacker, target, terrain_avoid)
+    if band is None:
+        return PursuerForecast(enemy_def.get('id'), boat['id'], weapon_range,
+                               arrival, dpr, None, None, None)
+    return PursuerForecast(enemy_def.get('id'), boat['id'], weapon_range, arrival, dpr,
+                           arrival + band.low, arrival + band.expected, arrival + band.high)
+
+
+def chapter_forecast(chapter):
+    """Every (declared pursuer x rescue boat) forecast for one chapter. [] on a chapter with
+    no `rescue_boats:` or no `rescue_pursuers:` -- there is no clock to forecast."""
+    boats = chapter.get('rescue_boats') or []
+    pursuers = chapter.get('rescue_pursuers') or []
+    if not boats or not pursuers:
+        return []
+    terrain = pp.terrain_grid(chapter)
+    roster = {e.get('id'): e for e in bc.chapter_roster_entries(chapter)}
+    out = []
+    for pursuer in pursuers:
+        enemy_def = roster.get(pursuer['id'])
+        if enemy_def is None:
+            continue                # a chapter-schema problem another guard already catches
+        for index in range(len(enemy_def.get('positions') or ())):
+            for boat in boats:
+                out.append(pursuer_forecast(chapter, terrain, enemy_def, index, boat))
+    return out
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('chapter', help='chapter id or prefix, e.g. ch06')
+    args = ap.parse_args(argv)
+
+    import campaign_chapters
+    chapter = pp.load_chapter(args.chapter)
+    rows = chapter_forecast(chapter)
+    if not rows:
+        print('%s: no rescue_boats/rescue_pursuers declared' % args.chapter)
+        return
+    for row in rows:
+        if row.arrival_turn is None:
+            print('%-22s -> %-10s never reaches a firing cell (weapon range %d)'
+                 % (row.enemy_id, row.boat_id, row.weapon_range))
+            continue
+        print('%-22s -> %-10s arrives turn %-3d %.2f dmg/phase  sinks turn %s-%s (expect %s)'
+             % (row.enemy_id, row.boat_id, row.arrival_turn, row.damage_per_phase,
+                row.sink_low, row.sink_high, row.sink_expected))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/tools/rescue_forecast.py
+++ b/tools/rescue_forecast.py
@@ -53,26 +53,10 @@ import fe_combat as fc                                                # noqa: E4
 import map_placement_preview as pp                                   # noqa: E402
 
 
-def firing_cells(terrain, target, weapon_range):
-    """Every cell at Manhattan distance 1..`weapon_range` from `target` that a foot unit can
-    stand on -- the set of tiles an attacker could occupy to hit it. FE8 has no line of
-    sight (decisions.md -> "What terrain cannot do is stop a ranged weapon"), so this is
-    pure Manhattan distance, not a walk: a range-2 firing cell three tiles out through a
-    wall is exactly as live as the door directly beside the target.
-
-    Standability is FOOT passability (`map_placement_preview.FOOT_COST`), a generic ground
-    proxy rather than any one attacker's own class -- the cell has to exist for SOME ground
-    unit to occupy it before who specifically reaches it is asked. The target's own tile
-    (distance 0) is never a firing cell."""
-    tx, ty = target
-    h, w = len(terrain), len(terrain[0])
-    out = []
-    for y in range(h):
-        for x in range(w):
-            d = abs(x - tx) + abs(y - ty)
-            if 1 <= d <= weapon_range and pp.FOOT_COST.get(terrain[y][x]) is not None:
-                out.append((x, y))
-    return sorted(out)
+# `firing_cells` is a terrain/range primitive -- the same family as `foot_reach` -- and
+# `map_placement_preview.units_reaching` needs the identical rule for its own reachability
+# check, so it lives there and this is an alias, not a second copy (#369 review).
+firing_cells = pp.firing_cells
 
 
 def arrival_to_cells(terrain, source, cost_table, mov, cells, blocked=()):
@@ -81,15 +65,12 @@ def arrival_to_cells(terrain, source, cost_table, mov, cells, blocked=()):
     of `cells`, walking the CONTESTED map (`blocked` -- turn-1 enemy bodies, which a unit
     may not enter or pass through). `None` if none of `cells` is reachable at all -- the
     enemy never gets a firing position, which is a first-class outcome (ch06's
-    merfolk-thrower: its own line corks every one of its four javelin cells)."""
-    if not cells:
-        return None
-    cost = pp.mov_cost_row(cost_table)
-    dist = pp.foot_reach(terrain, [tuple(source)], blocked=blocked, cost=cost)
-    reachable = [dist[c] for c in cells if c in dist]
-    if not reachable:
-        return None
-    return pp.arrival_turn(min(reachable), mov)
+    merfolk-thrower: its own line corks every one of its four javelin cells).
+
+    A thin, single-source wrapper over `map_placement_preview.arrival_turn_to`, which
+    `reached_on` also calls (many-sources-to-one-target, the mirror image of this
+    one-source-to-many-targets shape) -- one Dijkstra-then-arrival-turn composition, not two."""
+    return pp.arrival_turn_to(terrain, [source], cost_table, mov, cells, blocked=blocked)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -206,11 +187,14 @@ class PursuerForecast:
 
 
 def target_combatant(boat):
-    """The Combatant a `rescue_boats:` entry fights as: its declared class's base stats,
-    unarmed (a rescue target never attacks back -- FE8's civilian hulls carry no weapon)."""
-    enum = dif._enemy_class_enum(boat['class'])
-    base = dif._class_base(enum)
-    return dif._stats_to_combatant(boat.get('id', 'target'), base, weapon=None)
+    """The Combatant a `rescue_boats:` entry fights as, resolved through `difficulty._one_enemy`
+    -- the SAME path every other enemy in this codebase resolves through, so a boat that ever
+    declares a `level:`, a class carrying an effectiveness tag, or a `personal:` line is not
+    silently understated the way a hand-rolled class-base read would leave it. Unarmed always
+    (a rescue target never attacks back -- FE8's civilian hulls carry no weapon), regardless
+    of what its class would otherwise wield."""
+    return dif._one_enemy(boat.get('id', 'target'), boat['class'], boat.get('level', 1),
+                          None, personal=boat.get('personal'))
 
 
 def _boat_terrain_name(terrain, boat):

--- a/tools/test_build_campaign.py
+++ b/tools/test_build_campaign.py
@@ -7117,6 +7117,34 @@ class RawPidBossBaseLevel(unittest.TestCase):
             self.assertGreaterEqual(base, self.RAW_BOSSES.get(pid, base), pid)
 
 
+class EntryIsTurn1(unittest.TestCase):
+    """`entry_is_turn1` is the one predicate `difficulty.chapter_enemy_groups` and
+    `map_placement_preview.enemy_bodies` must now share (#367): both readers ask "is this
+    body on the opening board", and both got it wrong by testing `arrives_turn` alone --
+    which is absent, and therefore falsy, on a `reinforcements:`/`enemy_reinforcements:`
+    entry that carries `trigger_turn` instead. The KEY is what makes an entry a
+    reinforcement; `arrives_turn` only refines `enemy_units` itself (ch06's Difficult-only
+    wave stays inside `enemy_units` for exactly this reason)."""
+
+    def test_an_enemy_units_entry_with_no_arrives_turn_is_turn1(self):
+        self.assertTrue(bc.entry_is_turn1('enemy_units', {'id': 'a'}))
+
+    def test_an_enemy_units_entry_with_arrives_turn_1_is_turn1(self):
+        self.assertTrue(bc.entry_is_turn1('enemy_units', {'id': 'a', 'arrives_turn': 1}))
+
+    def test_an_enemy_units_entry_with_arrives_turn_above_1_is_not(self):
+        self.assertFalse(bc.entry_is_turn1('enemy_units', {'id': 'a', 'arrives_turn': 4}))
+
+    def test_a_reinforcements_key_entry_is_never_turn1_even_with_no_arrives_turn(self):
+        # The exact shape of the bug: ch02's `rear-raiders` carries `trigger_turn`, not
+        # `arrives_turn`, so `entry.get('arrives_turn')` alone reads it as turn-1.
+        self.assertFalse(bc.entry_is_turn1('reinforcements',
+                                           {'id': 'rear-raiders', 'trigger_turn': 3}))
+
+    def test_an_enemy_reinforcements_key_entry_is_never_turn1_either(self):
+        self.assertFalse(bc.entry_is_turn1('enemy_reinforcements', {'id': 'w'}))
+
+
 class ArenaTutorialPlaysInEveryMode(unittest.TestCase):
     """ch05's arena tutorial is SAFETY text, so it is not gated on tutorial mode (#303).
 

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -149,6 +149,15 @@ class LooseEnds(unittest.TestCase):
     def test_a_finished_chapter_has_fewer_loose_ends_than_a_planned_one(self):
         self.assertLess(len(cs.loose_ends('ch05')), len(cs.loose_ends('ch06')))
 
+    def test_ch06_reports_its_east_pursuer_cannot_engage(self):
+        """The confirmed #26/#367 finding, surfaced where a fresh session actually reads
+        chapter state -- `make chapter CH=ch06` -- not only in check.py's own stdout."""
+        ends = cs.loose_ends('ch06')
+        self.assertTrue(any('merfolk-thrower' in e for e in ends), ends)
+
+    def test_a_chapter_with_no_rescue_boats_says_nothing_about_a_clock(self):
+        self.assertFalse(any('rescue_pursuer' in e for e in cs.loose_ends('ch05')))
+
 
 class TheReport(unittest.TestCase):
     def test_a_record_scenario_is_not_reported_as_never_run(self):
@@ -200,8 +209,10 @@ class DegradedModesMustSayCannotTell(unittest.TestCase):
 
     def setUp(self):
         self._preview, self._bc = cs._preview_module, cs._build_campaign
+        self._rf = cs._rescue_forecast_module
         self.addCleanup(setattr, cs, '_preview_module', self._preview)
         self.addCleanup(setattr, cs, '_build_campaign', self._bc)
+        self.addCleanup(setattr, cs, '_rescue_forecast_module', self._rf)
         cs._scenes_cache.clear()
 
     def tearDown(self):
@@ -210,6 +221,12 @@ class DegradedModesMustSayCannotTell(unittest.TestCase):
     def test_without_the_preview_module_scenes_are_unknown_not_unpreviewable(self):
         cs._preview_module = lambda: None
         self.assertFalse(any('cannot be previewed' in e for e in cs.loose_ends('ch05')))
+
+    def test_without_rescue_forecast_the_clock_finding_is_silent_not_falsely_clean(self):
+        """ch06 genuinely has an unreachable pursuer; a degraded import must not silently
+        drop that finding by reporting nothing where it would otherwise report a bug."""
+        cs._rescue_forecast_module = lambda: None
+        self.assertFalse(any('merfolk-thrower' in e for e in cs.loose_ends('ch06')))
 
     def test_without_build_campaign_a_full_block_is_not_reported_as_undeclared(self):
         """ch05's block is FULL. Rendering that as 'no host block declared' makes it

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -202,6 +202,23 @@ class TheReport(unittest.TestCase):
             self.assertNotEqual('UNRULED', why, field)
 
 
+class TryImport(unittest.TestCase):
+    """`_preview_module`/`_build_campaign`/`_rescue_forecast_module` were three copies of
+    the same `try: import X; return X; except ImportError: return None` template, differing
+    only in the module name -- this is the one shared implementation each now calls."""
+
+    def test_a_real_module_is_returned(self):
+        self.assertIs(cs._try_import('os'), __import__('os'))
+
+    def test_an_unimportable_name_returns_none_not_a_raise(self):
+        self.assertIsNone(cs._try_import('no_such_module_xyz'))
+
+    def test_each_wrapper_still_resolves_its_own_module_by_name(self):
+        """The refactor must not collapse the three into one shared cache keyed wrong --
+        each wrapper is independently callable and returns ITS module."""
+        self.assertIs(cs._build_campaign(), __import__('build_campaign'))
+
+
 class DegradedModesMustSayCannotTell(unittest.TestCase):
     """Every optional import here has a fallback, and a fallback that reports a WRONG number
     is worse than one that reports none: the whole promise of this command is that its rows

--- a/tools/test_check_rescue_fuse_forecast.py
+++ b/tools/test_check_rescue_fuse_forecast.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Tests for check.py's rescue-fuse-forecast guard (#367, #26).
+
+`check_rescue_targets` (test_check_rescue_targets.py) proves nothing UNDECLARED can attack a
+rescue target. This guard asks the other question: can the DECLARED clock actually reach it,
+and does a declared fuse sit inside the forecast band. It is ADVISORY, not a gate -- ch06's
+own east pursuer fails the first question today (a real, already-confirmed bug, #26), and
+flipping this to a hard gate is a follow-up left for Nicolas once that pursuer is settled.
+Turning it into a gate before then would redden CI on `main` for a finding nobody asked this
+PR to fix.
+
+Run: python3 tools/test_check_rescue_fuse_forecast.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import check                                             # noqa: E402
+import rescue_forecast as rf                             # noqa: E402
+
+
+def row(enemy_id, boat_id, arrival=None, low=None, expected=None, high=None):
+    return rf.PursuerForecast(enemy_id, boat_id, 1, arrival, None, low, expected, high)
+
+
+class ADeclaredPursuerMustReachSomeTarget(unittest.TestCase):
+    def test_a_pursuer_that_reaches_a_boat_is_clean(self):
+        chap = {'rescue_pursuers': [{'id': 'crab'}], 'rescue_boats': [{'id': 'b'}]}
+        rows = [row('crab', 'b', arrival=2, low=6, expected=9, high=12)]
+        self.assertEqual(check._fuse_forecast_findings(chap, rows), [])
+
+    def test_a_pursuer_that_reaches_no_boat_is_reported(self):
+        chap = {'rescue_pursuers': [{'id': 'thrower'}], 'rescue_boats': [{'id': 'east'}]}
+        rows = [row('thrower', 'east', arrival=None)]
+        found = check._fuse_forecast_findings(chap, rows)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('thrower', found[0])
+
+    def test_a_pursuer_that_reaches_at_least_one_of_several_boats_is_clean(self):
+        chap = {'rescue_pursuers': [{'id': 'p'}], 'rescue_boats': [{'id': 'a'}, {'id': 'b'}]}
+        rows = [row('p', 'a', arrival=None), row('p', 'b', arrival=3, low=5, expected=7, high=9)]
+        self.assertEqual(check._fuse_forecast_findings(chap, rows), [])
+
+    def test_every_offending_pursuer_is_reported_not_just_the_first(self):
+        chap = {'rescue_pursuers': [{'id': 'p1'}, {'id': 'p2'}], 'rescue_boats': [{'id': 'a'}]}
+        rows = [row('p1', 'a', arrival=None), row('p2', 'a', arrival=None)]
+        self.assertEqual(2, len(check._fuse_forecast_findings(chap, rows)))
+
+    def test_a_chapter_with_no_rows_for_a_pursuer_says_nothing(self):
+        """A schema mismatch (the pursuer id names no roster entry) is a DIFFERENT guard's
+        job -- this one only speaks to pursuers it was actually able to forecast."""
+        chap = {'rescue_pursuers': [{'id': 'ghost'}], 'rescue_boats': [{'id': 'a'}]}
+        self.assertEqual(check._fuse_forecast_findings(chap, []), [])
+
+
+class ADeclaredFuseMustFallInsideTheBand(unittest.TestCase):
+    """Optional and forward-looking: no shipped chapter declares `declared_fuse` yet (ch06's
+    is prose, in `difficulty_note:`, not a schema field), so this never fires today -- it is
+    built in for the day a chapter adopts the field, per the model's own step 4."""
+
+    def test_a_fuse_inside_the_band_is_clean(self):
+        chap = {'rescue_pursuers': [{'id': 'p'}],
+                'rescue_boats': [{'id': 'b', 'declared_fuse': 8}]}
+        rows = [row('p', 'b', arrival=2, low=6, expected=9, high=12)]
+        self.assertEqual(check._fuse_forecast_findings(chap, rows), [])
+
+    def test_a_fuse_outside_every_reaching_pursuers_band_is_reported(self):
+        chap = {'rescue_pursuers': [{'id': 'p'}],
+                'rescue_boats': [{'id': 'b', 'declared_fuse': 30}]}
+        rows = [row('p', 'b', arrival=2, low=6, expected=9, high=12)]
+        found = check._fuse_forecast_findings(chap, rows)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('b', found[0])
+        self.assertIn('30', found[0])
+
+    def test_no_declared_fuse_means_nothing_to_check(self):
+        chap = {'rescue_pursuers': [{'id': 'p'}], 'rescue_boats': [{'id': 'b'}]}
+        rows = [row('p', 'b', arrival=2, low=6, expected=9, high=12)]
+        self.assertEqual(check._fuse_forecast_findings(chap, rows), [])
+
+    def test_a_fuse_is_not_double_reported_when_nothing_reaches(self):
+        """The unreachable-pursuer finding already says this boat's clock is broken; a
+        second finding about its fuse would just be noise on the same fact."""
+        chap = {'rescue_pursuers': [{'id': 'p'}],
+                'rescue_boats': [{'id': 'b', 'declared_fuse': 8}]}
+        rows = [row('p', 'b', arrival=None)]
+        found = check._fuse_forecast_findings(chap, rows)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('never', found[0])
+
+
+class TheGuardIsAdvisoryAndReproducesCh06(unittest.TestCase):
+    """`check_rescue_fuse_forecast` must NEVER append to `fail` -- ch06 fails the
+    reachability question today and CI on `main` must stay green."""
+
+    def test_the_check_never_fails_the_build(self):
+        fail = []
+        check.check_rescue_fuse_forecast(fail)
+        self.assertEqual(fail, [])
+
+    def test_ch06s_real_finding_is_the_east_pursuer(self):
+        """Not a synthetic stand-in: the real chapter YAML, the real compiled map. This is
+        the confirmed #26 bug the guard exists to surface."""
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            check.check_rescue_fuse_forecast([])
+        self.assertIn('merfolk-thrower', buf.getvalue())
+
+    def test_ch06s_west_pursuer_is_clean_so_it_prints_nothing_about_it(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            check.check_rescue_fuse_forecast([])
+        self.assertNotIn('ice-crab', buf.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_check_rescue_fuse_forecast.py
+++ b/tools/test_check_rescue_fuse_forecast.py
@@ -89,6 +89,18 @@ class ADeclaredFuseMustFallInsideTheBand(unittest.TestCase):
         self.assertEqual(len(found), 1, found)
         self.assertIn('never', found[0])
 
+    def test_a_reaching_pursuer_with_no_sink_band_does_not_crash_the_gate(self):
+        """`pursuer_forecast` returns `arrival_turn` set with `sink_low/high=None` when it
+        reaches a firing cell but deals no true damage (`sink_band`'s own `None` case, e.g.
+        0 hit chance or an effectiveness mismatch) -- a real return shape, not a synthetic
+        edge. This guard's whole docstring promise is that it NEVER fails the build; the
+        comparison must not blow up on the exact row that promise exists to cover."""
+        chap = {'rescue_pursuers': [{'id': 'p'}],
+                'rescue_boats': [{'id': 'b', 'declared_fuse': 8}]}
+        rows = [row('p', 'b', arrival=2)]           # reaches; low/expected/high all None
+        found = check._fuse_forecast_findings(chap, rows)   # must not raise
+        self.assertEqual(found, [])
+
 
 class TheGuardIsAdvisoryAndReproducesCh06(unittest.TestCase):
     """`check_rescue_fuse_forecast` must NEVER append to `fail` -- ch06 fails the

--- a/tools/test_check_rescue_targets.py
+++ b/tools/test_check_rescue_targets.py
@@ -58,5 +58,35 @@ class RescueTargetsHaveOnlyTheirDeclaredClock(unittest.TestCase):
         self.assertIn('pursuer', text)
 
 
+class TheGateSurvivesAnUngroundedRosterEntry(unittest.TestCase):
+    """`check_rescue_targets` now reaches `units_reaching`, which -- since #369 widened it to
+    every roster key -- calls `difficulty.enemy_ai_bytes` on `reinforcements:` and
+    `enemy_reinforcements:` entries too, and that call RAISES on an entry with neither
+    `donor:` nor `ai_override:` (a normal mid-draft state while a chapter is being
+    authored). No live chapter combines `rescue_boats` with such an entry today, but
+    `check.py`'s `main()` calls every check with zero per-check exception isolation, so this
+    is not a print-and-skip away from crashing the WHOLE gate for an unrelated future
+    chapter -- it is one YAML edit away."""
+
+    def _ch06_with_ungrounded_wave(self):
+        import copy
+        import check as chk
+        chap = copy.deepcopy(next(d for rel, d in chk._chapters()
+                                  if d.get('id', '').startswith('ch06')))
+        chap['reinforcements'] = [{'id': 'draft-stub', 'class': 'fighter', 'level': 1,
+                                   'positions': [[0, 0]], 'inventory': [{'id': 'iron-sword'}]}]
+        return chap
+
+    def test_an_ungrounded_reinforcement_does_not_crash_the_whole_gate(self):
+        chap = self._ch06_with_ungrounded_wave()
+        original = check._chapters
+        check._chapters = lambda: iter([('ch06-stub.yaml', chap)])
+        try:
+            fail = []
+            check.check_rescue_targets(fail)          # must not raise
+        finally:
+            check._chapters = original
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -174,6 +174,45 @@ class ContestedReach(unittest.TestCase):
         self.assertIsNone(pp.arrival_turn(None, 5))
 
 
+class EnemyBodiesAndUnitsReachingReadEveryRosterKey(unittest.TestCase):
+    """`enemy_bodies` and `units_reaching` both docstring-claimed to cover reinforcements and
+    both did not: `enemy_bodies` never looked past `enemy_units:`, and a naive fix that just
+    widened the loop without the KEY test would have flipped the bug rather than fixed it,
+    since a `reinforcements:`/`enemy_reinforcements:` entry carries `trigger_turn`, not
+    `arrives_turn` -- ch02's real `rear-raiders` wave (#367).
+    """
+
+    def test_a_reinforcements_key_entry_is_not_a_turn1_blocking_body(self):
+        chap = {'reinforcements': [{'id': 'w', 'trigger_turn': 3, 'positions': [[2, 0]]}]}
+        self.assertEqual(pp.enemy_bodies(chap), set())
+
+    def test_an_enemy_reinforcements_key_entry_is_not_a_turn1_body_either(self):
+        chap = {'enemy_reinforcements': [{'id': 'w', 'trigger_turn': 3,
+                                          'positions': [[2, 0]]}]}
+        self.assertEqual(pp.enemy_bodies(chap), set())
+
+    def test_an_enemy_units_entry_is_still_a_turn1_blocking_body(self):
+        chap = {'enemy_units': [{'id': 'a', 'positions': [[1, 0]]}]}
+        self.assertEqual(pp.enemy_bodies(chap), {(1, 0)})
+
+    def test_an_enemy_units_wave_past_turn_1_is_still_excluded(self):
+        chap = {'enemy_units': [{'id': 'a', 'arrives_turn': 4, 'positions': [[1, 0]]}]}
+        self.assertEqual(pp.enemy_bodies(chap), set())
+
+    def test_units_reaching_finds_a_unit_declared_under_reinforcements(self):
+        """The docstring has always claimed this ("REINFORCEMENTS ARE INCLUDED"); it was
+        only ever true of ch06 because ch06 happens to keep its wave inside `enemy_units`."""
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        terrain = [[plain] * 5]
+        chap = {'reinforcements': [{
+            'id': 'w', 'class': 'soldier', 'level': 1, 'trigger_turn': 3,
+            'inventory': [{'id': 'iron-lance'}], 'positions': [[0, 0]],
+            'ai_override': {'ai': '{0x0, 0x0, 0x0, 0x0}', 'why': 'test pursuer'},
+        }]}
+        found = pp.units_reaching(chap, terrain, [(4, 0)])
+        self.assertEqual([f[0] for f in found], ['w'])
+
+
 class ReachedOnIsDerived(unittest.TestCase):
     """ch06 declares `reached_on:` per class. It is now derived and compared, because a hand-kept
     number that nothing reads is how "foot reaches either door on turn 6" survived as the

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -174,6 +174,45 @@ class ContestedReach(unittest.TestCase):
         self.assertIsNone(pp.arrival_turn(None, 5))
 
 
+class FiringCellsLivesHereNotInRescueForecast(unittest.TestCase):
+    """`firing_cells` (every foot-standable cell within weapon range of a target) is a
+    terrain/range primitive, the same family as `foot_reach`/`mov_cost_row` -- it belongs on
+    this module's desk, not `rescue_forecast`'s, which had grown its own copy of the exact
+    Manhattan-range check `units_reaching` already does inline. `rescue_forecast.firing_cells`
+    is now an alias, so a fix to the rule (the range bound, the passability gate) cannot land
+    in one consumer and not the other."""
+
+    def test_firing_cells_lives_on_map_placement_preview(self):
+        terrain = [[pp.TERRAIN['TERRAIN_PLAINS']] * 5] * 5
+        self.assertEqual(pp.firing_cells(terrain, (2, 2), 1),
+                         [(1, 2), (2, 1), (2, 3), (3, 2)])
+
+    def test_rescue_forecast_is_an_alias_not_a_second_copy(self):
+        import rescue_forecast as rf
+        self.assertIs(rf.firing_cells, pp.firing_cells)
+
+    def test_units_reaching_shares_the_same_range_rule_firing_cells_uses(self):
+        """A STATUE (budget 0 -- cannot move, even to attack) is a threat only from the tile
+        it already stands on, which isolates the pure RANGE check from any movement search:
+        a body on one of `firing_cells`'s own cells is found; the same tile one step outside
+        the range bound is not -- both directions, so a swap to a shared implementation
+        can't silently widen or narrow who counts as a threat."""
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        terrain = [[plain] * 6]
+        statue = {'ai': '{0x3, 0x3, 0x0, 0x0}', 'why': 't'}   # ActionStanding + NeverMove
+        chap = {'enemy_units': [
+            {'id': 'in-range', 'class': 'soldier', 'level': 1,
+             'inventory': [{'id': 'iron-lance'}], 'positions': [[1, 0]],
+             'ai_override': statue},
+            {'id': 'out-of-range', 'class': 'soldier', 'level': 1,
+             'inventory': [{'id': 'iron-lance'}], 'positions': [[5, 0]],
+             'ai_override': statue},
+        ]}
+        found = {eid for eid, _ai in pp.units_reaching(chap, terrain, [(2, 0)])}
+        self.assertIn('in-range', found)          # iron-lance range 2: |1-2| = 1
+        self.assertNotIn('out-of-range', found)   # |5-2| = 3, past range
+
+
 class EnemyBodiesAndUnitsReachingReadEveryRosterKey(unittest.TestCase):
     """`enemy_bodies` and `units_reaching` both docstring-claimed to cover reinforcements and
     both did not: `enemy_bodies` never looked past `enemy_units:`, and a naive fix that just
@@ -211,6 +250,84 @@ class EnemyBodiesAndUnitsReachingReadEveryRosterKey(unittest.TestCase):
         }]}
         found = pp.units_reaching(chap, terrain, [(4, 0)])
         self.assertEqual([f[0] for f in found], ['w'])
+
+    def _reinforcement_entry(self, eid='w'):
+        return {'id': eid, 'class': 'soldier', 'level': 1, 'trigger_turn': 3,
+                'inventory': [{'id': 'iron-lance'}], 'positions': [[0, 0]],
+                'ai_override': {'ai': '{0x0, 0x0, 0x0, 0x0}', 'why': 'test pursuer'}}
+
+    def test_placed_units_draws_a_reinforcements_key_wave_too(self):
+        """`placed_units` -- the tool's own PNG render, not a value any gate consumes --
+        was the THIRD copy of this exact bug: it still read `chapter.get('enemy_units')`
+        alone, so a `reinforcements:`/`enemy_reinforcements:` wave was simply absent from
+        the picture, even after `enemy_bodies` and `units_reaching` were fixed to see it."""
+        chap = {'reinforcements': [self._reinforcement_entry()]}
+        units = pp.placed_units(chap)
+        self.assertEqual([eid for _tile, _code, _beh, eid, _late in units], ['w'])
+
+    def test_placed_units_marks_a_reinforcements_key_wave_as_LATE(self):
+        """The render draws a late body as a hollow ring -- 'not here at turn 1'. A
+        reinforcement-key entry is never turn-1 regardless of its own fields, per
+        `build_campaign.entry_is_turn1`."""
+        chap = {'reinforcements': [self._reinforcement_entry()]}
+        _tile, _code, _beh, _eid, late = pp.placed_units(chap)[0]
+        self.assertTrue(late)
+
+    def test_placed_units_still_marks_a_hard_mode_only_enemy_units_entry_as_LATE(self):
+        """`hard_mode_only` is a MODE gate, not a turn-arrival one -- `entry_is_turn1` does
+        not know about it, so the two conditions have to stay OR'd, not replaced."""
+        chap = {'enemy_units': [{'id': 'h', 'class': 'soldier', 'level': 1,
+                                 'hard_mode_only': True,
+                                 'inventory': [{'id': 'iron-lance'}], 'positions': [[0, 0]],
+                                 'ai_override': {'ai': '{0x0, 0x0, 0x0, 0x0}', 'why': 't'}}]}
+        _tile, _code, _beh, _eid, late = pp.placed_units(chap)[0]
+        self.assertTrue(late)
+
+    def test_placed_units_still_marks_a_plain_enemy_units_body_as_not_late(self):
+        chap = {'enemy_units': [{'id': 'a', 'class': 'soldier', 'level': 1,
+                                 'inventory': [{'id': 'iron-lance'}], 'positions': [[0, 0]],
+                                 'ai_override': {'ai': '{0x0, 0x0, 0x0, 0x0}', 'why': 't'}}]}
+        _tile, _code, _beh, _eid, late = pp.placed_units(chap)[0]
+        self.assertFalse(late)
+
+
+class ArrivalTurnToIsSharedByBothDirections(unittest.TestCase):
+    """`reached_on` (MANY deploy cells -> ONE target) and `rescue_forecast.arrival_to_cells`
+    (ONE enemy -> MANY candidate firing cells) were mirror-image compositions of the exact
+    same two primitives, `foot_reach` then `arrival_turn`, glued together twice. One
+    function that takes both ends as lists covers either direction; `reached_on` and
+    `arrival_to_cells` are both thin callers of it now."""
+
+    def test_many_sources_to_one_target_matches_reached_on(self):
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        terrain = [[plain] * 6]
+        got = pp.arrival_turn_to(terrain, [(0, 0), (5, 0)], 'TerrainTable_MovCost_CommonT1Normal',
+                                 mov=3, targets=[(2, 0)])
+        self.assertEqual(got, 1)          # (0,0) is 2 points away, one turn at mov 3
+
+    def test_one_source_to_many_targets_matches_arrival_to_cells(self):
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        terrain = [[plain] * 6]
+        got = pp.arrival_turn_to(terrain, [(0, 0)], 'TerrainTable_MovCost_CommonT1Normal',
+                                 mov=3, targets=[(5, 0), (2, 0)])
+        self.assertEqual(got, 1)          # the NEARER target wins, whichever list position
+
+    def test_no_reachable_target_is_none_not_an_error(self):
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        terrain = [[plain] * 6]
+        got = pp.arrival_turn_to(terrain, [(0, 0)], 'TerrainTable_MovCost_CommonT1Normal',
+                                 mov=3, targets=[])
+        self.assertIsNone(got)
+
+    def test_rescue_forecasts_arrival_to_cells_delegates_to_the_shared_primitive(self):
+        import rescue_forecast as rf
+        plain = [t for t, c in pp.FOOT_COST.items() if c == 1][0]
+        terrain = [[plain] * 6]
+        via_wrapper = rf.arrival_to_cells(terrain, (0, 0),
+                                          'TerrainTable_MovCost_CommonT1Normal', 3, [(2, 0)])
+        via_shared = pp.arrival_turn_to(terrain, [(0, 0)],
+                                        'TerrainTable_MovCost_CommonT1Normal', 3, [(2, 0)])
+        self.assertEqual(via_wrapper, via_shared)
 
 
 class ReachedOnIsDerived(unittest.TestCase):

--- a/tools/test_rescue_forecast.py
+++ b/tools/test_rescue_forecast.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Tests for tools/rescue_forecast.py -- the rescue-fuse forecast + guard (#367, #26).
+
+The oracle here is ch06's own measured numbers (given, not re-derived): boat-east's four
+javelin-range firing cells and one melee door, boat-west's three and one, merfolk-thrower's
+2.76 dmg/phase and total inability to reach a firing cell on the contested snapshot, and
+ice-crab's 2.82 dmg/phase, turn-2 arrival, and ~turn-9 forecast sink against a declared 8.
+Every one of these is pinned against the REAL ch06 chapter YAML + compiled map, never a
+synthetic stand-in, because the whole value of this tool is that it reproduces a chapter
+nobody hand-checked correctly the first time.
+
+Run: python3 tools/test_rescue_forecast.py
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import fe_combat as fc                                                # noqa: E402
+import map_placement_preview as pp                                    # noqa: E402
+import rescue_forecast as rf                                          # noqa: E402
+
+
+def ch06():
+    return pp.load_chapter('ch06')
+
+
+class FiringCells(unittest.TestCase):
+    """Every cell within weapon range that a foot unit can stand on -- the throughput
+    bound: at most one attacker per cell per phase."""
+
+    def setUp(self):
+        self.terrain = pp.terrain_grid(ch06())
+
+    def test_boat_east_javelin_range_cells_are_exactly_the_measured_four(self):
+        cells = rf.firing_cells(self.terrain, (17, 12), 2)
+        self.assertEqual(sorted(cells), sorted([(15, 12), (17, 10), (17, 13), (17, 14)]))
+
+    def test_boat_east_melee_range_is_only_its_declared_door(self):
+        cells = rf.firing_cells(self.terrain, (17, 12), 1)
+        self.assertEqual(cells, [(17, 13)])
+
+    def test_boat_west_javelin_range_cells_are_exactly_the_measured_three(self):
+        cells = rf.firing_cells(self.terrain, (4, 17), 2)
+        self.assertEqual(sorted(cells), sorted([(2, 17), (4, 18), (4, 19)]))
+
+    def test_boat_west_melee_range_is_only_its_declared_door(self):
+        cells = rf.firing_cells(self.terrain, (4, 17), 1)
+        self.assertEqual(cells, [(4, 18)])
+
+    def test_a_cell_ON_the_target_is_never_a_firing_cell(self):
+        """Distance 0 is the target's own tile, not a place to stand and shoot from."""
+        cells = rf.firing_cells(self.terrain, (17, 12), 2)
+        self.assertNotIn((17, 12), cells)
+
+
+class ArrivalToFiringCells(unittest.TestCase):
+    """The clock's first half: does a pursuer even get a shot, and when.
+
+    Pinned against the exact ch06 finding (#26): the east pursuer's own allies cork every
+    one of its four firing cells on the contested (turn-1-blocked) snapshot, so its declared
+    fuse describes a unit that never arrives; the west pursuer reaches its one door on turn 2.
+    """
+
+    def setUp(self):
+        self.chap = ch06()
+        self.terrain = pp.terrain_grid(self.chap)
+        self.blocked = pp.enemy_bodies(self.chap)
+
+    def test_merfolk_thrower_cannot_reach_any_east_firing_cell(self):
+        cells = rf.firing_cells(self.terrain, (17, 12), 2)
+        table, mov = pp.class_movement('soldier')
+        arrival = rf.arrival_to_cells(self.terrain, (14, 9), table, mov, cells, self.blocked)
+        self.assertIsNone(arrival)
+
+    def test_ice_crab_reaches_its_door_on_turn_2(self):
+        cells = rf.firing_cells(self.terrain, (4, 17), 1)
+        table, mov = pp.class_movement('bael')
+        arrival = rf.arrival_to_cells(self.terrain, (7, 20), table, mov, cells, self.blocked)
+        self.assertEqual(arrival, 2)
+
+    def test_an_empty_cell_list_never_arrives(self):
+        table, mov = pp.class_movement('bael')
+        self.assertIsNone(rf.arrival_to_cells(self.terrain, (7, 20), table, mov, [], set()))
+
+    def test_the_source_itself_may_be_a_firing_cell(self):
+        table, mov = pp.class_movement('bael')
+        arrival = rf.arrival_to_cells(self.terrain, (7, 20), table, mov, [(7, 20)], set())
+        self.assertEqual(arrival, 1)
+
+
+def _hull_on_forest():
+    """CLASS_FLEET's real base stats (19 HP, 5 Def), fighting on FOREST (+1 Def / +20 avoid)
+    -- the oracle's own combatant, resolved the same way `difficulty.on_terrain` resolves
+    any defender."""
+    import difficulty as dif
+    hull = fc.Combatant('hull', hp=19, pow=1, skl=1, spd=2, df=5, res=0, lck=0, con=25,
+                        weapon=None)
+    return dif.on_terrain(hull, 'TERRAIN_FOREST')          # (combatant, terrain_avoid)
+
+
+class DamagePerPhase(unittest.TestCase):
+    """Thin pass-through to fe_combat -- never a second combat model. Pinned against the
+    two ch06 pursuers' measured numbers."""
+
+    def test_merfolk_thrower_deals_the_measured_2_76(self):
+        hull, avo = _hull_on_forest()
+        thrower = fc.Combatant('merfolk-thrower', hp=25, pow=6, skl=2, spd=2, df=1, res=1,
+                               lck=2, con=6, weapon=fc.W['javelin'])
+        self.assertAlmostEqual(fc.damage_per_round(thrower, hull, avo), 2.76, places=2)
+
+    def test_ice_crab_deals_the_measured_2_82(self):
+        hull, avo = _hull_on_forest()
+        crab = fc.Combatant('ice-crab', hp=25, pow=6, skl=3, spd=3, df=6, res=1, lck=0,
+                            con=12, weapon=fc.W['venin-claw'])
+        self.assertAlmostEqual(fc.damage_per_round(crab, hull, avo), 2.82, places=2)
+
+
+class SinkBand(unittest.TestCase):
+    """A rescue clock is a HIT RATE (decisions.md), so the sink turn is reported as a BAND.
+
+    `sink_band` returns phases-from-arrival, not turns -- the caller adds the arrival turn.
+    """
+
+    def test_a_weaponless_attacker_never_sinks_anything(self):
+        hull, avo = _hull_on_forest()
+        nobody = fc.Combatant('nobody', hp=1, pow=0, skl=0, spd=0, df=0, res=0, lck=0,
+                              con=1, weapon=None)
+        self.assertIsNone(rf.sink_band(hull.hp, nobody, hull, avo))
+
+    def test_zero_damage_against_the_target_never_sinks_it(self):
+        hull, avo = _hull_on_forest()
+        toothless = fc.Combatant('toothless', hp=10, pow=0, skl=0, spd=0, df=0, res=0,
+                                 lck=0, con=1, weapon=fc.Weapon('nub', 0, 90, 0, 1, 'sword'))
+        self.assertIsNone(rf.sink_band(hull.hp, toothless, hull, avo))
+
+    def test_the_point_estimate_matches_hp_over_damage_per_phase(self):
+        """The literal spec: forecast sink turn = arrival + HP / damage_per_phase. `expected`
+        is that quantity (in phases, ceiling'd -- a turn is whole)."""
+        import math
+        hull, avo = _hull_on_forest()
+        crab = fc.Combatant('ice-crab', hp=25, pow=6, skl=3, spd=3, df=6, res=1, lck=0,
+                            con=12, weapon=fc.W['venin-claw'])
+        band = rf.sink_band(hull.hp, crab, hull, avo)
+        dpr = fc.damage_per_round(crab, hull, avo)
+        self.assertEqual(band.expected, math.ceil(hull.hp / dpr))
+        # The oracle: arrival(2) + this expected phase count lands turn 9.
+        self.assertEqual(2 + band.expected, 9)
+
+    def test_the_band_widens_around_the_point_estimate_never_narrows_to_it(self):
+        hull, avo = _hull_on_forest()
+        crab = fc.Combatant('ice-crab', hp=25, pow=6, skl=3, spd=3, df=6, res=1, lck=0,
+                            con=12, weapon=fc.W['venin-claw'])
+        band = rf.sink_band(hull.hp, crab, hull, avo)
+        self.assertLessEqual(band.low, band.expected)
+        self.assertGreaterEqual(band.high, band.expected)
+
+    def test_the_low_bound_never_beats_every_hit_connecting(self):
+        """No amount of luck sinks a hull faster than one hit per phase connecting every
+        time -- the deterministic floor."""
+        import math
+        hull, avo = _hull_on_forest()
+        crab = fc.Combatant('ice-crab', hp=25, pow=6, skl=3, spd=3, df=6, res=1, lck=0,
+                            con=12, weapon=fc.W['venin-claw'])
+        band = rf.sink_band(hull.hp, crab, hull, avo)
+        dmg = fc.damage(crab, hull)
+        hits = 2 if fc.doubles(crab, hull) else 1
+        floor_phases = math.ceil(math.ceil(hull.hp / dmg) / hits)
+        self.assertGreaterEqual(band.low, floor_phases)
+
+    def test_a_declared_fuse_of_8_falls_inside_the_west_band(self):
+        """The oracle's own sanity check: ch06's declared west fuse (turn 8) should sit
+        inside the arrival + band this tool reports, or the design note and the model
+        disagree about the same hull."""
+        hull, avo = _hull_on_forest()
+        crab = fc.Combatant('ice-crab', hp=25, pow=6, skl=3, spd=3, df=6, res=1, lck=0,
+                            con=12, weapon=fc.W['venin-claw'])
+        band = rf.sink_band(hull.hp, crab, hull, avo)
+        arrival = 2
+        self.assertLessEqual(arrival + band.low, 8)
+        self.assertGreaterEqual(arrival + band.high, 8)
+
+    def test_a_higher_hit_chance_narrows_the_band(self):
+        """More certainty -> tighter spread. A sanity check on the shape of the model, not
+        a fourth combat system: everything here is fe_combat's own hit/damage math."""
+        hull, avo = _hull_on_forest()
+        iffy = fc.Combatant('iffy', hp=25, pow=0, skl=0, spd=0, df=0, res=0, lck=0, con=20,
+                            weapon=fc.Weapon('poke', 3, 40, 0, 1, 'sword'))
+        sure = fc.Combatant('sure', hp=25, pow=0, skl=20, spd=0, df=0, res=0, lck=0, con=20,
+                            weapon=fc.Weapon('poke', 3, 90, 0, 1, 'sword'))
+        target = fc.Combatant('t', hp=20, pow=0, skl=0, spd=0, df=0, res=0, lck=0, con=1,
+                              weapon=None)
+        wide = rf.sink_band(target.hp, iffy, target, 0)
+        narrow = rf.sink_band(target.hp, sure, target, 0)
+        self.assertGreater(wide.high - wide.low, narrow.high - narrow.low)
+
+
+class ConcurrentAttackerCap(unittest.TestCase):
+    """The throughput bound generalised past one door: `ch06's two hulls each have exactly
+    ONE melee door so this is not load-bearing there, but later chapters will have wider
+    targets` -- so it is pinned on synthetic grids wide enough to exercise it, plus ch06's
+    real single-door case."""
+
+    def setUp(self):
+        self.terrain = pp.terrain_grid(ch06())
+
+    def test_ch06_boat_east_caps_melee_at_its_one_door(self):
+        cap = rf.concurrent_attacker_cap(self.terrain, (17, 12), [1, 1, 1])
+        self.assertEqual(cap, 1)
+
+    def test_ch06_boat_east_caps_javelin_range_attackers_at_four(self):
+        cap = rf.concurrent_attacker_cap(self.terrain, (17, 12), [2, 2, 2, 2, 2])
+        self.assertEqual(cap, 4)
+
+    def test_a_mixed_group_each_takes_its_own_cell(self):
+        """One melee attacker (needs the one door) plus one range-2 attacker (any of four
+        cells, one of which is the door) -- a correct MATCHING gives each its own cell."""
+        cap = rf.concurrent_attacker_cap(self.terrain, (17, 12), [1, 2])
+        self.assertEqual(cap, 2)
+
+    def test_a_second_melee_attacker_with_no_other_cell_goes_unmatched(self):
+        """Two melee attackers both need the ONE door; only one gets it. The two range-2
+        attackers still get their own cells from the other three, so the matching is 3 of
+        4, not 4 of 4 -- the melee slot is the bottleneck, not the whole group."""
+        cap = rf.concurrent_attacker_cap(self.terrain, (17, 12), [1, 1, 2, 2])
+        self.assertEqual(cap, 3)
+
+    def test_no_attackers_is_a_cap_of_zero(self):
+        self.assertEqual(rf.concurrent_attacker_cap(self.terrain, (17, 12), []), 0)
+
+
+class PursuerForecast(unittest.TestCase):
+    """The whole orchestration, end to end, against the chapter YAML -- exactly what the
+    guard and `make chapter CH=ch06` read."""
+
+    def setUp(self):
+        self.chap = ch06()
+        self.terrain = pp.terrain_grid(self.chap)
+
+    def _entry(self, uid):
+        import difficulty as dif
+        return next(e for e in dif.chapter_roster_entries(self.chap) if e.get('id') == uid)
+
+    def _boat(self, bid):
+        return next(b for b in self.chap['rescue_boats'] if b['id'] == bid)
+
+    def test_merfolk_thrower_never_engages_boat_east(self):
+        row = rf.pursuer_forecast(self.chap, self.terrain, self._entry('merfolk-thrower'),
+                                  0, self._boat('boat-east'))
+        self.assertIsNone(row.arrival_turn)
+        self.assertIsNone(row.sink_low)
+        self.assertIsNone(row.sink_expected)
+        self.assertIsNone(row.sink_high)
+
+    def test_ice_crab_engages_boat_west_on_turn_2_and_sinks_around_9(self):
+        row = rf.pursuer_forecast(self.chap, self.terrain, self._entry('ice-crab'),
+                                  0, self._boat('boat-west'))
+        self.assertEqual(row.arrival_turn, 2)
+        self.assertAlmostEqual(row.damage_per_phase, 2.82, places=2)
+        self.assertEqual(row.sink_expected, 9)
+        self.assertLessEqual(row.sink_low, 8)
+        self.assertGreaterEqual(row.sink_high, 8)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_rescue_forecast.py
+++ b/tools/test_rescue_forecast.py
@@ -16,6 +16,7 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import difficulty as dif                                              # noqa: E402
 import fe_combat as fc                                                # noqa: E402
 import map_placement_preview as pp                                    # noqa: E402
 import rescue_forecast as rf                                          # noqa: E402
@@ -97,6 +98,42 @@ def _hull_on_forest():
     hull = fc.Combatant('hull', hp=19, pow=1, skl=1, spd=2, df=5, res=0, lck=0, con=25,
                         weapon=None)
     return dif.on_terrain(hull, 'TERRAIN_FOREST')          # (combatant, terrain_avoid)
+
+
+class TargetCombatant(unittest.TestCase):
+    """A `rescue_boats:` entry's fighting stats resolve through `difficulty._one_enemy` --
+    the SAME path every other enemy in the codebase resolves through -- rather than a
+    hand-rolled `_class_base` + `_stats_to_combatant` that skips autolevel, class tags and
+    a personal line. ch06's boats are level-1, no-personal `CLASS_FLEET`, so the bypass was
+    a no-op there; these pin the three things it would get wrong the day a boat entry
+    declares any of them."""
+
+    def test_a_boats_stats_come_from_ONE_of_enemy(self):
+        boat = {'id': 'hull', 'class': 'fleet'}
+        got = rf.target_combatant(boat)
+        want = dif._one_enemy('hull', 'fleet', 1, None)
+        self.assertEqual((got.hp, got.pow, got.skl, got.spd, got.df, got.res, got.lck,
+                          got.con), (want.hp, want.pow, want.skl, want.spd, want.df,
+                                     want.res, want.lck, want.con))
+
+    def test_a_declared_level_is_autoleveled_not_ignored(self):
+        """The exact bug: a naive class-base read never grows past L1."""
+        l1 = rf.target_combatant({'id': 'hull', 'class': 'armor-knight'})
+        l10 = rf.target_combatant({'id': 'hull', 'class': 'armor-knight', 'level': 10})
+        self.assertGreater(l10.hp, l1.hp)
+
+    def test_a_class_carrying_an_effectiveness_tag_keeps_it(self):
+        """`fe_combat` reads `tags` to resolve effective weapons (a Rapier vs `armor`). A
+        hand-rolled Combatant that skips `CLASS_TAGS` is invisible to that -- silently
+        wrong, not merely incomplete."""
+        boat = rf.target_combatant({'id': 'hull', 'class': 'armor-knight'})
+        self.assertIn('armor', boat.tags)
+
+    def test_a_boat_never_carries_a_weapon(self):
+        """The one thing the bypass got right on purpose: a rescue target never attacks
+        back, so `_one_enemy` is called with `weapon=None` regardless of the boat's class."""
+        boat = rf.target_combatant({'id': 'hull', 'class': 'fleet'})
+        self.assertIsNone(boat.weapon)
 
 
 class DamagePerPhase(unittest.TestCase):


### PR DESCRIPTION
#367 asked whether the difficulty model has a spatial element that was designed and never wired. A full per-tile danger grid was explicitly cut from scope (Nicolas, 2026-09-05) in favor of the narrower, reusable question every chapter with a rescue clock actually asks:

**for a protected tile (a rescue boat, a defend objective, a fragile NPC), which enemies can get a firing position on it, on what turn, for how much damage per phase, and therefore when does it die?**

`tools/rescue_forecast.py` answers exactly that, reusing three things that already existed on three different desks rather than building a new model: `map_placement_preview.foot_reach` (the contested Dijkstra `reached_on_contested:` already uses), `difficulty`'s stat resolution, and `fe_combat.damage_per_round` (the decomp's own combat math).

## The five pieces

1. `firing_cells(terrain, target, weapon_range)` — every cell within range a foot unit can stand on. FE8 has no line of sight, so this is pure Manhattan distance, not a walk.
2. `arrival_to_cells` — the turn an enemy first stands on any firing cell, walking the **contested** map (turn-1 bodies block). `None` — never engages — is a first-class result, not an error.
3. Damage/phase via `fe_combat.damage_per_round`, target resolved on its real terrain.
4. `sink_band` — HP / damage-per-phase is a **mean**, not a fact (`decisions.md` → *"A rescue clock is a HIT RATE"*), so the sink turn is reported as a band (Wald/inverse-Gaussian first-passage approximation), stated in the docstring as a heuristic width, not a claimed percentile.
5. `concurrent_attacker_cap` — a bipartite matching between attackers and the firing cells each one's range reaches, not a naive sum. ch06's two hulls each have exactly one melee door so this isn't load-bearing there yet, but it's built in for wider targets later chapters will ship.

## Validated against ch06's own measured numbers, not synthetic stand-ins

```
merfolk-thrower  -> boat-east   never reaches a firing cell (weapon range 2)
merfolk-thrower  -> boat-west   never reaches a firing cell (weapon range 2)
ice-crab         -> boat-east   never reaches a firing cell (weapon range 1)
ice-crab         -> boat-west   arrives turn 2   2.82 dmg/phase   sinks turn 6-12 (expect 9)
```

boat-east's javelin-range firing cells compute to exactly `(15,12) (17,10) (17,13) (17,14)` (one melee cell `(17,13)`); boat-west's to `(2,17) (4,18) (4,19)` (one melee cell `(4,18)`) — both match their declared `door`.

**The finding this reproduces, in one number: ch06's declared "sinks the hull on turn 7" (east) describes a unit that never arrives.** `merfolk-thrower` computes to 2.76 dmg/phase against the hull's real fighting stats (19 HP / 6 Def in forest cover / +20 avoid) — respectable — but **cannot reach any east firing cell on the contested snapshot: its own allies cork all four.** That prose lived in `difficulty_note:`, not a schema field, so nothing was asserting it and nothing broke when it stopped being true. Same shape as the already-confirmed #26 bug: the tooling that measures a chapter's clock didn't exist, so the design note was never checked against the map it now sits on.

`ice-crab`'s west forecast (arrives turn 2, sinks turn 6–12, expected 9) matches the instrumented run on #26 — arriving enemy phase 2, attacking from `(4,18)` and only that cell for five phases — and lands inside a declared fuse of 8.

## The guard is advisory, not a gate — on purpose

`check.check_rescue_fuse_forecast` prints (never appends to `fail`) when a declared `rescue_pursuers:` id can't reach a firing cell for any of its chapter's `rescue_boats`. **This PR does not touch ch06's YAML to make the guard pass** — the finding is real and the fix (move the pursuer, or re-declare which hull is the east clock) is Nicolas's design call, not a bug in the tool. `chapter_status.loose_ends` surfaces the identical finding for `make chapter CH=ch06`, sharing `check._fuse_forecast_findings` so the two never drift into two different opinions about the same chapter. Flipping reachability to a hard gate is the natural follow-up once ch06's east pursuer is resettled.

## Same code path, two latent bugs fixed alongside it (`map_placement_preview.py`)

- `units_reaching` iterated `chapter['enemy_units']` only, though its docstring claimed reinforcements were included — true only because ch06 happens to keep its Difficult-only wave inside `enemy_units`. Now reads `build_campaign.chapter_roster_entries`, every roster key.
- `enemy_bodies` never read past `enemy_units:` at all, so a `reinforcements:`/`enemy_reinforcements:` entry's body was invisible to the contested Dijkstra's blockers regardless of timing — and simply widening the loop without also fixing the timing test would have flipped the bug rather than closed it, since those keys carry `trigger_turn`, not `arrives_turn` (testing `arrives_turn` alone reads an absent field as falsy, i.e. turn-1 — exactly backwards). The one correct predicate was already living correctly, but only, inside `difficulty.chapter_enemy_groups`; it's now `build_campaign.entry_is_turn1(key, enemy_def)`, and both readers share it.

## Verification

- Output diff over **all nine chapters** (ch00–ch08 — a previous PR in this area got burned diffing only seven): `enemy_bodies`, `units_reaching` (against each chapter's own `rescue_boats`, `[]` where none declared) and `difficulty.chapter_enemy_groups` — **byte-identical before and after, on every chapter.** ch02 is the only chapter using a `reinforcements:` key today, and its wave was invisible to `enemy_bodies` both before (never read) and after (correctly excluded as not-turn-1); no chapter besides ch06 declares `rescue_boats`. `chapter_status.report()` moves on exactly one chapter (ch06), by exactly one line — the new advisory loose-end.
- `tools/test_rescue_forecast.py` (25), `tools/test_check_rescue_fuse_forecast.py` (12), `tools/test_map_placement_preview.py` (28, +new), `tools/test_build_campaign.py`, `tools/test_chapter_status.py` — all green, each test written first and watched fail.
- `make check` — green, drift clean, advisory finding prints as designed (not gating).
- No ROM build, no emulator, no playtest run.

ADR: `docs/decisions.md` → *"A rescue-fuse FORECAST is the reusable question, and it is not a danger grid"*.

Part of #367. The corking bug it reproduces is on #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
