### PR TITLE
A map's tileset has one home, and it is the one the BUILD reads (#26)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8693,6 +8693,53 @@ is ch02's `placed_units` gaining its two `rear-raiders` bodies, correctly marked
 is simultaneously the proof that the four refactors are behaviour-preserving and that the
 fifth was a real bug.
 
+### A map's tileset has one home: the chapter YAML, not its sidecar JSON too (2026-09-06, #26)
+
+`map_placement_preview.load_map(stem)` read the tileset name from the map's compiled sidecar
+JSON (`<stem>.json`'s `meta['tileset']`) — a plain `dict['key']` lookup. Every chapter YAML
+already declares the identical fact under `map.tileset` (it's how `import_map_layout` and the
+build know which set to compile against in the first place), so the sidecar copy was never a
+second fact, only a second place the first one could go stale. It did: ch00–ch02's sidecars
+predate the `tileset` key entirely (ch03 onward all carry it, and every chapter where both
+exist agrees), so `load_map` — and therefore `terrain_grid` and `render`, its only two
+production callers — hard-crashed with a bare `KeyError: 'tileset'` on exactly the three
+oldest chapters. No *gate* lost coverage from this (`check_rescue_targets` and
+`check_rescue_fuse_forecast` both try/except-and-skip on `terrain_grid`, and none of ch00–02
+declare `rescue_boats`), but the tool this repo calls "the picture a placement decision gets
+made on" could not draw that picture for a third of the campaign.
+
+Backfilling `"tileset"` into the three old sidecars would have made the crash go away without
+touching the actual defect: two places still carrying the same fact, with nothing stopping the
+next hand-made map from shipping a sidecar that once again forgot the key. Instead
+`load_map(stem, tileset=None)` takes the tileset from its caller when given one, and both
+production callers (`terrain_grid`, `render`) now pass their chapter dict's own
+`chapter['map']['tileset']` — the chapter YAML is the single source of truth, and the sidecar
+copy is read only as a **fallback**, for the one caller with no chapter dict in hand
+(`test_map_placement_preview.py`'s own `load_map('ch06-maer-monster')`, which predates this
+change and is pinned to keep working exactly as before).
+
+**When both are given and they disagree, `load_map` raises rather than picking a winner.**
+This repo has been burned repeatedly by one fact living in two places where a copy silently
+diverged — a parity ratio that didn't say what it counted, ch02 never counting its own
+reinforcement wave (`decisions.md` → "A parity ratio does not say how much of the twin it
+COPIED", "What asking 'what is a body' found") — and letting YAML win unconditionally repeats
+that shape rather than closing it: the sidecar's tileset is the one the `.mar` was actually
+*compiled* against, so silently preferring the YAML could render a map under the wrong
+tileset while looking exactly as confident as a correct render. A raised, named contradiction
+(`ValueError` naming the stem, both values, and both places looked) is the only outcome that
+can't be mistaken for a working render; a stale copy either source is discovered and fixed at
+the point it's read, not laundered into a picture that quietly lies. Absence of BOTH (the
+ch00–ch02 shape) gets the same treatment: a `ValueError` naming the stem and both places
+looked, never the bare `KeyError` this ADR exists to retire.
+
+**Verified byte-identical**, not just "still passes": for the four chapters whose sidecars
+already carried a tileset (ch03–ch06), `terrain_grid`'s output and `render`'s full PNG output
+are hashed before and after this change and match exactly — this only moves *where* the name
+is read from, never *which* tileset is used for a chapter that already worked. ch00–ch02, which
+previously could not render at all, now do; ch07/ch08 (no compiled `.mar`/`.json` yet — planned
+chapters) still fail the same way they always did, a `FileNotFoundError` naming the missing
+sidecar, unchanged by this fix and already clear rather than confusing.
+
 ## Open Questions (not yet decided)
 
 See `docs/PRD.md §13` for the full list. Key unresolved items:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -8693,52 +8693,53 @@ is ch02's `placed_units` gaining its two `rear-raiders` bodies, correctly marked
 is simultaneously the proof that the four refactors are behaviour-preserving and that the
 fifth was a real bug.
 
-### A map's tileset has one home: the chapter YAML, not its sidecar JSON too (2026-09-06, #26)
+### A map's tileset has one home, and it is the one the BUILD reads (2026-09-06, #26)
 
-`map_placement_preview.load_map(stem)` read the tileset name from the map's compiled sidecar
-JSON (`<stem>.json`'s `meta['tileset']`) — a plain `dict['key']` lookup. Every chapter YAML
-already declares the identical fact under `map.tileset` (it's how `import_map_layout` and the
-build know which set to compile against in the first place), so the sidecar copy was never a
-second fact, only a second place the first one could go stale. It did: ch00–ch02's sidecars
-predate the `tileset` key entirely (ch03 onward all carry it, and every chapter where both
-exist agrees), so `load_map` — and therefore `terrain_grid` and `render`, its only two
-production callers — hard-crashed with a bare `KeyError: 'tileset'` on exactly the three
-oldest chapters. No *gate* lost coverage from this (`check_rescue_targets` and
-`check_rescue_fuse_forecast` both try/except-and-skip on `terrain_grid`, and none of ch00–02
-declare `rescue_boats`), but the tool this repo calls "the picture a placement decision gets
-made on" could not draw that picture for a third of the campaign.
+`map_placement_preview.load_map(stem)` read the tileset with a bare `meta['tileset']` off the
+map's sidecar `<stem>.json`. ch00–ch02's sidecars predate that key, so the tool this repo calls
+"the picture a placement decision gets made on" hard-crashed with `KeyError: 'tileset'` on half
+the built maps. No *gate* lost coverage (`check_rescue_targets` and `check_rescue_fuse_forecast`
+both skip on an unreadable map, and none of ch00–ch02 declare `rescue_boats`), but a third of the
+campaign could not be previewed at all.
 
-Backfilling `"tileset"` into the three old sidecars would have made the crash go away without
-touching the actual defect: two places still carrying the same fact, with nothing stopping the
-next hand-made map from shipping a sidecar that once again forgot the key. Instead
-`load_map(stem, tileset=None)` takes the tileset from its caller when given one, and both
-production callers (`terrain_grid`, `render`) now pass their chapter dict's own
-`chapter['map']['tileset']` — the chapter YAML is the single source of truth, and the sidecar
-copy is read only as a **fallback**, for the one caller with no chapter dict in hand
-(`test_map_placement_preview.py`'s own `load_map('ch06-maer-monster')`, which predates this
-change and is pinned to keep working exactly as before).
+**The first fix was right about the shape and wrong about the direction, and the difference is
+the whole ADR.** Every chapter YAML also declares `map.tileset`, and it reads like the authored
+source — so the first attempt promoted it to the single source of truth, threaded
+`chapter['map']['tileset']` through `terrain_grid` and `render`, and raised when the two
+disagreed. Review caught the premise: **nothing in the build reads that field.**
+`_register_chapter_map` resolves the tileset from the SIDECAR, defaulting to `WINTER_TILESET`
+when the key is absent — which is precisely why ch00–ch02 compile correctly today and always
+have. A preview sourced from the YAML would be drawing a fact the cartridge never consults, and
+for exactly the keyless chapters the mismatch guard could not fire, so editing ch00's YAML would
+have produced a confident render of a tileset the game does not load. The fix would have
+introduced a subtler version of the bug it was closing.
 
-**When both are given and they disagree, `load_map` raises rather than picking a winner.**
-This repo has been burned repeatedly by one fact living in two places where a copy silently
-diverged — a parity ratio that didn't say what it counted, ch02 never counting its own
-reinforcement wave (`decisions.md` → "A parity ratio does not say how much of the twin it
-COPIED", "What asking 'what is a body' found") — and letting YAML win unconditionally repeats
-that shape rather than closing it: the sidecar's tileset is the one the `.mar` was actually
-*compiled* against, so silently preferring the YAML could render a map under the wrong
-tileset while looking exactly as confident as a correct render. A raised, named contradiction
-(`ValueError` naming the stem, both values, and both places looked) is the only outcome that
-can't be mistaken for a working render; a stale copy either source is discovered and fixed at
-the point it's read, not laundered into a picture that quietly lies. Absence of BOTH (the
-ch00–ch02 shape) gets the same treatment: a `ValueError` naming the stem and both places
-looked, never the bare `KeyError` this ADR exists to retire.
+**The rule the build already uses is the rule, and it now exists once.** It was written twice
+inside `build_campaign` itself (`_register_chapter_map` and the layout terrain reader), and the
+preview would have been a third copy; it is now `build_campaign.map_tileset(meta)`, and all three
+call it. `load_map(stem)` takes no tileset argument at all — the picture cannot disagree with the
+cartridge, by construction rather than by vigilance.
 
-**Verified byte-identical**, not just "still passes": for the four chapters whose sidecars
-already carried a tileset (ch03–ch06), `terrain_grid`'s output and `render`'s full PNG output
-are hashed before and after this change and match exactly — this only moves *where* the name
-is read from, never *which* tileset is used for a chapter that already worked. ch00–ch02, which
-previously could not render at all, now do; ch07/ch08 (no compiled `.mar`/`.json` yet — planned
-chapters) still fail the same way they always did, a `FileNotFoundError` naming the missing
-sidecar, unchanged by this fix and already clear rather than confusing.
+**The YAML field stays, and stays honest by being CHECKED.** It is documentation, and
+documentation nothing reads is documentation free to rot — which is how this started.
+`check_documented_tileset` fails the build when a chapter's `map.tileset` names anything other
+than what `map_tileset` resolves for its compiled map. All nine chapters agree today; the point
+is that they cannot quietly stop agreeing.
+
+**A gate that cannot read its map now REPORTS rather than skipping or crashing.**
+`check_rescue_targets` swallowed every exception from `terrain_grid` as a skip, which hides a
+hard gate not running. The two obvious repairs are both wrong: letting it propagate crashes every
+other check with it (`main` runs them with no isolation), and swallowing is what it already did.
+A missing map — a chapter with no compiled `.mar` yet — stays a legitimate skip; anything else
+appends to `fail`, attributed and without a traceback.
+
+**Verified byte-identical, twice, across two different designs.** ch03–ch06 `terrain_grid` SHAs
+and full PNG renders are identical before and after — and identical again between the rejected
+YAML-sourced version and the shipped build-sourced one, because every chapter's documented
+tileset happens to match its effective one today. That agreement is exactly why the wrong premise
+produced right answers and could have shipped unnoticed; it is now a gate rather than a
+coincidence. ch00–ch02 render for the first time; ch07/ch08 still have no compiled `.mar` and
+still fail the same `FileNotFoundError` they always did.
 
 ## Open Questions (not yet decided)
 

--- a/tools/build_campaign.py
+++ b/tools/build_campaign.py
@@ -5826,6 +5826,20 @@ CHAPTER_SETTINGS_JSON = os.path.join(DECOMP, 'src', 'data', 'chapter_settings.js
 # (e.g. cave-interior, #40/#23) register in the chapter injector that first
 # consumes them.
 WINTER_TILESET = 'snowy-bern'         # shared winter overworld (#41), stem Snow
+
+
+def map_tileset(meta):
+    """The tileset a compiled map is built against, from its sidecar `<stem>.json`.
+
+    THE resolution rule, in one place. A sidecar that names no tileset gets
+    `WINTER_TILESET`, which is not a guess: the three oldest maps (ch00-ch02) predate
+    the key entirely and have always been compiled as snowy-bern by exactly this
+    default. The chapter YAML's own `map.tileset` is DOCUMENTATION -- nothing in the
+    build reads it -- so anything needing to know which tileset a map really uses asks
+    HERE, and cannot end up drawing a picture of a tileset the cartridge does not use
+    (`decisions.md` -> "A map's tileset has one home").
+    """
+    return meta.get('tileset', WINTER_TILESET)
 WINTER_TEST_LAYOUT = ('ChTestSnowMap', 'ch-test-snowfield')  # (asset label, campaign source stem)
 
 
@@ -6934,7 +6948,7 @@ def _register_chapter_map(maps_dir, layout, comment):
         shutil.copyfile(os.path.join(maps_dir, '%s.%s' % (stem, ext)),
                         os.path.join(MAP_LAYOUT_DIR, '%s.%s' % (label, ext)))
     with open(os.path.join(maps_dir, '%s.json' % stem), encoding='utf-8') as f:
-        tileset = json.load(f).get('tileset', WINTER_TILESET)
+        tileset = map_tileset(json.load(f))
     if tileset not in TILESET_STEMS:
         sys.exit('ERROR: %s.json names tileset %r -- add it to TILESET_STEMS and '
                  'register it (_register_tileset) first' % (stem, tileset))
@@ -11817,7 +11831,7 @@ def _map_terrain_grid(maps_dir, stem):
     ours is the committed source, the decomp's is the untracked artifact injection writes."""
     with open(os.path.join(maps_dir, stem + '.json'), encoding='utf-8') as f:
         meta = json.load(f)
-    width, tileset = meta['width'], meta.get('tileset', WINTER_TILESET)
+    width, tileset = meta['width'], map_tileset(meta)
     with open(os.path.join(maps_dir, 'tilesets', tileset, tileset + '.bin'), 'rb') as f:
         terrain = f.read()[TERRAIN_TABLE_OFFSET:]
     with open(os.path.join(maps_dir, stem + '.mar'), 'rb') as f:

--- a/tools/check.py
+++ b/tools/check.py
@@ -1062,6 +1062,47 @@ def _rescue_target_violations(short, reachers, pursuers):
     return out
 
 
+def _documented_tileset_violations(rel, d, effective):
+    """The chapter YAML's `map.tileset` must name the tileset the BUILD will actually use.
+
+    Nothing in the build reads this field -- `_register_chapter_map` resolves the tileset
+    from the map's sidecar JSON via `build_campaign.map_tileset` -- so it is documentation,
+    and documentation nothing reads is documentation free to rot. It very nearly did: the
+    first fix for ch00-ch02's `KeyError: 'tileset'` promoted this field to the preview's
+    source of truth, which would have let an edit here render a confident picture of a
+    tileset the cartridge never loads. The field stays, and stays honest, by being CHECKED
+    against the effective answer rather than trusted as one."""
+    documented = ((d.get('map') or {}).get('tileset'))
+    if documented is None or documented == effective:
+        return []
+    return ['%s: map.tileset documents %r but the build compiles this map as %r (its '
+            'sidecar JSON, via build_campaign.map_tileset) -- fix whichever is stale'
+            % (rel, documented, effective)]
+
+
+def check_documented_tileset(fail):
+    """#26: a chapter's documented `map.tileset` agrees with the one the build resolves."""
+    sys.path.insert(0, os.path.join(REPO, 'tools'))
+    try:
+        import build_campaign as bc
+    except ImportError as exc:      # Pillow absent on the lightweight checks job
+        print('check_documented_tileset: skipping (%s; the build job\'s `make test` '
+              'covers it)' % exc)
+        return
+    import json
+    for rel, d in _chapters():
+        mapfile = ((d.get('map') or {}).get('file'))
+        if not mapfile:
+            continue
+        sidecar = os.path.join(REPO, 'campaigns', rel.split(os.sep)[1], 'maps',
+                               os.path.basename(mapfile).replace('.mar', '.json'))
+        if not os.path.exists(sidecar):
+            continue              # a planned chapter with no compiled map yet
+        with open(sidecar, encoding='utf-8') as f:
+            effective = bc.map_tileset(json.load(f))
+        fail.extend(_documented_tileset_violations(rel, d, effective))
+
+
 def check_rescue_targets(fail):
     """A chapter's rescue targets are reachable only by units it declared (#26)."""
     sys.path.insert(0, os.path.join(REPO, 'tools'))
@@ -1079,8 +1120,18 @@ def check_rescue_targets(fail):
         short = str(doc.get('id', '')).split('-')[0]
         try:
             terrain = pp.terrain_grid(doc)
-        except Exception as exc:    # noqa: BLE001 -- an unbuilt map is not this gate's business
+        except FileNotFoundError as exc:
+            # A chapter with no compiled map yet is not this gate's business.
             print('check_rescue_targets: skipping %s (%s)' % (short, exc))
+            continue
+        except Exception as exc:    # noqa: BLE001
+            # Anything else -- an unreadable tileset, a corrupt .mar -- is a REAL problem,
+            # and the two wrong ways to handle it are the two obvious ones: swallowing it
+            # skips a hard gate silently, and letting it propagate crashes every OTHER check
+            # too (`main` runs them with no isolation). Report it as drift: loud, attributed,
+            # and it fails the build without taking the rest of the run down.
+            fail.append('%s: rescue-target gate could not read the map (%s: %s) -- this gate '
+                        'did not run for this chapter' % (short, type(exc).__name__, exc))
             continue
         hulls = [tuple(b['tile']) for b in boats]
         pursuers = {p['id'] for p in (doc.get('rescue_pursuers') or [])}
@@ -2515,6 +2566,7 @@ def main():
                   check_no_shadowed_definitions, check_gate_chapter_window,
                   check_declared_cases, check_chapter_lua_facts,
                   check_rescue_targets, check_rescue_fuse_forecast,
+                  check_documented_tileset,
                   check_harness_local_ratchet,
                   check_verdict_scenarios_are_guarded,
                   check_no_hardcoded_symbol_addresses,

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -108,45 +108,28 @@ ROLE_LEGEND = [('Sp', 'spear'), ('Ax', 'axe'), ('Sw', 'sword'), ('Cv', 'cavalry'
                ('St', 'staff'), ('Bs', 'beast')]
 
 
-def load_map(stem, tileset=None):
+def load_map(stem):
     """(grid, terrain, tileset) for one of our compiled maps.
 
-    The tileset name has one true home: the chapter YAML's own `map.tileset` (every hosted
-    chapter declares it -- it's how `import_map_layout` and the build already know which set
-    to compile against). A map's sidecar JSON (`<stem>.json`) ALSO carries a `tileset` key,
-    but that's a second copy of the same fact, not a second fact, and three of the oldest
-    sidecars (ch00-ch02) predate the key entirely -- so reading it as the only source made
-    `load_map` a bare `KeyError: 'tileset'` on exactly those chapters.
+    The tileset comes from the map's sidecar `<stem>.json`, resolved through
+    `build_campaign.map_tileset` -- the SAME function the ROM build resolves it with. This
+    used to be a bare `meta['tileset']`, which hard-crashed with `KeyError: 'tileset'` on
+    ch00-ch02, whose sidecars predate that key; the build never had that problem because it
+    has always defaulted a keyless sidecar to `WINTER_TILESET`.
 
-    Pass `tileset` (the caller's chapter dict already has `chapter['map']['tileset']`) and
-    it wins. Omit it and the sidecar is used as a fallback, for the one caller that has no
-    chapter dict at hand (`test_map_placement_preview.py`'s own `load_map('ch06-...')` call,
-    which predates `terrain_grid`/`render` threading the chapter through).
-
-    If BOTH are given and they disagree, that is not "YAML wins" -- it's a contradiction
-    between two things that are supposed to be the same fact, and the map that got compiled
-    is the sidecar's, so a silent pick could render the WRONG tileset while claiming to be
-    faithful to the YAML. Raise, the same call this repo has made every other time one fact
-    lived in two places and a copy quietly diverged (decisions.md: a parity ratio not saying
-    what it counted; ch02 never counting its own wave). Neither present is the ch00-ch02
-    case this function exists to stop being a crash: name the stem and both places looked.
+    The chapter YAML also declares `map.tileset`, and it is tempting to treat that as the
+    source of truth since it reads like the authored one. It is not: nothing in the build
+    consults it, so a preview sourced from it would be drawing a fact the cartridge ignores,
+    and could render a confident picture of a tileset the game does not use. Sharing the
+    build's own resolver instead makes disagreement between the picture and the ROM
+    impossible by construction (`decisions.md` -> "A map's tileset has one home").
     """
+    import build_campaign as bc
     meta = json.load(open(os.path.join(MAPS, stem + '.json')))
     w, h = meta['width'], meta['height']
-    sidecar = meta.get('tileset')
-    if tileset is not None and sidecar is not None and tileset != sidecar:
-        raise ValueError(
-            "tileset mismatch for %r: caller says %r (chapter YAML's map.tileset) but "
-            "%s.json says %r -- one of these is stale; fix the wrong one rather than "
-            "picking a winner" % (stem, tileset, stem, sidecar))
-    name = tileset if tileset is not None else sidecar
-    if name is None:
-        raise ValueError(
-            "no tileset for %r: not passed by the caller (chapter YAML's map.tileset), "
-            "and %s.json has no 'tileset' key either" % (stem, stem))
     raw = open(os.path.join(MAPS, stem + '.mar'), 'rb').read()
     cells = [struct.unpack_from('<H', raw, i * 2)[0] >> 5 for i in range(w * h)]
-    ts = mt._tileset_from_dir(os.path.join(MAPS, 'tilesets', name))
+    ts = mt._tileset_from_dir(os.path.join(MAPS, 'tilesets', bc.map_tileset(meta)))
     grid = [[cells[y * w + x] for x in range(w)] for y in range(h)]
     terrain = [[ts.terrain(m) for m in row] for row in grid]
     return grid, terrain, ts
@@ -375,7 +358,7 @@ def load_chapter(prefix):
 def terrain_grid(chapter):
     """The chapter's compiled terrain, by the map its YAML names."""
     stem = os.path.splitext(os.path.basename(chapter['map']['file']))[0]
-    return load_map(stem, chapter['map']['tileset'])[1]
+    return load_map(stem)[1]
 
 
 def reached_on(chapter, terrain, target, contested=True):
@@ -457,7 +440,7 @@ def _font(size, bold=False):
 
 def render(chapter, stem, out_png, concept=None, shade=None, zoom=3):
     from PIL import Image, ImageDraw
-    grid, terrain, ts = load_map(stem, chapter['map']['tileset'])
+    grid, terrain, ts = load_map(stem)
     h, w = len(grid), len(grid[0])
     cell = 16 * zoom
     pad = cell                       # a cell of margin for the coordinate ruler

--- a/tools/map_placement_preview.py
+++ b/tools/map_placement_preview.py
@@ -108,13 +108,45 @@ ROLE_LEGEND = [('Sp', 'spear'), ('Ax', 'axe'), ('Sw', 'sword'), ('Cv', 'cavalry'
                ('St', 'staff'), ('Bs', 'beast')]
 
 
-def load_map(stem):
-    """(grid, terrain, tileset) for one of our compiled maps."""
+def load_map(stem, tileset=None):
+    """(grid, terrain, tileset) for one of our compiled maps.
+
+    The tileset name has one true home: the chapter YAML's own `map.tileset` (every hosted
+    chapter declares it -- it's how `import_map_layout` and the build already know which set
+    to compile against). A map's sidecar JSON (`<stem>.json`) ALSO carries a `tileset` key,
+    but that's a second copy of the same fact, not a second fact, and three of the oldest
+    sidecars (ch00-ch02) predate the key entirely -- so reading it as the only source made
+    `load_map` a bare `KeyError: 'tileset'` on exactly those chapters.
+
+    Pass `tileset` (the caller's chapter dict already has `chapter['map']['tileset']`) and
+    it wins. Omit it and the sidecar is used as a fallback, for the one caller that has no
+    chapter dict at hand (`test_map_placement_preview.py`'s own `load_map('ch06-...')` call,
+    which predates `terrain_grid`/`render` threading the chapter through).
+
+    If BOTH are given and they disagree, that is not "YAML wins" -- it's a contradiction
+    between two things that are supposed to be the same fact, and the map that got compiled
+    is the sidecar's, so a silent pick could render the WRONG tileset while claiming to be
+    faithful to the YAML. Raise, the same call this repo has made every other time one fact
+    lived in two places and a copy quietly diverged (decisions.md: a parity ratio not saying
+    what it counted; ch02 never counting its own wave). Neither present is the ch00-ch02
+    case this function exists to stop being a crash: name the stem and both places looked.
+    """
     meta = json.load(open(os.path.join(MAPS, stem + '.json')))
     w, h = meta['width'], meta['height']
+    sidecar = meta.get('tileset')
+    if tileset is not None and sidecar is not None and tileset != sidecar:
+        raise ValueError(
+            "tileset mismatch for %r: caller says %r (chapter YAML's map.tileset) but "
+            "%s.json says %r -- one of these is stale; fix the wrong one rather than "
+            "picking a winner" % (stem, tileset, stem, sidecar))
+    name = tileset if tileset is not None else sidecar
+    if name is None:
+        raise ValueError(
+            "no tileset for %r: not passed by the caller (chapter YAML's map.tileset), "
+            "and %s.json has no 'tileset' key either" % (stem, stem))
     raw = open(os.path.join(MAPS, stem + '.mar'), 'rb').read()
     cells = [struct.unpack_from('<H', raw, i * 2)[0] >> 5 for i in range(w * h)]
-    ts = mt._tileset_from_dir(os.path.join(MAPS, 'tilesets', meta['tileset']))
+    ts = mt._tileset_from_dir(os.path.join(MAPS, 'tilesets', name))
     grid = [[cells[y * w + x] for x in range(w)] for y in range(h)]
     terrain = [[ts.terrain(m) for m in row] for row in grid]
     return grid, terrain, ts
@@ -343,7 +375,7 @@ def load_chapter(prefix):
 def terrain_grid(chapter):
     """The chapter's compiled terrain, by the map its YAML names."""
     stem = os.path.splitext(os.path.basename(chapter['map']['file']))[0]
-    return load_map(stem)[1]
+    return load_map(stem, chapter['map']['tileset'])[1]
 
 
 def reached_on(chapter, terrain, target, contested=True):
@@ -425,7 +457,7 @@ def _font(size, bold=False):
 
 def render(chapter, stem, out_png, concept=None, shade=None, zoom=3):
     from PIL import Image, ImageDraw
-    grid, terrain, ts = load_map(stem)
+    grid, terrain, ts = load_map(stem, chapter['map']['tileset'])
     h, w = len(grid), len(grid[0])
     cell = 16 * zoom
     pad = cell                       # a cell of margin for the coordinate ruler

--- a/tools/test_check_chapter_schema.py
+++ b/tools/test_check_chapter_schema.py
@@ -201,6 +201,35 @@ class TestPersonalLineRoutes(unittest.TestCase):
         self.assertIn('already carries', msgs[0])
 
 
+class TestDocumentedTileset(unittest.TestCase):
+    """`map.tileset` in a chapter YAML is DOCUMENTATION -- the build resolves the real
+    tileset from the map's sidecar JSON (`build_campaign.map_tileset`). Documentation
+    nothing reads is free to rot, and it nearly did: the first fix for ch00-ch02's
+    `KeyError: 'tileset'` promoted this field to the preview's source of truth, which would
+    have let an edit here draw a confident picture of a tileset the cartridge never loads."""
+
+    def test_agreement_is_clean(self):
+        self.assertEqual([], check._documented_tileset_violations(
+            'chNN.yaml', {'map': {'tileset': 'snowy-bern'}}, 'snowy-bern'))
+
+    def test_drift_between_the_doc_and_the_build_is_reported(self):
+        found = check._documented_tileset_violations(
+            'chNN.yaml', {'map': {'tileset': 'cave-interior'}}, 'snowy-bern')
+        self.assertEqual(len(found), 1, found)
+        self.assertIn('cave-interior', found[0])
+        self.assertIn('snowy-bern', found[0])
+
+    def test_a_chapter_documenting_nothing_is_not_a_violation(self):
+        """The field is optional; this gate exists to catch a WRONG one, not a missing one."""
+        self.assertEqual([], check._documented_tileset_violations(
+            'chNN.yaml', {'map': {'file': 'maps/x.mar'}}, 'snowy-bern'))
+
+    def test_every_shipped_chapter_agrees_with_its_build_tileset(self):
+        fail = []
+        check.check_documented_tileset(fail)
+        self.assertEqual([], fail)
+
+
 class TestRosterKeysAgree(unittest.TestCase):
     def test_checks_roster_keys_match_the_content_desks(self):
         # check.py names them rather than importing, so the bare-interpreter `checks` job

--- a/tools/test_check_rescue_targets.py
+++ b/tools/test_check_rescue_targets.py
@@ -77,6 +77,40 @@ class TheGateSurvivesAnUngroundedRosterEntry(unittest.TestCase):
                                    'positions': [[0, 0]], 'inventory': [{'id': 'iron-sword'}]}]
         return chap
 
+    def test_an_unreadable_map_is_reported_as_drift_not_swallowed_or_crashed(self):
+        """Three outcomes are possible for a map this gate cannot read, and two are wrong.
+        Swallowing it skips a HARD gate in silence; letting it propagate takes down every
+        other check with it (`main` runs them with no isolation). It is reported instead --
+        the gate fails, attributed, without a traceback. A missing map (a chapter with no
+        compiled `.mar` yet) stays a legitimate skip, which is what the narrowing preserves."""
+        import map_placement_preview as pp
+        chap = {'id': 'ch99-broken', 'rescue_boats': [{'id': 'b', 'tile': [1, 1]}],
+                'map': {'file': 'maps/ch99.mar'}}
+        original = check._chapters
+        real_terrain_grid = pp.terrain_grid
+        check._chapters = lambda: iter([('ch99.yaml', chap)])
+        pp.terrain_grid = lambda _d: (_ for _ in ()).throw(ValueError('unreadable tileset'))
+        try:
+            fail = []
+            check.check_rescue_targets(fail)          # must not raise
+            self.assertEqual(len(fail), 1, fail)
+            self.assertIn('unreadable tileset', fail[0])
+        finally:
+            check._chapters = original
+            pp.terrain_grid = real_terrain_grid
+
+    def test_a_chapter_with_no_compiled_map_is_still_just_skipped(self):
+        chap = {'id': 'ch99-planned', 'rescue_boats': [{'id': 'b', 'tile': [1, 1]}],
+                'map': {'file': 'maps/ch99-does-not-exist.mar'}}
+        original = check._chapters
+        check._chapters = lambda: iter([('ch99.yaml', chap)])
+        try:
+            fail = []
+            check.check_rescue_targets(fail)
+            self.assertEqual([], fail)
+        finally:
+            check._chapters = original
+
     def test_an_ungrounded_reinforcement_does_not_crash_the_whole_gate(self):
         chap = self._ch06_with_ungrounded_wave()
         original = check._chapters

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -134,54 +134,63 @@ class Board(unittest.TestCase):
             self.assertEqual(placed['nerra'], (9, 12))
 
 
-class LoadMapTilesetSourceOfTruth(unittest.TestCase):
-    """The tileset name used to be read ONLY from a map's sidecar JSON (`meta['tileset']`),
-    which is a second copy of a fact the chapter YAML's own `map.tileset` already owns -- and
-    ch00-ch02's sidecars predate that key entirely, so `load_map` hard-crashed with a bare
-    `KeyError: 'tileset'` on exactly the three oldest maps. The chapter YAML is now the single
-    source of truth: `load_map(stem, tileset=...)` uses what it is given, and only falls back
-    to the sidecar for the one caller with no chapter dict in hand (this module's own ch06
-    fixture, which predates `terrain_grid` threading the chapter through)."""
+class LoadMapResolvesTheTilesetTheBuildWillUse(unittest.TestCase):
+    """`load_map` read the tileset with a bare `meta['tileset']`, so it hard-crashed with
+    `KeyError: 'tileset'` on ch00-ch02, whose sidecars predate that key.
 
-    def test_an_explicit_tileset_is_used_even_when_the_sidecar_predates_the_key(self):
-        """ch01's sidecar genuinely has no 'tileset' key -- this is the real crash, not a
-        synthetic fixture standing in for it."""
-        _grid, _terrain, ts = pp.load_map('ch01-the-iron-trail', tileset='snowy-bern')
-        want = mt._tileset_from_dir(os.path.join(pp.MAPS, 'tilesets', 'snowy-bern'))
-        self.assertEqual(ts.gfx, want.gfx)
+    The fix is NOT to read the chapter YAML's `map.tileset` instead. Nothing in the ROM
+    build reads that field -- `build_campaign._register_chapter_map` reads the SIDECAR,
+    defaulting to `WINTER_TILESET` when the key is absent, and that default is exactly why
+    ch00-ch02 build fine today. A preview that sourced its tileset from the YAML would be
+    rendering a fact the game never consults, and could draw a confident picture of a
+    tileset the ROM does not use.
 
-    def test_with_no_explicit_tileset_the_sidecar_is_still_a_valid_fallback(self):
-        """The one caller with no chapter dict at hand -- this test module's own `setUp` --
-        must keep working exactly as before."""
+    So the preview resolves the tileset the same way the build does, through the build's own
+    `map_tileset(meta)` -- one function, one rule, and the picture cannot disagree with the
+    cartridge by construction.
+    """
+
+    def _ts(self, name):
+        return mt._tileset_from_dir(os.path.join(pp.MAPS, 'tilesets', name))
+
+    def test_a_keyless_sidecar_resolves_to_the_builds_own_default(self):
+        """ch00-ch02's sidecars have no `tileset` key; the build gives them WINTER_TILESET,
+        so the preview must give them the same thing rather than raising."""
+        import build_campaign as bc
+        _grid, _terrain, ts = pp.load_map('ch01-the-iron-trail')
+        self.assertEqual(ts.palettes, self._ts(bc.WINTER_TILESET).palettes)
+
+    def test_a_sidecar_that_names_a_tileset_uses_that_one(self):
         _grid, _terrain, ts = pp.load_map('ch06-maer-monster')
-        want = mt._tileset_from_dir(os.path.join(pp.MAPS, 'tilesets', 'snowy-bern-ice'))
-        self.assertEqual(ts.gfx, want.gfx)
+        self.assertEqual(ts.palettes, self._ts('snowy-bern-ice').palettes)
 
-    def test_neither_source_having_a_tileset_names_the_stem_not_a_bare_keyerror(self):
-        with self.assertRaises(Exception) as ctx:
-            pp.load_map('ch01-the-iron-trail')
-        self.assertNotIsInstance(ctx.exception, KeyError)
-        self.assertIn('ch01-the-iron-trail', str(ctx.exception))
+    def test_the_two_snowy_tilesets_are_told_apart_by_PALETTE_not_gfx(self):
+        """Guards the two assertions above from passing vacuously: snowy-bern and
+        snowy-bern-ice ship byte-identical `.4bpp` gfx and differ only in palette, so a test
+        that compared `ts.gfx` would pass even when the wrong tileset was loaded."""
+        plain, ice = self._ts('snowy-bern'), self._ts('snowy-bern-ice')
+        self.assertEqual(plain.gfx, ice.gfx)
+        self.assertNotEqual(plain.palettes, ice.palettes)
 
-    def test_disagreement_between_the_two_sources_raises_rather_than_silently_picking_one(self):
-        """ch06's sidecar says 'snowy-bern-ice'. Passing a DIFFERENT name -- as if the chapter
-        YAML had drifted from the map actually compiled -- must be caught, not resolved in
-        either source's favour: `decisions.md` has repeatedly been burned by one fact in two
-        places where a copy silently diverged (a parity ratio not saying what it counted; ch02
-        never counting its own wave)."""
-        with self.assertRaises(Exception) as ctx:
-            pp.load_map('ch06-maer-monster', tileset='snowy-bern')
-        msg = str(ctx.exception)
-        self.assertIn('ch06-maer-monster', msg)
-        self.assertIn('snowy-bern-ice', msg)
-        self.assertIn('snowy-bern', msg)
+    def test_the_preview_agrees_with_the_build_for_every_compiled_map(self):
+        """The property that matters, asserted directly rather than chapter by chapter:
+        whatever the build would compile a map against is what the preview draws it with."""
+        import build_campaign as bc
+        import glob
+        import json
+        for path in sorted(glob.glob(os.path.join(pp.MAPS, '*.json'))):
+            stem = os.path.splitext(os.path.basename(path))[0]
+            if not os.path.exists(os.path.join(pp.MAPS, stem + '.mar')):
+                continue
+            with open(path, encoding='utf-8') as f:
+                meta = json.load(f)
+            _grid, _terrain, ts = pp.load_map(stem)
+            self.assertEqual(ts.palettes, self._ts(bc.map_tileset(meta)).palettes, stem)
 
-    def test_terrain_grid_passes_the_chapters_own_tileset_so_ch01_no_longer_crashes(self):
-        """The regression itself: `terrain_grid` used to hand `load_map` nothing but the
-        stem, so ch01 (whose sidecar predates 'tileset') inherited the bare KeyError."""
-        chapter = pp.load_chapter('ch01')
-        terrain = pp.terrain_grid(chapter)
-        self.assertTrue(terrain)
+    def test_terrain_grid_no_longer_crashes_on_the_oldest_chapters(self):
+        """The regression itself: ch00-ch02 could not be previewed at all."""
+        for short in ('ch00', 'ch01', 'ch02'):
+            self.assertTrue(pp.terrain_grid(pp.load_chapter(short)), short)
 
 
 class ContestedReach(unittest.TestCase):

--- a/tools/test_map_placement_preview.py
+++ b/tools/test_map_placement_preview.py
@@ -14,6 +14,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import campaign_chapters as cc                                       # noqa: E402
 import map_placement_preview as pp                                   # noqa: E402
+import map_tileset_tool as mt                                        # noqa: E402
 
 
 def ch06():
@@ -131,6 +132,56 @@ class Board(unittest.TestCase):
             placed = dict((eid, tile) for tile, _, _, eid, _
                           in pp.placed_units(self.chap, concept))
             self.assertEqual(placed['nerra'], (9, 12))
+
+
+class LoadMapTilesetSourceOfTruth(unittest.TestCase):
+    """The tileset name used to be read ONLY from a map's sidecar JSON (`meta['tileset']`),
+    which is a second copy of a fact the chapter YAML's own `map.tileset` already owns -- and
+    ch00-ch02's sidecars predate that key entirely, so `load_map` hard-crashed with a bare
+    `KeyError: 'tileset'` on exactly the three oldest maps. The chapter YAML is now the single
+    source of truth: `load_map(stem, tileset=...)` uses what it is given, and only falls back
+    to the sidecar for the one caller with no chapter dict in hand (this module's own ch06
+    fixture, which predates `terrain_grid` threading the chapter through)."""
+
+    def test_an_explicit_tileset_is_used_even_when_the_sidecar_predates_the_key(self):
+        """ch01's sidecar genuinely has no 'tileset' key -- this is the real crash, not a
+        synthetic fixture standing in for it."""
+        _grid, _terrain, ts = pp.load_map('ch01-the-iron-trail', tileset='snowy-bern')
+        want = mt._tileset_from_dir(os.path.join(pp.MAPS, 'tilesets', 'snowy-bern'))
+        self.assertEqual(ts.gfx, want.gfx)
+
+    def test_with_no_explicit_tileset_the_sidecar_is_still_a_valid_fallback(self):
+        """The one caller with no chapter dict at hand -- this test module's own `setUp` --
+        must keep working exactly as before."""
+        _grid, _terrain, ts = pp.load_map('ch06-maer-monster')
+        want = mt._tileset_from_dir(os.path.join(pp.MAPS, 'tilesets', 'snowy-bern-ice'))
+        self.assertEqual(ts.gfx, want.gfx)
+
+    def test_neither_source_having_a_tileset_names_the_stem_not_a_bare_keyerror(self):
+        with self.assertRaises(Exception) as ctx:
+            pp.load_map('ch01-the-iron-trail')
+        self.assertNotIsInstance(ctx.exception, KeyError)
+        self.assertIn('ch01-the-iron-trail', str(ctx.exception))
+
+    def test_disagreement_between_the_two_sources_raises_rather_than_silently_picking_one(self):
+        """ch06's sidecar says 'snowy-bern-ice'. Passing a DIFFERENT name -- as if the chapter
+        YAML had drifted from the map actually compiled -- must be caught, not resolved in
+        either source's favour: `decisions.md` has repeatedly been burned by one fact in two
+        places where a copy silently diverged (a parity ratio not saying what it counted; ch02
+        never counting its own wave)."""
+        with self.assertRaises(Exception) as ctx:
+            pp.load_map('ch06-maer-monster', tileset='snowy-bern')
+        msg = str(ctx.exception)
+        self.assertIn('ch06-maer-monster', msg)
+        self.assertIn('snowy-bern-ice', msg)
+        self.assertIn('snowy-bern', msg)
+
+    def test_terrain_grid_passes_the_chapters_own_tileset_so_ch01_no_longer_crashes(self):
+        """The regression itself: `terrain_grid` used to hand `load_map` nothing but the
+        stem, so ch01 (whose sidecar predates 'tileset') inherited the bare KeyError."""
+        chapter = pp.load_chapter('ch01')
+        terrain = pp.terrain_grid(chapter)
+        self.assertTrue(terrain)
 
 
 class ContestedReach(unittest.TestCase):


### PR DESCRIPTION
Found while output-diffing #369 — `map_placement_preview` crashed with a bare `KeyError: 'tileset'` on ch00/ch01/ch02, half the built maps.

> **Two commits, and the second corrects the first's premise.** `/code-review` caught that the original fix made the chapter YAML the source of truth for a field **nothing in the build reads**. Both are kept so the correction is visible; the final state is described below.

## The bug

`load_map(stem)` read the tileset with a bare `meta['tileset']` off the map's sidecar JSON. ch00–ch02's sidecars predate that key, so the tool this repo calls *"the picture a placement decision gets made on"* hard-crashed on half the built maps. No *gate* lost coverage (both rescue gates skip an unreadable map, and none of ch00–ch02 declare `rescue_boats`) — but a third of the campaign could not be previewed at all.

## The premise that was wrong, and why it mattered

Every chapter YAML *also* declares `map.tileset`, and it reads like the authored source. The first fix promoted it to single source of truth and threaded it through `terrain_grid`/`render`.

**Nothing in the build reads that field.** `_register_chapter_map` resolves the tileset from the **sidecar**, defaulting to `WINTER_TILESET` when the key is absent — which is exactly why ch00–ch02 compile correctly today and always have.

So that fix would have introduced a subtler version of the bug it closed: the preview drawing a fact the cartridge never consults. And for precisely the keyless chapters, the mismatch guard **could not fire** — editing ch00's YAML tileset would have yielded a confident render of a tileset the game does not load.

## The fix

**The build's own rule is the rule, and it now exists once.** It was already written twice inside `build_campaign` (`_register_chapter_map` and the layout terrain reader); the preview would have been a third copy. It is now `build_campaign.map_tileset(meta)`, and all three call it. `load_map(stem)` takes no tileset argument at all — the picture cannot disagree with the cartridge by construction rather than by vigilance. With one source, the raise-on-disagreement guard has nothing to guard and is gone.

**The YAML field stays, and stays honest by being checked.** `check_documented_tileset` fails the build when a chapter's `map.tileset` names anything other than what `map_tileset` resolves for its compiled map. All nine agree today; the point is that they cannot quietly stop agreeing. That is the real closure for *"documentation nothing reads is free to rot"* — which is how this started.

**A gate that cannot read its map now reports.** `check_rescue_targets` swallowed every `terrain_grid` exception as a skip, silently not running a hard gate. Propagating instead would crash every other check with it (`main` has no per-check isolation). Third option: an unreadable map is appended to `fail` — attributed, no traceback, rest of the run intact. A chapter with no compiled `.mar` stays a legitimate skip.

## Test defects the review found (all real, all fixed)

- Assertions on `ts.gfx` **could not tell `snowy-bern` from `snowy-bern-ice`** — byte-identical `.4bpp`, only the palettes differ — so they would have passed with the *wrong* tileset loaded. They compare palettes now, and a new test pins that gfx-equality as the reason.
- `assertIn('snowy-bern', msg)` was a substring of the already-asserted `'snowy-bern-ice'`, so it could not fail.
- One test pinned the **absence** of the key in ch01's shipped sidecar; a routine `import_map_layout` re-import backfills it and would have turned the suite red for no defect.

Replaced with a property test — *the preview resolves what the build resolves, for every compiled map* — which immediately caught `ch-test-snowfield`: a keyless map with no chapter YAML at all, and therefore invisible to the rejected design.

## Verification

**Byte-identical, twice, across two different designs.** ch03–ch06 `terrain_grid` SHAs and full PNG renders match pre-change `main` — and match the rejected YAML-sourced version too, because every chapter's documented tileset happens to equal its effective one today.

That agreement is exactly why a wrong premise produced right answers and could have shipped unnoticed. It is a gate now rather than a coincidence.

```
ch03 87c17162...  ch04 0604d2fe...  ch05 96770c8d...  ch06 f14c5ee4...
all four: cmp before/after -> IDENTICAL   (terrain_grid SHA and full PNG render)
```

- **ch00/ch01/ch02 render for the first time** (76K/159K/103K) — previously a hard crash.
- ch07/ch08 still fail the same pre-existing `FileNotFoundError` naming the missing sidecar.
- 44 + 10 + 32 + 29 + 13 + 62 tests green across the six touched suites; new tests written first and watched fail.
- `make check` green, drift clean. No ROM build, no emulator, no playtest run.

ADR: `docs/decisions.md` → *"A map's tileset has one home, and it is the one the BUILD reads"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
