### PR TITLE
ch06: move the east pursuer's own line off its firing-cell corridor (#26, #367)

### DIFF
--- a/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
+++ b/campaigns/rime-of-the-frostmaiden/chapters/ch06-the-maer-monster.yaml
@@ -272,7 +272,13 @@ enemy_units:
     # only foot channel to the west door -- contested foot arrival was turn 11 against a
     # turn-8 fuse, i.e. unsaveable. At (3,14) it is turn 6, which is vanilla Ch6's own
     # foot number. Derived, not eyeballed: `map_placement_preview.reached_on`.
-    positions: [[18, 14], [3, 14], [13, 11], [7, 15]]
+    # (13,11) -> (13,13): the EAST clock's mirror of the same bug. This body plus
+    # ironshell-horseslayer at (14,12) corked all four of merfolk-thrower's javelin firing
+    # cells, so the declared east pursuer never reached one on the contested snapshot --
+    # its "sinks turn 7" fuse described a unit that never arrived (#26, #367,
+    # `tools/rescue_forecast.py`). At (13,13) the corridor opens: the thrower reaches
+    # (15,12) on turn 2, same as the empty-map design always assumed.
+    positions: [[18, 14], [3, 14], [13, 13], [7, 15]]
     donor: [[14, 9], [15, 7], [20, 7], [19, 13]] # vanilla's four HOLDING L7 soldiers
     skin:
       look: "merfolk spear-guard; the anim's lance IS a trident"
@@ -499,7 +505,11 @@ enemy_units:
       - id: horseslayer
       - id: javelin
     damage_type: piercing
-    positions: [[14, 12]]
+    # (14,12) -> (15,13): its old tile plus merfolk-trident's (13,11) body corked all four
+    # of merfolk-thrower's east firing cells, so the declared pursuer never engaged (#26,
+    # #367). Moved off the corridor rather than off the map: it keeps its own do-not-attack
+    # AI_A_08 override and its javelin still threatens the same corridor, one tile south.
+    positions: [[15, 13]]
     donor: [21, 13]                 # vanilla's third L6 knight
     skin: {look: "as ironshell-guard", source: "as ironshell-guard"}
 

--- a/tools/test_chapter_status.py
+++ b/tools/test_chapter_status.py
@@ -149,11 +149,16 @@ class LooseEnds(unittest.TestCase):
     def test_a_finished_chapter_has_fewer_loose_ends_than_a_planned_one(self):
         self.assertLess(len(cs.loose_ends('ch05')), len(cs.loose_ends('ch06')))
 
-    def test_ch06_reports_its_east_pursuer_cannot_engage(self):
-        """The confirmed #26/#367 finding, surfaced where a fresh session actually reads
-        chapter state -- `make chapter CH=ch06` -- not only in check.py's own stdout."""
+    def test_ch06s_rescue_clock_is_clean_after_the_east_pursuer_fix(self):
+        """Was the confirmed #26/#367 finding (the east pursuer corked by its own line,
+        `merfolk-thrower` at (14,9) unable to reach any of boat-east's firing cells) --
+        fixed on ch06-east-pursuer by moving the two corking bodies off the corridor. The
+        WIRING that would surface such a finding (`make chapter CH=chNN`, not just
+        check.py's stdout) is still exercised by the mocked-module test below plus the pure
+        `_fuse_forecast_findings` logic tests in test_check_rescue_fuse_forecast.py -- this
+        test only pins that ch06's real data no longer trips it."""
         ends = cs.loose_ends('ch06')
-        self.assertTrue(any('merfolk-thrower' in e for e in ends), ends)
+        self.assertFalse(any('merfolk-thrower' in e for e in ends), ends)
 
     def test_a_chapter_with_no_rescue_boats_says_nothing_about_a_clock(self):
         self.assertFalse(any('rescue_pursuer' in e for e in cs.loose_ends('ch05')))

--- a/tools/test_check_rescue_fuse_forecast.py
+++ b/tools/test_check_rescue_fuse_forecast.py
@@ -103,23 +103,26 @@ class ADeclaredFuseMustFallInsideTheBand(unittest.TestCase):
 
 
 class TheGuardIsAdvisoryAndReproducesCh06(unittest.TestCase):
-    """`check_rescue_fuse_forecast` must NEVER append to `fail` -- ch06 fails the
-    reachability question today and CI on `main` must stay green."""
+    """`check_rescue_fuse_forecast` must NEVER append to `fail`, regardless of whether any
+    chapter's rescue clock is currently clean -- ch06's east pursuer was the confirmed #26
+    bug this guard was built to surface (`merfolk-thrower` corked by its own line), fixed on
+    ch06-east-pursuer by moving the two corking bodies off the corridor. The advisory
+    contract has to hold either way, so this class no longer needs a live finding to test it."""
 
     def test_the_check_never_fails_the_build(self):
         fail = []
         check.check_rescue_fuse_forecast(fail)
         self.assertEqual(fail, [])
 
-    def test_ch06s_real_finding_is_the_east_pursuer(self):
-        """Not a synthetic stand-in: the real chapter YAML, the real compiled map. This is
-        the confirmed #26 bug the guard exists to surface."""
+    def test_ch06s_pursuers_are_now_clean_so_it_prints_nothing_about_them(self):
+        """Not a synthetic stand-in: the real chapter YAML, the real compiled map. Confirms
+        the fix, not just the tool -- a regression here means the corridor corked again."""
         import io
         from contextlib import redirect_stdout
         buf = io.StringIO()
         with redirect_stdout(buf):
             check.check_rescue_fuse_forecast([])
-        self.assertIn('merfolk-thrower', buf.getvalue())
+        self.assertNotIn('merfolk-thrower', buf.getvalue())
 
     def test_ch06s_west_pursuer_is_clean_so_it_prints_nothing_about_it(self):
         import io

--- a/tools/test_rescue_forecast.py
+++ b/tools/test_rescue_forecast.py
@@ -58,9 +58,12 @@ class FiringCells(unittest.TestCase):
 class ArrivalToFiringCells(unittest.TestCase):
     """The clock's first half: does a pursuer even get a shot, and when.
 
-    Pinned against the exact ch06 finding (#26): the east pursuer's own allies cork every
-    one of its four firing cells on the contested (turn-1-blocked) snapshot, so its declared
-    fuse describes a unit that never arrives; the west pursuer reaches its one door on turn 2.
+    Pinned against the ch06 finding (#26, #367) and its fix (ch06-east-pursuer): the east
+    pursuer's own allies -- merfolk-trident's (13,11) body and ironshell-horseslayer at
+    (14,12) -- corked every one of its four firing cells on the contested snapshot, so its
+    declared fuse described a unit that never arrived. Moved off the corridor, it reaches
+    (15,12) on turn 2 -- the same empty-map arrival the chapter was designed around. The
+    west pursuer reaches its one door on turn 2 unchanged throughout.
     """
 
     def setUp(self):
@@ -68,11 +71,11 @@ class ArrivalToFiringCells(unittest.TestCase):
         self.terrain = pp.terrain_grid(self.chap)
         self.blocked = pp.enemy_bodies(self.chap)
 
-    def test_merfolk_thrower_cannot_reach_any_east_firing_cell(self):
+    def test_merfolk_thrower_reaches_an_east_firing_cell_on_turn_2(self):
         cells = rf.firing_cells(self.terrain, (17, 12), 2)
         table, mov = pp.class_movement('soldier')
         arrival = rf.arrival_to_cells(self.terrain, (14, 9), table, mov, cells, self.blocked)
-        self.assertIsNone(arrival)
+        self.assertEqual(arrival, 2)
 
     def test_ice_crab_reaches_its_door_on_turn_2(self):
         cells = rf.firing_cells(self.terrain, (4, 17), 1)
@@ -281,13 +284,17 @@ class PursuerForecast(unittest.TestCase):
     def _boat(self, bid):
         return next(b for b in self.chap['rescue_boats'] if b['id'] == bid)
 
-    def test_merfolk_thrower_never_engages_boat_east(self):
+    def test_merfolk_thrower_engages_boat_east_on_turn_2(self):
+        # Was `never_engages`: the thrower's own line -- merfolk-trident's (13,11) body and
+        # ironshell-horseslayer at (14,12) -- corked all four east firing cells (#26, #367).
+        # Fixed by moving those two bodies off the corridor (ch06-east-pursuer); this is the
+        # SAME empty-map arrival (turn 2 from (14,9)) the chapter was always designed around,
+        # now reachable on the contested snapshot too.
         row = rf.pursuer_forecast(self.chap, self.terrain, self._entry('merfolk-thrower'),
                                   0, self._boat('boat-east'))
-        self.assertIsNone(row.arrival_turn)
-        self.assertIsNone(row.sink_low)
-        self.assertIsNone(row.sink_expected)
-        self.assertIsNone(row.sink_high)
+        self.assertEqual(row.arrival_turn, 2)
+        self.assertAlmostEqual(row.damage_per_phase, 2.76, places=2)
+        self.assertEqual(row.sink_expected, 9)
 
     def test_ice_crab_engages_boat_west_on_turn_2_and_sinks_around_9(self):
         row = rf.pursuer_forecast(self.chap, self.terrain, self._entry('ice-crab'),


### PR DESCRIPTION
Stacked on #369 (`fuse-forecast`) — this branch is the tool's first real consumer, and should be retargeted to `main` (`gh pr edit --base main`) once #369 merges, per the stacked-PR flow.

## The fix

`tools/rescue_forecast.py` (#369) reproduced #26's confirmed bug in code: the east hull's declared pursuer, `merfolk-thrower` at (14,9), could not reach any of `boat-east`'s four javelin firing cells on the contested snapshot — corked by two of its own allies, `merfolk-trident`'s (13,11) body and `ironshell-horseslayer` at (14,12). Its declared "sinks turn 7" fuse described a unit that never arrived.

Nicolas's call: **move the thrower's own line, not the thrower.** Nudged the two corking bodies off the corridor — `merfolk-trident` (13,11) → (13,13), `ironshell-horseslayer` (14,12) → (15,13) — verified against the real forecast tool rather than by eye:

```
merfolk-thrower -> boat-east  arrives turn 2   2.76 dmg/phase  sinks turn 7-12 (expect 9)
```

Turn-2 arrival from (14,9) is the *same* empty-map number the chapter's own `reached_on` comment always assumed; the fix only clears the contested corridor to it.

## Verification

- **The player's own declared route to both doors (`reached_on_contested`) is byte-identical before and after** — neither nudged body ever sat on it.
- **Parity is unaffected**: same class/level/donor on both bodies, so ch06 stays x1.00/x1.00, 100% mirror, 27/27 bodies (#368's mirror%).
- The guard's advisory finding (`check_rescue_fuse_forecast`) is now silent for ch06; `make chapter CH=ch06`'s loose ends no longer name the pursuer.
- Four tests across three files were pinning the bug being fixed here (`test_rescue_forecast.py` ×2, `test_check_rescue_fuse_forecast.py`, `test_chapter_status.py`) — each flipped to assert the corrected behavior, watched fail against the pre-fix YAML first.
- `make check` green, drift clean. No ROM build, no emulator, no playtest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
